### PR TITLE
[cli] feat: add deploy command group for LoRA adapter inference

### DIFF
--- a/osmosis_ai/cli/commands/deploy.py
+++ b/osmosis_ai/cli/commands/deploy.py
@@ -58,6 +58,46 @@ def _fetch_all_deployments(client: Any, credentials: Any) -> list[Any]:
     return deployments
 
 
+def _print_query_example(
+    ws_name: str,
+    base_model: str | None,
+    lora_name: str,
+) -> None:
+    """Print a ready-to-copy curl example for the freshly deployed adapter.
+
+    The model identifier on the inference endpoint is ``{base_model}:{lora_name}``.
+    If ``base_model`` is unknown (e.g., the follow-up fetch failed), we fall back
+    to a ``<base-model>`` placeholder so the user still gets a usable template.
+    """
+    from osmosis_ai.platform.cli.utils import platform_entity_url
+    from osmosis_ai.platform.constants import INFERENCE_URL
+
+    model_id = f"{base_model or '<base-model>'}:{lora_name}"
+    endpoint = f"{INFERENCE_URL}/v1/chat/completions"
+    api_keys_url = platform_entity_url(ws_name, "api-keys")
+
+    # Built as a plain string so users can select + copy as-is. Rich markup is
+    # disabled when printing to avoid any interpretation of `{`, `[`, `$` etc.
+    curl_cmd = (
+        f"  curl -X POST {endpoint} \\\n"
+        f'    -H "Content-Type: application/json" \\\n'
+        f'    -H "Authorization: Bearer $OSMOSIS_API_KEY" \\\n'
+        f"    -d '{{\n"
+        f'      "model": "{model_id}",\n'
+        f'      "messages": [{{"role": "user", "content": "Hello"}}]\n'
+        f"    }}'"
+    )
+
+    console.print()
+    console.print("Try it (once status is active):", style="bold")
+    console.print()
+    # soft_wrap=True keeps each line intact so the command is copy-paste safe
+    # even when the terminal is narrower than the longest line.
+    console.print(curl_cmd, markup=False, highlight=False, soft_wrap=True)
+    console.print()
+    console.print(f"Create an API key: {api_keys_url}", style="dim")
+
+
 def _default_lora_name(run_name: str, step: int) -> str:
     """Mirror of monolith src/lib/slug-generator.ts::generateLoraName.
 
@@ -157,6 +197,20 @@ def create(
     )
     console.print(f"  Status: {result.status}")
     console.print(f"  View: {url}")
+
+    # Fetch full deployment details to get `base_model` for the curl example.
+    # The POST /deployments response intentionally omits it; we silently skip
+    # the curl block if this lookup fails so display issues never mask a
+    # successful deployment.
+    base_model: str | None = None
+    try:
+        details = client.get_deployment(result.lora_name, credentials=credentials)
+        base_model = details.base_model or None
+    except Exception:
+        # Best-effort display enhancement — never mask a successful deployment.
+        base_model = None
+
+    _print_query_example(ws_name, base_model, result.lora_name)
 
 
 @app.command("list")

--- a/osmosis_ai/cli/commands/deploy.py
+++ b/osmosis_ai/cli/commands/deploy.py
@@ -1,0 +1,284 @@
+"""Deployment management commands (LoRA adapters for inference)."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import typer
+
+from osmosis_ai.cli.console import console
+from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE
+
+app: typer.Typer = typer.Typer(
+    help="Manage inference deployments (create, list, status, delete, rename).",
+    no_args_is_help=True,
+)
+
+
+def _print_deployment_section(
+    deployments: list[Any],
+    total_count: int,
+) -> None:
+    """Print a list of deployments with consistent formatting."""
+    from osmosis_ai.platform.cli.utils import entity_status_style, format_dim_date
+
+    if not deployments:
+        return
+    console.print(f"Deployments ({total_count}):", style="bold")
+    for d in deployments:
+        style = entity_status_style(d.status) or "dim"
+        status_str = console.format_styled(f"[{d.status}]", style)
+        name = console.escape(d.lora_name)
+        base = console.format_styled(d.base_model, "dim") if d.base_model else ""
+        run = (
+            console.format_styled(f"from {d.training_run_name}", "dim")
+            if d.training_run_name
+            else ""
+        )
+        step = console.format_styled(f"step:{d.checkpoint_step}", "dim")
+        date = format_dim_date(d.created_at)
+        console.print(
+            f"  {name}  {status_str}  {base}  {run}  {step}  {date}",
+            highlight=False,
+        )
+    console.print()
+
+
+def _fetch_all_deployments(client: Any, credentials: Any) -> list[Any]:
+    """Fetch all deployments via exhaustive pagination."""
+    from osmosis_ai.platform.cli.utils import fetch_all_pages
+
+    deployments, _ = fetch_all_pages(
+        lambda lim, off: client.list_deployments(
+            limit=lim, offset=off, credentials=credentials
+        ),
+        items_attr="deployments",
+    )
+    return deployments
+
+
+def _default_lora_name(run_name: str, step: int) -> str:
+    """Mirror of monolith src/lib/slug-generator.ts::generateLoraName.
+
+    Used for the confirmation preview only. Server computes the
+    authoritative name if none is passed; in the rare event of drift,
+    the preview may disagree with what the server stores, but the
+    server response is what the CLI ultimately renders.
+    """
+    raw = f"{run_name}-step-{step}-lora"
+    slug = re.sub(r"[^a-zA-Z0-9_-]", "-", raw)
+    slug = re.sub(r"-{2,}", "-", slug)
+    slug = slug.strip("-")
+    return slug[:255]
+
+
+@app.command("create")
+def create(
+    training_run: str = typer.Argument(..., help="Training run name (or UUID)."),
+    step: int | None = typer.Option(
+        None,
+        "--step",
+        "-s",
+        help="Checkpoint step. Defaults to the latest uploaded checkpoint.",
+    ),
+    name: str | None = typer.Option(
+        None,
+        "--name",
+        "-n",
+        help=(
+            "LoRA adapter name. 1-255 chars, [a-zA-Z0-9_-]+. "
+            "Defaults to '<run>-step-<N>-lora'."
+        ),
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation."),
+) -> None:
+    """Deploy a LoRA checkpoint as an inference adapter."""
+    from osmosis_ai.cli.errors import CLIError
+    from osmosis_ai.cli.prompts import require_confirmation
+    from osmosis_ai.platform.api.client import OsmosisClient
+    from osmosis_ai.platform.cli.utils import (
+        _require_auth,
+        platform_entity_url,
+    )
+
+    ws_name, credentials = _require_auth()
+    client = OsmosisClient()
+
+    with console.spinner("Fetching checkpoints..."):
+        ckpts = client.list_training_run_checkpoints(
+            training_run, credentials=credentials
+        )
+
+    if not ckpts.checkpoints:
+        raise CLIError(
+            f"No uploaded checkpoints found for '{training_run}'.\n"
+            "Wait for training to finish, or check "
+            "'osmosis train status'."
+        )
+
+    # Defensive sort so auto-pick always returns the highest step
+    sorted_cps = sorted(
+        ckpts.checkpoints, key=lambda c: c.checkpoint_step, reverse=True
+    )
+
+    if step is None:
+        selected = sorted_cps[0]
+    else:
+        selected = next((c for c in sorted_cps if c.checkpoint_step == step), None)
+        if selected is None:
+            available = ", ".join(str(c.checkpoint_step) for c in sorted_cps)
+            raise CLIError(
+                f"No uploaded checkpoint at step {step}. Available steps: {available}."
+            )
+
+    run_display = ckpts.training_run_name or training_run
+    preview_name = name or _default_lora_name(run_display, selected.checkpoint_step)
+
+    rows: list[tuple[str, str]] = [
+        ("Training run", console.escape(run_display)),
+        ("Checkpoint", f"step {selected.checkpoint_step}"),
+        ("LoRA name", console.escape(preview_name)),
+    ]
+    console.table(rows, title="Deploy")
+    require_confirmation("Deploy this checkpoint?", yes=yes)
+
+    with console.spinner("Deploying..."):
+        result = client.create_deployment(
+            training_run=training_run,
+            checkpoint_step=selected.checkpoint_step,
+            lora_name=name,
+            credentials=credentials,
+        )
+
+    url = platform_entity_url(ws_name, "deployments")
+    console.print(
+        f"Deployment created: {console.escape(result.lora_name)}", style="green"
+    )
+    console.print(f"  Status: {result.status}")
+    console.print(f"  View: {url}")
+
+
+@app.command("list")
+def list_deployments(
+    limit: int = typer.Option(
+        DEFAULT_PAGE_SIZE,
+        "--limit",
+        help="Maximum number of deployments to show.",
+    ),
+    all_: bool = typer.Option(False, "--all", help="Show all deployments."),
+) -> None:
+    """List deployments in the current workspace."""
+    from osmosis_ai.platform.api.client import OsmosisClient
+    from osmosis_ai.platform.cli.utils import (
+        _require_auth,
+        print_pagination_footer,
+        validate_list_options,
+    )
+
+    effective_limit, fetch_all = validate_list_options(limit=limit, all_=all_)
+
+    _ws_name, credentials = _require_auth()
+    client = OsmosisClient()
+
+    with console.spinner("Fetching deployments..."):
+        if fetch_all:
+            deployments = _fetch_all_deployments(client, credentials)
+            total = len(deployments)
+        else:
+            result = client.list_deployments(
+                limit=effective_limit, credentials=credentials
+            )
+            deployments = result.deployments
+            total = result.total_count
+
+    if not deployments:
+        console.print("No deployments found.")
+        return
+
+    _print_deployment_section(deployments, total)
+
+    if not fetch_all:
+        print_pagination_footer(len(deployments), total, "deployments")
+
+
+@app.command("status")
+def status(
+    name: str = typer.Argument(..., help="Deployment name (LoRA name) or UUID."),
+) -> None:
+    """Show deployment details."""
+    from osmosis_ai.platform.api.client import OsmosisClient
+    from osmosis_ai.platform.cli.utils import (
+        _require_auth,
+        format_date,
+    )
+
+    _ws_name, credentials = _require_auth()
+    client = OsmosisClient()
+
+    with console.spinner("Fetching deployment..."):
+        d = client.get_deployment(name, credentials=credentials)
+
+    rows: list[tuple[str, str]] = [
+        ("LoRA name", console.escape(d.lora_name)),
+        ("ID", d.id),
+        ("Status", d.status),
+        ("Base model", console.escape(d.base_model) if d.base_model else "—"),
+        ("Checkpoint", f"step {d.checkpoint_step}"),
+    ]
+    if d.training_run_name:
+        rows.append(("Training run", console.escape(d.training_run_name)))
+    elif d.training_run_id:
+        rows.append(("Training run", d.training_run_id))
+    if d.creator_name:
+        rows.append(("Creator", console.escape(d.creator_name)))
+    if d.created_at:
+        rows.append(("Created", format_date(d.created_at)))
+
+    console.table(rows, title="Deployment")
+
+
+@app.command("delete")
+def delete(
+    name: str = typer.Argument(..., help="LoRA name or UUID."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+) -> None:
+    """Delete a deployment (remove the LoRA adapter from inference)."""
+    from osmosis_ai.cli.prompts import require_confirmation
+    from osmosis_ai.platform.api.client import OsmosisClient
+    from osmosis_ai.platform.cli.utils import _require_auth
+
+    _ws_name, credentials = _require_auth()
+    client = OsmosisClient()
+
+    require_confirmation(
+        f'Delete deployment "{name}"? The LoRA adapter will be removed from inference.',
+        yes=yes,
+    )
+    client.delete_deployment(name, credentials=credentials)
+    console.print(f'Deployment "{name}" deleted.', style="green")
+
+
+@app.command("rename")
+def rename(
+    name: str = typer.Argument(..., help="Current LoRA name or UUID."),
+    new_name: str = typer.Argument(..., help="New LoRA name."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+) -> None:
+    """Rename a deployment's LoRA adapter name."""
+    from osmosis_ai.cli.prompts import require_confirmation
+    from osmosis_ai.platform.api.client import OsmosisClient
+    from osmosis_ai.platform.cli.utils import _require_auth
+
+    _ws_name, credentials = _require_auth()
+    client = OsmosisClient()
+
+    require_confirmation(f'Rename "{name}" to "{new_name}"?', yes=yes)
+
+    with console.spinner("Renaming..."):
+        result = client.rename_deployment(name, new_name, credentials=credentials)
+
+    console.print(
+        f'Renamed: "{name}" → "{console.escape(result.lora_name)}"',
+        style="green",
+    )

--- a/osmosis_ai/cli/commands/model.py
+++ b/osmosis_ai/cli/commands/model.py
@@ -8,7 +8,6 @@ from typing import Any
 import typer
 
 from osmosis_ai.cli.console import console
-from osmosis_ai.cli.errors import not_implemented
 from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE
 
 app: typer.Typer = typer.Typer(
@@ -106,18 +105,6 @@ def list_models(
 
     if not fetch_all:
         print_pagination_footer(len(models), total, "base models")
-
-
-@app.command("export")
-def export() -> None:
-    """Export a model."""
-    not_implemented("model", "export")
-
-
-@app.command("build")
-def build() -> None:
-    """Build a model."""
-    not_implemented("model", "build")
 
 
 @app.command("delete")

--- a/osmosis_ai/cli/commands/model.py
+++ b/osmosis_ai/cli/commands/model.py
@@ -12,7 +12,8 @@ from osmosis_ai.cli.errors import not_implemented
 from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE
 
 app: typer.Typer = typer.Typer(
-    help="Manage models (list, deploy, export, build, delete).", no_args_is_help=True
+    help="Manage models (base models and trainable checkpoints).",
+    no_args_is_help=True,
 )
 
 
@@ -22,7 +23,7 @@ def _print_model_section(
     title: str,
     metadata_fn: Callable[[Any], str],
 ) -> None:
-    """Print a section of models (base or output) with consistent formatting."""
+    """Print a section of base models with consistent formatting."""
     from osmosis_ai.platform.cli.utils import entity_status_style, format_dim_date
 
     if not models:
@@ -42,7 +43,7 @@ def _print_model_section(
 
 
 def _fetch_all_models(client: Any, credentials: Any) -> list[Any]:
-    """Fetch all models via exhaustive pagination."""
+    """Fetch all base models via exhaustive pagination."""
     from osmosis_ai.platform.cli.utils import fetch_all_pages
 
     models, _ = fetch_all_pages(
@@ -59,11 +60,11 @@ def list_models(
     limit: int = typer.Option(
         DEFAULT_PAGE_SIZE,
         "--limit",
-        help="Maximum number of models to show.",
+        help="Maximum number of base models to show.",
     ),
-    all_: bool = typer.Option(False, "--all", help="Show all models."),
+    all_: bool = typer.Option(False, "--all", help="Show all base models."),
 ) -> None:
-    """List models in the current workspace."""
+    """List base models in the current workspace."""
     from osmosis_ai.platform.cli.utils import (
         _require_auth,
         print_pagination_footer,
@@ -95,7 +96,7 @@ def list_models(
     _print_model_section(
         models,
         total,
-        "Models",
+        "Base Models",
         lambda m: (
             console.format_styled(f"by {m.creator_name}", "dim")
             if m.creator_name
@@ -104,13 +105,7 @@ def list_models(
     )
 
     if not fetch_all:
-        print_pagination_footer(len(models), total, "models")
-
-
-@app.command("deploy")
-def deploy() -> None:
-    """Deploy a model."""
-    not_implemented("model", "deploy")
+        print_pagination_footer(len(models), total, "base models")
 
 
 @app.command("export")
@@ -130,19 +125,19 @@ def delete(
     name: str = typer.Argument(..., help="Model path (e.g. google/gemma-2-9b-it)."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
 ) -> None:
-    """Delete a model."""
+    """Delete a base model."""
     from osmosis_ai.cli.errors import CLIError
+    from osmosis_ai.cli.prompts import require_confirmation
+    from osmosis_ai.platform.api.client import OsmosisClient
+    from osmosis_ai.platform.auth.platform_client import PlatformAPIError
     from osmosis_ai.platform.cli.utils import _require_auth
 
     _ws_name, credentials = _require_auth()
-
-    from osmosis_ai.platform.api.client import OsmosisClient
-
     client = OsmosisClient()
 
     try:
         affected = client.get_model_affected_resources(name, credentials=credentials)
-    except Exception as e:
+    except PlatformAPIError as e:
         raise CLIError(f"Unable to verify model dependencies: {e}") from e
 
     if affected.has_blocking_runs:
@@ -161,9 +156,6 @@ def delete(
         console.print("\nDelete these training runs first, then retry.", style="dim")
         raise typer.Exit(1)
 
-    from osmosis_ai.cli.prompts import require_confirmation
-
     require_confirmation(f'Delete model "{name}"? This cannot be undone.', yes=yes)
-
     client.delete_model(name, credentials=credentials)
     console.print(f'Model "{name}" deleted.', style="green")

--- a/osmosis_ai/cli/commands/train.py
+++ b/osmosis_ai/cli/commands/train.py
@@ -79,15 +79,18 @@ def status(
     name: str = typer.Argument(..., help="Training run name."),
 ) -> None:
     """Show training run details."""
+    from osmosis_ai.platform.api.client import OsmosisClient
+    from osmosis_ai.platform.api.models import RUN_STATUSES_SUCCESS
+    from osmosis_ai.platform.auth.platform_client import PlatformAPIError
     from osmosis_ai.platform.cli.utils import (
         _require_auth,
         build_run_detail_rows,
+        entity_status_style,
         format_date,
+        format_dim_date,
     )
 
     _, credentials = _require_auth()
-
-    from osmosis_ai.platform.api.client import OsmosisClient
 
     client = OsmosisClient()
     run = client.get_training_run(name, credentials=credentials)
@@ -105,6 +108,27 @@ def status(
         rows.append(("Completed", format_date(run.completed_at)))
 
     console.table(rows, title="Training Run")
+
+    if run.status in RUN_STATUSES_SUCCESS:
+        try:
+            ckpts = client.list_training_run_checkpoints(name, credentials=credentials)
+        except PlatformAPIError:
+            ckpts = None
+
+        if ckpts is not None and ckpts.checkpoints:
+            console.print()
+            console.print("Checkpoints:", style="bold")
+            for cp in ckpts.checkpoints:
+                step_str = f"step {cp.checkpoint_step}"
+                status_style = entity_status_style(cp.status) or "dim"
+                status_str = console.format_styled(f"[{cp.status}]", status_style)
+                date = format_dim_date(cp.created_at)
+                console.print(f"  {step_str}  {status_str}  {date}", highlight=False)
+            console.print()
+            console.print(
+                f"Deploy with:  osmosis deploy create {console.escape(name)} --step <N>",
+                style="dim",
+            )
 
 
 @app.command("submit")

--- a/osmosis_ai/cli/console.py
+++ b/osmosis_ai/cli/console.py
@@ -59,15 +59,23 @@ class Console:
             rich_size["width"] = width
             rich_size["height"] = 25
 
+        # Disable Rich's default auto-highlighter: ReprHighlighter recolors
+        # numbers, hex strings, UUIDs, URLs, etc. inside printed strings,
+        # which clashes with explicit `style=` passed to Console.print (e.g.,
+        # a "green" message would show mixed colors on tokens like
+        # "step-40-lora" or "2d7a22"). Callers can opt back in per-call via
+        # `console.print(..., highlight=True)`.
         self._rich = RichConsole(
             file=file,
             force_terminal=force_terminal,
             no_color=no_color,
+            highlight=False,
             **rich_size,
         )
         self._rich_stderr = RichConsole(
             file=sys.stderr,
             no_color=no_color,
+            highlight=False,
             **rich_size,
         )
 

--- a/osmosis_ai/cli/main.py
+++ b/osmosis_ai/cli/main.py
@@ -80,6 +80,7 @@ def _register_commands() -> None:
     # -- Command groups --
     from osmosis_ai.cli.commands.auth import app as auth_app
     from osmosis_ai.cli.commands.dataset import app as dataset_app
+    from osmosis_ai.cli.commands.deploy import app as deploy_app
     from osmosis_ai.cli.commands.eval import app as eval_app
     from osmosis_ai.cli.commands.model import app as model_app
     from osmosis_ai.cli.commands.rollout import app as rollout_app
@@ -92,6 +93,7 @@ def _register_commands() -> None:
     app.add_typer(dataset_app, name="dataset", rich_help_panel=_WORKFLOW)
     app.add_typer(train_app, name="train", rich_help_panel=_WORKFLOW)
     app.add_typer(model_app, name="model", rich_help_panel=_WORKFLOW)
+    app.add_typer(deploy_app, name="deploy", rich_help_panel=_WORKFLOW)
     app.add_typer(eval_app, name="eval", rich_help_panel=_WORKFLOW)
     app.add_typer(rollout_app, name="rollout", rich_help_panel=_WORKFLOW)
 

--- a/osmosis_ai/platform/api/client.py
+++ b/osmosis_ai/platform/api/client.py
@@ -416,23 +416,24 @@ class OsmosisClient:
         self,
         *,
         training_run: str,
-        checkpoint_step: int | None = None,
-        lora_checkpoint_id: str | None = None,
+        checkpoint_step: int,
         lora_name: str | None = None,
         credentials: Credentials | None = None,
     ) -> CreateDeploymentResult:
         """Create a deployment.
 
-        Exactly one of ``checkpoint_step`` / ``lora_checkpoint_id`` must
-        be provided. ``training_run`` accepts a UUID or training run name.
+        The CLI API accepts ``training_run`` + ``checkpoint_step``.
+        ``training_run`` may be a UUID or training run name, and
         ``lora_name`` is optional — the server generates one when
         omitted.
         """
-        body: dict[str, Any] = {"training_run": training_run}
-        if checkpoint_step is not None:
-            body["checkpoint_step"] = checkpoint_step
-        if lora_checkpoint_id is not None:
-            body["lora_checkpoint_id"] = lora_checkpoint_id
+        if checkpoint_step is None:
+            raise ValueError("checkpoint_step is required.")
+
+        body: dict[str, Any] = {
+            "training_run": training_run,
+            "checkpoint_step": checkpoint_step,
+        }
         if lora_name is not None:
             body["lora_name"] = lora_name
         data = platform_request(

--- a/osmosis_ai/platform/api/client.py
+++ b/osmosis_ai/platform/api/client.py
@@ -9,15 +9,20 @@ from osmosis_ai.platform.auth.platform_client import platform_request
 from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE
 
 from .models import (
+    CreateDeploymentResult,
     DatasetAffectedResources,
     DatasetFile,
     DeleteTrainingRunResult,
+    DeploymentInfo,
     ModelAffectedResources,
     PaginatedBaseModels,
     PaginatedDatasets,
+    PaginatedDeployments,
     PaginatedRollouts,
     PaginatedTrainingRuns,
+    RenameDeploymentResult,
     SubmitTrainingRunResult,
+    TrainingRunCheckpoints,
     TrainingRunDetail,
     TrainingRunMetrics,
     WorkspaceDeletionStatus,
@@ -389,3 +394,103 @@ class OsmosisClient:
             credentials=credentials,
         )
         return ModelAffectedResources.from_dict(data)
+
+    # ── Deployments ───────────────────────────────────────────────
+
+    def list_deployments(
+        self,
+        limit: int = DEFAULT_PAGE_SIZE,
+        offset: int = 0,
+        *,
+        search: str | None = None,
+        credentials: Credentials | None = None,
+    ) -> PaginatedDeployments:
+        params: dict[str, str | int] = {"limit": limit, "offset": offset}
+        if search:
+            params["search"] = search
+        qs = urlencode(params)
+        data = platform_request(f"/api/cli/deployments?{qs}", credentials=credentials)
+        return PaginatedDeployments.from_dict(data)
+
+    def create_deployment(
+        self,
+        *,
+        training_run: str,
+        checkpoint_step: int | None = None,
+        lora_checkpoint_id: str | None = None,
+        lora_name: str | None = None,
+        credentials: Credentials | None = None,
+    ) -> CreateDeploymentResult:
+        """Create a deployment.
+
+        Exactly one of ``checkpoint_step`` / ``lora_checkpoint_id`` must
+        be provided. ``training_run`` accepts a UUID or training run name.
+        ``lora_name`` is optional — the server generates one when
+        omitted.
+        """
+        body: dict[str, Any] = {"training_run": training_run}
+        if checkpoint_step is not None:
+            body["checkpoint_step"] = checkpoint_step
+        if lora_checkpoint_id is not None:
+            body["lora_checkpoint_id"] = lora_checkpoint_id
+        if lora_name is not None:
+            body["lora_name"] = lora_name
+        data = platform_request(
+            "/api/cli/deployments",
+            method="POST",
+            data=body,
+            credentials=credentials,
+        )
+        return CreateDeploymentResult.from_dict(data["deployment"])
+
+    def get_deployment(
+        self,
+        name_or_id: str,
+        *,
+        credentials: Credentials | None = None,
+    ) -> DeploymentInfo:
+        data = platform_request(
+            f"/api/cli/deployments/{_safe_path(name_or_id)}",
+            credentials=credentials,
+        )
+        return DeploymentInfo.from_dict(data["deployment"])
+
+    def delete_deployment(
+        self,
+        name_or_id: str,
+        *,
+        credentials: Credentials | None = None,
+    ) -> bool:
+        platform_request(
+            f"/api/cli/deployments/{_safe_path(name_or_id)}",
+            method="DELETE",
+            credentials=credentials,
+        )
+        return True
+
+    def rename_deployment(
+        self,
+        name_or_id: str,
+        new_name: str,
+        *,
+        credentials: Credentials | None = None,
+    ) -> RenameDeploymentResult:
+        data = platform_request(
+            f"/api/cli/deployments/{_safe_path(name_or_id)}",
+            method="PATCH",
+            data={"lora_name": new_name},
+            credentials=credentials,
+        )
+        return RenameDeploymentResult.from_dict(data["deployment"])
+
+    def list_training_run_checkpoints(
+        self,
+        name_or_id: str,
+        *,
+        credentials: Credentials | None = None,
+    ) -> TrainingRunCheckpoints:
+        data = platform_request(
+            f"/api/cli/training-runs/{_safe_path(name_or_id)}/checkpoints",
+            credentials=credentials,
+        )
+        return TrainingRunCheckpoints.from_dict(data)

--- a/osmosis_ai/platform/api/models.py
+++ b/osmosis_ai/platform/api/models.py
@@ -620,7 +620,7 @@ class RenameDeploymentResult:
         return cls(id=data["id"], lora_name=data["lora_name"])
 
 
-# ── LoRA checkpoints (for `osmosis train status` + `model deploy`) ─────
+# ── LoRA checkpoints (for `osmosis train status` + `deploy create`) ─────
 
 
 @dataclass

--- a/osmosis_ai/platform/api/models.py
+++ b/osmosis_ai/platform/api/models.py
@@ -533,3 +533,129 @@ class PaginatedRollouts:
             has_more=data.get("has_more", False),
             next_offset=data.get("next_offset"),
         )
+
+
+# ── Deployments (output models) ──────────────────────────────────
+
+
+@dataclass
+class DeploymentInfo:
+    """A deployment record — the 'output model' produced by a training run.
+
+    One deployment == one live LoRA adapter registered with inference.
+    """
+
+    id: str
+    lora_name: str
+    status: str
+    base_model: str
+    checkpoint_step: int
+    training_run_id: str | None = None
+    training_run_name: str | None = None
+    creator_name: str | None = None
+    created_at: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DeploymentInfo:
+        return cls(
+            id=data["id"],
+            lora_name=data["lora_name"],
+            status=data.get("status", ""),
+            base_model=data.get("base_model", ""),
+            checkpoint_step=data.get("checkpoint_step", 0),
+            training_run_id=data.get("training_run_id"),
+            training_run_name=data.get("training_run_name"),
+            creator_name=data.get("creator_name"),
+            created_at=data.get("created_at", ""),
+        )
+
+
+@dataclass
+class PaginatedDeployments:
+    """Paginated list of deployments."""
+
+    deployments: list[DeploymentInfo]
+    total_count: int
+    has_more: bool
+    next_offset: int | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PaginatedDeployments:
+        return cls(
+            deployments=[
+                DeploymentInfo.from_dict(d) for d in data.get("deployments", [])
+            ],
+            total_count=data.get("total_count", 0),
+            has_more=data.get("has_more", False),
+            next_offset=data.get("next_offset"),
+        )
+
+
+@dataclass
+class CreateDeploymentResult:
+    """Result of creating a deployment."""
+
+    id: str
+    lora_name: str
+    status: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CreateDeploymentResult:
+        return cls(
+            id=data["id"],
+            lora_name=data["lora_name"],
+            status=data.get("status", ""),
+        )
+
+
+@dataclass
+class RenameDeploymentResult:
+    """Result of renaming a deployment."""
+
+    id: str
+    lora_name: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RenameDeploymentResult:
+        return cls(id=data["id"], lora_name=data["lora_name"])
+
+
+# ── LoRA checkpoints (for `osmosis train status` + `model deploy`) ─────
+
+
+@dataclass
+class LoraCheckpointInfo:
+    """A LoRA checkpoint produced by a training run."""
+
+    id: str
+    checkpoint_step: int
+    status: str
+    created_at: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> LoraCheckpointInfo:
+        return cls(
+            id=data["id"],
+            checkpoint_step=data.get("checkpoint_step", 0),
+            status=data.get("status", ""),
+            created_at=data.get("created_at", ""),
+        )
+
+
+@dataclass
+class TrainingRunCheckpoints:
+    """All deployable LoRA checkpoints for a training run."""
+
+    training_run_id: str
+    training_run_name: str
+    checkpoints: list[LoraCheckpointInfo]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TrainingRunCheckpoints:
+        return cls(
+            training_run_id=data["training_run_id"],
+            training_run_name=data.get("training_run_name", ""),
+            checkpoints=[
+                LoraCheckpointInfo.from_dict(c) for c in data.get("checkpoints", [])
+            ],
+        )

--- a/osmosis_ai/platform/auth/platform_client.py
+++ b/osmosis_ai/platform/auth/platform_client.py
@@ -28,18 +28,39 @@ class AuthenticationExpiredError(Exception):
 class PlatformAPIError(Exception):
     """Raised when a Platform API call fails."""
 
-    def __init__(self, message: str, status_code: int | None = None):
+    def __init__(
+        self,
+        message: str,
+        status_code: int | None = None,
+        *,
+        error_code: str | None = None,
+        field: str | None = None,
+        details: dict[str, Any] | None = None,
+    ):
         super().__init__(message)
         self.status_code = status_code
+        self.error_code = error_code
+        self.field = field
+        self.details = details
 
 
 class SubscriptionRequiredError(PlatformAPIError):
     """Raised when the workspace requires an active subscription for the requested action."""
 
-    def __init__(self, message: str | None = None):
+    def __init__(
+        self,
+        message: str | None = None,
+        *,
+        error_code: str | None = None,
+        field: str | None = None,
+        details: dict[str, Any] | None = None,
+    ):
         super().__init__(
             message or "Active subscription required",
             status_code=403,
+            error_code=error_code,
+            field=field,
+            details=details,
         )
 
 
@@ -173,6 +194,8 @@ def platform_request(
         # Best-effort capture of structured error message from response body
         detail = ""
         error_body: dict[str, Any] = {}
+        error_code: str | None = None
+        field: str | None = None
         try:
             raw = e.read()
             text = raw.decode("utf-8", errors="replace").strip() if raw else ""
@@ -182,6 +205,10 @@ def platform_request(
                     # Only treat as error_body if it's actually a dict
                     if isinstance(parsed, dict):
                         error_body = parsed
+                        if isinstance(error_body.get("code"), str):
+                            error_code = error_body["code"]
+                        if isinstance(error_body.get("field"), str):
+                            field = error_body["field"]
                 # Prefer structured error/message field over raw body
                 error_msg = error_body.get("error") or error_body.get("message")
                 if error_msg and isinstance(error_msg, str):
@@ -198,16 +225,30 @@ def platform_request(
             error_msg = error_body.get("error", "")
             if isinstance(error_msg, str):
                 if "subscription" in error_msg.lower():
-                    raise SubscriptionRequiredError(error_msg) from e
+                    raise SubscriptionRequiredError(
+                        error_msg,
+                        error_code=error_code,
+                        field=field,
+                        details=error_body or None,
+                    ) from e
                 if "workspace" in error_msg.lower() and "access" in error_msg.lower():
                     raise PlatformAPIError(
                         f"{error_msg}\n"
                         "Your workspace context may be stale. "
                         "Run 'osmosis auth login' or 'osmosis workspace' to re-select.",
                         e.code,
+                        error_code=error_code,
+                        field=field,
+                        details=error_body or None,
                     ) from e
 
-        raise PlatformAPIError(f"API error: HTTP {e.code}.{detail}", e.code) from e
+        raise PlatformAPIError(
+            f"API error: HTTP {e.code}.{detail}",
+            e.code,
+            error_code=error_code,
+            field=field,
+            details=error_body or None,
+        ) from e
     except URLError as e:
         raise PlatformAPIError(f"Connection error: {e.reason}") from e
     except json.JSONDecodeError as e:

--- a/osmosis_ai/platform/constants.py
+++ b/osmosis_ai/platform/constants.py
@@ -1,5 +1,7 @@
 """Shared constants for the Osmosis Platform package."""
 
+import os
+
 # ── Pagination ───────────────────────────────────────────────────
 
 DEFAULT_PAGE_SIZE = 50
@@ -10,3 +12,9 @@ MSG_SESSION_EXPIRED = (
     "Your session has expired. Please run 'osmosis auth login' to re-authenticate."
 )
 MSG_NOT_LOGGED_IN = "Not logged in. Run 'osmosis auth login' first."
+
+# ── Inference endpoint ───────────────────────────────────────────
+
+# OpenAI-compatible inference base URL. Override for local/dev inference.
+DEFAULT_INFERENCE_URL = "https://inference.osmosis.ai"
+INFERENCE_URL = os.environ.get("OSMOSIS_INFERENCE_URL", DEFAULT_INFERENCE_URL)

--- a/tests/unit/auth/test_platform_client.py
+++ b/tests/unit/auth/test_platform_client.py
@@ -20,6 +20,7 @@ from osmosis_ai.platform.auth.credentials import (
 from osmosis_ai.platform.auth.platform_client import (
     AuthenticationExpiredError,
     PlatformAPIError,
+    SubscriptionRequiredError,
     platform_request,
     revoke_cli_token,
 )
@@ -82,12 +83,29 @@ class TestExceptionClasses:
         err = PlatformAPIError("connection failed")
         assert str(err) == "connection failed"
         assert err.status_code is None
+        assert err.error_code is None
+        assert err.field is None
+        assert err.details is None
 
     def test_platform_api_error_with_status_code(self) -> None:
         """Verify PlatformAPIError stores the HTTP status code."""
         err = PlatformAPIError("not found", status_code=404)
         assert err.status_code == 404
         assert "not found" in str(err)
+
+    def test_platform_api_error_with_structured_metadata(self) -> None:
+        """Verify PlatformAPIError preserves optional structured metadata."""
+        err = PlatformAPIError(
+            "validation failed",
+            status_code=400,
+            error_code="VALIDATION",
+            field="checkpoint_step",
+            details={"error": "validation failed", "code": "VALIDATION"},
+        )
+        assert err.status_code == 400
+        assert err.error_code == "VALIDATION"
+        assert err.field == "checkpoint_step"
+        assert err.details == {"error": "validation failed", "code": "VALIDATION"}
 
 
 # =============================================================================
@@ -374,6 +392,59 @@ class TestPlatformRequest:
 
         assert "Agent not found" in str(exc_info.value)
         assert exc_info.value.status_code == 404
+
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_http_error_extracts_structured_error_metadata(
+        self, mock_urlopen: MagicMock
+    ) -> None:
+        """Verify structured error metadata is preserved when provided by the API."""
+        error_body = json.dumps(
+            {
+                "error": "A deployment with this LoRA name already exists",
+                "code": "CONFLICT",
+                "field": "loraName",
+            }
+        )
+        mock_urlopen.side_effect = _make_http_error(409, error_body)
+        creds = _make_credentials()
+
+        with pytest.raises(PlatformAPIError) as exc_info:
+            platform_request("/api/test", credentials=creds)
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.error_code == "CONFLICT"
+        assert exc_info.value.field == "loraName"
+        assert exc_info.value.details == {
+            "error": "A deployment with this LoRA name already exists",
+            "code": "CONFLICT",
+            "field": "loraName",
+        }
+        assert "A deployment with this LoRA name already exists" in str(exc_info.value)
+
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_subscription_error_preserves_structured_metadata(
+        self, mock_urlopen: MagicMock
+    ) -> None:
+        """Verify subscription-required responses preserve structured metadata."""
+        error_body = json.dumps(
+            {
+                "error": "Active subscription required to create deployments",
+                "code": "FORBIDDEN",
+            }
+        )
+        mock_urlopen.side_effect = _make_http_error(403, error_body)
+        creds = _make_credentials()
+
+        with pytest.raises(SubscriptionRequiredError) as exc_info:
+            platform_request("/api/test", credentials=creds)
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.error_code == "FORBIDDEN"
+        assert exc_info.value.field is None
+        assert exc_info.value.details == {
+            "error": "Active subscription required to create deployments",
+            "code": "FORBIDDEN",
+        }
 
     @patch("osmosis_ai.platform.auth.platform_client.urlopen")
     def test_http_error_truncates_long_response_body(

--- a/tests/unit/cli/test_command_groups.py
+++ b/tests/unit/cli/test_command_groups.py
@@ -32,8 +32,6 @@ def test_help_exits_zero(args, capfd):
 @pytest.mark.parametrize(
     "args",
     [
-        ["model", "export"],
-        ["model", "build"],
         ["train", "traces"],
         ["rollout", "list"],
     ],
@@ -42,6 +40,16 @@ def test_placeholder_commands_exit_one(args):
     """Placeholder commands should exit with code 1."""
     rc = main(args)
     assert rc == 1
+
+
+@pytest.mark.parametrize("subcommand", ["export", "build"])
+def test_removed_model_commands_are_unknown(subcommand, capfd):
+    """Removed model commands should report unknown-command errors."""
+    rc = main(["model", subcommand])
+    captured = capfd.readouterr()
+
+    assert rc != 0
+    assert f"No such command '{subcommand}'" in captured.err
 
 
 def test_deprecated_login_alias_works(capfd):

--- a/tests/unit/cli/test_command_groups.py
+++ b/tests/unit/cli/test_command_groups.py
@@ -32,7 +32,6 @@ def test_help_exits_zero(args, capfd):
 @pytest.mark.parametrize(
     "args",
     [
-        ["model", "deploy"],
         ["model", "export"],
         ["model", "build"],
         ["train", "traces"],

--- a/tests/unit/cli/test_deploy_commands.py
+++ b/tests/unit/cli/test_deploy_commands.py
@@ -1,0 +1,325 @@
+"""Tests for osmosis deploy {create, list, status, delete, rename}."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+
+import osmosis_ai.cli.commands.deploy as deploy_module
+import osmosis_ai.platform.api.client as api_client_module
+import osmosis_ai.platform.cli.utils as utils_module
+from osmosis_ai.cli.console import Console
+from osmosis_ai.platform.api.models import (
+    CreateDeploymentResult,
+    DeploymentInfo,
+    LoraCheckpointInfo,
+    PaginatedDeployments,
+    RenameDeploymentResult,
+    TrainingRunCheckpoints,
+)
+
+
+@pytest.fixture()
+def console_capture(monkeypatch: pytest.MonkeyPatch) -> StringIO:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False)
+    monkeypatch.setattr(deploy_module, "console", console)
+    monkeypatch.setattr(utils_module, "console", console)
+    return output
+
+
+@pytest.fixture(autouse=True)
+def _mock_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.utils._require_auth",
+        lambda: ("ws-test", object()),
+    )
+
+
+def _make_ckpts(steps: list[int]) -> TrainingRunCheckpoints:
+    return TrainingRunCheckpoints(
+        training_run_id="run_1",
+        training_run_name="qwen3-run1",
+        checkpoints=[
+            LoraCheckpointInfo(
+                id=f"cp_{s}",
+                checkpoint_step=s,
+                status="uploaded",
+                created_at="2026-04-20T00:00:00Z",
+            )
+            for s in steps
+        ],
+    )
+
+
+class TestCreate:
+    def test_happy_path_with_step(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        captured = {}
+
+        class FakeClient:
+            def list_training_run_checkpoints(self, name, *, credentials=None):
+                return _make_ckpts([100, 200])
+
+            def create_deployment(
+                self,
+                *,
+                training_run,
+                checkpoint_step=None,
+                lora_checkpoint_id=None,
+                lora_name=None,
+                credentials=None,
+            ):
+                captured["training_run"] = training_run
+                captured["checkpoint_step"] = checkpoint_step
+                captured["lora_name"] = lora_name
+                return CreateDeploymentResult(
+                    id="dep_1",
+                    lora_name=lora_name or "qwen3-run1-step-100-lora",
+                    status="deployed",
+                )
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        deploy_module.create(training_run="qwen3-run1", step=100, name=None, yes=True)
+        assert captured["training_run"] == "qwen3-run1"
+        assert captured["checkpoint_step"] == 100
+        assert captured["lora_name"] is None  # server generates
+        assert "Deployment created" in console_capture.getvalue()
+
+    def test_default_step_picks_latest(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        captured = {}
+
+        class FakeClient:
+            def list_training_run_checkpoints(self, name, *, credentials=None):
+                # Intentionally unsorted to verify defensive sort
+                return _make_ckpts([50, 200, 100])
+
+            def create_deployment(self, *, training_run, **kw):
+                captured.update(kw)
+                return CreateDeploymentResult(
+                    id="dep_1", lora_name="auto", status="deployed"
+                )
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        deploy_module.create(training_run="qwen3-run1", step=None, name=None, yes=True)
+        assert captured["checkpoint_step"] == 200
+
+    def test_no_checkpoints_errors(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        from osmosis_ai.cli.errors import CLIError
+
+        class FakeClient:
+            def list_training_run_checkpoints(self, name, *, credentials=None):
+                return TrainingRunCheckpoints(
+                    training_run_id="run_1",
+                    training_run_name="qwen3-run1",
+                    checkpoints=[],
+                )
+
+            def create_deployment(self, *a, **kw):  # pragma: no cover
+                raise AssertionError("should not create")
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        with pytest.raises(CLIError, match="No uploaded checkpoints"):
+            deploy_module.create(
+                training_run="qwen3-run1", step=None, name=None, yes=True
+            )
+
+    def test_unknown_step_errors_with_available(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        from osmosis_ai.cli.errors import CLIError
+
+        class FakeClient:
+            def list_training_run_checkpoints(self, name, *, credentials=None):
+                return _make_ckpts([100, 200])
+
+            def create_deployment(self, *a, **kw):  # pragma: no cover
+                raise AssertionError("should not create")
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        with pytest.raises(CLIError) as excinfo:
+            deploy_module.create(
+                training_run="qwen3-run1", step=999, name=None, yes=True
+            )
+        assert "100" in str(excinfo.value)
+        assert "200" in str(excinfo.value)
+
+    def test_explicit_name_passed_through(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        captured = {}
+
+        class FakeClient:
+            def list_training_run_checkpoints(self, name, *, credentials=None):
+                return _make_ckpts([100])
+
+            def create_deployment(self, *, training_run, **kw):
+                captured["lora_name"] = kw.get("lora_name")
+                return CreateDeploymentResult(
+                    id="dep_1", lora_name="my-custom", status="deployed"
+                )
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        deploy_module.create(
+            training_run="qwen3-run1",
+            step=100,
+            name="my-custom",
+            yes=True,
+        )
+        assert captured["lora_name"] == "my-custom"
+
+
+class TestList:
+    def test_empty(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        class FakeClient:
+            def list_deployments(self, limit=30, offset=0, *, credentials=None):
+                return PaginatedDeployments(
+                    deployments=[], total_count=0, has_more=False
+                )
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        deploy_module.list_deployments(limit=30, all_=False)
+        assert "No deployments found" in console_capture.getvalue()
+
+    def test_with_deployments(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        dep = DeploymentInfo(
+            id="dep_1",
+            lora_name="qwen3-run1-step-100-lora",
+            status="deployed",
+            base_model="Qwen/Qwen3-30B",
+            checkpoint_step=100,
+            training_run_id="run_1",
+            training_run_name="qwen3-run1",
+            created_at="2026-04-20T00:00:00Z",
+        )
+
+        class FakeClient:
+            def list_deployments(self, limit=30, offset=0, *, credentials=None):
+                return PaginatedDeployments(
+                    deployments=[dep], total_count=1, has_more=False
+                )
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        deploy_module.list_deployments(limit=30, all_=False)
+        out = console_capture.getvalue()
+        assert "Deployments" in out
+        assert "qwen3-run1-step-100-lora" in out
+
+    def test_has_more_truncation(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        dep = DeploymentInfo(
+            id="dep_1",
+            lora_name="x",
+            status="deployed",
+            base_model="Qwen/Qwen3",
+            checkpoint_step=1,
+        )
+
+        class FakeClient:
+            def list_deployments(self, limit=1, offset=0, *, credentials=None):
+                return PaginatedDeployments(
+                    deployments=[dep], total_count=5, has_more=True
+                )
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        deploy_module.list_deployments(limit=1, all_=False)
+        out = console_capture.getvalue()
+        assert "Showing 1 of 5 deployments" in out
+        assert "--all" in out
+
+
+class TestStatus:
+    def test_full_details(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        dep = DeploymentInfo(
+            id="dep_1",
+            lora_name="my-lora",
+            status="deployed",
+            base_model="Qwen/Qwen3-30B",
+            checkpoint_step=100,
+            training_run_id="run_1",
+            training_run_name="qwen3-run1",
+            creator_name="brian",
+            created_at="2026-04-20T00:00:00Z",
+        )
+
+        class FakeClient:
+            def get_deployment(self, name, *, credentials=None):
+                return dep
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        deploy_module.status(name="my-lora")
+        out = console_capture.getvalue()
+        assert "my-lora" in out
+        assert "Qwen/Qwen3-30B" in out
+        assert "step 100" in out
+        assert "qwen3-run1" in out
+        assert "brian" in out
+
+    def test_minimal_fields(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        dep = DeploymentInfo(
+            id="dep_1",
+            lora_name="my-lora",
+            status="deployed",
+            base_model="",
+            checkpoint_step=0,
+        )
+
+        class FakeClient:
+            def get_deployment(self, name, *, credentials=None):
+                return dep
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        deploy_module.status(name="my-lora")
+        out = console_capture.getvalue()
+        assert "my-lora" in out
+        assert "Deployment" in out
+
+
+class TestRename:
+    def test_happy_path(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        captured = {}
+
+        class FakeClient:
+            def rename_deployment(self, name, new_name, *, credentials=None):
+                captured["old"] = name
+                captured["new"] = new_name
+                return RenameDeploymentResult(id="dep_1", lora_name=new_name)
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        deploy_module.rename(name="foo", new_name="bar", yes=True)
+        assert captured == {"old": "foo", "new": "bar"}
+        assert "Renamed" in console_capture.getvalue()
+
+
+class TestDelete:
+    def test_happy_path(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        class FakeClient:
+            def delete_deployment(self, name, *, credentials=None):
+                captured["deleted"] = name
+                return True
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        deploy_module.delete(name="my-lora", yes=True)
+        assert captured["deleted"] == "my-lora"
+        assert 'Deployment "my-lora" deleted' in console_capture.getvalue()

--- a/tests/unit/cli/test_deploy_commands.py
+++ b/tests/unit/cli/test_deploy_commands.py
@@ -81,12 +81,54 @@ class TestCreate:
                     status="deployed",
                 )
 
+            def get_deployment(self, name, *, credentials=None):
+                return DeploymentInfo(
+                    id="dep_1",
+                    lora_name=name,
+                    status="deployed",
+                    base_model="Qwen/Qwen3-30B",
+                    checkpoint_step=100,
+                )
+
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
         deploy_module.create(training_run="qwen3-run1", step=100, name=None, yes=True)
         assert captured["training_run"] == "qwen3-run1"
         assert captured["checkpoint_step"] == 100
         assert captured["lora_name"] is None  # server generates
-        assert "Deployment created" in console_capture.getvalue()
+        out = console_capture.getvalue()
+        assert "Deployment created" in out
+        # Curl example surfaces the model id + inference endpoint + key hint
+        assert "Qwen/Qwen3-30B:qwen3-run1-step-100-lora" in out
+        assert "inference.osmosis.ai/v1/chat/completions" in out
+        assert "$OSMOSIS_API_KEY" in out
+        assert "api-keys" in out
+
+    def test_query_example_falls_back_when_lookup_fails(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        """If the follow-up get_deployment fails, we still print a usable
+        curl template with a `<base-model>` placeholder — a failed display
+        enhancement must never mask a successful deployment."""
+
+        class FakeClient:
+            def list_training_run_checkpoints(self, name, *, credentials=None):
+                return _make_ckpts([100])
+
+            def create_deployment(self, *, training_run, **kw):
+                return CreateDeploymentResult(
+                    id="dep_1",
+                    lora_name="qwen3-run1-step-100-lora",
+                    status="deployed",
+                )
+
+            def get_deployment(self, name, *, credentials=None):
+                raise RuntimeError("backend unavailable")
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        deploy_module.create(training_run="qwen3-run1", step=100, name=None, yes=True)
+        out = console_capture.getvalue()
+        assert "Deployment created" in out
+        assert "<base-model>:qwen3-run1-step-100-lora" in out
 
     def test_default_step_picks_latest(
         self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO

--- a/tests/unit/cli/test_deploy_commands.py
+++ b/tests/unit/cli/test_deploy_commands.py
@@ -67,8 +67,7 @@ class TestCreate:
                 self,
                 *,
                 training_run,
-                checkpoint_step=None,
-                lora_checkpoint_id=None,
+                checkpoint_step,
                 lora_name=None,
                 credentials=None,
             ):

--- a/tests/unit/cli/test_model_commands.py
+++ b/tests/unit/cli/test_model_commands.py
@@ -11,7 +11,9 @@ import osmosis_ai.platform.api.client as api_client_module
 import osmosis_ai.platform.cli.utils as utils_module
 from osmosis_ai.cli.console import Console
 from osmosis_ai.platform.api.models import (
+    AffectedTrainingRun,
     BaseModelInfo,
+    ModelAffectedResources,
     PaginatedBaseModels,
 )
 
@@ -64,7 +66,7 @@ class TestListModels:
         model_module.list_models(limit=30, all_=False)
         out = console_capture.getvalue()
         assert "gpt-2" in out
-        assert "Models" in out
+        assert "Base Models" in out
 
     def test_list_has_more_truncation(
         self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
@@ -83,5 +85,67 @@ class TestListModels:
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
         model_module.list_models(limit=1, all_=False)
         out = console_capture.getvalue()
-        assert "Showing 1 of 5 models" in out
+        assert "Showing 1 of 5 base models" in out
         assert "--all" in out
+
+
+class TestDeleteModel:
+    def test_happy_path(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        class FakeClient:
+            def get_model_affected_resources(self, name, *, credentials=None):
+                return ModelAffectedResources(training_runs_using_model=[])
+
+            def delete_model(self, name, *, credentials=None):
+                captured["deleted"] = name
+                return True
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        model_module.delete(name="Qwen/Qwen3", yes=True)
+        assert captured["deleted"] == "Qwen/Qwen3"
+        assert 'Model "Qwen/Qwen3" deleted' in console_capture.getvalue()
+
+    def test_blocked_by_training_runs(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        import typer
+
+        class FakeClient:
+            def get_model_affected_resources(self, name, *, credentials=None):
+                return ModelAffectedResources(
+                    training_runs_using_model=[
+                        AffectedTrainingRun(id="run_abcdef12", training_run_name="r1"),
+                    ]
+                )
+
+            def delete_model(
+                self, name, *, credentials=None
+            ):  # pragma: no cover — blocked
+                raise AssertionError("should not delete when blocked")
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        with pytest.raises(typer.Exit):
+            model_module.delete(name="Qwen/Qwen3", yes=True)
+        out = console_capture.getvalue()
+        assert "Cannot delete this model" in out
+        assert "r1" in out
+
+    def test_affected_resources_api_error(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        from osmosis_ai.cli.errors import CLIError
+        from osmosis_ai.platform.auth.platform_client import PlatformAPIError
+
+        class FakeClient:
+            def get_model_affected_resources(self, name, *, credentials=None):
+                raise PlatformAPIError("boom", 500)
+
+            def delete_model(self, name, *, credentials=None):  # pragma: no cover
+                raise AssertionError("should not delete")
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        with pytest.raises(CLIError, match="verify model dependencies"):
+            model_module.delete(name="Qwen/Qwen3", yes=True)

--- a/tests/unit/cli/test_train_status_checkpoints.py
+++ b/tests/unit/cli/test_train_status_checkpoints.py
@@ -1,0 +1,143 @@
+"""Tests for 'osmosis train status' checkpoints section."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+
+import osmosis_ai.cli.commands.train as train_module
+import osmosis_ai.platform.api.client as api_client_module
+import osmosis_ai.platform.cli.utils as utils_module
+from osmosis_ai.cli.console import Console
+from osmosis_ai.platform.api.models import (
+    LoraCheckpointInfo,
+    TrainingRunCheckpoints,
+    TrainingRunDetail,
+)
+
+
+@pytest.fixture()
+def console_capture(monkeypatch: pytest.MonkeyPatch) -> StringIO:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False)
+    monkeypatch.setattr(train_module, "console", console)
+    monkeypatch.setattr(utils_module, "console", console)
+    return output
+
+
+@pytest.fixture(autouse=True)
+def _mock_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.utils._require_auth",
+        lambda: ("ws-test", object()),
+    )
+
+
+def _make_finished_run() -> TrainingRunDetail:
+    return TrainingRunDetail(
+        id="run_1",
+        name="qwen3-run1",
+        status="finished",
+        model_name="Qwen/Qwen3",
+        created_at="2026-04-01T00:00:00Z",
+    )
+
+
+def _make_running_run() -> TrainingRunDetail:
+    return TrainingRunDetail(
+        id="run_1",
+        name="qwen3-run1",
+        status="running",
+        model_name="Qwen/Qwen3",
+        created_at="2026-04-01T00:00:00Z",
+    )
+
+
+class TestStatusCheckpoints:
+    def test_finished_run_shows_checkpoints_section(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        class FakeClient:
+            def get_training_run(self, name, *, credentials=None):
+                return _make_finished_run()
+
+            def list_training_run_checkpoints(self, name, *, credentials=None):
+                return TrainingRunCheckpoints(
+                    training_run_id="run_1",
+                    training_run_name="qwen3-run1",
+                    checkpoints=[
+                        LoraCheckpointInfo(
+                            id="cp_1",
+                            checkpoint_step=100,
+                            status="uploaded",
+                            created_at="2026-04-20T00:00:00Z",
+                        )
+                    ],
+                )
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        train_module.status(name="qwen3-run1")
+        out = console_capture.getvalue()
+        assert "Checkpoints" in out
+        assert "step 100" in out
+        assert "osmosis deploy create qwen3-run1" in out
+
+    def test_running_run_skips_checkpoints(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        called = {"ckpts": False}
+
+        class FakeClient:
+            def get_training_run(self, name, *, credentials=None):
+                return _make_running_run()
+
+            def list_training_run_checkpoints(
+                self, name, *, credentials=None
+            ):  # pragma: no cover
+                called["ckpts"] = True
+                raise AssertionError("should not call for running run")
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        train_module.status(name="qwen3-run1")
+        out = console_capture.getvalue()
+        assert "Checkpoints" not in out
+        assert called["ckpts"] is False
+
+    def test_endpoint_error_is_non_fatal(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        from osmosis_ai.platform.auth.platform_client import PlatformAPIError
+
+        class FakeClient:
+            def get_training_run(self, name, *, credentials=None):
+                return _make_finished_run()
+
+            def list_training_run_checkpoints(self, name, *, credentials=None):
+                raise PlatformAPIError("Internal server error", 500)
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        train_module.status(name="qwen3-run1")
+        out = console_capture.getvalue()
+        assert "Checkpoints" not in out
+        assert "Training Run" in out
+
+    def test_finished_but_no_checkpoints(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        class FakeClient:
+            def get_training_run(self, name, *, credentials=None):
+                return _make_finished_run()
+
+            def list_training_run_checkpoints(self, name, *, credentials=None):
+                return TrainingRunCheckpoints(
+                    training_run_id="run_1",
+                    training_run_name="qwen3-run1",
+                    checkpoints=[],
+                )
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        train_module.status(name="qwen3-run1")
+        out = console_capture.getvalue()
+        assert "Checkpoints" not in out
+        assert "Deploy with:" not in out

--- a/tests/unit/platform/api/test_client_deployments.py
+++ b/tests/unit/platform/api/test_client_deployments.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from osmosis_ai.platform.api.client import OsmosisClient
 
 
@@ -92,19 +94,6 @@ class TestCreateDeployment:
         assert kwargs["data"]["lora_name"] == "custom"
 
     @patch("osmosis_ai.platform.api.client.platform_request")
-    def test_with_checkpoint_id(self, mock_req: MagicMock) -> None:
-        mock_req.return_value = {
-            "deployment": {"id": "dep_1", "lora_name": "x", "status": "deployed"}
-        }
-        client = OsmosisClient()
-        client.create_deployment(
-            training_run="qwen3-run1", lora_checkpoint_id="cp-uuid"
-        )
-        _, kwargs = mock_req.call_args
-        assert kwargs["data"]["lora_checkpoint_id"] == "cp-uuid"
-        assert "checkpoint_step" not in kwargs["data"]
-
-    @patch("osmosis_ai.platform.api.client.platform_request")
     def test_none_fields_omitted(self, mock_req: MagicMock) -> None:
         mock_req.return_value = {
             "deployment": {"id": "dep_1", "lora_name": "x", "status": "deployed"}
@@ -113,6 +102,14 @@ class TestCreateDeployment:
         client.create_deployment(training_run="run", checkpoint_step=0)
         _, kwargs = mock_req.call_args
         assert set(kwargs["data"].keys()) == {"training_run", "checkpoint_step"}
+
+    def test_requires_checkpoint_step(self) -> None:
+        client = OsmosisClient()
+        with pytest.raises(ValueError, match="checkpoint_step is required"):
+            client.create_deployment(
+                training_run="run",
+                checkpoint_step=None,  # type: ignore[arg-type]
+            )
 
 
 class TestGetDeployment:

--- a/tests/unit/platform/api/test_client_deployments.py
+++ b/tests/unit/platform/api/test_client_deployments.py
@@ -1,0 +1,196 @@
+"""Tests for OsmosisClient deployment + checkpoint methods."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from osmosis_ai.platform.api.client import OsmosisClient
+
+
+class TestListDeployments:
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_basic(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = {
+            "deployments": [],
+            "total_count": 0,
+            "has_more": False,
+            "next_offset": None,
+        }
+        client = OsmosisClient()
+        result = client.list_deployments(limit=10, offset=5)
+        assert result.total_count == 0
+        args, _kwargs = mock_req.call_args
+        assert "/api/cli/deployments?" in args[0]
+        assert "limit=10" in args[0]
+        assert "offset=5" in args[0]
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_with_search(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = {
+            "deployments": [],
+            "total_count": 0,
+            "has_more": False,
+            "next_offset": None,
+        }
+        client = OsmosisClient()
+        client.list_deployments(search="my-lora")
+        args, _ = mock_req.call_args
+        assert "search=my-lora" in args[0]
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_no_search_no_param(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = {
+            "deployments": [],
+            "total_count": 0,
+            "has_more": False,
+            "next_offset": None,
+        }
+        client = OsmosisClient()
+        client.list_deployments()
+        args, _ = mock_req.call_args
+        assert "search=" not in args[0]
+
+
+class TestCreateDeployment:
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_with_step(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = {
+            "deployment": {
+                "id": "dep_1",
+                "lora_name": "auto-generated",
+                "status": "deployed",
+            }
+        }
+        client = OsmosisClient()
+        result = client.create_deployment(
+            training_run="qwen3-run1", checkpoint_step=100
+        )
+        assert result.id == "dep_1"
+
+        args, kwargs = mock_req.call_args
+        assert args[0] == "/api/cli/deployments"
+        assert kwargs["method"] == "POST"
+        assert kwargs["data"] == {
+            "training_run": "qwen3-run1",
+            "checkpoint_step": 100,
+        }
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_with_name_override(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = {
+            "deployment": {
+                "id": "dep_1",
+                "lora_name": "custom",
+                "status": "deployed",
+            }
+        }
+        client = OsmosisClient()
+        client.create_deployment(
+            training_run="qwen3-run1", checkpoint_step=100, lora_name="custom"
+        )
+        _, kwargs = mock_req.call_args
+        assert kwargs["data"]["lora_name"] == "custom"
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_with_checkpoint_id(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = {
+            "deployment": {"id": "dep_1", "lora_name": "x", "status": "deployed"}
+        }
+        client = OsmosisClient()
+        client.create_deployment(
+            training_run="qwen3-run1", lora_checkpoint_id="cp-uuid"
+        )
+        _, kwargs = mock_req.call_args
+        assert kwargs["data"]["lora_checkpoint_id"] == "cp-uuid"
+        assert "checkpoint_step" not in kwargs["data"]
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_none_fields_omitted(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = {
+            "deployment": {"id": "dep_1", "lora_name": "x", "status": "deployed"}
+        }
+        client = OsmosisClient()
+        client.create_deployment(training_run="run", checkpoint_step=0)
+        _, kwargs = mock_req.call_args
+        assert set(kwargs["data"].keys()) == {"training_run", "checkpoint_step"}
+
+
+class TestGetDeployment:
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_by_name(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = {
+            "deployment": {
+                "id": "dep_1",
+                "lora_name": "x",
+                "status": "deployed",
+                "base_model": "Qwen/Qwen3",
+                "checkpoint_step": 1,
+            }
+        }
+        client = OsmosisClient()
+        result = client.get_deployment("my-lora")
+        assert result.lora_name == "x"
+        args, _ = mock_req.call_args
+        assert args[0] == "/api/cli/deployments/my-lora"
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_urlencodes_path(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = {
+            "deployment": {
+                "id": "d",
+                "lora_name": "x",
+                "status": "deployed",
+                "base_model": "q",
+                "checkpoint_step": 0,
+            }
+        }
+        client = OsmosisClient()
+        client.get_deployment("../bad")
+        args, _ = mock_req.call_args
+        assert "../" not in args[0]
+
+
+class TestDeleteDeployment:
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_delete(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = {"deleted": True}
+        client = OsmosisClient()
+        assert client.delete_deployment("my-lora") is True
+        args, kwargs = mock_req.call_args
+        assert args[0] == "/api/cli/deployments/my-lora"
+        assert kwargs["method"] == "DELETE"
+
+
+class TestRenameDeployment:
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_rename(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = {"deployment": {"id": "dep_1", "lora_name": "new-name"}}
+        client = OsmosisClient()
+        result = client.rename_deployment("old-name", "new-name")
+        assert result.lora_name == "new-name"
+        args, kwargs = mock_req.call_args
+        assert args[0] == "/api/cli/deployments/old-name"
+        assert kwargs["method"] == "PATCH"
+        assert kwargs["data"] == {"lora_name": "new-name"}
+
+
+class TestListTrainingRunCheckpoints:
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_list(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = {
+            "training_run_id": "run_1",
+            "training_run_name": "qwen3-run1",
+            "checkpoints": [
+                {
+                    "id": "cp_1",
+                    "checkpoint_step": 100,
+                    "status": "uploaded",
+                    "created_at": "2026-04-20T00:00:00Z",
+                }
+            ],
+        }
+        client = OsmosisClient()
+        result = client.list_training_run_checkpoints("qwen3-run1")
+        assert len(result.checkpoints) == 1
+        args, _ = mock_req.call_args
+        assert args[0] == "/api/cli/training-runs/qwen3-run1/checkpoints"

--- a/tests/unit/platform/api/test_models.py
+++ b/tests/unit/platform/api/test_models.py
@@ -384,3 +384,125 @@ class TestTrainingRunMetrics:
         }
         result = TrainingRunMetrics.from_dict(data)
         assert result.metrics == []
+
+
+class TestDeploymentModels:
+    def test_deployment_info_from_dict(self) -> None:
+        from osmosis_ai.platform.api.models import DeploymentInfo
+
+        d = DeploymentInfo.from_dict(
+            {
+                "id": "dep_1",
+                "lora_name": "qwen3-run1-step-100-lora",
+                "status": "deployed",
+                "training_run_id": "run_1",
+                "training_run_name": "qwen3-run1",
+                "checkpoint_step": 100,
+                "base_model": "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8",
+                "creator_name": "brian",
+                "created_at": "2026-04-20T00:00:00Z",
+            }
+        )
+        assert d.id == "dep_1"
+        assert d.lora_name == "qwen3-run1-step-100-lora"
+        assert d.status == "deployed"
+        assert d.checkpoint_step == 100
+        assert d.base_model == "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8"
+
+    def test_deployment_info_minimal(self) -> None:
+        """Server may omit optional fields — from_dict must tolerate it."""
+        from osmosis_ai.platform.api.models import DeploymentInfo
+
+        d = DeploymentInfo.from_dict(
+            {
+                "id": "dep_1",
+                "lora_name": "x",
+                "status": "deployed",
+                "base_model": "Qwen/Qwen3",
+                "checkpoint_step": 0,
+            }
+        )
+        assert d.training_run_id is None
+        assert d.training_run_name is None
+        assert d.creator_name is None
+        assert d.created_at == ""
+
+    def test_paginated_deployments_from_dict(self) -> None:
+        from osmosis_ai.platform.api.models import PaginatedDeployments
+
+        p = PaginatedDeployments.from_dict(
+            {
+                "deployments": [
+                    {
+                        "id": "dep_1",
+                        "lora_name": "a",
+                        "status": "deployed",
+                        "base_model": "Qwen/Qwen3",
+                        "checkpoint_step": 1,
+                    }
+                ],
+                "total_count": 1,
+                "has_more": False,
+                "next_offset": None,
+            }
+        )
+        assert len(p.deployments) == 1
+        assert p.total_count == 1
+        assert p.has_more is False
+        assert p.next_offset is None
+
+    def test_create_deployment_result(self) -> None:
+        from osmosis_ai.platform.api.models import CreateDeploymentResult
+
+        r = CreateDeploymentResult.from_dict(
+            {"id": "dep_1", "lora_name": "x", "status": "deployed"}
+        )
+        assert r.id == "dep_1"
+        assert r.status == "deployed"
+
+    def test_rename_deployment_result(self) -> None:
+        from osmosis_ai.platform.api.models import RenameDeploymentResult
+
+        r = RenameDeploymentResult.from_dict({"id": "dep_1", "lora_name": "new"})
+        assert r.lora_name == "new"
+
+    def test_lora_checkpoint_info(self) -> None:
+        from osmosis_ai.platform.api.models import LoraCheckpointInfo
+
+        c = LoraCheckpointInfo.from_dict(
+            {
+                "id": "cp_1",
+                "checkpoint_step": 100,
+                "status": "uploaded",
+                "created_at": "2026-04-20T00:00:00Z",
+            }
+        )
+        assert c.checkpoint_step == 100
+        assert c.status == "uploaded"
+
+    def test_training_run_checkpoints(self) -> None:
+        from osmosis_ai.platform.api.models import TrainingRunCheckpoints
+
+        r = TrainingRunCheckpoints.from_dict(
+            {
+                "training_run_id": "run_1",
+                "training_run_name": "qwen3-run1",
+                "checkpoints": [
+                    {
+                        "id": "cp_1",
+                        "checkpoint_step": 100,
+                        "status": "uploaded",
+                        "created_at": "2026-04-20T00:00:00Z",
+                    },
+                    {
+                        "id": "cp_2",
+                        "checkpoint_step": 200,
+                        "status": "uploaded",
+                        "created_at": "2026-04-20T01:00:00Z",
+                    },
+                ],
+            }
+        )
+        assert r.training_run_name == "qwen3-run1"
+        assert len(r.checkpoints) == 2
+        assert r.checkpoints[1].checkpoint_step == 200


### PR DESCRIPTION
## What

- Add `osmosis deploy` command group with `create`, `list`, `status`, `delete`, and `rename` subcommands (`osmosis_ai/cli/commands/deploy.py`).
- Extend `osmosis train status` to list deployable LoRA checkpoints and surface a `osmosis deploy create <run> --step <N>` hint for successful runs.
- Reword `osmosis model` help/output as "base models" and remove the stub `osmosis model deploy` (superseded by the new group).
- After a successful deploy, print a ready-to-copy `curl` example targeting `INFERENCE_URL` (`OSMOSIS_INFERENCE_URL`-overridable), with a `<base-model>` fallback when the follow-up fetch fails.
- Add platform API client methods + dataclasses: `list/create/get/delete/rename_deployment`, `list_training_run_checkpoints`, and `DeploymentInfo`, `PaginatedDeployments`, `CreateDeploymentResult`, `RenameDeploymentResult`, `LoraCheckpointInfo`, `TrainingRunCheckpoints`.
- Disable Rich's auto-highlighter on the shared `Console` so tokens like `step-40-lora` or hex-like slugs don't get recolored against the explicit `style=` argument.
- Replace bare `except Exception` with `PlatformAPIError`-scoped handling in `model delete` and `train status`.
- Add tests: `tests/unit/cli/test_deploy_commands.py`, `tests/unit/cli/test_train_status_checkpoints.py`, `tests/unit/platform/api/test_client_deployments.py`, plus extensions to `test_model_commands.py` and `test_models.py`.

## Why

The platform now supports deploying individual LoRA checkpoints as inference adapters, but the CLI had no way to drive that flow. This PR adds a first-class `osmosis deploy` group and wires `train status` into the same UX so users can go from "training succeeded" to "hit my adapter with curl" without leaving the terminal. Model-vs-deployment terminology is clarified at the same time so the `model` group stays focused on base models.

## How to Test

- `uv run pytest tests/unit/cli/test_deploy_commands.py tests/unit/cli/test_train_status_checkpoints.py tests/unit/platform/api/test_client_deployments.py tests/unit/cli/test_model_commands.py tests/unit/platform/api/test_models.py`
- `uv run pytest`
- `uv run ruff check . && uv run ruff format --check .`
- `uv run pyright osmosis_ai/`
- Manual: `osmosis train status <run>` on a completed run shows the checkpoints section + deploy hint.
- Manual: `osmosis deploy create <run> --step <N>` → confirm the `curl` example renders with the right `<base_model>:<lora_name>` identifier; then `osmosis deploy list`, `status`, `rename`, `delete` round-trip cleanly.

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included