### PR TITLE
added cli for version display

### DIFF
--- a/osmosis_ai/__init__.py
+++ b/osmosis_ai/__init__.py
@@ -7,6 +7,7 @@ Features:
 - Type-safe interfaces for LLM-centric workflows
 """
 
+from .consts import PACKAGE_VERSION as __version__
 from .rubric_eval import MissingAPIKeyError, evaluate_rubric
 from .rubric_types import ModelNotFoundError, ProviderRequestError
 from .utils import osmosis_reward, osmosis_rubric
@@ -41,6 +42,8 @@ from .rollout import (
 )
 
 __all__ = [
+    # Version
+    "__version__",
     # Reward function decorators
     "osmosis_reward",
     "osmosis_rubric",

--- a/osmosis_ai/cli.py
+++ b/osmosis_ai/cli.py
@@ -8,6 +8,7 @@ from dotenv import load_dotenv
 
 from .cli_commands import EvalCommand, LoginCommand, LogoutCommand, PreviewCommand, WhoamiCommand, WorkspaceCommand
 from .cli_services import CLIError
+from .consts import PACKAGE_VERSION, package_name
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -35,6 +36,14 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="osmosis",
         description="Osmosis AI SDK - rubric evaluation and remote rollout server.",
     )
+    
+    parser.add_argument(
+        "-V", "--version",
+        action="version",
+        version=f"{package_name} {PACKAGE_VERSION}",
+        help="Show version number.",
+    )
+    
     subparsers = parser.add_subparsers(dest="command")
 
     login_parser = subparsers.add_parser(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a CLI flag to show the package version and exposed __version__ for programmatic access. This makes it easier to check versions in scripts and when debugging.

- **New Features**
  - Added -V/--version to the osmosis CLI to print "<package_name> <version>".
  - Exported __version__ from osmosis_ai for libraries and tooling.

<sup>Written for commit 4263f626ed9cc01717041c6a7a030c6189b64fab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

