### PR TITLE
[BREAKING][misc] chore: align codebase with Python 3.12

### DIFF
--- a/osmosis_ai/cli/metrics_export.py
+++ b/osmosis_ai/cli/metrics_export.py
@@ -18,7 +18,7 @@ _METRIC_KEY_MAP: dict[str, str] = {
 
 def _epoch_ms_to_iso(epoch_ms: int) -> str:
     """Convert epoch milliseconds to ISO 8601 string."""
-    dt = datetime.datetime.fromtimestamp(epoch_ms / 1000, tz=datetime.timezone.utc)
+    dt = datetime.datetime.fromtimestamp(epoch_ms / 1000, tz=datetime.UTC)
     return dt.isoformat()
 
 

--- a/osmosis_ai/eval/config.py
+++ b/osmosis_ai/eval/config.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 from typing import Annotated
 
-import tomllib
 from pydantic import BaseModel, ConfigDict, Field
 
 from osmosis_ai.cli.errors import CLIError

--- a/osmosis_ai/eval/llm_proxy.py
+++ b/osmosis_ai/eval/llm_proxy.py
@@ -321,7 +321,7 @@ async def _wait_for_port(host: str, port: int, timeout: float = 10.0) -> None:
             writer.close()
             await writer.wait_closed()
             return
-        except (OSError, asyncio.TimeoutError):
+        except (TimeoutError, OSError):
             await asyncio.sleep(0.05)
     raise TimeoutError(f"LiteLLMProxy did not start within {timeout}s")
 

--- a/osmosis_ai/eval/rubric/report.py
+++ b/osmosis_ai/eval/rubric/report.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from statistics import mean, pstdev, pvariance
 from typing import Any
@@ -87,7 +87,7 @@ class JsonReportWriter:
     def write(self, report: RubricReport, output_path: Path) -> Path:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         payload: dict[str, Any] = {
-            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "generated_at": datetime.now(UTC).isoformat(),
             "model": report.model,
             "rubric": report.rubric_text,
             "data_path": str(report.data_path),

--- a/osmosis_ai/platform/auth/credentials.py
+++ b/osmosis_ai/platform/auth/credentials.py
@@ -18,7 +18,7 @@ import json
 import os
 import sys
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 import keyring
@@ -177,14 +177,14 @@ class Credentials:
             access_token=token,
             token_type="Bearer",
             expires_at=verified.expires_at,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
             user=verified.user,
             token_id=verified.token_id,
         )
 
     def is_expired(self) -> bool:
         """Check if the token has expired."""
-        return datetime.now(timezone.utc) >= self.expires_at.astimezone(timezone.utc)
+        return datetime.now(UTC) >= self.expires_at.astimezone(UTC)
 
 
 # ---------------------------------------------------------------------------
@@ -250,8 +250,8 @@ def load_credentials() -> Credentials | None:
         return Credentials(
             access_token=env_token,
             token_type="Bearer",
-            expires_at=datetime.max.replace(tzinfo=timezone.utc),
-            created_at=datetime.now(timezone.utc),
+            expires_at=datetime.max.replace(tzinfo=UTC),
+            created_at=datetime.now(UTC),
             user=UserInfo(id="", email="", name=None),
             token_id=None,
         )

--- a/osmosis_ai/platform/auth/flow.py
+++ b/osmosis_ai/platform/auth/flow.py
@@ -15,7 +15,7 @@ import sys
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
@@ -79,14 +79,14 @@ def _parse_expires_at(raw: str | None) -> datetime:
         LoginError: If the timestamp is naive (no timezone) or already expired.
     """
     if not raw:
-        return datetime.now(timezone.utc) + timedelta(days=90)
+        return datetime.now(UTC) + timedelta(days=90)
 
     expires_at = datetime.fromisoformat(raw.replace("Z", "+00:00"))
     if expires_at.tzinfo is None:
         raise LoginError(
             "Invalid expires_at from platform: expected timezone-aware ISO8601 timestamp"
         )
-    if datetime.now(timezone.utc) >= expires_at:
+    if datetime.now(UTC) >= expires_at:
         raise LoginError(
             "Received token is already expired. Please check system clock or try again."
         )
@@ -392,7 +392,7 @@ def device_login(timeout: float = 600.0) -> tuple[LoginResult, Credentials]:
         access_token=token,
         token_type="Bearer",
         expires_at=expires_at,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         user=user,
         token_id=token_id,
     )

--- a/osmosis_ai/platform/cli/init.py
+++ b/osmosis_ai/platform/cli/init.py
@@ -113,7 +113,7 @@ def _write_scaffold(target: Path, ws_name: str, *, update: bool = False) -> None
     variables = {
         "name": ws_name,
         "sdk_version": PACKAGE_VERSION,
-        "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "created_at": datetime.datetime.now(datetime.UTC).isoformat(),
     }
 
     for entry in SCAFFOLD:
@@ -148,11 +148,9 @@ def _update_workspace_metadata(target: Path) -> None:
 
     match = re.search(_CREATED_AT_RE, original)
     created_at = (
-        match.group(1)
-        if match
-        else datetime.datetime.now(datetime.timezone.utc).isoformat()
+        match.group(1) if match else datetime.datetime.now(datetime.UTC).isoformat()
     )
-    updated_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    updated_at = datetime.datetime.now(datetime.UTC).isoformat()
 
     ws_toml.write_text(
         "# Osmosis Workspace Configuration\n"

--- a/osmosis_ai/platform/cli/serve_config.py
+++ b/osmosis_ai/platform/cli/serve_config.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 from typing import Annotated, Literal
 
-import tomllib
 from pydantic import BaseModel, ConfigDict, Field
 
 from osmosis_ai.cli.errors import CLIError

--- a/osmosis_ai/platform/cli/templates/pyproject.toml.tpl
+++ b/osmosis_ai/platform/cli/templates/pyproject.toml.tpl
@@ -2,7 +2,7 @@
 name = "{name}"
 description = "Osmosis workspace with training rollouts"
 version = "0.1.0"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "osmosis-ai>={sdk_version}",
 ]

--- a/osmosis_ai/platform/cli/training_config.py
+++ b/osmosis_ai/platform/cli/training_config.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 from typing import Any
 
-import tomllib
 from pydantic import BaseModel, ConfigDict
 
 from osmosis_ai.cli.errors import CLIError

--- a/osmosis_ai/rollout/agent_workflow.py
+++ b/osmosis_ai/rollout/agent_workflow.py
@@ -1,13 +1,11 @@
 from abc import ABC, abstractmethod
-from typing import Any, Generic, TypeVar
+from typing import Any
 
 from osmosis_ai.rollout.context import AgentWorkflowContext
 from osmosis_ai.rollout.types import AgentWorkflowConfig
 
-TConfig = TypeVar("TConfig", bound=AgentWorkflowConfig)
 
-
-class AgentWorkflow(Generic[TConfig], ABC):
+class AgentWorkflow[TConfig: AgentWorkflowConfig](ABC):
     def __init__(self, config: TConfig | None = None):
         self.config = config
 

--- a/osmosis_ai/rollout/backend/harbor/backend.py
+++ b/osmosis_ai/rollout/backend/harbor/backend.py
@@ -6,11 +6,11 @@ import logging
 import platform
 import shutil
 import subprocess
+import tomllib
 from pathlib import Path
 from typing import Any
 
 import toml
-import tomllib
 from harbor.models.trial.config import (
     AgentConfig as HarborAgentConfig,
 )

--- a/osmosis_ai/rollout/context.py
+++ b/osmosis_ai/rollout/context.py
@@ -1,7 +1,7 @@
 import os
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import Any, Generic, TypeVar
+from typing import Any
 
 from osmosis_ai.rollout.types import (
     AgentWorkflowConfig,
@@ -11,7 +11,6 @@ from osmosis_ai.rollout.types import (
 rollout_contextvar: ContextVar["RolloutContext | None"] = ContextVar(
     "rollout_contextvar", default=None
 )
-TConfig = TypeVar("TConfig", bound=AgentWorkflowConfig)
 
 # Env var names used by the container-side runners
 CHAT_COMPLETIONS_URL_ENV = "OSMOSIS_CHAT_COMPLETIONS_URL"
@@ -80,7 +79,7 @@ class GraderContext:
 
 
 @dataclass
-class AgentWorkflowContext(Generic[TConfig]):
+class AgentWorkflowContext[TConfig: AgentWorkflowConfig]:
     prompt: list[dict[str, Any]]
     config: TConfig | None = None
 
@@ -94,7 +93,9 @@ class AgentWorkflowContext(Generic[TConfig]):
 
 
 @dataclass
-class HarborAgentWorkflowContext(AgentWorkflowContext[TConfig]):
+class HarborAgentWorkflowContext[TConfig: AgentWorkflowConfig](
+    AgentWorkflowContext[TConfig]
+):
     """Context for agent workflow execution under HarborBackend.
 
     Extends AgentWorkflowContext with the Harbor ``BaseEnvironment``,

--- a/osmosis_ai/rollout/types/protocol.py
+++ b/osmosis_ai/rollout/types/protocol.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel
@@ -57,7 +57,7 @@ class GraderInitRequest(BaseModel):
 class GraderInitResponse(BaseModel): ...
 
 
-class GraderStatus(str, Enum):
+class GraderStatus(StrEnum):
     PENDING = "pending"
     SUCCESS = "success"
     FAILURE = "failure"

--- a/osmosis_ai/rollout/types/sample.py
+++ b/osmosis_ai/rollout/types/sample.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -18,20 +18,20 @@ class RolloutSample(BaseModel):
     extra_fields: dict[str, Any] = Field(default_factory=dict)
 
 
-class RolloutStatus(str, Enum):
+class RolloutStatus(StrEnum):
     PENDING = "pending"
     SUCCESS = "success"
     FAILURE = "failure"
 
 
-class RolloutErrorCategory(str, Enum):
+class RolloutErrorCategory(StrEnum):
     TIMEOUT = "timeout"
     VALIDATION_ERROR = "validation_error"
     HTTP_ERROR = "http_error"
     AGENT_ERROR = "agent_error"
 
 
-class MultiTurnMode(str, Enum):
+class MultiTurnMode(StrEnum):
     MULTI_SAMPLE = "multi_sample"
     SINGLE_SAMPLE = "single_sample"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ exclude_lines = [
 ]
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py312"
 line-length = 88
 
 [tool.ruff.lint]

--- a/tests/unit/auth/test_credentials.py
+++ b/tests/unit/auth/test_credentials.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 from osmosis_ai.platform.auth.credentials import (
@@ -23,7 +23,7 @@ def _make_credentials(
     created_at: datetime | None = None,
     token_id: str | None = None,
 ) -> Credentials:
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     return Credentials(
         access_token="test-token",
         token_type="Bearer",
@@ -35,7 +35,7 @@ def _make_credentials(
 
 
 def test_credentials_roundtrip_preserves_tz_aware_expires_at() -> None:
-    now_utc = datetime.now(timezone.utc)
+    now_utc = datetime.now(UTC)
     creds = _make_credentials(
         expires_at=now_utc + timedelta(minutes=5),
         created_at=now_utc,
@@ -580,9 +580,7 @@ def test_delete_with_missing_file_still_cleans_keyring(tmp_path, monkeypatch) ->
 
 
 def test_is_expired_true() -> None:
-    creds = _make_credentials(
-        expires_at=datetime.now(timezone.utc) - timedelta(hours=1)
-    )
+    creds = _make_credentials(expires_at=datetime.now(UTC) - timedelta(hours=1))
     assert creds.is_expired() is True
 
 

--- a/tests/unit/auth/test_device_flow.py
+++ b/tests/unit/auth/test_device_flow.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 from urllib.error import HTTPError, URLError
 
@@ -32,7 +32,7 @@ def _make_device_code_response() -> bytes:
 
 def _make_token_response(**overrides: object) -> bytes:
     """Build a flat token response dict (matches device/token endpoint)."""
-    expires_str = (datetime.now(timezone.utc) + timedelta(days=90)).isoformat()
+    expires_str = (datetime.now(UTC) + timedelta(days=90)).isoformat()
     data: dict[str, object] = {
         "token": "jwt-user-token",
         "expires_at": expires_str,

--- a/tests/unit/auth/test_error_messages.py
+++ b/tests/unit/auth/test_error_messages.py
@@ -7,7 +7,7 @@ is correct end-to-end.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 import pytest
@@ -21,7 +21,7 @@ from osmosis_ai.platform.auth.platform_client import (
 
 
 def _make_credentials(*, expired: bool = False) -> Credentials:
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     offset = timedelta(days=-1) if expired else timedelta(days=30)
     return Credentials(
         access_token="test-token",

--- a/tests/unit/auth/test_flow.py
+++ b/tests/unit/auth/test_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import socket
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import MagicMock, patch
 from urllib.error import HTTPError, URLError
@@ -67,7 +67,7 @@ def _make_verify_response(
 
 class TestVerifyAndGetUserInfo:
     def test_successful_verification(self) -> None:
-        expires_str = (datetime.now(timezone.utc) + timedelta(days=90)).isoformat()
+        expires_str = (datetime.now(UTC) + timedelta(days=90)).isoformat()
         body = _make_verify_response(expires_at=expires_str)
         mock_resp = MagicMock()
         mock_resp.read.return_value = body
@@ -90,10 +90,10 @@ class TestVerifyAndGetUserInfo:
         mock_resp.__enter__ = MagicMock(return_value=mock_resp)
         mock_resp.__exit__ = MagicMock(return_value=False)
 
-        before = datetime.now(timezone.utc)
+        before = datetime.now(UTC)
         with patch("osmosis_ai.platform.auth.flow.urlopen", return_value=mock_resp):
             result = verify_token("token")
-        after = datetime.now(timezone.utc)
+        after = datetime.now(UTC)
 
         assert result.expires_at >= before + timedelta(days=89)
         assert result.expires_at <= after + timedelta(days=91)
@@ -177,7 +177,7 @@ class TestVerifyAndGetUserInfo:
         self, user_data: dict, expected_match: str
     ) -> None:
         """Incomplete user fields should raise LoginError."""
-        expires_str = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
+        expires_str = (datetime.now(UTC) + timedelta(days=30)).isoformat()
         body = _make_verify_response(
             user=user_data,
             expires_at=expires_str,
@@ -192,7 +192,7 @@ class TestVerifyAndGetUserInfo:
                 verify_token("token")
 
     def test_no_token_id_in_response(self) -> None:
-        expires_str = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
+        expires_str = (datetime.now(UTC) + timedelta(days=30)).isoformat()
         body = _make_verify_response(
             expires_at=expires_str,
             token_id=None,

--- a/tests/unit/auth/test_platform_client.py
+++ b/tests/unit/auth/test_platform_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import http.client
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from io import BytesIO
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -34,7 +34,7 @@ def _make_credentials(
     access_token: str = "test-token-abc123",
 ) -> Credentials:
     """Create valid Credentials for testing."""
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     return Credentials(
         access_token=access_token,
         token_type="Bearer",

--- a/tests/unit/platform/cli/test_login.py
+++ b/tests/unit/platform/cli/test_login.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import osmosis_ai.cli.commands.auth as auth_module
 from osmosis_ai.platform.auth.credentials import Credentials, UserInfo
@@ -12,7 +12,7 @@ from osmosis_ai.platform.auth.flow import LoginResult
 def _make_credentials(
     user_id: str = "user_1", email: str = "a@example.com"
 ) -> Credentials:
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     return Credentials(
         access_token="tok",
         token_type="Bearer",
@@ -25,7 +25,7 @@ def _make_credentials(
 def _make_login_result(email: str = "a@example.com") -> LoginResult:
     return LoginResult(
         user=UserInfo(id="user_1", email=email, name="User"),
-        expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+        expires_at=datetime.now(UTC) + timedelta(days=30),
     )
 
 

--- a/tests/unit/platform/cli/test_workspace_setup.py
+++ b/tests/unit/platform/cli/test_workspace_setup.py
@@ -227,10 +227,10 @@ class TestWriteScaffold:
         assert "created_at = " in content
         assert 'setup_source = "osmosis init"' in content
 
-    def test_pyproject_toml_contains_workspace_name_and_dependency(
+    def test_pyproject_toml_contains_workspace_name_dependency_and_python_requirement(
         self, tmp_path: Path
     ) -> None:
-        """pyproject.toml contains the workspace name and osmosis-ai dependency."""
+        """pyproject.toml contains the workspace name, dependency, and Python floor."""
         from osmosis_ai.consts import PACKAGE_VERSION
         from osmosis_ai.platform.cli.init import _write_scaffold
 
@@ -240,6 +240,7 @@ class TestWriteScaffold:
 
         content = (target / "pyproject.toml").read_text(encoding="utf-8")
         assert 'name = "cool-project"' in content
+        assert 'requires-python = ">=3.12"' in content
         assert f'"osmosis-ai>={PACKAGE_VERSION}"' in content
 
     def test_gitignore_has_python_sections(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## What

- Raise the repo Python floor to 3.12 by updating `pyproject.toml`, Ruff's `target-version`, and the `osmosis init` workspace template.
- Apply the resulting Ruff/pyupgrade cleanup across CLI, auth, eval, and rollout codepaths, including `datetime.UTC`, `StrEnum`, PEP 695 generics, and import ordering fixes.
- Update unit tests to assert the new generated `requires-python` value and keep the auth/login coverage aligned with the py312-oriented lint changes.

## Why

This branch moves the SDK and generated workspaces onto the same Python 3.12 baseline so the configured runtime, scaffolded projects, and Ruff's py312 upgrades no longer disagree.

This is a breaking change for anyone still on Python 3.10 or 3.11: they will need to upgrade to Python 3.12+ before installing the SDK or using newly scaffolded workspaces.

## How to Test

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright osmosis_ai/` (currently exits with 0 errors and 1 existing warning in `osmosis_ai/__init__.py`)
- `uv run pytest`
- `rg 'requires-python = \">=3.12\"|target-version = \"py312\"' pyproject.toml osmosis_ai/platform/cli/templates/pyproject.toml.tpl`

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [ ] Public API changes are documented
- [x] No secrets or credentials included