### PR TITLE
Fix tool call handling in InteractiveRunner to prevent potential NoneType errors by ensuring tool_calls is always iterable.

### DIFF
--- a/osmosis_ai/rollout/eval/test_mode/interactive.py
+++ b/osmosis_ai/rollout/eval/test_mode/interactive.py
@@ -222,7 +222,7 @@ class InteractiveRunner:
         name_map: Dict[str, str] = {}
         for msg in messages:
             if msg.get("role") == "assistant":
-                for tc in msg.get("tool_calls", []):
+                for tc in msg.get("tool_calls") or []:
                     tc_id = tc.get("id", "")
                     func_name = tc.get("function", {}).get("name", "unknown")
                     if tc_id:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevented a crash in InteractiveRunner by safely iterating over tool_calls even when it’s None. This ensures assistant messages without tool calls don’t break the tool name map in test mode.

- **Bug Fixes**
  - Use msg.get("tool_calls") or [] to avoid TypeError when tool_calls is None.

<sup>Written for commit f50d79d84428efac1209de43f75f796a272e773c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

