### PR TITLE
Enhance evaluation function to support asynchronous execution

### DIFF
--- a/osmosis_ai/rollout/eval/evaluation/eval_fn.py
+++ b/osmosis_ai/rollout/eval/evaluation/eval_fn.py
@@ -107,7 +107,8 @@ class EvalFnWrapper:
         if self._is_async:
             result = await self.fn(**kwargs)
         else:
-            result = self.fn(**kwargs)
+            loop = asyncio.get_running_loop()
+            result = await loop.run_in_executor(None, lambda: self.fn(**kwargs))
 
         if not isinstance(result, (int, float)):
             raise EvalFnError(

--- a/osmosis_ai/rollout/eval/evaluation/report.py
+++ b/osmosis_ai/rollout/eval/evaluation/report.py
@@ -28,10 +28,10 @@ def pass_at_k(n: int, c: int, k: int) -> float:
     Returns:
         Estimated pass@k probability in [0, 1].
     """
-    if n < k:
-        return 0.0
     if c == 0:
         return 0.0
+    if n <= k:
+        return 1.0
     if c >= n:
         return 1.0
     if n - c < k:


### PR DESCRIPTION
- Updated `EvalFnWrapper` to run synchronous functions in an executor for better async compatibility.
- Modified `pass_at_k` function to return 1.0 when the number of items is less than or equal to k, improving probability estimation logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make EvalFnWrapper async-friendly by running synchronous evaluation functions in a background executor, preventing event loop blocking. Also fix pass_at_k to return 1.0 when n <= k (and 0.0 when c == 0) for more accurate estimates with small sample sizes.

<sup>Written for commit 3fcf6e2bcf7301e6e88a5bdcdb58d102d8c3ea3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

