### PR TITLE
publish automation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - release
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    environment: Release-secret
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build distribution artifacts
+        run: ./build_package.sh
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate publishing Python packages when changes are pushed to the `release` branch or triggered manually. The workflow ensures that package builds and publishing to PyPI are handled consistently and securely.

Continuous integration and deployment:

* Added a new workflow file, `.github/workflows/publish.yml`, to automate the build and publishing process for Python packages. The workflow runs on pushes to the `release` branch and via manual triggers, sets up Python 3.12, builds distribution artifacts using `build_package.sh`, and publishes to PyPI using the `pypa/gh-action-pypi-publish` action with secrets for authentication.