### PR TITLE
add decorator function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ coverage.xml
 *~ 
 
 todo.md
+.DS_Store

--- a/osmosis_ai/__init__.py
+++ b/osmosis_ai/__init__.py
@@ -15,7 +15,7 @@ Currently supported adapters:
 def _import_modules():
     global utils, logger, reconfigure_logger
     global set_log_destination, log_destination, LogDestination
-    global init, enabled, disable_osmosis, enable_osmosis
+    global init, enabled, disable_osmosis, enable_osmosis, osmosis_reward
 
     from . import utils
     from .logger import logger, reconfigure_logger, set_log_destination, log_destination
@@ -30,6 +30,9 @@ def _import_modules():
 
     # Re-export initialization function
     init = utils.init
+    
+    # Export the reward decorator
+    osmosis_reward = utils.osmosis_reward
 
     # Initialize wrappers as None
     global wrap_anthropic, wrap_openai, wrap_langchain

--- a/osmosis_ai/utils.py
+++ b/osmosis_ai/utils.py
@@ -4,8 +4,9 @@ Utility functions for osmosisadapters
 
 import json
 from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import Any, Dict, Callable
 import xxhash
+import functools
 
 # Import constants
 from .consts import osmosis_api_url
@@ -95,3 +96,25 @@ def send_to_osmosis(
         )
     except Exception as e:
         logger.warning(f"Failed to send data to OSMOSIS API: {str(e)}")
+
+
+def osmosis_reward(func: Callable) -> Callable:
+    """
+    Decorator for reward functions.
+    
+    Args:
+        func: The reward function to be wrapped
+        
+    Returns:
+        The wrapped function
+        
+    Example:
+        @osmosis_reward
+        def calculate_reward(state, action):
+            return state.score + action.value
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    
+    return wrapper


### PR DESCRIPTION
## Description

This pull request introduces a new decorator for reward functions and makes it available for import from the main package. The changes are focused on utility improvements and package exports.

**Utility improvements:**

* Added a new `osmosis_reward` decorator in `utils.py` to wrap reward functions, providing a standardized way to annotate these functions.

**Package exports:**

* Updated `__init__.py` to re-export the `osmosis_reward` decorator, allowing it to be imported directly from the `osmosis_ai` package. [[1]](diffhunk://#diff-6c1993b6305a4d5eceeeeb3796028cb56b67bbb47847ddf236e1190bd89f99b4L18-R18) [[2]](diffhunk://#diff-6c1993b6305a4d5eceeeeb3796028cb56b67bbb47847ddf236e1190bd89f99b4R34-R36)
* Modified imports in `utils.py` to include `Callable` and `functools` for the new decorator implementation.

## Type of Change

<!-- Please check the options that are relevant -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Code refactoring
- [ ] CI/CD or build process changes
- [ ] Other (please describe):

## Related Issues

<!-- Please link to any related issues. Use syntax like "fixes #123" or "closes #456" -->

## Testing

<!-- Describe the tests you ran to verify your changes. 
     Provide instructions so reviewers can reproduce.
     Include relevant details for your test configuration. -->

- [ ] New unit tests added
- [ ] Existing tests passing
- [x] Manually tested the changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] Any dependent changes have been merged and published

## Additional Context

<!-- Add any other context about the PR here --> 