### PR TITLE
fix: relax MessageDict to accept any value type

### DIFF
--- a/osmosis_ai/rollout/types/sample.py
+++ b/osmosis_ai/rollout/types/sample.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-MessageDict = dict[str, list[Any] | str]
+MessageDict = dict[str, Any]
 
 
 class RolloutSample(BaseModel):


### PR DESCRIPTION
## Problem

Every rollout was crashing silently with a Pydantic `ValidationError`, causing all training rewards to be 0.

The error in the rollout server ECS logs:
```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for RolloutSample
  messages.2.metadata.list[any]
    Input should be a valid list [input_value={'usage': {'inputTokens':...}}]
  messages.2.metadata.str
    Input should be a valid string [input_value={'usage': {'inputTokens':...}}]
```

## Root Cause

`MessageDict = dict[str, list[Any] | str]` only allows `list` or `str` values. However, the Strands `LiteLLMModel` stores usage statistics (`{'usage': {'inputTokens': ..., 'ToFirstByteMs': ...}}`) as a `dict` in the message `metadata` field. When `context.py::get_samples()` constructs a `RolloutSample` from the agent's messages, Pydantic rejects the dict-typed metadata value.

## Fix

Relax `MessageDict` to `dict[str, Any]` so any valid dict value passes validation.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxed `MessageDict` to `dict[str, Any]` so dict-typed `metadata` values pass Pydantic validation. This prevents rollout crashes and restores training rewards.

<sup>Written for commit 36c06c64c0d5a79647356a03d04a8a1b098e2eed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

