### PR TITLE
[cli][auth] feat: streamline workspace selection and setup

### DIFF
--- a/osmosis_ai/__init__.py
+++ b/osmosis_ai/__init__.py
@@ -9,7 +9,18 @@ Remote rollout uses ``osmosis_ai.rollout`` and is not re-exported at package
 top level.
 """
 
+from typing import TYPE_CHECKING
+
 from .consts import PACKAGE_VERSION as __version__
+
+if TYPE_CHECKING:
+    from .eval.rubric import (
+        MissingAPIKeyError,
+        ModelNotFoundError,
+        ProviderRequestError,
+        RubricResult,
+        evaluate_rubric,
+    )
 
 # ---------------------------------------------------------------------------
 # Lazy-loaded exports: these names are resolved on first access so that
@@ -17,13 +28,15 @@ from .consts import PACKAGE_VERSION as __version__
 # openai, …) unless actually needed.
 # ---------------------------------------------------------------------------
 
-_RUBRIC_EXPORTS: set[str] = {
-    "MissingAPIKeyError",
-    "ModelNotFoundError",
-    "ProviderRequestError",
-    "RubricResult",
-    "evaluate_rubric",
-}
+_RUBRIC_EXPORTS: frozenset[str] = frozenset(
+    {
+        "MissingAPIKeyError",
+        "ModelNotFoundError",
+        "ProviderRequestError",
+        "RubricResult",
+        "evaluate_rubric",
+    }
+)
 
 
 def __getattr__(name: str) -> object:
@@ -37,6 +50,10 @@ def __getattr__(name: str) -> object:
 
 
 __all__ = [
+    "MissingAPIKeyError",
+    "ModelNotFoundError",
+    "ProviderRequestError",
+    "RubricResult",
     "__version__",
-    *sorted(_RUBRIC_EXPORTS),
+    "evaluate_rubric",
 ]

--- a/osmosis_ai/cli/commands/auth.py
+++ b/osmosis_ai/cli/commands/auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import shlex
 from typing import TYPE_CHECKING, Any
@@ -253,7 +254,7 @@ def login(
                     "Run 'osmosis workspace' later to choose one.",
                     style="yellow",
                 )
-        elif auto_selected:
+        elif auto_selected and active_workspace is not None:
             console.print(
                 f"\nAutomatically selected your only workspace: "
                 f"{esc(active_workspace['name'])}",
@@ -337,7 +338,12 @@ def logout(
 @app.command("whoami")
 def whoami() -> None:
     """Show current authenticated user and workspace."""
-    from osmosis_ai.platform.auth import ensure_active_workspace, load_credentials
+    from osmosis_ai.platform.auth import (
+        AuthenticationExpiredError,
+        PlatformAPIError,
+        ensure_active_workspace,
+        load_credentials,
+    )
     from osmosis_ai.platform.constants import MSG_NOT_LOGGED_IN
 
     credentials = load_credentials()
@@ -345,7 +351,12 @@ def whoami() -> None:
     if credentials is None:
         raise CLIError(MSG_NOT_LOGGED_IN)
 
-    active_workspace = ensure_active_workspace(credentials=credentials)
+    active_workspace = None
+    with contextlib.suppress(AuthenticationExpiredError, PlatformAPIError):
+        active_workspace = ensure_active_workspace(
+            credentials=credentials,
+            cleanup_on_401=False,
+        )
     esc = console.escape
 
     rows = [("Email", esc(credentials.user.email))]

--- a/osmosis_ai/cli/commands/auth.py
+++ b/osmosis_ai/cli/commands/auth.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING
+import shlex
+from typing import TYPE_CHECKING, Any
 
 import typer
 
@@ -34,7 +35,50 @@ ASCII_ART = r"""
 ASCII_ART_MIN_WIDTH = 113
 
 
-def _validate_workspace_context(creds: Credentials) -> None:
+def _normalize_workspaces(raw_workspaces: Any) -> list[dict[str, str]]:
+    """Return workspace entries that have both an ID and a name."""
+    if not isinstance(raw_workspaces, list):
+        return []
+
+    workspaces: list[dict[str, str]] = []
+    for workspace in raw_workspaces:
+        if not isinstance(workspace, dict):
+            continue
+        ws_id = workspace.get("id")
+        ws_name = workspace.get("name")
+        if isinstance(ws_id, str) and ws_id and isinstance(ws_name, str) and ws_name:
+            workspaces.append({"id": ws_id, "name": ws_name})
+    return workspaces
+
+
+def _load_login_workspaces(
+    creds: Credentials,
+) -> tuple[list[dict[str, str]] | None, str | None]:
+    """Best-effort workspace lookup for post-login messaging."""
+    from osmosis_ai.platform.auth import (
+        AuthenticationExpiredError,
+        PlatformAPIError,
+        platform_request,
+    )
+
+    try:
+        data = platform_request(
+            "/api/cli/workspaces",
+            credentials=creds,
+            require_workspace=False,
+            cleanup_on_401=False,
+        )
+    except (AuthenticationExpiredError, PlatformAPIError) as exc:
+        return None, str(exc)
+
+    return _normalize_workspaces(data.get("workspaces")), None
+
+
+def _validate_workspace_context(
+    creds: Credentials,
+    *,
+    workspaces: list[dict[str, str]] | None = None,
+) -> None:
     """Validate the stored workspace is still accessible with new credentials.
 
     After login, the workspace ID in config.json may be stale (e.g. the user
@@ -46,20 +90,17 @@ def _validate_workspace_context(creds: Credentials) -> None:
         get_active_workspace,
         set_active_workspace,
     )
-    from osmosis_ai.platform.auth.platform_client import platform_request
 
     ws = get_active_workspace()
     if not ws:
         return
 
     try:
-        data = platform_request(
-            "/api/cli/workspaces",
-            credentials=creds,
-            require_workspace=False,
-            cleanup_on_401=False,
-        )
-        workspaces = data.get("workspaces", [])
+        if workspaces is None:
+            workspaces, _ = _load_login_workspaces(creds)
+        if workspaces is None:
+            return
+
         ws_by_id = {w["id"]: w for w in workspaces if "id" in w}
         ws_by_name = {w["name"]: w for w in workspaces if "name" in w}
 
@@ -83,6 +124,26 @@ def _validate_workspace_context(creds: Credentials) -> None:
         pass  # Don't block login for validation errors
 
 
+def _ensure_login_workspace_selection(
+    workspaces: list[dict[str, str]] | None,
+) -> tuple[dict[str, str] | None, bool]:
+    """Return the active workspace, auto-selecting the only available one."""
+    from osmosis_ai.platform.auth.local_config import (
+        get_active_workspace,
+        set_active_workspace,
+    )
+
+    active_workspace = get_active_workspace()
+    if active_workspace is not None:
+        return active_workspace, False
+    if workspaces is None or len(workspaces) != 1:
+        return None, False
+
+    workspace = workspaces[0]
+    set_active_workspace(workspace["id"], workspace["name"])
+    return workspace, True
+
+
 @app.command("login")
 def login(
     force: bool = typer.Option(
@@ -96,7 +157,6 @@ def login(
     from osmosis_ai.platform.auth import (
         LoginError,
         device_login,
-        ensure_active_workspace,
         load_credentials,
         verify_token,
     )
@@ -106,10 +166,7 @@ def login(
         save_credentials,
     )
     from osmosis_ai.platform.auth.flow import LoginResult
-    from osmosis_ai.platform.auth.local_config import (
-        clear_all_local_data,
-        get_active_workspace,
-    )
+    from osmosis_ai.platform.auth.local_config import clear_all_local_data
     from osmosis_ai.platform.auth.platform_client import revoke_cli_token
 
     if console.rich.width >= ASCII_ART_MIN_WIDTH:
@@ -156,6 +213,8 @@ def login(
 
         save_credentials(creds)
 
+        workspaces, workspace_lookup_error = _load_login_workspaces(creds)
+
         # Clear stale workspace and local state when user identity changes
         # or when explicitly forcing a fresh start, to prevent subsequent
         # commands from sending the old workspace ID in X-Osmosis-Org.
@@ -164,10 +223,10 @@ def login(
         )
         if local_data_cleared:
             clear_all_local_data()
-        else:
-            _validate_workspace_context(creds)
-        ensure_active_workspace(creds)
-        active_workspace = get_active_workspace()
+        elif workspaces is not None:
+            _validate_workspace_context(creds, workspaces=workspaces)
+
+        active_workspace, auto_selected = _ensure_login_workspace_selection(workspaces)
 
         # Display login success
         esc = console.escape
@@ -181,7 +240,44 @@ def login(
 
         console.panel("Login Successful", "\n".join(info_lines), style="green")
 
-        if active_workspace is None:
+        if workspace_lookup_error is not None:
+            if active_workspace is not None:
+                console.print(
+                    "\nAuthenticated, but could not refresh your workspace list. "
+                    "Current workspace selection was kept.",
+                    style="yellow",
+                )
+            else:
+                console.print(
+                    "\nAuthenticated, but could not load your workspaces yet. "
+                    "Run 'osmosis workspace' later to choose one.",
+                    style="yellow",
+                )
+        elif auto_selected:
+            console.print(
+                f"\nAutomatically selected your only workspace: "
+                f"{esc(active_workspace['name'])}",
+                style="green",
+            )
+        elif workspaces and len(workspaces) > 1:
+            console.print(
+                "\nMultiple workspaces are available. Switch with:",
+                style="dim",
+            )
+            for workspace in workspaces:
+                command = f"osmosis workspace switch {shlex.quote(workspace['name'])}"
+                console.print(f"  {esc(command)}")
+            console.print(
+                "Or run 'osmosis workspace' for interactive selection.",
+                style="dim",
+            )
+        elif active_workspace is None and workspaces == []:
+            console.print(
+                "\nNo workspaces were found for this account. "
+                "Run 'osmosis workspace' to manage workspaces.",
+                style="dim",
+            )
+        elif active_workspace is None:
             console.print(
                 "\nRun 'osmosis workspace' to select a workspace.",
                 style="dim",

--- a/osmosis_ai/cli/commands/auth.py
+++ b/osmosis_ai/cli/commands/auth.py
@@ -76,7 +76,7 @@ def _validate_workspace_context(creds: Credentials) -> None:
         clear_all_local_data()
         console.print(
             "\nPrevious workspace is no longer accessible. "
-            "Run 'osmosis workspace' to select a workspace.",
+            "Resetting local workspace selection.",
             style="yellow",
         )
     except Exception:
@@ -96,6 +96,7 @@ def login(
     from osmosis_ai.platform.auth import (
         LoginError,
         device_login,
+        ensure_active_workspace,
         load_credentials,
         verify_token,
     )
@@ -105,7 +106,10 @@ def login(
         save_credentials,
     )
     from osmosis_ai.platform.auth.flow import LoginResult
-    from osmosis_ai.platform.auth.local_config import clear_all_local_data
+    from osmosis_ai.platform.auth.local_config import (
+        clear_all_local_data,
+        get_active_workspace,
+    )
     from osmosis_ai.platform.auth.platform_client import revoke_cli_token
 
     if console.rich.width >= ASCII_ART_MIN_WIDTH:
@@ -162,6 +166,8 @@ def login(
             clear_all_local_data()
         else:
             _validate_workspace_context(creds)
+        ensure_active_workspace(creds)
+        active_workspace = get_active_workspace()
 
         # Display login success
         esc = console.escape
@@ -169,14 +175,17 @@ def login(
         info_lines = [f"Email: {esc(result.user.email)}"]
         if result.user.name:
             info_lines.append(f"Name: {esc(result.user.name)}")
+        if active_workspace:
+            info_lines.append(f"Workspace: {esc(active_workspace['name'])}")
         info_lines.append(f"Expires: {result.expires_at.strftime('%Y-%m-%d')}")
 
         console.panel("Login Successful", "\n".join(info_lines), style="green")
 
-        console.print(
-            "\nRun 'osmosis workspace' to select a workspace.",
-            style="dim",
-        )
+        if active_workspace is None:
+            console.print(
+                "\nRun 'osmosis workspace' to select a workspace.",
+                style="dim",
+            )
 
     except LoginError as e:
         console.print_error(str(e))
@@ -232,8 +241,7 @@ def logout(
 @app.command("whoami")
 def whoami() -> None:
     """Show current authenticated user and workspace."""
-    from osmosis_ai.platform.auth import load_credentials
-    from osmosis_ai.platform.auth.local_config import get_active_workspace_name
+    from osmosis_ai.platform.auth import ensure_active_workspace, load_credentials
     from osmosis_ai.platform.constants import MSG_NOT_LOGGED_IN
 
     credentials = load_credentials()
@@ -241,14 +249,14 @@ def whoami() -> None:
     if credentials is None:
         raise CLIError(MSG_NOT_LOGGED_IN)
 
-    ws_name = get_active_workspace_name()
+    active_workspace = ensure_active_workspace(credentials=credentials)
     esc = console.escape
 
     rows = [("Email", esc(credentials.user.email))]
     if credentials.user.name:
         rows.append(("Name", esc(credentials.user.name)))
-    if ws_name:
-        rows.append(("Workspace", esc(ws_name)))
+    if active_workspace:
+        rows.append(("Workspace", esc(active_workspace["name"])))
     rows.append(("Expires", credentials.expires_at.strftime("%Y-%m-%d")))
 
     console.table(rows)

--- a/osmosis_ai/platform/api/client.py
+++ b/osmosis_ai/platform/api/client.py
@@ -51,6 +51,7 @@ class OsmosisClient:
         *,
         credentials: Credentials | None = None,
         workspace_name: str,
+        cleanup_on_401: bool = True,
     ) -> dict[str, Any]:
         """Fetch workspace metadata via /api/cli/workspaces.
 
@@ -62,6 +63,7 @@ class OsmosisClient:
             "/api/cli/workspaces",
             credentials=credentials,
             require_workspace=False,
+            cleanup_on_401=cleanup_on_401,
         )
         for ws in data.get("workspaces", []):
             if ws.get("name") == workspace_name:

--- a/osmosis_ai/platform/api/client.py
+++ b/osmosis_ai/platform/api/client.py
@@ -52,10 +52,11 @@ class OsmosisClient:
         credentials: Credentials | None = None,
         workspace_name: str,
     ) -> dict[str, Any]:
-        """Fetch subscription status for a workspace via /api/cli/workspaces.
+        """Fetch workspace metadata via /api/cli/workspaces.
 
-        Returns a dict with ``has_subscription`` for the matched workspace,
-        or an empty dict if the workspace is not found.
+        Returns a dict with ``has_subscription`` plus optional Git integration
+        fields for the matched workspace, or an empty dict if the workspace is
+        not found.
         """
         data = platform_request(
             "/api/cli/workspaces",
@@ -64,7 +65,16 @@ class OsmosisClient:
         )
         for ws in data.get("workspaces", []):
             if ws.get("name") == workspace_name:
-                return {"found": True, "has_subscription": ws.get("has_subscription")}
+                return {
+                    "found": True,
+                    "has_subscription": ws.get("has_subscription"),
+                    # Default missing fields so newer SDKs stay compatible with
+                    # older platform deployments during rollout.
+                    "has_github_app_installation": ws.get(
+                        "has_github_app_installation", False
+                    ),
+                    "connected_repo": ws.get("connected_repo"),
+                }
         return {"found": False}
 
     def list_workspaces(

--- a/osmosis_ai/platform/auth/__init__.py
+++ b/osmosis_ai/platform/auth/__init__.py
@@ -21,6 +21,7 @@ from .platform_client import (
     AuthenticationExpiredError,
     PlatformAPIError,
     SubscriptionRequiredError,
+    ensure_active_workspace,
     platform_request,
 )
 
@@ -37,6 +38,7 @@ __all__ = [
     "UserInfo",
     "delete_credentials",
     "device_login",
+    "ensure_active_workspace",
     "get_active_workspace",
     "get_active_workspace_id",
     "get_credential_store",

--- a/osmosis_ai/platform/auth/platform_client.py
+++ b/osmosis_ai/platform/auth/platform_client.py
@@ -15,7 +15,12 @@ from osmosis_ai.platform.constants import MSG_NOT_LOGGED_IN
 
 from .config import PLATFORM_URL
 from .credentials import load_credentials
-from .local_config import get_active_workspace_id, reset_session
+from .local_config import (
+    get_active_workspace,
+    get_active_workspace_id,
+    reset_session,
+    set_active_workspace,
+)
 
 if TYPE_CHECKING:
     from .credentials import Credentials
@@ -105,6 +110,43 @@ def revoke_cli_token(credentials: Credentials) -> bool:
         return False
 
 
+def ensure_active_workspace(
+    credentials: Credentials | None = None,
+    *,
+    cleanup_on_401: bool = True,
+) -> dict[str, str] | None:
+    """Return the active workspace, auto-selecting it when only one exists."""
+    active_workspace = get_active_workspace()
+    if active_workspace is not None:
+        return active_workspace
+
+    if credentials is None:
+        credentials = load_credentials()
+    if credentials is None:
+        return None
+
+    data = platform_request(
+        "/api/cli/workspaces",
+        credentials=credentials,
+        require_workspace=False,
+        cleanup_on_401=cleanup_on_401,
+    )
+    workspaces = data.get("workspaces", [])
+    if len(workspaces) != 1:
+        return None
+
+    workspace = workspaces[0]
+    ws_id = workspace.get("id")
+    ws_name = workspace.get("name")
+    if not isinstance(ws_id, str) or not ws_id:
+        return None
+    if not isinstance(ws_name, str) or not ws_name:
+        return None
+
+    set_active_workspace(ws_id, ws_name)
+    return {"id": ws_id, "name": ws_name}
+
+
 def platform_request(
     endpoint: str,
     method: str = "GET",
@@ -161,6 +203,12 @@ def platform_request(
     # Add workspace context if required
     if require_workspace:
         resolved_workspace_id = workspace_id or get_active_workspace_id()
+        if not resolved_workspace_id:
+            active_workspace = ensure_active_workspace(
+                credentials=credentials,
+                cleanup_on_401=cleanup_on_401,
+            )
+            resolved_workspace_id = active_workspace["id"] if active_workspace else None
         if not resolved_workspace_id:
             raise PlatformAPIError(
                 "No workspace selected. Run 'osmosis workspace' to select a workspace."

--- a/osmosis_ai/platform/cli/dataset.py
+++ b/osmosis_ai/platform/cli/dataset.py
@@ -145,6 +145,11 @@ def _check_file_basics(file: str) -> tuple[Path, str, int]:
     return file_path, ext, file_size
 
 
+def _dataset_name_from_path(file_path: Path) -> str:
+    """Derive the platform dataset name from a local file path."""
+    return file_path.stem
+
+
 def _perform_upload(
     *,
     file_path: Path,
@@ -165,9 +170,10 @@ def _perform_upload(
     )
 
     client = OsmosisClient()
+    dataset_name = _dataset_name_from_path(file_path)
 
     dataset = client.create_dataset(
-        file_path.name,
+        dataset_name,
         file_size,
         ext,
         credentials=credentials,
@@ -269,7 +275,9 @@ def upload(
         credentials=credentials,
     )
 
-    console.print(f"Dataset uploaded: {console.escape(file_path.name)}", style="green")
+    console.print(
+        f"Dataset uploaded: {console.escape(dataset.file_name)}", style="green"
+    )
     url = platform_entity_url(ws_name, "datasets", dataset.id)
     console.print(f"Processing will continue on the platform. Check status at: {url}")
 

--- a/osmosis_ai/platform/cli/init.py
+++ b/osmosis_ai/platform/cli/init.py
@@ -13,11 +13,16 @@ import subprocess as _subprocess
 from dataclasses import dataclass
 from importlib.resources import files
 from pathlib import Path
+from typing import Any
 
 from osmosis_ai.cli.console import console
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.platform.auth.config import PLATFORM_URL
-from osmosis_ai.platform.auth.local_config import get_active_workspace_name
+from osmosis_ai.platform.auth.local_config import (
+    get_active_workspace_id,
+    get_active_workspace_name,
+    set_active_workspace,
+)
 from osmosis_ai.platform.cli.constants import validate_name
 
 # ── Prerequisites ────────────────────────────────────────────────
@@ -220,58 +225,110 @@ def _git_initial_commit(target: Path) -> None:
 
 
 def _selected_workspace_git_context() -> dict[str, str | bool | None]:
-    """Best-effort Git integration context for the active workspace."""
-    selected_workspace_name = get_active_workspace_name()
-    if not selected_workspace_name:
-        return {
-            "workspace_name": None,
-            "git_sync_url": None,
-            "has_github_app_installation": False,
-            "connected_repo_url": None,
-        }
+    """Best-effort Git integration context for the active workspace.
 
-    context: dict[str, str | bool | None] = {
-        "workspace_name": selected_workspace_name,
-        "git_sync_url": f"{PLATFORM_URL}/{selected_workspace_name}/integrations/git",
-        "has_github_app_installation": False,
-        "connected_repo_url": None,
-    }
+    Always verifies the active workspace against the platform when
+    credentials are usable, so a stale local selection (e.g. a
+    workspace the user no longer belongs to) can't silently bypass Git
+    Sync guidance or connected-repo blocking. Also auto-selects the
+    only available workspace when nothing is saved locally, keeping
+    behavior consistent with the rest of the CLI for single-workspace
+    users.
 
-    from osmosis_ai.platform.api.client import OsmosisClient
+    Falls back to the locally cached workspace name (without
+    connected-repo metadata) only when the platform is unreachable or
+    credentials are missing/expired.
+    """
     from osmosis_ai.platform.auth import (
         AuthenticationExpiredError,
         PlatformAPIError,
         load_credentials,
+        platform_request,
     )
+
+    empty_context: dict[str, str | bool | None] = {
+        "workspace_name": None,
+        "git_sync_url": None,
+        "has_github_app_installation": False,
+        "connected_repo_url": None,
+    }
+
+    def _offline_fallback() -> dict[str, str | bool | None]:
+        local_name = get_active_workspace_name()
+        if not local_name:
+            return empty_context
+        return {
+            "workspace_name": local_name,
+            "git_sync_url": f"{PLATFORM_URL}/{local_name}/integrations/git",
+            "has_github_app_installation": False,
+            "connected_repo_url": None,
+        }
 
     credentials = load_credentials()
     if credentials is None or credentials.is_expired():
-        return context
+        return _offline_fallback()
 
     try:
-        workspace_info = OsmosisClient().refresh_workspace_info(
+        data = platform_request(
+            "/api/cli/workspaces",
             credentials=credentials,
-            workspace_name=selected_workspace_name,
+            require_workspace=False,
             cleanup_on_401=False,
         )
     except (AuthenticationExpiredError, PlatformAPIError):
-        return context
+        return _offline_fallback()
 
-    connected_repo = workspace_info.get("connected_repo")
+    workspaces = [ws for ws in data.get("workspaces", []) if isinstance(ws, dict)]
+
+    local_id = get_active_workspace_id()
+    matched: dict[str, Any] | None = None
+    if local_id:
+        matched = next((ws for ws in workspaces if ws.get("id") == local_id), None)
+
+    # Auto-select the only workspace when nothing valid is saved locally.
+    # Mirrors ensure_active_workspace() so single-workspace users get the
+    # same Git Sync guidance and connected-repo blocking as everyone else.
+    if matched is None and len(workspaces) == 1:
+        only_ws = workspaces[0]
+        only_id = only_ws.get("id")
+        only_name = only_ws.get("name")
+        if (
+            isinstance(only_id, str)
+            and only_id
+            and isinstance(only_name, str)
+            and only_name
+        ):
+            set_active_workspace(only_id, only_name)
+            matched = only_ws
+
+    if matched is None:
+        return empty_context
+
+    selected_name = matched.get("name")
+    if not isinstance(selected_name, str) or not selected_name:
+        return empty_context
+
+    connected_repo_url: str | None = None
+    connected_repo = matched.get("connected_repo")
     if isinstance(connected_repo, dict):
         repo_url = connected_repo.get("repo_url")
         if isinstance(repo_url, str) and repo_url:
-            context["connected_repo_url"] = repo_url
+            connected_repo_url = repo_url
 
-    context["has_github_app_installation"] = bool(
-        workspace_info.get("has_github_app_installation")
-    )
-    return context
+    return {
+        "workspace_name": selected_name,
+        "git_sync_url": f"{PLATFORM_URL}/{selected_name}/integrations/git",
+        "has_github_app_installation": bool(matched.get("has_github_app_installation")),
+        "connected_repo_url": connected_repo_url,
+    }
 
 
-def _git_sync_cta_text() -> str:
+def _git_sync_cta_text(
+    git_context: dict[str, str | bool | None] | None = None,
+) -> str:
     """Build the Git Sync CTA shown after workspace scaffolding."""
-    git_context = _selected_workspace_git_context()
+    if git_context is None:
+        git_context = _selected_workspace_git_context()
 
     connected_repo_url = git_context.get("connected_repo_url")
     if isinstance(connected_repo_url, str) and connected_repo_url:
@@ -289,9 +346,12 @@ def _git_sync_cta_text() -> str:
     return f"Go to [cyan]{PLATFORM_URL}[/cyan] → Git Sync to connect your repo"
 
 
-def _raise_if_selected_workspace_has_connected_repo() -> None:
+def _raise_if_selected_workspace_has_connected_repo(
+    git_context: dict[str, str | bool | None] | None = None,
+) -> None:
     """Block fresh init when the active workspace already has a connected repo."""
-    git_context = _selected_workspace_git_context()
+    if git_context is None:
+        git_context = _selected_workspace_git_context()
     workspace_name = git_context.get("workspace_name")
     connected_repo_url = git_context.get("connected_repo_url")
 
@@ -315,7 +375,12 @@ def _raise_if_selected_workspace_has_connected_repo() -> None:
     )
 
 
-def _print_next_steps(ws_name: str, *, here: bool = False) -> None:
+def _print_next_steps(
+    ws_name: str,
+    *,
+    here: bool = False,
+    git_context: dict[str, str | bool | None] | None = None,
+) -> None:
     """Print post-setup CTA with Rich panels."""
     from rich import box as rich_box
     from rich.console import Group
@@ -345,7 +410,7 @@ def _print_next_steps(ws_name: str, *, here: bool = False) -> None:
     cmd_table.add_row()
     cmd_table.add_row(
         "[bold green]>[/bold green]",
-        _git_sync_cta_text(),
+        _git_sync_cta_text(git_context),
     )
 
     prompt_body = (
@@ -403,6 +468,16 @@ def init(name: str, here: bool = False) -> None:
 
     # Determine target directory
     created_dir = False
+    # Resolve active workspace (and Git integration state) once so we don't
+    # hit the platform twice during a single `osmosis init`.
+    git_context: dict[str, str | bool | None] | None = None
+
+    def _ensure_git_context() -> dict[str, str | bool | None]:
+        nonlocal git_context
+        if git_context is None:
+            git_context = _selected_workspace_git_context()
+        return git_context
+
     if here:
         target = Path.cwd()
         if any(p.name != ".git" for p in target.iterdir()):
@@ -411,7 +486,7 @@ def init(name: str, here: bool = False) -> None:
                 "Use 'osmosis init <name>' (without --here) to create a new directory, "
                 "or empty this directory first."
             )
-        _raise_if_selected_workspace_has_connected_repo()
+        _raise_if_selected_workspace_has_connected_repo(_ensure_git_context())
     else:
         target = Path.cwd() / name
         if target.exists():
@@ -426,7 +501,7 @@ def init(name: str, here: bool = False) -> None:
                     "Use --here to initialize in the current directory."
                 )
         else:
-            _raise_if_selected_workspace_has_connected_repo()
+            _raise_if_selected_workspace_has_connected_repo(_ensure_git_context())
             target.mkdir()
             created_dir = True
 
@@ -444,4 +519,4 @@ def init(name: str, here: bool = False) -> None:
             shutil.rmtree(target)
         raise
 
-    _print_next_steps(name, here=here)
+    _print_next_steps(name, here=here, git_context=_ensure_git_context())

--- a/osmosis_ai/platform/cli/init.py
+++ b/osmosis_ai/platform/cli/init.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from osmosis_ai.cli.console import console
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.platform.auth.config import PLATFORM_URL
+from osmosis_ai.platform.auth.local_config import get_active_workspace_name
 from osmosis_ai.platform.cli.constants import validate_name
 
 # ── Prerequisites ────────────────────────────────────────────────
@@ -218,6 +219,97 @@ def _git_initial_commit(target: Path) -> None:
     )
 
 
+def _selected_workspace_git_context() -> dict[str, str | bool | None]:
+    """Best-effort Git integration context for the active workspace."""
+    selected_workspace_name = get_active_workspace_name()
+    if not selected_workspace_name:
+        return {
+            "workspace_name": None,
+            "git_sync_url": None,
+            "has_github_app_installation": False,
+            "connected_repo_url": None,
+        }
+
+    context: dict[str, str | bool | None] = {
+        "workspace_name": selected_workspace_name,
+        "git_sync_url": f"{PLATFORM_URL}/{selected_workspace_name}/integrations/git",
+        "has_github_app_installation": False,
+        "connected_repo_url": None,
+    }
+
+    from osmosis_ai.platform.api.client import OsmosisClient
+    from osmosis_ai.platform.auth import PlatformAPIError, load_credentials
+
+    credentials = load_credentials()
+    if credentials is None or credentials.is_expired():
+        return context
+
+    try:
+        workspace_info = OsmosisClient().refresh_workspace_info(
+            credentials=credentials,
+            workspace_name=selected_workspace_name,
+        )
+    except PlatformAPIError:
+        return context
+
+    connected_repo = workspace_info.get("connected_repo")
+    if isinstance(connected_repo, dict):
+        repo_url = connected_repo.get("repo_url")
+        if isinstance(repo_url, str) and repo_url:
+            context["connected_repo_url"] = repo_url
+
+    context["has_github_app_installation"] = bool(
+        workspace_info.get("has_github_app_installation")
+    )
+    return context
+
+
+def _git_sync_cta_text() -> str:
+    """Build the Git Sync CTA shown after workspace scaffolding."""
+    git_context = _selected_workspace_git_context()
+
+    connected_repo_url = git_context.get("connected_repo_url")
+    if isinstance(connected_repo_url, str) and connected_repo_url:
+        return f"Connected repo: [cyan]{connected_repo_url}[/cyan]"
+
+    git_sync_url = git_context.get("git_sync_url")
+    if isinstance(git_sync_url, str) and git_sync_url:
+        action = (
+            "choose a repo"
+            if git_context.get("has_github_app_installation")
+            else "connect your repo"
+        )
+        return f"Go to [cyan]{git_sync_url}[/cyan] to {action}"
+
+    return f"Go to [cyan]{PLATFORM_URL}[/cyan] → Git Sync to connect your repo"
+
+
+def _raise_if_selected_workspace_has_connected_repo() -> None:
+    """Block fresh init when the active workspace already has a connected repo."""
+    git_context = _selected_workspace_git_context()
+    workspace_name = git_context.get("workspace_name")
+    connected_repo_url = git_context.get("connected_repo_url")
+
+    if not (
+        isinstance(workspace_name, str)
+        and workspace_name
+        and isinstance(connected_repo_url, str)
+        and connected_repo_url
+    ):
+        return
+
+    raise CLIError(
+        f"Workspace '{workspace_name}' is already connected to:\n"
+        f"  {connected_repo_url}\n"
+        "\n"
+        "Clone the connected repo instead:\n"
+        f"  git clone {connected_repo_url}\n"
+        "\n"
+        "Or switch to another workspace first:\n"
+        "  osmosis workspace switch"
+    )
+
+
 def _print_next_steps(ws_name: str, *, here: bool = False) -> None:
     """Print post-setup CTA with Rich panels."""
     from rich import box as rich_box
@@ -248,7 +340,7 @@ def _print_next_steps(ws_name: str, *, here: bool = False) -> None:
     cmd_table.add_row()
     cmd_table.add_row(
         "[bold green]>[/bold green]",
-        f"Go to [cyan]{PLATFORM_URL}[/cyan] → Git Sync to connect your repo",
+        _git_sync_cta_text(),
     )
 
     prompt_body = (
@@ -314,6 +406,7 @@ def init(name: str, here: bool = False) -> None:
                 "Use 'osmosis init <name>' (without --here) to create a new directory, "
                 "or empty this directory first."
             )
+        _raise_if_selected_workspace_has_connected_repo()
     else:
         target = Path.cwd() / name
         if target.exists():
@@ -328,6 +421,7 @@ def init(name: str, here: bool = False) -> None:
                     "Use --here to initialize in the current directory."
                 )
         else:
+            _raise_if_selected_workspace_has_connected_repo()
             target.mkdir()
             created_dir = True
 

--- a/osmosis_ai/platform/cli/init.py
+++ b/osmosis_ai/platform/cli/init.py
@@ -238,7 +238,11 @@ def _selected_workspace_git_context() -> dict[str, str | bool | None]:
     }
 
     from osmosis_ai.platform.api.client import OsmosisClient
-    from osmosis_ai.platform.auth import PlatformAPIError, load_credentials
+    from osmosis_ai.platform.auth import (
+        AuthenticationExpiredError,
+        PlatformAPIError,
+        load_credentials,
+    )
 
     credentials = load_credentials()
     if credentials is None or credentials.is_expired():
@@ -248,8 +252,9 @@ def _selected_workspace_git_context() -> dict[str, str | bool | None]:
         workspace_info = OsmosisClient().refresh_workspace_info(
             credentials=credentials,
             workspace_name=selected_workspace_name,
+            cleanup_on_401=False,
         )
-    except PlatformAPIError:
+    except (AuthenticationExpiredError, PlatformAPIError):
         return context
 
     connected_repo = workspace_info.get("connected_repo")

--- a/osmosis_ai/platform/cli/utils.py
+++ b/osmosis_ai/platform/cli/utils.py
@@ -20,6 +20,7 @@ from osmosis_ai.platform.api.models import (
 from osmosis_ai.platform.auth import (
     AuthenticationExpiredError,
     PlatformAPIError,
+    ensure_active_workspace,
     load_credentials,
 )
 from osmosis_ai.platform.auth.config import PLATFORM_URL
@@ -268,9 +269,15 @@ def validate_list_options(
     return limit, all_
 
 
-def _get_active_workspace_name() -> str:
+def _get_active_workspace_name(
+    credentials: Credentials | None = None,
+) -> str:
     """Return the active workspace name, or raise if none is selected."""
     workspace_name = get_active_workspace_name()
+    if workspace_name is None:
+        active_workspace = ensure_active_workspace(credentials=credentials)
+        if active_workspace is not None:
+            workspace_name = active_workspace["name"]
     if workspace_name is None:
         raise CLIError(
             "No workspace selected. Run 'osmosis workspace' to select a workspace."
@@ -289,7 +296,7 @@ def _require_auth(
     """
     credentials = require_credentials()
     if workspace_name is None:
-        workspace_name = _get_active_workspace_name()
+        workspace_name = _get_active_workspace_name(credentials)
     return workspace_name, credentials
 
 

--- a/osmosis_ai/platform/cli/workspace.py
+++ b/osmosis_ai/platform/cli/workspace.py
@@ -195,7 +195,10 @@ def _upload_dataset_interactive(
         console.print_error(str(e))
         return False
 
-    console.print(f"Upload complete. Dataset ID: {dataset.id}", style="green")
+    console.print(
+        f"Upload complete. Dataset: {console.escape(dataset.file_name)}",
+        style="green",
+    )
     url = platform_entity_url(ws_name, "datasets", dataset.id)
     console.print(f"Check status at: {url}")
     return True

--- a/osmosis_ai/platform/cli/workspace.py
+++ b/osmosis_ai/platform/cli/workspace.py
@@ -19,13 +19,11 @@ from osmosis_ai.cli.prompts import (
 )
 from osmosis_ai.platform.auth import (
     PlatformAPIError,
+    ensure_active_workspace,
     load_credentials,
     platform_request,
 )
-from osmosis_ai.platform.auth.local_config import (
-    get_active_workspace,
-    set_active_workspace,
-)
+from osmosis_ai.platform.auth.local_config import set_active_workspace
 from osmosis_ai.platform.constants import MSG_NOT_LOGGED_IN
 
 from .constants import BACK, DEFAULT_VISIBLE_CHOICES
@@ -397,6 +395,7 @@ def _open_in_browser(ws_name: str) -> None:
 def list_workspaces() -> None:
     """List all workspaces (non-interactive)."""
     credentials = require_credentials()
+    active_ws = ensure_active_workspace(credentials=credentials)
     result = platform_request(
         "/api/cli/workspaces", require_workspace=False, credentials=credentials
     )
@@ -406,7 +405,6 @@ def list_workspaces() -> None:
         console.print("No workspaces found.")
         return
 
-    active_ws = get_active_workspace()
     active_name = active_ws["name"] if active_ws else None
 
     console.print(f"Workspaces ({len(workspaces)}):", style="bold")
@@ -449,7 +447,7 @@ def workspace() -> None:
     if credentials is None:
         raise CLIError(MSG_NOT_LOGGED_IN)
 
-    active_ws = get_active_workspace()
+    active_ws = ensure_active_workspace(credentials=credentials)
     ws_name = active_ws["name"] if active_ws else None
 
     _show_context(ws_name)

--- a/tests/unit/auth/test_error_messages.py
+++ b/tests/unit/auth/test_error_messages.py
@@ -70,7 +70,13 @@ class TestGetActiveWorkspaceMessages:
         "osmosis_ai.platform.cli.utils.get_active_workspace_name",
         return_value=None,
     )
-    def test_no_workspace_raises_correct_message(self, _mock: object) -> None:
+    @patch(
+        "osmosis_ai.platform.cli.utils.ensure_active_workspace",
+        return_value=None,
+    )
+    def test_no_workspace_raises_correct_message(
+        self, _auto_mock: object, _mock: object
+    ) -> None:
         from osmosis_ai.platform.cli.utils import _get_active_workspace_name
 
         with pytest.raises(CLIError, match="No workspace selected"):
@@ -80,7 +86,13 @@ class TestGetActiveWorkspaceMessages:
         "osmosis_ai.platform.cli.utils.get_active_workspace_name",
         return_value=None,
     )
-    def test_no_workspace_does_not_say_not_logged_in(self, _mock: object) -> None:
+    @patch(
+        "osmosis_ai.platform.cli.utils.ensure_active_workspace",
+        return_value=None,
+    )
+    def test_no_workspace_does_not_say_not_logged_in(
+        self, _auto_mock: object, _mock: object
+    ) -> None:
         from osmosis_ai.platform.cli.utils import _get_active_workspace_name
 
         with pytest.raises(CLIError) as exc_info:
@@ -88,6 +100,21 @@ class TestGetActiveWorkspaceMessages:
 
         assert "Not logged in" not in str(exc_info.value)
         assert "login" not in str(exc_info.value).lower()
+
+    @patch(
+        "osmosis_ai.platform.cli.utils.get_active_workspace_name",
+        return_value=None,
+    )
+    @patch(
+        "osmosis_ai.platform.cli.utils.ensure_active_workspace",
+        return_value={"id": "ws_only", "name": "solo-workspace"},
+    )
+    def test_single_workspace_is_auto_selected(
+        self, _auto_mock: object, _mock: object
+    ) -> None:
+        from osmosis_ai.platform.cli.utils import _get_active_workspace_name
+
+        assert _get_active_workspace_name() == "solo-workspace"
 
 
 class TestRequireAuthMessages:
@@ -112,8 +139,12 @@ class TestRequireAuthMessages:
         "osmosis_ai.platform.cli.utils.get_active_workspace_name",
         return_value=None,
     )
+    @patch(
+        "osmosis_ai.platform.cli.utils.ensure_active_workspace",
+        return_value=None,
+    )
     def test_logged_in_but_no_workspace_says_no_workspace(
-        self, _ws_mock: object, mock_load: object
+        self, _auto_mock: object, _ws_mock: object, mock_load: object
     ) -> None:
         """When logged in but no workspace, error should say 'No workspace selected'."""
         from osmosis_ai.platform.cli.utils import _require_auth
@@ -122,6 +153,29 @@ class TestRequireAuthMessages:
 
         with pytest.raises(CLIError, match="No workspace selected"):
             _require_auth()
+
+    @patch("osmosis_ai.platform.cli.utils.load_credentials")
+    @patch(
+        "osmosis_ai.platform.cli.utils.get_active_workspace_name",
+        return_value=None,
+    )
+    @patch(
+        "osmosis_ai.platform.cli.utils.ensure_active_workspace",
+        return_value={"id": "ws_only", "name": "solo-workspace"},
+    )
+    def test_logged_in_with_single_workspace_auto_selects(
+        self, _auto_mock: object, _ws_mock: object, mock_load: object
+    ) -> None:
+        """When only one workspace exists, _require_auth should resolve it automatically."""
+        from osmosis_ai.platform.cli.utils import _require_auth
+
+        creds = _make_credentials()
+        mock_load.return_value = creds
+
+        workspace_name, resolved_credentials = _require_auth()
+
+        assert workspace_name == "solo-workspace"
+        assert resolved_credentials is creds
 
 
 class TestPlatformRequestMessages:
@@ -140,7 +194,13 @@ class TestPlatformRequestMessages:
         "osmosis_ai.platform.auth.platform_client.get_active_workspace_id",
         return_value=None,
     )
-    def test_no_workspace_says_workspace_not_expired(self, _mock: object) -> None:
+    @patch(
+        "osmosis_ai.platform.auth.platform_client.ensure_active_workspace",
+        return_value=None,
+    )
+    def test_no_workspace_says_workspace_not_expired(
+        self, _auto_mock: object, _mock: object
+    ) -> None:
         from osmosis_ai.platform.auth.platform_client import platform_request
 
         creds = _make_credentials()

--- a/tests/unit/auth/test_platform_client.py
+++ b/tests/unit/auth/test_platform_client.py
@@ -119,9 +119,15 @@ class TestPlatformRequest:
     @pytest.fixture(autouse=True)
     def _mock_active_workspace(self) -> Any:
         """Provide a default workspace ID so require_workspace=True doesn't fail."""
-        with patch(
-            "osmosis_ai.platform.auth.platform_client.get_active_workspace_id",
-            return_value="default_ws_test",
+        with (
+            patch(
+                "osmosis_ai.platform.auth.platform_client.get_active_workspace_id",
+                return_value="default_ws_test",
+            ),
+            patch(
+                "osmosis_ai.platform.auth.platform_client.get_active_workspace",
+                return_value={"id": "default_ws_test", "name": "default-workspace"},
+            ),
         ):
             yield
 
@@ -260,12 +266,86 @@ class TestPlatformRequest:
         """Verify PlatformAPIError when require_workspace=True but no workspace is available."""
         creds = _make_credentials()
 
-        with patch(
-            "osmosis_ai.platform.auth.platform_client.get_active_workspace_id",
-            return_value=None,
+        with (
+            patch(
+                "osmosis_ai.platform.auth.platform_client.get_active_workspace_id",
+                return_value=None,
+            ),
+            patch(
+                "osmosis_ai.platform.auth.platform_client.ensure_active_workspace",
+                return_value=None,
+            ),
         ):
             with pytest.raises(PlatformAPIError, match="No workspace selected"):
                 platform_request("/api/test", credentials=creds)
+
+    @patch("osmosis_ai.platform.auth.platform_client.set_active_workspace")
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_auto_selects_single_workspace_when_none_active(
+        self,
+        mock_urlopen: MagicMock,
+        mock_set_active_workspace: MagicMock,
+    ) -> None:
+        """Verify a single available workspace is auto-selected and reused."""
+        creds = _make_credentials()
+        mock_urlopen.side_effect = [
+            _make_http_response(
+                {"workspaces": [{"id": "ws_only", "name": "solo-workspace"}]}
+            ),
+            _make_http_response({"ok": True}),
+        ]
+
+        with (
+            patch(
+                "osmosis_ai.platform.auth.platform_client.get_active_workspace_id",
+                return_value=None,
+            ),
+            patch(
+                "osmosis_ai.platform.auth.platform_client.get_active_workspace",
+                return_value=None,
+            ),
+        ):
+            platform_request("/api/test", credentials=creds)
+
+        mock_set_active_workspace.assert_called_once_with("ws_only", "solo-workspace")
+        workspace_lookup = mock_urlopen.call_args_list[0][0][0]
+        api_request = mock_urlopen.call_args_list[1][0][0]
+        assert workspace_lookup.full_url.endswith("/api/cli/workspaces")
+        assert api_request.get_header("X-osmosis-org") == "ws_only"
+
+    @patch("osmosis_ai.platform.auth.platform_client.set_active_workspace")
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_does_not_auto_select_when_multiple_workspaces_available(
+        self,
+        mock_urlopen: MagicMock,
+        mock_set_active_workspace: MagicMock,
+    ) -> None:
+        """Verify multiple workspaces still require an explicit user selection."""
+        creds = _make_credentials()
+        mock_urlopen.return_value = _make_http_response(
+            {
+                "workspaces": [
+                    {"id": "ws_1", "name": "first-workspace"},
+                    {"id": "ws_2", "name": "second-workspace"},
+                ]
+            }
+        )
+
+        with (
+            patch(
+                "osmosis_ai.platform.auth.platform_client.get_active_workspace_id",
+                return_value=None,
+            ),
+            patch(
+                "osmosis_ai.platform.auth.platform_client.get_active_workspace",
+                return_value=None,
+            ),
+        ):
+            with pytest.raises(PlatformAPIError, match="No workspace selected"):
+                platform_request("/api/test", credentials=creds)
+
+        mock_set_active_workspace.assert_not_called()
+        assert mock_urlopen.call_count == 1
 
     @patch("osmosis_ai.platform.auth.platform_client.urlopen")
     def test_get_request_has_no_body(self, mock_urlopen: MagicMock) -> None:

--- a/tests/unit/platform/api/test_client.py
+++ b/tests/unit/platform/api/test_client.py
@@ -245,6 +245,75 @@ class TestGetWorkspaceDeletionStatus:
         assert call_kwargs.kwargs.get("require_workspace") is False
 
 
+class TestRefreshWorkspaceInfo:
+    """Tests for OsmosisClient.refresh_workspace_info."""
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_returns_git_metadata_for_matching_workspace(
+        self, mock_request: MagicMock
+    ) -> None:
+        mock_request.return_value = {
+            "workspaces": [
+                {
+                    "id": "ws-1",
+                    "name": "team-alpha",
+                    "has_subscription": True,
+                    "has_github_app_installation": True,
+                    "connected_repo": {
+                        "id": "repo-1",
+                        "repo_full_name": "acme/rollouts",
+                        "repo_url": "https://github.com/acme/rollouts",
+                        "default_branch": "main",
+                        "sync_status": "ready",
+                        "last_synced_commit_sha": "abcdef123456",
+                    },
+                }
+            ]
+        }
+        client = OsmosisClient()
+        result = client.refresh_workspace_info(workspace_name="team-alpha")
+        assert result["found"] is True
+        assert result["has_subscription"] is True
+        assert result["has_github_app_installation"] is True
+        assert (
+            result["connected_repo"]["repo_url"] == "https://github.com/acme/rollouts"
+        )
+        call_kwargs = mock_request.call_args
+        assert call_kwargs.args[0] == "/api/cli/workspaces"
+        assert call_kwargs.kwargs["require_workspace"] is False
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_defaults_new_fields_for_older_platform_response(
+        self, mock_request: MagicMock
+    ) -> None:
+        mock_request.return_value = {
+            "workspaces": [
+                {
+                    "id": "ws-1",
+                    "name": "team-alpha",
+                    "has_subscription": True,
+                }
+            ]
+        }
+        client = OsmosisClient()
+        result = client.refresh_workspace_info(workspace_name="team-alpha")
+        assert result == {
+            "found": True,
+            "has_subscription": True,
+            "has_github_app_installation": False,
+            "connected_repo": None,
+        }
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_returns_found_false_when_workspace_missing(
+        self, mock_request: MagicMock
+    ) -> None:
+        mock_request.return_value = {"workspaces": []}
+        client = OsmosisClient()
+        result = client.refresh_workspace_info(workspace_name="missing")
+        assert result == {"found": False}
+
+
 class TestGetTrainingRunMetrics:
     """Tests for OsmosisClient.get_training_run_metrics."""
 

--- a/tests/unit/platform/cli/test_dataset_workspace_context.py
+++ b/tests/unit/platform/cli/test_dataset_workspace_context.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from io import StringIO
+
 import osmosis_ai.platform.api.client as api_client_module
 import osmosis_ai.platform.api.upload as upload_module
 import osmosis_ai.platform.cli.dataset as dataset_module
+from osmosis_ai.cli.console import Console
 from osmosis_ai.platform.api.models import DatasetFile, PaginatedDatasets, UploadInfo
 
 
@@ -42,6 +45,7 @@ def test_upload_passes_active_workspace_context_to_subscription_and_api_calls(
 ) -> None:
     calls: dict[str, object] = {}
     fake_credentials = object()
+    output = StringIO()
 
     file_path = tmp_path / "data.jsonl"
     file_path.write_text("{}", encoding="utf-8")
@@ -58,6 +62,14 @@ def test_upload_passes_active_workspace_context_to_subscription_and_api_calls(
     )
     monkeypatch.setattr(dataset_module, "_validate_file", lambda _path, _ext: [])
     monkeypatch.setattr(dataset_module, "is_interactive", lambda: False)
+    monkeypatch.setattr(
+        dataset_module, "console", Console(file=output, force_terminal=False)
+    )
+    monkeypatch.setattr(
+        dataset_module,
+        "platform_entity_url",
+        lambda ws, entity, item_id: f"https://example.com/{ws}/{entity}/{item_id}",
+    )
     from contextlib import nullcontext
 
     monkeypatch.setattr(
@@ -80,7 +92,7 @@ def test_upload_passes_active_workspace_context_to_subscription_and_api_calls(
             *,
             credentials=None,
         ) -> DatasetFile:
-            assert file_name == "data.jsonl"
+            assert file_name == "data"
             assert file_size > 0
             assert extension == "jsonl"
             calls["create_credentials"] = credentials
@@ -91,7 +103,7 @@ def test_upload_passes_active_workspace_context_to_subscription_and_api_calls(
                 status="created",
                 upload=UploadInfo(
                     method="simple",
-                    s3_key="uploads/data.jsonl",
+                    s3_key="uploads/data",
                     presigned_url="https://example.com/upload",
                 ),
             )
@@ -108,7 +120,7 @@ def test_upload_passes_active_workspace_context_to_subscription_and_api_calls(
             calls["complete_credentials"] = credentials
             return DatasetFile(
                 id=file_id,
-                file_name="data.jsonl",
+                file_name="data",
                 file_size=2,
                 status="uploaded",
             )
@@ -122,3 +134,6 @@ def test_upload_passes_active_workspace_context_to_subscription_and_api_calls(
         "create_credentials": fake_credentials,
         "complete_credentials": fake_credentials,
     }
+    rendered = output.getvalue()
+    assert "Dataset uploaded: data" in rendered
+    assert "https://example.com/ws-b/datasets/dataset-1" in rendered

--- a/tests/unit/platform/cli/test_login.py
+++ b/tests/unit/platform/cli/test_login.py
@@ -9,6 +9,7 @@ import pytest
 
 import osmosis_ai.cli.commands.auth as auth_module
 from osmosis_ai.cli.console import Console
+from osmosis_ai.platform.auth import AuthenticationExpiredError, PlatformAPIError
 from osmosis_ai.platform.auth.credentials import Credentials, UserInfo
 from osmosis_ai.platform.auth.flow import LoginResult
 
@@ -36,13 +37,34 @@ def _make_login_result(email: str = "a@example.com") -> LoginResult:
 @pytest.fixture(autouse=True)
 def _stub_workspace_resolution(monkeypatch) -> None:
     """Keep login tests offline unless a test overrides workspace resolution."""
+    active_workspace: dict[str, str] | None = None
+
+    def get_active_workspace() -> dict[str, str] | None:
+        return active_workspace
+
+    def set_active_workspace(workspace_id: str, workspace_name: str) -> None:
+        nonlocal active_workspace
+        active_workspace = {"id": workspace_id, "name": workspace_name}
+
+    def clear_all_local_data() -> None:
+        nonlocal active_workspace
+        active_workspace = None
+
     monkeypatch.setattr(
-        "osmosis_ai.platform.auth.ensure_active_workspace",
-        lambda credentials=None, **kwargs: None,
+        "osmosis_ai.platform.auth.platform_request",
+        lambda *args, **kwargs: {"workspaces": []},
     )
     monkeypatch.setattr(
         "osmosis_ai.platform.auth.local_config.get_active_workspace",
-        lambda: None,
+        get_active_workspace,
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.local_config.set_active_workspace",
+        set_active_workspace,
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.local_config.clear_all_local_data",
+        clear_all_local_data,
     )
 
 
@@ -193,15 +215,10 @@ def test_login_auto_selects_only_workspace(monkeypatch) -> None:
         lambda **kw: (result, new_creds),
     )
     monkeypatch.setattr(
-        "osmosis_ai.platform.auth.ensure_active_workspace",
-        lambda credentials=None, **kwargs: {
-            "id": "ws_only",
-            "name": "solo-workspace",
+        "osmosis_ai.platform.auth.platform_request",
+        lambda *args, **kwargs: {
+            "workspaces": [{"id": "ws_only", "name": "solo-workspace"}]
         },
-    )
-    monkeypatch.setattr(
-        "osmosis_ai.platform.auth.local_config.get_active_workspace",
-        lambda: {"id": "ws_only", "name": "solo-workspace"},
     )
     monkeypatch.setattr(
         auth_module,
@@ -213,4 +230,87 @@ def test_login_auto_selects_only_workspace(monkeypatch) -> None:
 
     rendered = output.getvalue()
     assert "Workspace: solo-workspace" in rendered
+    assert "Automatically selected your only workspace: solo-workspace" in rendered
     assert "Run 'osmosis workspace' to select a workspace." not in rendered
+
+
+def test_login_prints_switch_commands_for_multiple_workspaces(monkeypatch) -> None:
+    """Login should print copyable switch commands when multiple workspaces exist."""
+    new_creds = _make_credentials(user_id="user_1")
+    result = _make_login_result()
+    output = io.StringIO()
+
+    monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
+    monkeypatch.setattr("osmosis_ai.platform.auth.load_credentials", lambda: None)
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.save_credentials", lambda c: "keyring"
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.device_login",
+        lambda **kw: (result, new_creds),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.platform_request",
+        lambda *args, **kwargs: {
+            "workspaces": [
+                {"id": "ws_alpha", "name": "team-alpha"},
+                {"id": "ws_beta", "name": "ML Team"},
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        auth_module,
+        "console",
+        Console(file=output, force_terminal=False, no_color=True, width=80),
+    )
+
+    auth_module.login(force=False, token=None)
+
+    rendered = output.getvalue()
+    assert "Multiple workspaces are available. Switch with:" in rendered
+    assert "osmosis workspace switch team-alpha" in rendered
+    assert "osmosis workspace switch 'ML Team'" in rendered
+    assert "Or run 'osmosis workspace' for interactive selection." in rendered
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        PlatformAPIError("workspace endpoint unavailable"),
+        AuthenticationExpiredError("session expired"),
+    ],
+)
+def test_login_does_not_fail_when_workspace_lookup_fails(monkeypatch, error) -> None:
+    """Workspace lookup errors should not turn a successful login into a failure."""
+    new_creds = _make_credentials(user_id="user_1")
+    result = _make_login_result()
+    output = io.StringIO()
+
+    monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
+    monkeypatch.setattr("osmosis_ai.platform.auth.load_credentials", lambda: None)
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.save_credentials", lambda c: "keyring"
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.device_login",
+        lambda **kw: (result, new_creds),
+    )
+
+    def raise_workspace_error(*args, **kwargs):
+        raise error
+
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.platform_request",
+        raise_workspace_error,
+    )
+    monkeypatch.setattr(
+        auth_module,
+        "console",
+        Console(file=output, force_terminal=False, no_color=True, width=80),
+    )
+
+    auth_module.login(force=False, token=None)
+
+    rendered = output.getvalue()
+    assert "Login Successful" in rendered
+    assert "Authenticated, but could not load your workspaces yet." in rendered

--- a/tests/unit/platform/cli/test_login.py
+++ b/tests/unit/platform/cli/test_login.py
@@ -314,3 +314,49 @@ def test_login_does_not_fail_when_workspace_lookup_fails(monkeypatch, error) -> 
     rendered = output.getvalue()
     assert "Login Successful" in rendered
     assert "Authenticated, but could not load your workspaces yet." in rendered
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        PlatformAPIError("workspace endpoint unavailable"),
+        AuthenticationExpiredError("session expired"),
+    ],
+)
+def test_whoami_prints_local_identity_when_workspace_lookup_fails(
+    monkeypatch, error
+) -> None:
+    """whoami should still print local identity info when workspace lookup fails."""
+    creds = _make_credentials(user_id="user_1")
+    output = io.StringIO()
+    calls: list[dict[str, object]] = []
+
+    monkeypatch.setattr("osmosis_ai.platform.auth.load_credentials", lambda: creds)
+
+    def raise_workspace_error(*, credentials=None, cleanup_on_401=True):
+        calls.append(
+            {
+                "credentials": credentials,
+                "cleanup_on_401": cleanup_on_401,
+            }
+        )
+        raise error
+
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.ensure_active_workspace",
+        raise_workspace_error,
+    )
+    monkeypatch.setattr(
+        auth_module,
+        "console",
+        Console(file=output, force_terminal=False, no_color=True, width=80),
+    )
+
+    auth_module.whoami()
+
+    rendered = output.getvalue()
+    assert "a@example.com" in rendered
+    assert "User" in rendered
+    assert creds.expires_at.strftime("%Y-%m-%d") in rendered
+    assert "Workspace" not in rendered
+    assert calls == [{"credentials": creds, "cleanup_on_401": False}]

--- a/tests/unit/platform/cli/test_login.py
+++ b/tests/unit/platform/cli/test_login.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import io
 from datetime import UTC, datetime, timedelta
 
+import pytest
+
 import osmosis_ai.cli.commands.auth as auth_module
+from osmosis_ai.cli.console import Console
 from osmosis_ai.platform.auth.credentials import Credentials, UserInfo
 from osmosis_ai.platform.auth.flow import LoginResult
 
@@ -26,6 +30,19 @@ def _make_login_result(email: str = "a@example.com") -> LoginResult:
     return LoginResult(
         user=UserInfo(id="user_1", email=email, name="User"),
         expires_at=datetime.now(UTC) + timedelta(days=30),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_workspace_resolution(monkeypatch) -> None:
+    """Keep login tests offline unless a test overrides workspace resolution."""
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.ensure_active_workspace",
+        lambda credentials=None, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.local_config.get_active_workspace",
+        lambda: None,
     )
 
 
@@ -158,3 +175,42 @@ def test_first_login_does_not_clear_workspace(monkeypatch) -> None:
     auth_module.login(force=False, token=None)
 
     assert not clear_calls, "no cleanup needed for first-time login"
+
+
+def test_login_auto_selects_only_workspace(monkeypatch) -> None:
+    """Login should auto-select the only available workspace and skip the prompt."""
+    new_creds = _make_credentials(user_id="user_1")
+    result = _make_login_result()
+    output = io.StringIO()
+
+    monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
+    monkeypatch.setattr("osmosis_ai.platform.auth.load_credentials", lambda: None)
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.save_credentials", lambda c: "keyring"
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.device_login",
+        lambda **kw: (result, new_creds),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.ensure_active_workspace",
+        lambda credentials=None, **kwargs: {
+            "id": "ws_only",
+            "name": "solo-workspace",
+        },
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.local_config.get_active_workspace",
+        lambda: {"id": "ws_only", "name": "solo-workspace"},
+    )
+    monkeypatch.setattr(
+        auth_module,
+        "console",
+        Console(file=output, force_terminal=False, no_color=True, width=80),
+    )
+
+    auth_module.login(force=False, token=None)
+
+    rendered = output.getvalue()
+    assert "Workspace: solo-workspace" in rendered
+    assert "Run 'osmosis workspace' to select a workspace." not in rendered

--- a/tests/unit/platform/cli/test_workspace_setup.py
+++ b/tests/unit/platform/cli/test_workspace_setup.py
@@ -189,6 +189,46 @@ def test_init_here_raises_when_selected_workspace_has_connected_repo(
         init_module.init(name="test-ws", here=True)
 
 
+def test_init_ignores_auth_expiry_in_best_effort_workspace_lookup(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """init should continue when best-effort workspace Git metadata lookup hits 401."""
+    import osmosis_ai.platform.api.client as api_client_module
+    import osmosis_ai.platform.auth as auth_module
+    import osmosis_ai.platform.cli.init as init_module
+
+    class _Creds:
+        def is_expired(self) -> bool:
+            return False
+
+    class FakeClient:
+        def refresh_workspace_info(
+            self, *, credentials, workspace_name, cleanup_on_401=True
+        ):
+            assert isinstance(credentials, _Creds)
+            assert workspace_name == "team-alpha"
+            assert cleanup_on_401 is False
+            raise auth_module.AuthenticationExpiredError("session expired")
+
+    monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
+    for fn_name in (
+        "_write_scaffold",
+        "_git_init",
+        "_git_initial_commit",
+        "_update_workspace_metadata",
+    ):
+        monkeypatch.setattr(init_module, fn_name, lambda *a, **kw: None)
+    monkeypatch.setattr(init_module, "get_active_workspace_name", lambda: "team-alpha")
+    monkeypatch.setattr(auth_module, "load_credentials", lambda: _Creds())
+    monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+
+    monkeypatch.chdir(tmp_path)
+
+    init_module.init(name="test-ws")
+
+    assert (tmp_path / "test-ws").is_dir()
+
+
 # ── _render_template ─────────────────────────────────────────────
 
 
@@ -585,9 +625,12 @@ class TestPrintNextSteps:
                 return False
 
         class FakeClient:
-            def refresh_workspace_info(self, *, credentials, workspace_name):
+            def refresh_workspace_info(
+                self, *, credentials, workspace_name, cleanup_on_401=True
+            ):
                 assert isinstance(credentials, _Creds)
                 assert workspace_name == "team-alpha"
+                assert cleanup_on_401 is False
                 return {
                     "found": True,
                     "has_github_app_installation": True,
@@ -623,9 +666,12 @@ class TestPrintNextSteps:
                 return False
 
         class FakeClient:
-            def refresh_workspace_info(self, *, credentials, workspace_name):
+            def refresh_workspace_info(
+                self, *, credentials, workspace_name, cleanup_on_401=True
+            ):
                 assert isinstance(credentials, _Creds)
                 assert workspace_name == "team-alpha"
+                assert cleanup_on_401 is False
                 return {
                     "found": True,
                     "has_github_app_installation": True,

--- a/tests/unit/platform/cli/test_workspace_setup.py
+++ b/tests/unit/platform/cli/test_workspace_setup.py
@@ -137,6 +137,58 @@ def test_init_here_allows_git_dir(monkeypatch, tmp_path: Path) -> None:
     init_module.init(name="test-ws", here=True)
 
 
+def test_init_raises_when_selected_workspace_has_connected_repo(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Fresh init should stop before creating a directory when the active workspace already has a repo."""
+    import osmosis_ai.platform.cli.init as init_module
+
+    monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
+    monkeypatch.setattr(
+        init_module,
+        "_selected_workspace_git_context",
+        lambda: {
+            "workspace_name": "team-alpha",
+            "git_sync_url": "https://platform.osmosis.ai/team-alpha/integrations/git",
+            "has_github_app_installation": True,
+            "connected_repo_url": "https://github.com/acme/rollouts",
+        },
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    target = tmp_path / "test-ws"
+    with pytest.raises(CLIError, match="already connected"):
+        init_module.init(name="test-ws")
+
+    assert not target.exists()
+
+
+def test_init_here_raises_when_selected_workspace_has_connected_repo(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """init(here=True) should stop when the active workspace already has a connected repo."""
+    import osmosis_ai.platform.cli.init as init_module
+
+    monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
+    monkeypatch.setattr(
+        init_module,
+        "_selected_workspace_git_context",
+        lambda: {
+            "workspace_name": "team-alpha",
+            "git_sync_url": "https://platform.osmosis.ai/team-alpha/integrations/git",
+            "has_github_app_installation": True,
+            "connected_repo_url": "https://github.com/acme/rollouts",
+        },
+    )
+
+    (tmp_path / ".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(CLIError, match=r"git clone https://github\.com/acme/rollouts"):
+        init_module.init(name="test-ws", here=True)
+
+
 # ── _render_template ─────────────────────────────────────────────
 
 
@@ -482,7 +534,7 @@ class TestGitInitialCommit:
 
 class TestPrintNextSteps:
     def test_print_next_steps_default(self, monkeypatch) -> None:
-        """_print_next_steps includes 'cd' and platform URL when here=False."""
+        """_print_next_steps includes 'cd' and generic Git Sync CTA when no workspace is selected."""
         import io
 
         import osmosis_ai.platform.cli.init as mod
@@ -492,10 +544,104 @@ class TestPrintNextSteps:
         buf = io.StringIO()
         test_console = Console(file=buf, force_terminal=False, no_color=True)
         monkeypatch.setattr(mod, "console", test_console)
+        monkeypatch.setattr(mod, "get_active_workspace_name", lambda: None)
         _print_next_steps("my-workspace", here=False)
         output = buf.getvalue()
         assert "cd my-workspace" in output
         assert "Git Sync" in output
+        assert "integrations/git" not in output
+
+    def test_print_next_steps_selected_workspace(self, monkeypatch) -> None:
+        """_print_next_steps shows a workspace Git Sync URL when no repo is connected."""
+        import io
+
+        import osmosis_ai.platform.auth as auth_module
+        import osmosis_ai.platform.cli.init as mod
+        from osmosis_ai.cli.console import Console
+        from osmosis_ai.platform.cli.init import _print_next_steps
+
+        buf = io.StringIO()
+        test_console = Console(file=buf, force_terminal=False, no_color=True)
+        monkeypatch.setattr(mod, "console", test_console)
+        monkeypatch.setattr(mod, "get_active_workspace_name", lambda: "team-alpha")
+        monkeypatch.setattr(auth_module, "load_credentials", lambda: None)
+        _print_next_steps("my-workspace", here=False)
+        output = buf.getvalue()
+        assert "cd my-workspace" in output
+        assert f"{mod.PLATFORM_URL}/team-alpha/integrations/git" in output
+
+    def test_print_next_steps_connected_repo(self, monkeypatch) -> None:
+        """_print_next_steps shows the connected repository URL when one exists."""
+        import io
+
+        import osmosis_ai.platform.api.client as api_client_module
+        import osmosis_ai.platform.auth as auth_module
+        import osmosis_ai.platform.cli.init as mod
+        from osmosis_ai.cli.console import Console
+        from osmosis_ai.platform.cli.init import _print_next_steps
+
+        class _Creds:
+            def is_expired(self) -> bool:
+                return False
+
+        class FakeClient:
+            def refresh_workspace_info(self, *, credentials, workspace_name):
+                assert isinstance(credentials, _Creds)
+                assert workspace_name == "team-alpha"
+                return {
+                    "found": True,
+                    "has_github_app_installation": True,
+                    "connected_repo": {
+                        "repo_url": "https://github.com/acme/rollouts",
+                    },
+                }
+
+        buf = io.StringIO()
+        test_console = Console(file=buf, force_terminal=False, no_color=True)
+        monkeypatch.setattr(mod, "console", test_console)
+        monkeypatch.setattr(mod, "get_active_workspace_name", lambda: "team-alpha")
+        monkeypatch.setattr(auth_module, "load_credentials", lambda: _Creds())
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        _print_next_steps("my-workspace", here=False)
+        output = buf.getvalue()
+        assert "cd my-workspace" in output
+        assert "Connected repo:" in output
+        assert "https://github.com/acme/rollouts" in output
+
+    def test_print_next_steps_choose_repo_when_app_installed(self, monkeypatch) -> None:
+        """_print_next_steps asks the user to choose a repo when GitHub is connected but no repo is linked."""
+        import io
+
+        import osmosis_ai.platform.api.client as api_client_module
+        import osmosis_ai.platform.auth as auth_module
+        import osmosis_ai.platform.cli.init as mod
+        from osmosis_ai.cli.console import Console
+        from osmosis_ai.platform.cli.init import _print_next_steps
+
+        class _Creds:
+            def is_expired(self) -> bool:
+                return False
+
+        class FakeClient:
+            def refresh_workspace_info(self, *, credentials, workspace_name):
+                assert isinstance(credentials, _Creds)
+                assert workspace_name == "team-alpha"
+                return {
+                    "found": True,
+                    "has_github_app_installation": True,
+                    "connected_repo": None,
+                }
+
+        buf = io.StringIO()
+        test_console = Console(file=buf, force_terminal=False, no_color=True)
+        monkeypatch.setattr(mod, "console", test_console)
+        monkeypatch.setattr(mod, "get_active_workspace_name", lambda: "team-alpha")
+        monkeypatch.setattr(auth_module, "load_credentials", lambda: _Creds())
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        _print_next_steps("my-workspace", here=False)
+        output = buf.getvalue()
+        assert f"{mod.PLATFORM_URL}/team-alpha/integrations/git" in output
+        assert "choose a repo" in output
 
     def test_print_next_steps_here(self, monkeypatch) -> None:
         """_print_next_steps omits 'cd' when here=True but keeps platform URL."""
@@ -508,6 +654,7 @@ class TestPrintNextSteps:
         buf = io.StringIO()
         test_console = Console(file=buf, force_terminal=False, no_color=True)
         monkeypatch.setattr(mod, "console", test_console)
+        monkeypatch.setattr(mod, "get_active_workspace_name", lambda: None)
         _print_next_steps("my-workspace", here=True)
         output = buf.getvalue()
         assert "cd my-workspace" not in output

--- a/tests/unit/platform/cli/test_workspace_setup.py
+++ b/tests/unit/platform/cli/test_workspace_setup.py
@@ -193,7 +193,6 @@ def test_init_ignores_auth_expiry_in_best_effort_workspace_lookup(
     monkeypatch, tmp_path: Path
 ) -> None:
     """init should continue when best-effort workspace Git metadata lookup hits 401."""
-    import osmosis_ai.platform.api.client as api_client_module
     import osmosis_ai.platform.auth as auth_module
     import osmosis_ai.platform.cli.init as init_module
 
@@ -201,14 +200,10 @@ def test_init_ignores_auth_expiry_in_best_effort_workspace_lookup(
         def is_expired(self) -> bool:
             return False
 
-    class FakeClient:
-        def refresh_workspace_info(
-            self, *, credentials, workspace_name, cleanup_on_401=True
-        ):
-            assert isinstance(credentials, _Creds)
-            assert workspace_name == "team-alpha"
-            assert cleanup_on_401 is False
-            raise auth_module.AuthenticationExpiredError("session expired")
+    def fake_platform_request(endpoint, **kwargs):
+        assert endpoint == "/api/cli/workspaces"
+        assert kwargs.get("cleanup_on_401") is False
+        raise auth_module.AuthenticationExpiredError("session expired")
 
     monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
     for fn_name in (
@@ -220,13 +215,169 @@ def test_init_ignores_auth_expiry_in_best_effort_workspace_lookup(
         monkeypatch.setattr(init_module, fn_name, lambda *a, **kw: None)
     monkeypatch.setattr(init_module, "get_active_workspace_name", lambda: "team-alpha")
     monkeypatch.setattr(auth_module, "load_credentials", lambda: _Creds())
-    monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+    monkeypatch.setattr(auth_module, "platform_request", fake_platform_request)
 
     monkeypatch.chdir(tmp_path)
 
     init_module.init(name="test-ws")
 
     assert (tmp_path / "test-ws").is_dir()
+
+
+def test_init_auto_selects_single_workspace_for_git_context(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """init should auto-select the only workspace when none is saved locally.
+
+    This also persists the selection to local config so subsequent CLI
+    commands see the same active workspace.
+    """
+    import osmosis_ai.platform.auth as auth_module
+    import osmosis_ai.platform.cli.init as init_module
+
+    class _Creds:
+        def is_expired(self) -> bool:
+            return False
+
+    calls: list[tuple[str, dict]] = []
+    persisted: dict[str, str] = {}
+
+    def fake_platform_request(endpoint, **kwargs):
+        calls.append((endpoint, kwargs))
+        assert endpoint == "/api/cli/workspaces"
+        assert kwargs.get("cleanup_on_401") is False
+        return {
+            "workspaces": [
+                {
+                    "id": "ws_solo",
+                    "name": "solo-team",
+                    "has_github_app_installation": False,
+                    "connected_repo": None,
+                }
+            ]
+        }
+
+    def fake_set_active_workspace(workspace_id, workspace_name):
+        persisted["id"] = workspace_id
+        persisted["name"] = workspace_name
+
+    monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
+    for fn_name in (
+        "_write_scaffold",
+        "_git_init",
+        "_git_initial_commit",
+        "_update_workspace_metadata",
+    ):
+        monkeypatch.setattr(init_module, fn_name, lambda *a, **kw: None)
+    monkeypatch.setattr(init_module, "get_active_workspace_name", lambda: None)
+    monkeypatch.setattr(init_module, "get_active_workspace_id", lambda: None)
+    monkeypatch.setattr(init_module, "set_active_workspace", fake_set_active_workspace)
+    monkeypatch.setattr(auth_module, "load_credentials", lambda: _Creds())
+    monkeypatch.setattr(auth_module, "platform_request", fake_platform_request)
+
+    monkeypatch.chdir(tmp_path)
+
+    init_module.init(name="test-ws")
+
+    assert (tmp_path / "test-ws").is_dir()
+    # Only one API call — fetch + verify + extract metadata are unified.
+    assert len(calls) == 1
+    # Auto-selection should have been persisted.
+    assert persisted == {"id": "ws_solo", "name": "solo-team"}
+
+
+def test_init_blocks_when_auto_selected_workspace_has_connected_repo(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """init should raise when the auto-selected single workspace already has a connected repo."""
+    import osmosis_ai.platform.auth as auth_module
+    import osmosis_ai.platform.cli.init as init_module
+
+    class _Creds:
+        def is_expired(self) -> bool:
+            return False
+
+    def fake_platform_request(endpoint, **kwargs):
+        assert endpoint == "/api/cli/workspaces"
+        return {
+            "workspaces": [
+                {
+                    "id": "ws_solo",
+                    "name": "solo-team",
+                    "has_github_app_installation": True,
+                    "connected_repo": {
+                        "repo_url": "https://github.com/acme/rollouts",
+                    },
+                }
+            ]
+        }
+
+    monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
+    monkeypatch.setattr(init_module, "get_active_workspace_name", lambda: None)
+    monkeypatch.setattr(init_module, "get_active_workspace_id", lambda: None)
+    monkeypatch.setattr(init_module, "set_active_workspace", lambda *a, **kw: None)
+    monkeypatch.setattr(auth_module, "load_credentials", lambda: _Creds())
+    monkeypatch.setattr(auth_module, "platform_request", fake_platform_request)
+
+    monkeypatch.chdir(tmp_path)
+
+    target = tmp_path / "test-ws"
+    with pytest.raises(CLIError, match="already connected"):
+        init_module.init(name="test-ws")
+
+    assert not target.exists()
+
+
+def test_init_does_not_trust_stale_local_workspace_id(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """init should ignore a locally cached workspace id that the server no longer returns.
+
+    Regression guard: previously, a stale local workspace name would be
+    trusted verbatim, producing broken Git Sync links and bypassing the
+    connected-repo guardrail.
+    """
+    import osmosis_ai.platform.auth as auth_module
+    import osmosis_ai.platform.cli.init as init_module
+
+    class _Creds:
+        def is_expired(self) -> bool:
+            return False
+
+    def fake_platform_request(endpoint, **kwargs):
+        assert endpoint == "/api/cli/workspaces"
+        # Server lists two *other* workspaces — the local id is gone.
+        return {
+            "workspaces": [
+                {"id": "ws_a", "name": "team-a"},
+                {"id": "ws_b", "name": "team-b"},
+            ]
+        }
+
+    monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
+    for fn_name in (
+        "_write_scaffold",
+        "_git_init",
+        "_git_initial_commit",
+        "_update_workspace_metadata",
+    ):
+        monkeypatch.setattr(init_module, fn_name, lambda *a, **kw: None)
+    # Local state points to a workspace the user no longer belongs to.
+    monkeypatch.setattr(init_module, "get_active_workspace_name", lambda: "old-team")
+    monkeypatch.setattr(init_module, "get_active_workspace_id", lambda: "ws_stale")
+    monkeypatch.setattr(auth_module, "load_credentials", lambda: _Creds())
+    monkeypatch.setattr(auth_module, "platform_request", fake_platform_request)
+
+    monkeypatch.chdir(tmp_path)
+
+    # init should still succeed (empty Git context, no false connected-repo block).
+    init_module.init(name="test-ws")
+
+    context = init_module._selected_workspace_git_context()
+    # Stale id wasn't trusted, and there's no unambiguous auto-selection.
+    assert context["workspace_name"] is None
+    assert context["git_sync_url"] is None
+    assert context["connected_repo_url"] is None
 
 
 # ── _render_template ─────────────────────────────────────────────
@@ -577,6 +728,7 @@ class TestPrintNextSteps:
         """_print_next_steps includes 'cd' and generic Git Sync CTA when no workspace is selected."""
         import io
 
+        import osmosis_ai.platform.auth as auth_module
         import osmosis_ai.platform.cli.init as mod
         from osmosis_ai.cli.console import Console
         from osmosis_ai.platform.cli.init import _print_next_steps
@@ -585,6 +737,7 @@ class TestPrintNextSteps:
         test_console = Console(file=buf, force_terminal=False, no_color=True)
         monkeypatch.setattr(mod, "console", test_console)
         monkeypatch.setattr(mod, "get_active_workspace_name", lambda: None)
+        monkeypatch.setattr(auth_module, "load_credentials", lambda: None)
         _print_next_steps("my-workspace", here=False)
         output = buf.getvalue()
         assert "cd my-workspace" in output
@@ -614,7 +767,6 @@ class TestPrintNextSteps:
         """_print_next_steps shows the connected repository URL when one exists."""
         import io
 
-        import osmosis_ai.platform.api.client as api_client_module
         import osmosis_ai.platform.auth as auth_module
         import osmosis_ai.platform.cli.init as mod
         from osmosis_ai.cli.console import Console
@@ -624,27 +776,29 @@ class TestPrintNextSteps:
             def is_expired(self) -> bool:
                 return False
 
-        class FakeClient:
-            def refresh_workspace_info(
-                self, *, credentials, workspace_name, cleanup_on_401=True
-            ):
-                assert isinstance(credentials, _Creds)
-                assert workspace_name == "team-alpha"
-                assert cleanup_on_401 is False
-                return {
-                    "found": True,
-                    "has_github_app_installation": True,
-                    "connected_repo": {
-                        "repo_url": "https://github.com/acme/rollouts",
-                    },
-                }
+        def fake_platform_request(endpoint, **kwargs):
+            assert endpoint == "/api/cli/workspaces"
+            assert kwargs.get("cleanup_on_401") is False
+            return {
+                "workspaces": [
+                    {
+                        "id": "ws_alpha",
+                        "name": "team-alpha",
+                        "has_github_app_installation": True,
+                        "connected_repo": {
+                            "repo_url": "https://github.com/acme/rollouts",
+                        },
+                    }
+                ]
+            }
 
         buf = io.StringIO()
         test_console = Console(file=buf, force_terminal=False, no_color=True)
         monkeypatch.setattr(mod, "console", test_console)
         monkeypatch.setattr(mod, "get_active_workspace_name", lambda: "team-alpha")
+        monkeypatch.setattr(mod, "get_active_workspace_id", lambda: "ws_alpha")
         monkeypatch.setattr(auth_module, "load_credentials", lambda: _Creds())
-        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(auth_module, "platform_request", fake_platform_request)
         _print_next_steps("my-workspace", here=False)
         output = buf.getvalue()
         assert "cd my-workspace" in output
@@ -655,7 +809,6 @@ class TestPrintNextSteps:
         """_print_next_steps asks the user to choose a repo when GitHub is connected but no repo is linked."""
         import io
 
-        import osmosis_ai.platform.api.client as api_client_module
         import osmosis_ai.platform.auth as auth_module
         import osmosis_ai.platform.cli.init as mod
         from osmosis_ai.cli.console import Console
@@ -665,25 +818,26 @@ class TestPrintNextSteps:
             def is_expired(self) -> bool:
                 return False
 
-        class FakeClient:
-            def refresh_workspace_info(
-                self, *, credentials, workspace_name, cleanup_on_401=True
-            ):
-                assert isinstance(credentials, _Creds)
-                assert workspace_name == "team-alpha"
-                assert cleanup_on_401 is False
-                return {
-                    "found": True,
-                    "has_github_app_installation": True,
-                    "connected_repo": None,
-                }
+        def fake_platform_request(endpoint, **kwargs):
+            assert endpoint == "/api/cli/workspaces"
+            return {
+                "workspaces": [
+                    {
+                        "id": "ws_alpha",
+                        "name": "team-alpha",
+                        "has_github_app_installation": True,
+                        "connected_repo": None,
+                    }
+                ]
+            }
 
         buf = io.StringIO()
         test_console = Console(file=buf, force_terminal=False, no_color=True)
         monkeypatch.setattr(mod, "console", test_console)
         monkeypatch.setattr(mod, "get_active_workspace_name", lambda: "team-alpha")
+        monkeypatch.setattr(mod, "get_active_workspace_id", lambda: "ws_alpha")
         monkeypatch.setattr(auth_module, "load_credentials", lambda: _Creds())
-        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(auth_module, "platform_request", fake_platform_request)
         _print_next_steps("my-workspace", here=False)
         output = buf.getvalue()
         assert f"{mod.PLATFORM_URL}/team-alpha/integrations/git" in output
@@ -693,6 +847,7 @@ class TestPrintNextSteps:
         """_print_next_steps omits 'cd' when here=True but keeps platform URL."""
         import io
 
+        import osmosis_ai.platform.auth as auth_module
         import osmosis_ai.platform.cli.init as mod
         from osmosis_ai.cli.console import Console
         from osmosis_ai.platform.cli.init import _print_next_steps
@@ -701,6 +856,7 @@ class TestPrintNextSteps:
         test_console = Console(file=buf, force_terminal=False, no_color=True)
         monkeypatch.setattr(mod, "console", test_console)
         monkeypatch.setattr(mod, "get_active_workspace_name", lambda: None)
+        monkeypatch.setattr(auth_module, "load_credentials", lambda: None)
         _print_next_steps("my-workspace", here=True)
         output = buf.getvalue()
         assert "cd my-workspace" not in output

--- a/tests/unit/platform/cli/test_workspace_upload.py
+++ b/tests/unit/platform/cli/test_workspace_upload.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
+from io import StringIO
 
 import pytest
 
+from osmosis_ai.cli.console import Console
 from osmosis_ai.platform.api.models import DatasetFile, UploadInfo
 
 # ---------------------------------------------------------------------------
@@ -54,7 +56,7 @@ class TestCleanFilePath:
 
 
 def _make_fake_dataset(
-    file_name: str = "data.jsonl",
+    file_name: str = "data",
     file_size: int = 2,
     method: str = "simple",
 ) -> DatasetFile:
@@ -96,7 +98,7 @@ class TestPerformUpload:
         class FakeClient:
             def create_dataset(self, file_name, file_size, ext, *, credentials=None):
                 calls["create"] = True
-                assert file_name == "data.jsonl"
+                assert file_name == "data"
                 assert ext == "jsonl"
                 assert credentials is fake_credentials
                 return fake_dataset
@@ -108,7 +110,7 @@ class TestPerformUpload:
                 assert credentials is fake_credentials
                 return DatasetFile(
                     id=file_id,
-                    file_name="data.jsonl",
+                    file_name="data",
                     file_size=file_size,
                     status="uploaded",
                 )
@@ -141,6 +143,53 @@ class TestPerformUpload:
         assert calls["s3_upload"]
         assert calls["complete"]
 
+    def test_strips_extension_from_dataset_name(self, monkeypatch, tmp_path):
+        """_perform_upload sends the dataset name without the file extension."""
+        import osmosis_ai.platform.api.client as api_client_module
+        import osmosis_ai.platform.api.upload as upload_module
+
+        file_path = tmp_path / "agent.eval.v2.jsonl"
+        file_path.write_text("{}")
+        file_size = file_path.stat().st_size
+
+        created: dict[str, str] = {}
+
+        class FakeClient:
+            def create_dataset(self, file_name, file_size, ext, *, credentials=None):
+                created["file_name"] = file_name
+                return _make_fake_dataset(file_name=file_name, file_size=file_size)
+
+            def complete_upload(self, file_id, parts=None, *, credentials=None):
+                return DatasetFile(
+                    id=file_id,
+                    file_name="agent.eval.v2",
+                    file_size=file_size,
+                    status="uploaded",
+                )
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(
+            upload_module,
+            "make_progress_bar",
+            lambda _size: (nullcontext(), lambda _done, _total: None),
+        )
+        monkeypatch.setattr(
+            upload_module,
+            "upload_file_simple",
+            lambda _fp, _info, progress_callback=None: None,
+        )
+
+        from osmosis_ai.platform.cli.dataset import _perform_upload
+
+        _perform_upload(
+            file_path=file_path,
+            ext="jsonl",
+            file_size=file_size,
+            credentials=None,
+        )
+
+        assert created == {"file_name": "agent.eval.v2"}
+
     def test_raises_on_missing_upload_info(self, monkeypatch, tmp_path):
         """_perform_upload raises CLIError if server returns no upload info."""
         import osmosis_ai.platform.api.client as api_client_module
@@ -153,7 +202,7 @@ class TestPerformUpload:
             def create_dataset(self, *args, **kwargs):
                 return DatasetFile(
                     id="dataset-1",
-                    file_name="data.jsonl",
+                    file_name="data",
                     file_size=2,
                     status="created",
                     upload=None,
@@ -244,18 +293,27 @@ class TestUploadDatasetInteractive:
         import osmosis_ai.platform.cli.workspace as workspace_module
 
         file_path, dataset_module, _ = self._setup_mocks(monkeypatch, tmp_path)
+        output = StringIO()
 
         # Mock text() to return file path (simulating drag & drop)
         monkeypatch.setattr(workspace_module, "text", lambda msg, **kw: str(file_path))
         # Mock confirm() to approve
         monkeypatch.setattr(workspace_module, "confirm", lambda msg, **kw: True)
+        monkeypatch.setattr(
+            workspace_module, "console", Console(file=output, force_terminal=False)
+        )
+        monkeypatch.setattr(
+            workspace_module,
+            "platform_entity_url",
+            lambda ws, entity, item_id: f"https://example.com/{ws}/{entity}/{item_id}",
+        )
 
         uploaded = {}
 
         def fake_perform_upload(*, file_path, ext, file_size, credentials):
             uploaded["called"] = True
             return DatasetFile(
-                id="ds-1", file_name="data.jsonl", file_size=2, status="uploaded"
+                id="ds-1", file_name="data", file_size=2, status="uploaded"
             )
 
         monkeypatch.setattr(dataset_module, "_perform_upload", fake_perform_upload)
@@ -269,6 +327,9 @@ class TestUploadDatasetInteractive:
 
         assert result is True
         assert uploaded["called"]
+        rendered = output.getvalue()
+        assert "Upload complete. Dataset: data" in rendered
+        assert "https://example.com/my-ws/datasets/ds-1" in rendered
 
     def test_returns_false_on_cancelled_input(self, monkeypatch, tmp_path):
         """Returns False when user cancels the file path prompt."""


### PR DESCRIPTION
## What

- Auto-select the active workspace during `login`, `whoami`, workspace listing, and workspace-required platform requests when an account only has one workspace.
- Enrich workspace metadata with Git integration state so `osmosis init` can point users to the right Git Sync action or block fresh init when the active workspace already has a connected repo.
- Derive dataset names from the uploaded file stem instead of the full filename, and surface the resolved dataset name in upload success output.
- Add and update unit coverage for workspace auto-selection, init Git Sync messaging, connected-repo guardrails, and dataset upload naming/output.

## Why

This branch smooths several rough edges in the CLI onboarding flow. Single-workspace users no longer need to manually select a workspace before basic commands work, `init` now gives setup guidance that matches the workspace's Git integration state, and dataset uploads default to cleaner platform names derived from the local path.

It also keeps the SDK compatible with older platform responses by defaulting the new Git metadata fields when they are absent.

## How to Test

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright osmosis_ai/`
- `uv run pytest`
- `osmosis auth login` with an account that has exactly one workspace, then run `osmosis auth whoami` and confirm the workspace is shown without a manual selection step.
- `osmosis init demo-workspace` (or `osmosis init --here`) with a workspace that already has a connected repo and confirm the CLI tells you to `git clone` instead of scaffolding a new project.
- `osmosis dataset upload path/to/agent.eval.v2.jsonl` and confirm the created dataset name is `agent.eval.v2` and the success output echoes that stem.

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [ ] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlined CLI onboarding with automatic workspace selection across commands, verified Git Sync guidance in `init`, and cleaner dataset names on upload. `login` and `whoami` show your workspace when available and never fail if workspace lookup is unavailable.

- **New Features**
  - Auto-select the only workspace via `ensure_active_workspace` across the CLI (`auth login`, `whoami`, workspace listing, and all workspace-scoped API requests).
  - Resilient workspace lookups: `login` and `whoami` continue on errors and keep your current selection; best‑effort calls disable `cleanup_on_401`.
  - Git-aware `init`: verifies the active workspace against the platform, auto-selects the only workspace when none is saved, shows a workspace Git Sync URL or the connected repo URL (asks to “choose a repo” if the GitHub app is installed but not linked), and blocks fresh init when a repo is already linked (asks to `git clone` or switch).
  - Dataset uploads use the file stem as the dataset name and echo that name in success output and interactive flows.

<sup>Written for commit 602b9d2aec1959474f763783457974681558b286. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

