### PR TITLE
[cli][auth] feat: add structured output modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ Python SDK for [Osmosis AI](https://platform.osmosis.ai), a platform for trainin
 
 **Documentation index:** [docs/README.md](docs/README.md)
 
+## Agent-friendly CLI output
+
+The `osmosis` CLI keeps Rich as the default output for humans, but every public command also speaks structured JSON and low-noise plain text for AI agents, CI/CD, and shell automation. Put these global output flags before the command:
+
+```bash
+osmosis dataset list                         # human-friendly Rich table
+osmosis --json dataset list                  # recommended for AI agents and CI/CD
+osmosis --format plain dataset list          # low-noise text for shell pipelines
+```
+
+JSON is the stable machine contract: every successful response includes `schema_version: 1`; list envelopes include `items`, `total_count`, `has_more`, and `next_offset`; detail envelopes include `data`; operation envelopes include `status`, `operation`, optional `resource`, and optional `next_steps_structured`. Errors are JSON-structured on stderr with `code`, `message`, `details`, optional `request_id`, plus the command path and SDK `cli_version`.
+
+Plain mode is for humans and simple shell pipelines, not a strict schema. `--format` and its `--json` / `--plain` aliases are global flags parsed before subcommands; prefer `osmosis --json <command>` or `osmosis --format plain <command>` over the default Rich output in non-interactive environments. Command-local `--output` always means a file path, not a format selector, so `osmosis dataset download my-dataset --output ./data.jsonl` works in every mode.
+
+In JSON or plain mode, interactive commands fail fast with `INTERACTIVE_REQUIRED` unless a non-interactive flow exists, typically by passing `--yes` or `--token`. `OSMOSIS_TOKEN` is verify-only across the CLI: it activates authentication for the current process but is never written to the on-disk credentials store, never revoked, and never deletes existing credentials.
+
 ## Installation
 
 Requires **Python 3.12+**. For development setup, see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/osmosis_ai/cli/commands/auth.py
+++ b/osmosis_ai/cli/commands/auth.py
@@ -146,16 +146,159 @@ def _ensure_login_workspace_selection(
     return workspace, True
 
 
-@app.command("login")
-def login(
-    force: bool = typer.Option(
-        False, "-f", "--force", help="Force re-login, clearing existing credentials."
-    ),
-    token: str | None = typer.Option(
-        None, "--token", help="Authenticate with a personal access token (for CI/CD)."
-    ),
-) -> None:
-    """Authenticate with Osmosis AI."""
+def _login_operation_result(
+    *,
+    email: str,
+    name: str | None,
+    expires_at: Any,
+    source: str,
+    saved: bool,
+    active_workspace: dict[str, str] | None = None,
+    token_store: str | None = None,
+    workspace_lookup_error: str | None = None,
+    auto_selected: bool = False,
+    local_data_cleared: bool = False,
+    workspace_count: int | None = None,
+) -> Any:
+    """Build the structured login result for JSON/plain output."""
+    from osmosis_ai.cli.output import OperationResult
+
+    workspace = (
+        {"id": active_workspace["id"], "name": active_workspace["name"]}
+        if active_workspace
+        else None
+    )
+    resource: dict[str, Any] = {
+        "email": email,
+        "name": name,
+        "expires_at": expires_at.isoformat(),
+        "workspace": workspace,
+        "source": source,
+        "verified": True,
+        "saved": saved,
+    }
+    if token_store is not None:
+        resource["token_store"] = token_store
+    if workspace_lookup_error is not None:
+        resource["workspace_lookup_error"] = workspace_lookup_error
+    if auto_selected:
+        resource["auto_selected_workspace"] = True
+    if local_data_cleared:
+        resource["local_data_cleared"] = True
+    if workspace_count is not None:
+        resource["workspace_count"] = workspace_count
+
+    next_steps: list[str] = []
+    next_steps_structured: list[dict[str, Any]] = []
+    if workspace is None and workspace_count and workspace_count > 1:
+        next_steps.append("Choose a workspace with: osmosis workspace switch <name>")
+        next_steps_structured.append({"action": "workspace.switch", "name": None})
+    elif workspace is None and saved:
+        next_steps.append("Choose a workspace with: osmosis workspace")
+        next_steps_structured.append({"action": "workspace.interactive"})
+
+    return OperationResult(
+        operation="auth.login",
+        status="success",
+        resource=resource,
+        message=f"Logged in as {email}.",
+        display_next_steps=next_steps,
+        next_steps_structured=next_steps_structured,
+    )
+
+
+def _machine_login_with_token(*, token: str, force: bool) -> Any:
+    """Verify and persist an explicit token, returning structured output."""
+    from osmosis_ai.cli.output import get_output_context
+    from osmosis_ai.platform.auth import load_credentials, verify_token
+    from osmosis_ai.platform.auth.credentials import (
+        Credentials,
+        save_credentials,
+    )
+    from osmosis_ai.platform.auth.flow import LoginResult
+    from osmosis_ai.platform.auth.local_config import clear_all_local_data
+    from osmosis_ai.platform.auth.platform_client import revoke_cli_token
+
+    output = get_output_context()
+    old_credentials = load_credentials()
+
+    with output.status("Verifying token..."):
+        verified = verify_token(token)
+    creds = Credentials.from_verify_result(token, verified)
+    result = LoginResult.from_verify_result(verified)
+
+    token_store = save_credentials(creds)
+
+    if (
+        old_credentials
+        and not old_credentials.is_expired()
+        and old_credentials.token_id
+        and old_credentials.token_id != creds.token_id
+    ):
+        with output.status("Revoking old session..."):
+            revoke_cli_token(old_credentials)
+
+    workspaces, workspace_lookup_error = _load_login_workspaces(creds)
+
+    local_data_cleared = force or (
+        old_credentials and old_credentials.user.id != creds.user.id
+    )
+    if local_data_cleared:
+        clear_all_local_data()
+    elif workspaces is not None:
+        _validate_workspace_context(creds, workspaces=workspaces)
+
+    active_workspace, auto_selected = _ensure_login_workspace_selection(workspaces)
+
+    return _login_operation_result(
+        email=result.user.email,
+        name=result.user.name,
+        expires_at=result.expires_at,
+        source="token",
+        saved=True,
+        active_workspace=active_workspace,
+        token_store=token_store,
+        workspace_lookup_error=workspace_lookup_error,
+        auto_selected=auto_selected,
+        local_data_cleared=bool(local_data_cleared),
+        workspace_count=len(workspaces) if workspaces is not None else None,
+    )
+
+
+def _machine_login_with_env_token(*, env_token: str) -> Any:
+    """Verify OSMOSIS_TOKEN without mutating local credential/session state."""
+    from osmosis_ai.cli.output import OperationResult, get_output_context
+    from osmosis_ai.platform.auth import verify_token
+
+    output = get_output_context()
+    with output.status("Verifying environment token..."):
+        verified = verify_token(env_token)
+
+    return OperationResult(
+        operation="auth.login",
+        status="success",
+        resource={
+            "email": verified.user.email,
+            "name": verified.user.name,
+            "expires_at": verified.expires_at.isoformat(),
+            "workspace": None,
+            "source": "environment",
+            "verified": True,
+            "saved": False,
+        },
+        message=f"Verified OSMOSIS_TOKEN for {verified.user.email}.",
+        display_next_steps=[
+            "OSMOSIS_TOKEN was not saved to local credentials.",
+            "Unset OSMOSIS_TOKEN to use interactive device login.",
+        ],
+        next_steps_structured=[
+            {"action": "unset_env", "name": "OSMOSIS_TOKEN"},
+        ],
+    )
+
+
+def _rich_login(force: bool, token: str | None) -> Any:
+    """Preserve the original rich, interactive login behavior."""
     from osmosis_ai.platform.auth import (
         LoginError,
         device_login,
@@ -164,7 +307,6 @@ def login(
     )
     from osmosis_ai.platform.auth.credentials import (
         Credentials,
-        delete_credentials,
         save_credentials,
     )
     from osmosis_ai.platform.auth.flow import LoginResult
@@ -178,20 +320,12 @@ def login(
         console.print("  Osmosis AI", style="bold magenta")
         console.print()
 
-    # Refuse to login if OSMOSIS_TOKEN env var is set
-    if os.environ.get("OSMOSIS_TOKEN"):
-        console.print_error(
-            "The OSMOSIS_TOKEN environment variable is set. "
-            "Unset it to use 'osmosis auth login'."
-        )
-        raise typer.Exit(1)
-
     try:
-        old_credentials = load_credentials()
+        env_token = os.environ.get("OSMOSIS_TOKEN")
+        if env_token and token is None:
+            return _machine_login_with_env_token(env_token=env_token)
 
-        # Clear existing credentials if forcing re-login
-        if force and old_credentials:
-            delete_credentials()
+        old_credentials = load_credentials()
 
         # Two login paths: token or device flow
         if token:
@@ -202,8 +336,10 @@ def login(
         else:
             result, creds = device_login()
 
-        # Revoke old token server-side before overwriting local credentials,
-        # so it doesn't become an unmanageable orphan on the platform.
+        save_credentials(creds)
+
+        # Revoke old token server-side after the new credentials are saved,
+        # so a failed login attempt does not destroy the current session.
         # Skip when re-logging with the same PAT to avoid revoking the
         # token we just verified.
         if (
@@ -214,8 +350,6 @@ def login(
         ):
             with console.spinner("Revoking old session..."):
                 revoke_cli_token(old_credentials)
-
-        save_credentials(creds)
 
         workspaces, workspace_lookup_error = _load_login_workspaces(creds)
 
@@ -296,25 +430,72 @@ def login(
         raise typer.Exit(1) from None
 
 
+@app.command("login")
+def login(
+    force: bool = typer.Option(
+        False, "-f", "--force", help="Force re-login, clearing existing credentials."
+    ),
+    token: str | None = typer.Option(
+        None, "--token", help="Authenticate with a personal access token (for CI/CD)."
+    ),
+) -> Any:
+    """Authenticate with Osmosis AI."""
+    from osmosis_ai.cli.output import OutputFormat, get_output_context
+    from osmosis_ai.platform.auth import LoginError
+
+    output = get_output_context()
+    if output.format is OutputFormat.rich:
+        return _rich_login(force=force, token=token)
+
+    try:
+        if token is not None:
+            return _machine_login_with_token(token=token, force=force)
+
+        env_token = os.environ.get("OSMOSIS_TOKEN")
+        if env_token:
+            return _machine_login_with_env_token(env_token=env_token)
+
+        raise CLIError(
+            "Login is interactive in this mode. Pass --token or set OSMOSIS_TOKEN.",
+            code="INTERACTIVE_REQUIRED",
+        )
+    except LoginError as exc:
+        raise CLIError(str(exc), code="AUTH_REQUIRED") from exc
+
+
 @app.command("logout")
 def logout(
     skip_confirm: bool = typer.Option(
         False, "-y", "--yes", help="Skip confirmation prompt."
     ),
-) -> None:
+) -> Any:
     """Logout from Osmosis AI CLI."""
+    from osmosis_ai.cli.output import OperationResult, OutputFormat, get_output_context
     from osmosis_ai.cli.prompts import confirm
     from osmosis_ai.platform.auth import load_credentials
     from osmosis_ai.platform.auth.local_config import reset_session
     from osmosis_ai.platform.auth.platform_client import revoke_cli_token
 
+    output = get_output_context()
     credentials = load_credentials()
 
     if credentials is None:
-        console.print("Not logged in.")
-        return
+        if output.format is OutputFormat.rich:
+            console.print("Not logged in.")
+            return None
+        return OperationResult(
+            operation="auth.logout",
+            status="noop",
+            resource={"logged_in": False},
+            message="Not logged in.",
+        )
 
     if not skip_confirm:
+        if output.format is not OutputFormat.rich or not output.interactive:
+            raise CLIError(
+                "Use --yes to confirm in non-interactive mode.",
+                code="INTERACTIVE_REQUIRED",
+            )
         result = confirm("Logout from Osmosis AI?", default=False)
         if result is None:  # User cancelled with Ctrl+C
             return
@@ -323,53 +504,140 @@ def logout(
             return
 
     # Best-effort server-side revocation
+    revoked = False
     if not credentials.is_expired():
-        with console.spinner("Revoking session..."):
-            revoke_cli_token(credentials)
+        with output.status("Revoking session..."):
+            revoked = revoke_cli_token(credentials)
 
     # Delete local credentials and workspace/local state
     reset_session()
 
+    env_token_set = bool(os.environ.get("OSMOSIS_TOKEN"))
+    if output.format is not OutputFormat.rich:
+        return OperationResult(
+            operation="auth.logout",
+            status="success",
+            resource={
+                "logged_in": False,
+                "revoked": revoked,
+                "env_token_set": env_token_set,
+            },
+            message="Logged out successfully.",
+            display_next_steps=(
+                ["Unset OSMOSIS_TOKEN to fully logout."] if env_token_set else []
+            ),
+            next_steps_structured=(
+                [{"action": "unset_env", "name": "OSMOSIS_TOKEN"}]
+                if env_token_set
+                else []
+            ),
+        )
+
     console.print("Logged out successfully.", style="green")
 
-    if os.environ.get("OSMOSIS_TOKEN"):
+    if env_token_set:
         console.print(
             "Warning: OSMOSIS_TOKEN environment variable is still set. "
             "Run 'unset OSMOSIS_TOKEN' to fully logout.",
             style="yellow",
         )
+    return None
 
 
 @app.command("whoami")
-def whoami() -> None:
+def whoami() -> Any:
     """Show current authenticated user and workspace."""
+    from osmosis_ai.cli.output import (
+        DetailField,
+        DetailResult,
+        OutputFormat,
+        get_output_context,
+    )
     from osmosis_ai.platform.auth import (
         AuthenticationExpiredError,
+        Credentials,
+        LoginError,
         PlatformAPIError,
         ensure_active_workspace,
+        get_active_workspace,
         load_credentials,
+        platform_request,
+        verify_token,
     )
     from osmosis_ai.platform.constants import MSG_NOT_LOGGED_IN
 
-    credentials = load_credentials()
+    output = get_output_context()
+    env_token = os.environ.get("OSMOSIS_TOKEN")
+    source = "environment" if env_token else "credentials"
+    active_workspace = None
+
+    if env_token:
+        try:
+            with output.status("Verifying token..."):
+                verified = verify_token(env_token)
+        except LoginError as exc:
+            raise CLIError(str(exc), code="AUTH_REQUIRED") from exc
+        credentials = Credentials.from_verify_result(env_token, verified)
+    else:
+        credentials = load_credentials()
 
     if credentials is None:
-        raise CLIError(MSG_NOT_LOGGED_IN)
+        raise CLIError(MSG_NOT_LOGGED_IN, code="AUTH_REQUIRED")
 
-    active_workspace = None
-    with contextlib.suppress(AuthenticationExpiredError, PlatformAPIError):
-        with console.spinner("Loading workspace..."):
-            active_workspace = ensure_active_workspace(
-                credentials=credentials,
-                cleanup_on_401=False,
-            )
-    esc = console.escape
+    if env_token:
+        with contextlib.suppress(AuthenticationExpiredError, PlatformAPIError):
+            with output.status("Loading workspace..."):
+                data = platform_request(
+                    "/api/cli/workspaces",
+                    credentials=credentials,
+                    require_workspace=False,
+                    cleanup_on_401=False,
+                )
+                workspaces = _normalize_workspaces(data.get("workspaces"))
+                local_workspace = get_active_workspace()
+                if local_workspace in workspaces:
+                    active_workspace = local_workspace
+                elif len(workspaces) == 1:
+                    active_workspace = workspaces[0]
+    else:
+        with contextlib.suppress(AuthenticationExpiredError, PlatformAPIError):
+            with output.status("Loading workspace..."):
+                active_workspace = ensure_active_workspace(
+                    credentials=credentials,
+                    cleanup_on_401=False,
+                )
 
-    rows = [("Email", esc(credentials.user.email))]
+    workspace = (
+        {"id": active_workspace["id"], "name": active_workspace["name"]}
+        if active_workspace
+        else None
+    )
+    data = {
+        "email": credentials.user.email,
+        "name": credentials.user.name,
+        "workspace": workspace,
+        "expires_at": credentials.expires_at.isoformat(),
+        "source": source,
+    }
+
+    fields = [DetailField(label="Email", value=credentials.user.email or "")]
     if credentials.user.name:
-        rows.append(("Name", esc(credentials.user.name)))
+        fields.append(DetailField(label="Name", value=credentials.user.name))
     if active_workspace:
-        rows.append(("Workspace", esc(active_workspace["name"])))
-    rows.append(("Expires", credentials.expires_at.strftime("%Y-%m-%d")))
+        fields.append(DetailField(label="Workspace", value=active_workspace["name"]))
+    fields.append(
+        DetailField(label="Expires", value=credentials.expires_at.strftime("%Y-%m-%d"))
+    )
 
-    console.table(rows)
+    result = DetailResult(title="Account", data=data, fields=fields)
+
+    # Some existing unit tests call this handler directly, outside Typer's
+    # result callback. Preserve that rich rendering path without duplicating
+    # output during normal CLI invocations.
+    if output.format is OutputFormat.rich:
+        import click
+
+        if click.get_current_context(silent=True) is None:
+            console.table([(field.label, field.value) for field in fields])
+
+    return result

--- a/osmosis_ai/cli/commands/auth.py
+++ b/osmosis_ai/cli/commands/auth.py
@@ -632,9 +632,16 @@ def whoami() -> Any:
                 )
                 workspaces = _normalize_workspaces(data.get("workspaces"))
                 local_workspace = get_active_workspace()
-                if local_workspace in workspaces:
-                    active_workspace = local_workspace
-                elif len(workspaces) == 1:
+                active_workspace = next(
+                    (
+                        workspace
+                        for workspace in workspaces
+                        if local_workspace
+                        and workspace.get("id") == local_workspace.get("id")
+                    ),
+                    None,
+                )
+                if active_workspace is None and len(workspaces) == 1:
                     active_workspace = workspaces[0]
     else:
         with contextlib.suppress(AuthenticationExpiredError, PlatformAPIError):
@@ -657,11 +664,22 @@ def whoami() -> Any:
         "source": source,
     }
 
-    fields = [DetailField(label="Email", value=credentials.user.email or "")]
+    fields = [
+        DetailField(
+            label="Email", value=console.format_text(credentials.user.email or "")
+        )
+    ]
     if credentials.user.name:
-        fields.append(DetailField(label="Name", value=credentials.user.name))
+        fields.append(
+            DetailField(label="Name", value=console.format_text(credentials.user.name))
+        )
     if active_workspace:
-        fields.append(DetailField(label="Workspace", value=active_workspace["name"]))
+        fields.append(
+            DetailField(
+                label="Workspace",
+                value=console.format_text(active_workspace["name"]),
+            )
+        )
     fields.append(
         DetailField(label="Expires", value=credentials.expires_at.strftime("%Y-%m-%d"))
     )

--- a/osmosis_ai/cli/commands/auth.py
+++ b/osmosis_ai/cli/commands/auth.py
@@ -275,7 +275,7 @@ def _machine_login_with_token(*, token: str, force: bool) -> Any:
     from osmosis_ai.platform.auth.platform_client import revoke_cli_token
 
     output = get_output_context()
-    old_credentials = load_credentials()
+    old_credentials = load_credentials(include_env=False)
 
     with output.status("Verifying token..."):
         verified = verify_token(token)
@@ -379,7 +379,9 @@ def _rich_login(force: bool, token: str | None) -> Any:
         if env_token and token is None:
             return _machine_login_with_env_token(env_token=env_token)
 
-        old_credentials = load_credentials()
+        old_credentials = (
+            load_credentials(include_env=False) if token else load_credentials()
+        )
 
         # Two login paths: token or device flow
         if token:

--- a/osmosis_ai/cli/commands/auth.py
+++ b/osmosis_ai/cli/commands/auth.py
@@ -63,12 +63,13 @@ def _load_login_workspaces(
     )
 
     try:
-        data = platform_request(
-            "/api/cli/workspaces",
-            credentials=creds,
-            require_workspace=False,
-            cleanup_on_401=False,
-        )
+        with console.spinner("Loading workspaces..."):
+            data = platform_request(
+                "/api/cli/workspaces",
+                credentials=creds,
+                require_workspace=False,
+                cleanup_on_401=False,
+            )
     except (AuthenticationExpiredError, PlatformAPIError) as exc:
         return None, str(exc)
 
@@ -171,7 +172,7 @@ def login(
     from osmosis_ai.platform.auth.platform_client import revoke_cli_token
 
     if console.rich.width >= ASCII_ART_MIN_WIDTH:
-        print(ASCII_ART)
+        console.print(ASCII_ART, markup=False, highlight=False)
     else:
         console.print()
         console.print("  Osmosis AI", style="bold magenta")
@@ -194,7 +195,8 @@ def login(
 
         # Two login paths: token or device flow
         if token:
-            verified = verify_token(token)
+            with console.spinner("Verifying token..."):
+                verified = verify_token(token)
             creds = Credentials.from_verify_result(token, verified)
             result = LoginResult.from_verify_result(verified)
         else:
@@ -210,7 +212,8 @@ def login(
             and old_credentials.token_id
             and old_credentials.token_id != creds.token_id
         ):
-            revoke_cli_token(old_credentials)
+            with console.spinner("Revoking old session..."):
+                revoke_cli_token(old_credentials)
 
         save_credentials(creds)
 
@@ -321,7 +324,8 @@ def logout(
 
     # Best-effort server-side revocation
     if not credentials.is_expired():
-        revoke_cli_token(credentials)
+        with console.spinner("Revoking session..."):
+            revoke_cli_token(credentials)
 
     # Delete local credentials and workspace/local state
     reset_session()
@@ -354,10 +358,11 @@ def whoami() -> None:
 
     active_workspace = None
     with contextlib.suppress(AuthenticationExpiredError, PlatformAPIError):
-        active_workspace = ensure_active_workspace(
-            credentials=credentials,
-            cleanup_on_401=False,
-        )
+        with console.spinner("Loading workspace..."):
+            active_workspace = ensure_active_workspace(
+                credentials=credentials,
+                cleanup_on_401=False,
+            )
     esc = console.escape
 
     rows = [("Email", esc(credentials.user.email))]

--- a/osmosis_ai/cli/commands/auth.py
+++ b/osmosis_ai/cli/commands/auth.py
@@ -228,18 +228,17 @@ def _verify_env_token(env_token: str) -> Any:
     try:
         return verify_token(env_token)
     except LoginError as exc:
-        message = env_messages.get(exc.code)
+        code = exc.code
+        message = env_messages.get(code) if code is not None else None
         if message is not None:
-            raise LoginError(
-                message, code=exc.code, status_code=exc.status_code
-            ) from exc
+            raise LoginError(message, code=code, status_code=exc.status_code) from exc
         raise
 
 
 def _cli_error_from_login_error(exc: Any) -> CLIError:
     status_code = getattr(exc, "status_code", None)
     if isinstance(status_code, int) and status_code != 401:
-        details = {"status_code": status_code}
+        details: dict[str, Any] = {"status_code": status_code}
         platform_code = getattr(exc, "code", None)
         if isinstance(platform_code, str):
             details["platform_code"] = platform_code

--- a/osmosis_ai/cli/commands/auth.py
+++ b/osmosis_ai/cli/commands/auth.py
@@ -207,6 +207,46 @@ def _login_operation_result(
     )
 
 
+def _verify_env_token(env_token: str) -> Any:
+    """Verify OSMOSIS_TOKEN and replace generic 401s with actionable guidance."""
+    from osmosis_ai.platform.auth import LoginError, verify_token
+    from osmosis_ai.platform.constants import (
+        MSG_ENV_TOKEN_EXPIRED,
+        MSG_ENV_TOKEN_INVALID,
+        MSG_ENV_TOKEN_REVOKED,
+    )
+
+    env_messages = {
+        "AUTH_HEADER_MISSING": MSG_ENV_TOKEN_INVALID,
+        "TOKEN_MISSING": MSG_ENV_TOKEN_INVALID,
+        "TOKEN_EXPIRED": MSG_ENV_TOKEN_EXPIRED,
+        "TOKEN_INVALID": MSG_ENV_TOKEN_INVALID,
+        "TOKEN_REVOKED": MSG_ENV_TOKEN_REVOKED,
+        "UNKNOWN_AUTH_ERROR": MSG_ENV_TOKEN_INVALID,
+    }
+
+    try:
+        return verify_token(env_token)
+    except LoginError as exc:
+        message = env_messages.get(exc.code)
+        if message is not None:
+            raise LoginError(
+                message, code=exc.code, status_code=exc.status_code
+            ) from exc
+        raise
+
+
+def _cli_error_from_login_error(exc: Any) -> CLIError:
+    status_code = getattr(exc, "status_code", None)
+    if isinstance(status_code, int) and status_code != 401:
+        details = {"status_code": status_code}
+        platform_code = getattr(exc, "code", None)
+        if isinstance(platform_code, str):
+            details["platform_code"] = platform_code
+        return CLIError(str(exc), code="PLATFORM_ERROR", details=details)
+    return CLIError(str(exc), code="AUTH_REQUIRED")
+
+
 def _machine_login_with_token(*, token: str, force: bool) -> Any:
     """Verify and persist an explicit token, returning structured output."""
     from osmosis_ai.cli.output import get_output_context
@@ -268,11 +308,10 @@ def _machine_login_with_token(*, token: str, force: bool) -> Any:
 def _machine_login_with_env_token(*, env_token: str) -> Any:
     """Verify OSMOSIS_TOKEN without mutating local credential/session state."""
     from osmosis_ai.cli.output import OperationResult, get_output_context
-    from osmosis_ai.platform.auth import verify_token
 
     output = get_output_context()
     with output.status("Verifying environment token..."):
-        verified = verify_token(env_token)
+        verified = _verify_env_token(env_token)
 
     return OperationResult(
         operation="auth.login",
@@ -460,7 +499,7 @@ def login(
             code="INTERACTIVE_REQUIRED",
         )
     except LoginError as exc:
-        raise CLIError(str(exc), code="AUTH_REQUIRED") from exc
+        raise _cli_error_from_login_error(exc) from exc
 
 
 @app.command("logout")
@@ -562,7 +601,6 @@ def whoami() -> Any:
         get_active_workspace,
         load_credentials,
         platform_request,
-        verify_token,
     )
     from osmosis_ai.platform.constants import MSG_NOT_LOGGED_IN
 
@@ -574,9 +612,9 @@ def whoami() -> Any:
     if env_token:
         try:
             with output.status("Verifying token..."):
-                verified = verify_token(env_token)
+                verified = _verify_env_token(env_token)
         except LoginError as exc:
-            raise CLIError(str(exc), code="AUTH_REQUIRED") from exc
+            raise _cli_error_from_login_error(exc) from exc
         credentials = Credentials.from_verify_result(env_token, verified)
     else:
         credentials = load_credentials()

--- a/osmosis_ai/cli/commands/auth.py
+++ b/osmosis_ai/cli/commands/auth.py
@@ -230,6 +230,8 @@ def _verify_env_token(env_token: str) -> Any:
     except LoginError as exc:
         code = exc.code
         message = env_messages.get(code) if code is not None else None
+        if message is None and exc.status_code == 401:
+            message = MSG_ENV_TOKEN_INVALID
         if message is not None:
             raise LoginError(message, code=code, status_code=exc.status_code) from exc
         raise

--- a/osmosis_ai/cli/commands/auth.py
+++ b/osmosis_ai/cli/commands/auth.py
@@ -35,6 +35,15 @@ ASCII_ART = r"""
 """
 ASCII_ART_MIN_WIDTH = 113
 
+_AUTH_LOGIN_ERROR_CODES = {
+    "AUTH_HEADER_MISSING",
+    "TOKEN_MISSING",
+    "TOKEN_EXPIRED",
+    "TOKEN_INVALID",
+    "TOKEN_REVOKED",
+    "UNKNOWN_AUTH_ERROR",
+}
+
 
 def _normalize_workspaces(raw_workspaces: Any) -> list[dict[str, str]]:
     """Return workspace entries that have both an ID and a name."""
@@ -239,13 +248,18 @@ def _verify_env_token(env_token: str) -> Any:
 
 def _cli_error_from_login_error(exc: Any) -> CLIError:
     status_code = getattr(exc, "status_code", None)
-    if isinstance(status_code, int) and status_code != 401:
-        details: dict[str, Any] = {"status_code": status_code}
-        platform_code = getattr(exc, "code", None)
-        if isinstance(platform_code, str):
-            details["platform_code"] = platform_code
-        return CLIError(str(exc), code="PLATFORM_ERROR", details=details)
-    return CLIError(str(exc), code="AUTH_REQUIRED")
+    platform_code = getattr(exc, "code", None)
+    if status_code == 401 or (
+        isinstance(platform_code, str) and platform_code in _AUTH_LOGIN_ERROR_CODES
+    ):
+        return CLIError(str(exc), code="AUTH_REQUIRED")
+
+    details: dict[str, Any] = {}
+    if isinstance(status_code, int):
+        details["status_code"] = status_code
+    if isinstance(platform_code, str):
+        details["platform_code"] = platform_code
+    return CLIError(str(exc), code="PLATFORM_ERROR", details=details)
 
 
 def _machine_login_with_token(*, token: str, force: bool) -> Any:

--- a/osmosis_ai/cli/commands/dataset.py
+++ b/osmosis_ai/cli/commands/dataset.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import typer
 
 from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE
@@ -15,11 +17,11 @@ app: typer.Typer = typer.Typer(
 @app.command("upload")
 def upload(
     file: str = typer.Argument(..., help="Path to the file to upload."),
-) -> None:
+) -> Any:
     """Upload a dataset file."""
     from osmosis_ai.platform.cli.dataset import upload as _upload
 
-    _upload(file=file)
+    return _upload(file=file)
 
 
 @app.command("download")
@@ -36,11 +38,11 @@ def download(
         "--overwrite",
         help="Replace the destination file if it already exists.",
     ),
-) -> None:
+) -> Any:
     """Download a dataset file."""
     from osmosis_ai.platform.cli.dataset import download as _download
 
-    _download(name=name, output=output, overwrite=overwrite)
+    return _download(name=name, output=output, overwrite=overwrite)
 
 
 @app.command("list")
@@ -49,50 +51,50 @@ def list_datasets(
         DEFAULT_PAGE_SIZE, "--limit", help="Maximum number of datasets to show."
     ),
     all_: bool = typer.Option(False, "--all", help="Show all datasets."),
-) -> None:
+) -> Any:
     """List datasets."""
     from osmosis_ai.platform.cli.dataset import list_datasets as _list_datasets
 
-    _list_datasets(limit=limit, all_=all_)
+    return _list_datasets(limit=limit, all_=all_)
 
 
 @app.command("info")
 def info(
     name: str = typer.Argument(..., help="Dataset name."),
-) -> None:
+) -> Any:
     """Show dataset details and processing status."""
     from osmosis_ai.platform.cli.dataset import info as _info
 
-    _info(name=name)
+    return _info(name=name)
 
 
 @app.command("preview")
 def preview(
     name: str = typer.Argument(..., help="Dataset name."),
     rows: int = typer.Option(5, "--rows", help="Number of rows to show."),
-) -> None:
+) -> Any:
     """Preview dataset rows."""
     from osmosis_ai.platform.cli.dataset import preview as _preview
 
-    _preview(name=name, rows=rows)
+    return _preview(name=name, rows=rows)
 
 
 @app.command("validate")
 def validate(
     file: str = typer.Argument(..., help="Path to the file to validate."),
-) -> None:
+) -> Any:
     """Validate a dataset file locally."""
     from osmosis_ai.platform.cli.dataset import validate as _validate
 
-    _validate(file=file)
+    return _validate(file=file)
 
 
 @app.command("delete")
 def delete(
     name: str = typer.Argument(..., help="Dataset name."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
-) -> None:
+) -> Any:
     """Delete a dataset."""
     from osmosis_ai.platform.cli.dataset import delete as _delete
 
-    _delete(name=name, yes=yes)
+    return _delete(name=name, yes=yes)

--- a/osmosis_ai/cli/commands/deployment.py
+++ b/osmosis_ai/cli/commands/deployment.py
@@ -21,6 +21,8 @@ the platform resolves both forms.
 
 from __future__ import annotations
 
+from typing import Any
+
 import typer
 
 from osmosis_ai.cli.console import console
@@ -30,6 +32,45 @@ app: typer.Typer = typer.Typer(
     help="Manage LoRA deployments (list, info, rename, delete).",
     no_args_is_help=True,
 )
+
+
+def _detail_fields(rows: list[tuple[str, str]]) -> list[Any]:
+    from osmosis_ai.cli.output import DetailField
+
+    return [DetailField(label=label, value=value) for label, value in rows]
+
+
+def _require_confirmation(message: str, *, yes: bool) -> None:
+    if yes:
+        return
+
+    from osmosis_ai.cli.errors import CLIError
+    from osmosis_ai.cli.output import OutputFormat, get_output_context
+
+    output = get_output_context()
+    if output.format is not OutputFormat.rich or not output.interactive:
+        err = CLIError(
+            "Use --yes to confirm in non-interactive mode.",
+            code="INTERACTIVE_REQUIRED",
+        )
+        if output.format is OutputFormat.json:
+            from osmosis_ai.cli.output import emit_structured_error_to_stderr
+
+            emit_structured_error_to_stderr(err)
+            raise typer.Exit(1)
+        raise err
+
+    from osmosis_ai.cli.prompts import require_confirmation
+
+    require_confirmation(message, yes=yes)
+
+
+def _deployment_summary_resource(result: Any) -> dict[str, Any]:
+    return {
+        "id": result.id,
+        "checkpoint_name": result.checkpoint_name,
+        "status": result.status,
+    }
 
 
 def _deployment_status_style(status: str) -> str | None:
@@ -64,14 +105,18 @@ def list_deployments(
         DEFAULT_PAGE_SIZE, "--limit", help="Maximum number of deployments to show."
     ),
     all_: bool = typer.Option(False, "--all", help="Show all deployments."),
-) -> None:
+) -> Any:
     """List LoRA deployments in the current workspace."""
+    from osmosis_ai.cli.output import (
+        ListColumn,
+        ListResult,
+        get_output_context,
+        serialize_deployment,
+    )
     from osmosis_ai.platform.api.client import OsmosisClient
     from osmosis_ai.platform.cli.utils import (
         _require_auth,
-        format_dim_date,
-        paginated_fetch,
-        print_pagination_footer,
+        fetch_all_pages,
         validate_list_options,
     )
 
@@ -79,34 +124,42 @@ def list_deployments(
 
     _, credentials = _require_auth()
 
-    with console.spinner("Fetching deployments..."):
-        client = OsmosisClient()
-        deployments, total_count, _has_more = paginated_fetch(
-            lambda lim, off: client.list_deployments(
-                limit=lim, offset=off, credentials=credentials
-            ),
-            items_attr="deployments",
-            limit=effective_limit,
-            fetch_all=fetch_all,
-        )
+    output = get_output_context()
+    client = OsmosisClient()
+    with output.status("Fetching deployments..."):
+        if fetch_all:
+            deployments, total_count = fetch_all_pages(
+                lambda lim, off: client.list_deployments(
+                    limit=lim, offset=off, credentials=credentials
+                ),
+                items_attr="deployments",
+            )
+            has_more = False
+            next_offset = None
+        else:
+            page = client.list_deployments(
+                limit=effective_limit, offset=0, credentials=credentials
+            )
+            deployments = page.deployments
+            total_count = page.total_count
+            has_more = page.has_more
+            next_offset = page.next_offset
 
-    if not deployments:
-        console.print("No deployments found.")
-        return
-
-    console.print(f"Deployments ({total_count}):", style="bold")
-    for d in deployments:
-        status_str = _format_deployment_status(d.status)
-        name = console.escape(d.checkpoint_name) if d.checkpoint_name else "—"
-        base_model = console.escape(d.base_model) if d.base_model else "—"
-        step = f"step:{d.checkpoint_step}"
-        date = format_dim_date(d.created_at)
-        console.print(
-            f"  {name}  {status_str}  {base_model}  {step}  {date}",
-            highlight=False,
-        )
-
-    print_pagination_footer(len(deployments), total_count, "deployments")
+    return ListResult(
+        title="Deployments",
+        items=[serialize_deployment(dep) for dep in deployments],
+        total_count=total_count,
+        has_more=has_more,
+        next_offset=next_offset,
+        columns=[
+            ListColumn(key="checkpoint_name", label="Checkpoint"),
+            ListColumn(key="status", label="Status"),
+            ListColumn(key="base_model", label="Base Model"),
+            ListColumn(key="checkpoint_step", label="Step"),
+            ListColumn(key="created_at", label="Created"),
+            ListColumn(key="id", label="ID", no_wrap=True),
+        ],
+    )
 
 
 @app.command("info")
@@ -114,19 +167,22 @@ def info(
     checkpoint: str = typer.Argument(
         ..., help="Checkpoint UUID or checkpoint_name.", metavar="CHECKPOINT"
     ),
-) -> None:
+) -> Any:
     """Show deployment details for a checkpoint."""
+    from osmosis_ai.cli.output import (
+        DetailResult,
+        get_output_context,
+        serialize_deployment,
+    )
     from osmosis_ai.platform.api.client import OsmosisClient
-    from osmosis_ai.platform.cli.utils import _require_auth, format_date, platform_call
+    from osmosis_ai.platform.cli.utils import _require_auth, format_date
 
     _, credentials = _require_auth()
 
     client = OsmosisClient()
-    d = platform_call(
-        "Fetching deployment...",
-        lambda: client.get_deployment(checkpoint, credentials=credentials),
-        output_console=console,
-    )
+    output = get_output_context()
+    with output.status("Fetching deployment..."):
+        d = client.get_deployment(checkpoint, credentials=credentials)
 
     rows: list[tuple[str, str]] = [
         ("Checkpoint", console.escape(d.checkpoint_name) if d.checkpoint_name else "—"),
@@ -144,53 +200,85 @@ def info(
     if d.created_at:
         rows.append(("Created", format_date(d.created_at)))
 
-    console.table(rows, title="Deployment")
+    return DetailResult(
+        title="Deployment",
+        data=serialize_deployment(d),
+        fields=_detail_fields(rows),
+    )
 
 
 def deploy(
     checkpoint: str = typer.Argument(
         ..., help="Checkpoint UUID or checkpoint_name.", metavar="CHECKPOINT"
     ),
-) -> None:
+) -> Any:
     """Deploy (or reactivate) a LoRA checkpoint."""
+    from osmosis_ai.cli.output import OperationResult, get_output_context
     from osmosis_ai.platform.api.client import OsmosisClient
-    from osmosis_ai.platform.cli.utils import _require_auth, platform_call
+    from osmosis_ai.platform.cli.utils import _require_auth
 
     _, credentials = _require_auth()
     client = OsmosisClient()
+    output = get_output_context()
 
-    result = platform_call(
-        f'Deploying checkpoint "{console.escape(checkpoint)}"...',
-        lambda: client.deploy_checkpoint(checkpoint, credentials=credentials),
-        output_console=console,
+    with output.status(f'Deploying checkpoint "{console.escape(checkpoint)}"...'):
+        result = client.deploy_checkpoint(checkpoint, credentials=credentials)
+
+    op_status = "failed" if result.status == "failed" else "success"
+    return OperationResult(
+        operation="deploy",
+        status=op_status,
+        resource=_deployment_summary_resource(result),
+        message=f"Deployment {result.checkpoint_name or '-'} {result.status}",
+        display_next_steps=[
+            f"Inspect with: osmosis deployment info {result.checkpoint_name}"
+        ]
+        if result.checkpoint_name
+        else [],
+        next_steps_structured=[
+            {"action": "deployment_info", "checkpoint_name": result.checkpoint_name}
+        ]
+        if result.checkpoint_name
+        else [],
+        exit_code=1 if op_status == "failed" else 0,
     )
-
-    status_str = _format_deployment_status(result.status)
-    name = console.escape(result.checkpoint_name) if result.checkpoint_name else "—"
-    console.print(f"Deployment {name} {status_str}", highlight=False)
 
 
 def undeploy(
     checkpoint: str = typer.Argument(
         ..., help="Checkpoint UUID or checkpoint_name.", metavar="CHECKPOINT"
     ),
-) -> None:
+) -> Any:
     """Undeploy a LoRA checkpoint (transition to ``inactive``)."""
+    from osmosis_ai.cli.output import OperationResult, get_output_context
     from osmosis_ai.platform.api.client import OsmosisClient
-    from osmosis_ai.platform.cli.utils import _require_auth, platform_call
+    from osmosis_ai.platform.cli.utils import _require_auth
 
     _, credentials = _require_auth()
     client = OsmosisClient()
+    output = get_output_context()
 
-    result = platform_call(
-        f'Undeploying checkpoint "{console.escape(checkpoint)}"...',
-        lambda: client.undeploy_checkpoint(checkpoint, credentials=credentials),
-        output_console=console,
+    with output.status(f'Undeploying checkpoint "{console.escape(checkpoint)}"...'):
+        result = client.undeploy_checkpoint(checkpoint, credentials=credentials)
+
+    op_status = "failed" if result.status == "failed" else "success"
+    return OperationResult(
+        operation="undeploy",
+        status=op_status,
+        resource=_deployment_summary_resource(result),
+        message=f"Deployment {result.checkpoint_name or '-'} {result.status}",
+        display_next_steps=[
+            f"Inspect with: osmosis deployment info {result.checkpoint_name}"
+        ]
+        if result.checkpoint_name
+        else [],
+        next_steps_structured=[
+            {"action": "deployment_info", "checkpoint_name": result.checkpoint_name}
+        ]
+        if result.checkpoint_name
+        else [],
+        exit_code=1 if op_status == "failed" else 0,
     )
-
-    status_str = _format_deployment_status(result.status)
-    name = console.escape(result.checkpoint_name) if result.checkpoint_name else "—"
-    console.print(f"Deployment {name} {status_str}", highlight=False)
 
 
 @app.command("rename")
@@ -201,28 +289,37 @@ def rename(
     new_name: str = typer.Argument(
         ..., help="New checkpoint name.", metavar="NEW_NAME"
     ),
-) -> None:
+) -> Any:
     """Rename a LoRA checkpoint (re-registers inference if active)."""
+    from osmosis_ai.cli.output import OperationResult, get_output_context
     from osmosis_ai.platform.api.client import OsmosisClient
-    from osmosis_ai.platform.cli.utils import _require_auth, platform_call
+    from osmosis_ai.platform.cli.utils import _require_auth
 
     _, credentials = _require_auth()
     client = OsmosisClient()
+    output = get_output_context()
 
-    result = platform_call(
-        "Renaming checkpoint...",
-        lambda: client.rename_checkpoint(checkpoint, new_name, credentials=credentials),
-        output_console=console,
-    )
+    with output.status("Renaming checkpoint..."):
+        result = client.rename_checkpoint(checkpoint, new_name, credentials=credentials)
 
-    old = console.escape(result.old_checkpoint_name)
-    new = console.escape(result.checkpoint_name)
-    console.print(f"Renamed {old} -> {new}", style="green", highlight=False)
+    display_next_steps = []
     if result.status == "failed":
-        console.print(
-            "Warning: inference re-registration failed; deployment is marked as failed.",
-            style="yellow",
+        display_next_steps.append(
+            "Warning: inference re-registration failed; deployment is marked as failed."
         )
+    return OperationResult(
+        operation="deployment.rename",
+        status="failed" if result.status == "failed" else "success",
+        resource={
+            "id": result.id,
+            "old_checkpoint_name": result.old_checkpoint_name,
+            "checkpoint_name": result.checkpoint_name,
+            "status": result.status,
+        },
+        message=f"Renamed {result.old_checkpoint_name} -> {result.checkpoint_name}",
+        display_next_steps=display_next_steps,
+        exit_code=1 if result.status == "failed" else 0,
+    )
 
 
 @app.command("delete")
@@ -231,27 +328,26 @@ def delete(
         ..., help="Checkpoint UUID or checkpoint_name.", metavar="CHECKPOINT"
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
-) -> None:
+) -> Any:
     """Delete a deployment record (idempotent)."""
-    from osmosis_ai.cli.prompts import require_confirmation
+    from osmosis_ai.cli.output import OperationResult, get_output_context
     from osmosis_ai.platform.api.client import OsmosisClient
-    from osmosis_ai.platform.cli.utils import _require_auth, platform_call
+    from osmosis_ai.platform.cli.utils import _require_auth
 
     _, credentials = _require_auth()
 
-    require_confirmation(
+    _require_confirmation(
         f'Delete deployment for checkpoint "{checkpoint}"? This cannot be undone.',
         yes=yes,
     )
 
     client = OsmosisClient()
-    platform_call(
-        "Deleting deployment...",
-        lambda: client.delete_deployment(checkpoint, credentials=credentials),
-        output_console=console,
-    )
-    console.print(
-        f'Deployment for "{console.escape(checkpoint)}" deleted.',
-        style="green",
-        highlight=False,
+    output = get_output_context()
+    with output.status("Deleting deployment..."):
+        client.delete_deployment(checkpoint, credentials=credentials)
+    return OperationResult(
+        operation="deployment.delete",
+        status="success",
+        resource={"checkpoint": checkpoint},
+        message=f'Deployment for "{checkpoint}" deleted.',
     )

--- a/osmosis_ai/cli/commands/deployment.py
+++ b/osmosis_ai/cli/commands/deployment.py
@@ -117,12 +117,16 @@ def info(
 ) -> None:
     """Show deployment details for a checkpoint."""
     from osmosis_ai.platform.api.client import OsmosisClient
-    from osmosis_ai.platform.cli.utils import _require_auth, format_date
+    from osmosis_ai.platform.cli.utils import _require_auth, format_date, platform_call
 
     _, credentials = _require_auth()
 
     client = OsmosisClient()
-    d = client.get_deployment(checkpoint, credentials=credentials)
+    d = platform_call(
+        "Fetching deployment...",
+        lambda: client.get_deployment(checkpoint, credentials=credentials),
+        output_console=console,
+    )
 
     rows: list[tuple[str, str]] = [
         ("Checkpoint", console.escape(d.checkpoint_name) if d.checkpoint_name else "—"),
@@ -150,13 +154,16 @@ def deploy(
 ) -> None:
     """Deploy (or reactivate) a LoRA checkpoint."""
     from osmosis_ai.platform.api.client import OsmosisClient
-    from osmosis_ai.platform.cli.utils import _require_auth
+    from osmosis_ai.platform.cli.utils import _require_auth, platform_call
 
     _, credentials = _require_auth()
     client = OsmosisClient()
 
-    with console.spinner(f'Deploying checkpoint "{console.escape(checkpoint)}"...'):
-        result = client.deploy_checkpoint(checkpoint, credentials=credentials)
+    result = platform_call(
+        f'Deploying checkpoint "{console.escape(checkpoint)}"...',
+        lambda: client.deploy_checkpoint(checkpoint, credentials=credentials),
+        output_console=console,
+    )
 
     status_str = _format_deployment_status(result.status)
     name = console.escape(result.checkpoint_name) if result.checkpoint_name else "—"
@@ -170,13 +177,16 @@ def undeploy(
 ) -> None:
     """Undeploy a LoRA checkpoint (transition to ``inactive``)."""
     from osmosis_ai.platform.api.client import OsmosisClient
-    from osmosis_ai.platform.cli.utils import _require_auth
+    from osmosis_ai.platform.cli.utils import _require_auth, platform_call
 
     _, credentials = _require_auth()
     client = OsmosisClient()
 
-    with console.spinner(f'Undeploying checkpoint "{console.escape(checkpoint)}"...'):
-        result = client.undeploy_checkpoint(checkpoint, credentials=credentials)
+    result = platform_call(
+        f'Undeploying checkpoint "{console.escape(checkpoint)}"...',
+        lambda: client.undeploy_checkpoint(checkpoint, credentials=credentials),
+        output_console=console,
+    )
 
     status_str = _format_deployment_status(result.status)
     name = console.escape(result.checkpoint_name) if result.checkpoint_name else "—"
@@ -194,13 +204,16 @@ def rename(
 ) -> None:
     """Rename a LoRA checkpoint (re-registers inference if active)."""
     from osmosis_ai.platform.api.client import OsmosisClient
-    from osmosis_ai.platform.cli.utils import _require_auth
+    from osmosis_ai.platform.cli.utils import _require_auth, platform_call
 
     _, credentials = _require_auth()
     client = OsmosisClient()
 
-    with console.spinner("Renaming checkpoint..."):
-        result = client.rename_checkpoint(checkpoint, new_name, credentials=credentials)
+    result = platform_call(
+        "Renaming checkpoint...",
+        lambda: client.rename_checkpoint(checkpoint, new_name, credentials=credentials),
+        output_console=console,
+    )
 
     old = console.escape(result.old_checkpoint_name)
     new = console.escape(result.checkpoint_name)
@@ -222,7 +235,7 @@ def delete(
     """Delete a deployment record (idempotent)."""
     from osmosis_ai.cli.prompts import require_confirmation
     from osmosis_ai.platform.api.client import OsmosisClient
-    from osmosis_ai.platform.cli.utils import _require_auth
+    from osmosis_ai.platform.cli.utils import _require_auth, platform_call
 
     _, credentials = _require_auth()
 
@@ -232,7 +245,11 @@ def delete(
     )
 
     client = OsmosisClient()
-    client.delete_deployment(checkpoint, credentials=credentials)
+    platform_call(
+        "Deleting deployment...",
+        lambda: client.delete_deployment(checkpoint, credentials=credentials),
+        output_console=console,
+    )
     console.print(
         f'Deployment for "{console.escape(checkpoint)}" deleted.',
         style="green",

--- a/osmosis_ai/cli/commands/eval.py
+++ b/osmosis_ai/cli/commands/eval.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 import typer
 
@@ -37,12 +37,13 @@ def eval_run(
     batch_size: int | None = typer.Option(
         None, "--batch-size", help="Override concurrent batch size."
     ),
-) -> None:
+) -> Any:
     """Evaluate agent against dataset using TOML config."""
+    from osmosis_ai.cli.output import CommandResult
     from osmosis_ai.eval.evaluation.cli import EvalCommand
 
     cmd = EvalCommand()
-    rc = cmd.run(
+    result = cmd.run(
         config_path=config_path,
         fresh=fresh,
         retry_failed=retry_failed,
@@ -54,8 +55,11 @@ def eval_run(
         log_samples=log_samples,
         batch_size_override=batch_size,
     )
-    if rc:
-        raise typer.Exit(rc)
+    if isinstance(result, CommandResult):
+        return result
+    if result:
+        raise typer.Exit(result)
+    return None
 
 
 @app.command("rubric")
@@ -86,11 +90,12 @@ def eval_rubric(
     ),
     score_min: float = typer.Option(0.0, "--score-min", help="Minimum score."),
     score_max: float = typer.Option(1.0, "--score-max", help="Maximum score."),
-) -> None:
+) -> Any:
     """Evaluate conversations against a rubric using LLM-as-judge."""
+    from osmosis_ai.cli.output import CommandResult
     from osmosis_ai.eval.rubric.cli import RubricCommand
 
-    rc = RubricCommand().run(
+    result = RubricCommand().run(
         data=data,
         rubric=rubric,
         model=model,
@@ -101,18 +106,25 @@ def eval_rubric(
         score_min=score_min,
         score_max=score_max,
     )
-    if rc:
-        raise typer.Exit(rc)
+    if isinstance(result, CommandResult):
+        return result
+    if result:
+        raise typer.Exit(result)
+    return None
 
 
 @cache_app.command("dir")
-def eval_cache_dir() -> None:
+def eval_cache_dir() -> Any:
     """Print cache root directory path."""
+    from osmosis_ai.cli.output import CommandResult
     from osmosis_ai.eval.evaluation.cli import EvalCommand
 
-    rc = EvalCommand()._run_cache_dir()
-    if rc:
-        raise typer.Exit(rc)
+    result = EvalCommand()._run_cache_dir()
+    if isinstance(result, CommandResult):
+        return result
+    if result:
+        raise typer.Exit(result)
+    return None
 
 
 @cache_app.command("ls")
@@ -126,17 +138,21 @@ def eval_cache_ls(
     cache_status: Literal["in_progress", "completed"] | None = typer.Option(
         None, "--status", help="Filter by status (in_progress, completed)."
     ),
-) -> None:
+) -> Any:
     """List cached evaluations."""
+    from osmosis_ai.cli.output import CommandResult
     from osmosis_ai.eval.evaluation.cli import EvalCommand
 
-    rc = EvalCommand()._run_cache_ls(
+    result = EvalCommand()._run_cache_ls(
         cache_model=cache_model,
         cache_dataset=cache_dataset,
         cache_status=cache_status,
     )
-    if rc:
-        raise typer.Exit(rc)
+    if isinstance(result, CommandResult):
+        return result
+    if result:
+        raise typer.Exit(result)
+    return None
 
 
 @cache_app.command("rm")
@@ -155,11 +171,12 @@ def eval_cache_rm(
         None, "--status", help="Filter by status (in_progress, completed)."
     ),
     yes: bool = typer.Option(False, "-y", "--yes", help="Skip confirmation prompt."),
-) -> None:
+) -> Any:
     """Remove cached evaluations."""
+    from osmosis_ai.cli.output import CommandResult
     from osmosis_ai.eval.evaluation.cli import EvalCommand
 
-    rc = EvalCommand()._run_cache_rm(
+    result = EvalCommand()._run_cache_rm(
         task_id=task_id,
         rm_all=rm_all,
         cache_model=cache_model,
@@ -167,5 +184,8 @@ def eval_cache_rm(
         cache_status=cache_status,
         yes=yes,
     )
-    if rc:
-        raise typer.Exit(rc)
+    if isinstance(result, CommandResult):
+        return result
+    if result:
+        raise typer.Exit(result)
+    return None

--- a/osmosis_ai/cli/commands/init.py
+++ b/osmosis_ai/cli/commands/init.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import typer
 
 
@@ -14,8 +16,8 @@ def init(
         "--here",
         help="Initialize in current directory instead of creating a subdirectory.",
     ),
-) -> None:
+) -> Any:
     """Initialize a new Osmosis workspace directory."""
     from osmosis_ai.platform.cli.init import init as do_init
 
-    do_init(name=name, here=here)
+    return do_init(name=name, here=here)

--- a/osmosis_ai/cli/commands/model.py
+++ b/osmosis_ai/cli/commands/model.py
@@ -120,13 +120,17 @@ def delete(
     from osmosis_ai.cli.prompts import require_confirmation
     from osmosis_ai.platform.api.client import OsmosisClient
     from osmosis_ai.platform.auth.platform_client import PlatformAPIError
-    from osmosis_ai.platform.cli.utils import _require_auth
+    from osmosis_ai.platform.cli.utils import _require_auth, platform_call
 
     _ws_name, credentials = _require_auth()
     client = OsmosisClient()
 
     try:
-        affected = client.get_model_affected_resources(name, credentials=credentials)
+        affected = platform_call(
+            "Checking model dependencies...",
+            lambda: client.get_model_affected_resources(name, credentials=credentials),
+            output_console=console,
+        )
     except PlatformAPIError as e:
         raise CLIError(f"Unable to verify model dependencies: {e}") from e
 
@@ -147,7 +151,11 @@ def delete(
         raise typer.Exit(1)
 
     require_confirmation(f'Delete model "{name}"? This cannot be undone.', yes=yes)
-    client.delete_model(name, credentials=credentials)
+    platform_call(
+        "Deleting model...",
+        lambda: client.delete_model(name, credentials=credentials),
+        output_console=console,
+    )
     console.print(
         f'Model "{console.escape(name)}" deleted.',
         style="green",

--- a/osmosis_ai/cli/commands/model.py
+++ b/osmosis_ai/cli/commands/model.py
@@ -6,7 +6,6 @@ scoped to base (foundation) models only.
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
 import typer
@@ -42,44 +41,6 @@ def _require_confirmation(message: str, *, yes: bool) -> None:
     from osmosis_ai.cli.prompts import require_confirmation
 
     require_confirmation(message, yes=yes)
-
-
-def _print_model_section(
-    models: list[Any],
-    total_count: int,
-    title: str,
-    metadata_fn: Callable[[Any], str],
-) -> None:
-    """Print a section of base models with consistent formatting."""
-    from osmosis_ai.platform.cli.utils import entity_status_style, format_dim_date
-
-    if not models:
-        return
-    console.print(f"{title} ({total_count}):", style="bold")
-    for m in models:
-        style = entity_status_style(m.status) or "dim"
-        status_str = console.format_styled(f"[{m.status}]", style)
-        name = console.escape(m.base_model or m.model_name)
-        meta = metadata_fn(m)
-        date = format_dim_date(m.created_at)
-        console.print(
-            f"  {name}  {status_str}  {meta}  {date}",
-            highlight=False,
-        )
-    console.print()
-
-
-def _fetch_all_models(client: Any, credentials: Any) -> list[Any]:
-    """Fetch all base models via exhaustive pagination."""
-    from osmosis_ai.platform.cli.utils import fetch_all_pages
-
-    models, _ = fetch_all_pages(
-        lambda lim, off: client.list_base_models(
-            limit=lim, offset=off, credentials=credentials
-        ),
-        items_attr="models",
-    )
-    return models
 
 
 @app.command("list")

--- a/osmosis_ai/cli/commands/model.py
+++ b/osmosis_ai/cli/commands/model.py
@@ -19,6 +19,31 @@ app: typer.Typer = typer.Typer(
 )
 
 
+def _require_confirmation(message: str, *, yes: bool) -> None:
+    if yes:
+        return
+
+    from osmosis_ai.cli.errors import CLIError
+    from osmosis_ai.cli.output import OutputFormat, get_output_context
+
+    output = get_output_context()
+    if output.format is not OutputFormat.rich or not output.interactive:
+        err = CLIError(
+            "Use --yes to confirm in non-interactive mode.",
+            code="INTERACTIVE_REQUIRED",
+        )
+        if output.format is OutputFormat.json:
+            from osmosis_ai.cli.output import emit_structured_error_to_stderr
+
+            emit_structured_error_to_stderr(err)
+            raise typer.Exit(1)
+        raise err
+
+    from osmosis_ai.cli.prompts import require_confirmation
+
+    require_confirmation(message, yes=yes)
+
+
 def _print_model_section(
     models: list[Any],
     total_count: int,
@@ -65,11 +90,17 @@ def list_models(
         help="Maximum number of base models to show.",
     ),
     all_: bool = typer.Option(False, "--all", help="Show all base models."),
-) -> None:
+) -> Any:
     """List base models in the current workspace."""
+    from osmosis_ai.cli.output import (
+        ListColumn,
+        ListResult,
+        get_output_context,
+        serialize_model,
+    )
     from osmosis_ai.platform.cli.utils import (
         _require_auth,
-        print_pagination_footer,
+        fetch_all_pages,
         validate_list_options,
     )
 
@@ -79,62 +110,81 @@ def list_models(
 
     from osmosis_ai.platform.api.client import OsmosisClient
 
-    with console.spinner("Fetching models..."):
-        client = OsmosisClient()
+    output = get_output_context()
+    client = OsmosisClient()
+    with output.status("Fetching models..."):
         if fetch_all:
-            models = _fetch_all_models(client, credentials)
-            total = len(models)
+            models, total = fetch_all_pages(
+                lambda lim, off: client.list_base_models(
+                    limit=lim, offset=off, credentials=credentials
+                ),
+                items_attr="models",
+            )
+            has_more = False
+            next_offset = None
         else:
             result = client.list_base_models(
-                limit=effective_limit, credentials=credentials
+                limit=effective_limit, offset=0, credentials=credentials
             )
             models = result.models
             total = result.total_count
+            has_more = result.has_more
+            next_offset = result.next_offset
 
-    if not models:
-        console.print("No models found.")
-        return
-
-    _print_model_section(
-        models,
-        total,
-        "Base Models",
-        lambda m: (
-            console.format_styled(f"by {m.creator_name}", "dim")
-            if m.creator_name
-            else ""
-        ),
+    return ListResult(
+        title="Base Models",
+        items=[serialize_model(model) for model in models],
+        total_count=total,
+        has_more=has_more,
+        next_offset=next_offset,
+        columns=[
+            ListColumn(key="model_name", label="Model"),
+            ListColumn(key="base_model", label="Base"),
+            ListColumn(key="status", label="Status"),
+            ListColumn(key="creator_name", label="Creator"),
+            ListColumn(key="created_at", label="Created"),
+            ListColumn(key="id", label="ID", no_wrap=True),
+        ],
     )
-
-    if not fetch_all:
-        print_pagination_footer(len(models), total, "base models")
 
 
 @app.command("delete")
 def delete(
     name: str = typer.Argument(..., help="Model path (e.g. google/gemma-2-9b-it)."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
-) -> None:
+) -> Any:
     """Delete a base model."""
     from osmosis_ai.cli.errors import CLIError
-    from osmosis_ai.cli.prompts import require_confirmation
+    from osmosis_ai.cli.output import OperationResult, OutputFormat, get_output_context
     from osmosis_ai.platform.api.client import OsmosisClient
     from osmosis_ai.platform.auth.platform_client import PlatformAPIError
-    from osmosis_ai.platform.cli.utils import _require_auth, platform_call
+    from osmosis_ai.platform.cli.utils import _require_auth
 
     _ws_name, credentials = _require_auth()
     client = OsmosisClient()
+    output = get_output_context()
 
     try:
-        affected = platform_call(
-            "Checking model dependencies...",
-            lambda: client.get_model_affected_resources(name, credentials=credentials),
-            output_console=console,
-        )
+        with output.status("Checking model dependencies..."):
+            affected = client.get_model_affected_resources(
+                name, credentials=credentials
+            )
     except PlatformAPIError as e:
         raise CLIError(f"Unable to verify model dependencies: {e}") from e
 
     if affected.has_blocking_runs:
+        blocking_runs = [
+            {
+                "id": run.id,
+                "training_run_name": run.training_run_name,
+            }
+            for run in affected.training_runs_using_model
+        ]
+        if output.format is not OutputFormat.rich:
+            raise CLIError(
+                "Cannot delete this model because training runs depend on it.",
+                details={"training_runs": blocking_runs},
+            )
         console.print(
             "Cannot delete this model — the following training runs depend on it:",
             style="red",
@@ -150,14 +200,12 @@ def delete(
         console.print("\nDelete these training runs first, then retry.", style="dim")
         raise typer.Exit(1)
 
-    require_confirmation(f'Delete model "{name}"? This cannot be undone.', yes=yes)
-    platform_call(
-        "Deleting model...",
-        lambda: client.delete_model(name, credentials=credentials),
-        output_console=console,
-    )
-    console.print(
-        f'Model "{console.escape(name)}" deleted.',
-        style="green",
-        highlight=False,
+    _require_confirmation(f'Delete model "{name}"? This cannot be undone.', yes=yes)
+    with output.status("Deleting model..."):
+        client.delete_model(name, credentials=credentials)
+    return OperationResult(
+        operation="model.delete",
+        status="success",
+        resource={"name": name},
+        message=f'Model "{name}" deleted.',
     )

--- a/osmosis_ai/cli/commands/rollout.py
+++ b/osmosis_ai/cli/commands/rollout.py
@@ -152,18 +152,6 @@ def validate(
     return _validate_rollout_config(config_path=config_path)
 
 
-def _format_commit(r: Any, console: Console) -> Any:
-    """Format commit SHA as a clickable terminal hyperlink (OSC 8 via Rich)."""
-    sha = r.last_synced_commit_sha
-    if not sha:
-        return console.format_text("—", style="dim")
-    short = sha[:7]
-    if r.repo_full_name:
-        url = f"https://github.com/{r.repo_full_name}/tree/{sha}"
-        return console.format_url(url, label=short, style="dim")
-    return console.format_text(short, style="dim")
-
-
 @app.command("list")
 def list_rollouts(
     limit: int = typer.Option(

--- a/osmosis_ai/cli/commands/rollout.py
+++ b/osmosis_ai/cli/commands/rollout.py
@@ -106,14 +106,14 @@ def _validate_rollout_config(*, config_path: Path, console: Console) -> None:
         grader_config_ref=grader_config_ref,
     )
 
-    rows: list[tuple[str, str]] = [
-        ("Config", str(config_path.resolve())),
-        ("Kind", config_kind),
-        ("Rollout", rollout),
-        ("Entrypoint", entrypoint),
+    rows: list[tuple[str, Any]] = [
+        ("Config", console.format_text(config_path.resolve())),
+        ("Kind", console.format_text(config_kind)),
+        ("Rollout", console.format_text(rollout)),
+        ("Entrypoint", console.format_text(entrypoint)),
     ]
     if grader_module:
-        rows.append(("Grader override", grader_module))
+        rows.append(("Grader override", console.format_text(grader_module)))
 
     console.table(rows, title="Rollout Validation")
     console.print("Validation passed.", style="green")
@@ -137,16 +137,16 @@ def validate(
     _validate_rollout_config(config_path=config_path, console=Console())
 
 
-def _format_commit(r: Any) -> str:
+def _format_commit(r: Any, console: Console) -> Any:
     """Format commit SHA as a clickable terminal hyperlink (OSC 8 via Rich)."""
     sha = r.last_synced_commit_sha
     if not sha:
-        return "[dim]—[/dim]"
+        return console.format_text("—", style="dim")
     short = sha[:7]
     if r.repo_full_name:
         url = f"https://github.com/{r.repo_full_name}/tree/{sha}"
-        return f"[dim][link={url}]{short}[/link][/dim]"
-    return f"[dim]{short}[/dim]"
+        return console.format_url(url, label=short, style="dim")
+    return console.format_text(short, style="dim")
 
 
 @app.command("list")
@@ -160,7 +160,7 @@ def list_rollouts(
     from osmosis_ai.cli.console import Console
     from osmosis_ai.platform.cli.utils import (
         _require_auth,
-        format_dim_date,
+        format_date,
         paginated_fetch,
         print_pagination_footer,
         validate_list_options,
@@ -190,17 +190,23 @@ def list_rollouts(
 
     console.print(f"Rollouts ({total_count}):", style="bold")
     for r in rollouts:
-        name = console.escape(r.name)
+        name = console.format_text(r.name)
         active = (
-            console.format_styled("[active]", "green")
+            console.format_text("[active]", style="green")
             if r.is_active
-            else console.format_styled("[inactive]", "dim")
+            else console.format_text("[inactive]", style="dim")
         )
-        commit = _format_commit(r)
-        date = format_dim_date(r.created_at)
+        commit = _format_commit(r, console)
+        date = console.format_text(format_date(r.created_at), style="dim")
         console.print(
-            f"  {name}  {active}  {commit}  {date}",
-            highlight=False,
+            console.format_text("  ")
+            + name
+            + console.format_text("  ")
+            + active
+            + console.format_text("  ")
+            + commit
+            + console.format_text("  ")
+            + date
         )
 
     print_pagination_footer(len(rollouts), total_count, "rollouts")

--- a/osmosis_ai/cli/commands/rollout.py
+++ b/osmosis_ai/cli/commands/rollout.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import typer
 
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE
-
-if TYPE_CHECKING:
-    from osmosis_ai.cli.console import Console
 
 app: typer.Typer = typer.Typer(
     help="Manage rollouts (validate, list).",
@@ -85,9 +82,7 @@ def _resolve_validation_target(
     )
 
 
-def _validate_rollout_config(
-    *, config_path: Path, console: Console | None = None
-) -> Any:
+def _validate_rollout_config(*, config_path: Path) -> Any:
     from osmosis_ai.cli.output import DetailField, DetailResult
     from osmosis_ai.platform.cli.workspace_contract import validate_rollout_backend
 

--- a/osmosis_ai/cli/commands/rollout.py
+++ b/osmosis_ai/cli/commands/rollout.py
@@ -85,7 +85,10 @@ def _resolve_validation_target(
     )
 
 
-def _validate_rollout_config(*, config_path: Path, console: Console) -> None:
+def _validate_rollout_config(
+    *, config_path: Path, console: Console | None = None
+) -> Any:
+    from osmosis_ai.cli.output import DetailField, DetailResult
     from osmosis_ai.platform.cli.workspace_contract import validate_rollout_backend
 
     (
@@ -107,16 +110,30 @@ def _validate_rollout_config(*, config_path: Path, console: Console) -> None:
     )
 
     rows: list[tuple[str, Any]] = [
-        ("Config", console.format_text(config_path.resolve())),
-        ("Kind", console.format_text(config_kind)),
-        ("Rollout", console.format_text(rollout)),
-        ("Entrypoint", console.format_text(entrypoint)),
+        ("Config", str(config_path.resolve())),
+        ("Kind", config_kind),
+        ("Rollout", rollout),
+        ("Entrypoint", entrypoint),
     ]
     if grader_module:
-        rows.append(("Grader override", console.format_text(grader_module)))
+        rows.append(("Grader override", grader_module))
+    rows.append(("Status", "Validation passed."))
 
-    console.table(rows, title="Rollout Validation")
-    console.print("Validation passed.", style="green")
+    return DetailResult(
+        title="Rollout Validation",
+        data={
+            "config": str(config_path.resolve()),
+            "kind": config_kind,
+            "rollout": rollout,
+            "entrypoint": entrypoint,
+            "grader_module": grader_module,
+            "grader_config": grader_config_ref,
+            "valid": True,
+        },
+        fields=[
+            DetailField(label=str(label), value=str(value)) for label, value in rows
+        ],
+    )
 
 
 @app.command("validate")
@@ -130,11 +147,9 @@ def validate(
         resolve_path=True,
         help="Path to training or eval TOML config file.",
     ),
-) -> None:
+) -> Any:
     """Validate a rollout entrypoint referenced by a config file."""
-    from osmosis_ai.cli.console import Console
-
-    _validate_rollout_config(config_path=config_path, console=Console())
+    return _validate_rollout_config(config_path=config_path)
 
 
 def _format_commit(r: Any, console: Console) -> Any:
@@ -155,58 +170,59 @@ def list_rollouts(
         DEFAULT_PAGE_SIZE, "--limit", help="Maximum number of rollouts to show."
     ),
     all_: bool = typer.Option(False, "--all", help="Show all rollouts."),
-) -> None:
+) -> Any:
     """List rollouts in the current workspace."""
-    from osmosis_ai.cli.console import Console
+    from osmosis_ai.cli.output import (
+        ListColumn,
+        ListResult,
+        get_output_context,
+        serialize_rollout,
+    )
     from osmosis_ai.platform.cli.utils import (
         _require_auth,
-        format_date,
-        paginated_fetch,
-        print_pagination_footer,
+        fetch_all_pages,
         validate_list_options,
     )
 
     effective_limit, fetch_all = validate_list_options(limit=limit, all_=all_)
 
-    console = Console()
     _, credentials = _require_auth()
 
     from osmosis_ai.platform.api.client import OsmosisClient
 
-    with console.spinner("Fetching rollouts..."):
-        client = OsmosisClient()
-        rollouts, total_count, _has_more = paginated_fetch(
-            lambda lim, off: client.list_rollouts(
-                limit=lim, offset=off, credentials=credentials
-            ),
-            items_attr="rollouts",
-            limit=effective_limit,
-            fetch_all=fetch_all,
-        )
+    output = get_output_context()
+    client = OsmosisClient()
+    with output.status("Fetching rollouts..."):
+        if fetch_all:
+            rollouts, total_count = fetch_all_pages(
+                lambda lim, off: client.list_rollouts(
+                    limit=lim, offset=off, credentials=credentials
+                ),
+                items_attr="rollouts",
+            )
+            has_more = False
+            next_offset = None
+        else:
+            page = client.list_rollouts(
+                limit=effective_limit, offset=0, credentials=credentials
+            )
+            rollouts = page.rollouts
+            total_count = page.total_count
+            has_more = page.has_more
+            next_offset = page.next_offset
 
-    if not rollouts:
-        console.print("No rollouts found.")
-        return
-
-    console.print(f"Rollouts ({total_count}):", style="bold")
-    for r in rollouts:
-        name = console.format_text(r.name)
-        active = (
-            console.format_text("[active]", style="green")
-            if r.is_active
-            else console.format_text("[inactive]", style="dim")
-        )
-        commit = _format_commit(r, console)
-        date = console.format_text(format_date(r.created_at), style="dim")
-        console.print(
-            console.format_text("  ")
-            + name
-            + console.format_text("  ")
-            + active
-            + console.format_text("  ")
-            + commit
-            + console.format_text("  ")
-            + date
-        )
-
-    print_pagination_footer(len(rollouts), total_count, "rollouts")
+    return ListResult(
+        title="Rollouts",
+        items=[serialize_rollout(rollout) for rollout in rollouts],
+        total_count=total_count,
+        has_more=has_more,
+        next_offset=next_offset,
+        columns=[
+            ListColumn(key="name", label="Name"),
+            ListColumn(key="is_active", label="Active"),
+            ListColumn(key="repo_full_name", label="Repository"),
+            ListColumn(key="last_synced_commit_sha", label="Commit"),
+            ListColumn(key="created_at", label="Created"),
+            ListColumn(key="id", label="ID", no_wrap=True),
+        ],
+    )

--- a/osmosis_ai/cli/commands/train.py
+++ b/osmosis_ai/cli/commands/train.py
@@ -87,12 +87,17 @@ def status(
         entity_status_style,
         format_date,
         format_dim_date,
+        platform_call,
     )
 
     _, credentials = _require_auth()
 
     client = OsmosisClient()
-    run = client.get_training_run(name, credentials=credentials)
+    run = platform_call(
+        "Fetching training run...",
+        lambda: client.get_training_run(name, credentials=credentials),
+        output_console=console,
+    )
 
     rows = build_run_detail_rows(run)
     if run.examples_processed_count is not None:
@@ -110,7 +115,13 @@ def status(
 
     if run.status in RUN_STATUSES_TERMINAL:
         try:
-            ckpts = client.list_training_run_checkpoints(name, credentials=credentials)
+            ckpts = platform_call(
+                "Fetching checkpoints...",
+                lambda: client.list_training_run_checkpoints(
+                    name, credentials=credentials
+                ),
+                output_console=console,
+            )
         except PlatformAPIError:
             ckpts = None
 
@@ -162,7 +173,11 @@ def submit(
 ) -> None:
     """Submit a new training run."""
     from osmosis_ai.platform.cli.training_config import load_training_config
-    from osmosis_ai.platform.cli.utils import _require_auth, platform_entity_url
+    from osmosis_ai.platform.cli.utils import (
+        _require_auth,
+        platform_call,
+        platform_entity_url,
+    )
     from osmosis_ai.platform.cli.workspace_contract import (
         ensure_workspace_config_path,
         resolve_workspace_root,
@@ -203,9 +218,10 @@ def submit(
 
     from osmosis_ai.platform.api.client import OsmosisClient
 
-    with console.spinner("Submitting training run..."):
-        client = OsmosisClient()
-        result = client.submit_training_run(
+    client = OsmosisClient()
+    result = platform_call(
+        "Submitting training run...",
+        lambda: client.submit_training_run(
             model_path=config.experiment_model_path,
             dataset=config.experiment_dataset,
             rollout_name=config.experiment_rollout,
@@ -213,7 +229,9 @@ def submit(
             commit_sha=config.experiment_commit_sha,
             config=config.to_api_config(),
             credentials=credentials,
-        )
+        ),
+        output_console=console,
+    )
 
     url = platform_entity_url(ws_name, "training", result.id)
     console.print(
@@ -222,7 +240,7 @@ def submit(
         highlight=False,
     )
     console.print(f"  Status: {result.status}")
-    console.print("  View: ", console.format_url(url), sep="", soft_wrap=True)
+    console.print_url("  View: ", url)
 
 
 def _safe_name(name: str) -> str:
@@ -311,14 +329,18 @@ def metrics(
     from osmosis_ai.platform.auth.platform_client import PlatformAPIError
     from osmosis_ai.platform.cli.utils import (
         _require_auth,
+        platform_call,
         platform_entity_url,
     )
 
     ws_name, credentials = _require_auth()
     client = OsmosisClient()
 
-    with console.spinner("Fetching training run..."):
-        run = client.get_training_run(name, credentials=credentials)
+    run = platform_call(
+        "Fetching training run...",
+        lambda: client.get_training_run(name, credentials=credentials),
+        output_console=console,
+    )
 
     if run.status == "pending":
         raise CLIError("Metrics are not yet available for pending training runs.")
@@ -328,22 +350,17 @@ def metrics(
     # ── Platform URL (no metrics dependency) ─────────────────────
     url = platform_entity_url(ws_name, "training", run.id)
     console.print()
-    console.print(
-        "View full details: ",
-        console.format_url(url, style="cyan"),
-        sep="",
-        highlight=False,
-        soft_wrap=True,
-    )
+    console.print_url("View full details: ", url, style="cyan")
     console.print()
 
     # ── Fetch metrics (best-effort) ──────────────────────────────
     metrics_data = None
     try:
-        with console.spinner("Fetching metrics..."):
-            metrics_data = client.get_training_run_metrics(
-                run.id, credentials=credentials
-            )
+        metrics_data = platform_call(
+            "Fetching metrics...",
+            lambda: client.get_training_run_metrics(run.id, credentials=credentials),
+            output_console=console,
+        )
     except (PlatformAPIError, KeyError):
         console.print("Could not fetch metrics data.", style="yellow")
 
@@ -440,7 +457,7 @@ def stop(
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
 ) -> None:
     """Stop a training run."""
-    from osmosis_ai.platform.cli.utils import _require_auth
+    from osmosis_ai.platform.cli.utils import _require_auth, platform_call
 
     _, credentials = _require_auth()
 
@@ -452,7 +469,11 @@ def stop(
 
     require_confirmation(f'Stop training run "{name}"?', yes=yes)
 
-    client.stop_training_run(name, credentials=credentials)
+    platform_call(
+        "Stopping training run...",
+        lambda: client.stop_training_run(name, credentials=credentials),
+        output_console=console,
+    )
     console.print(
         f'Training run "{console.escape(name)}" stopped.',
         style="green",
@@ -466,7 +487,7 @@ def delete(
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
 ) -> None:
     """Delete a training run."""
-    from osmosis_ai.platform.cli.utils import _require_auth
+    from osmosis_ai.platform.cli.utils import _require_auth, platform_call
 
     _, credentials = _require_auth()
 
@@ -480,7 +501,11 @@ def delete(
         f'Delete training run "{name}"? This cannot be undone.', yes=yes
     )
 
-    client.delete_training_run(name, credentials=credentials)
+    platform_call(
+        "Deleting training run...",
+        lambda: client.delete_training_run(name, credentials=credentials),
+        output_console=console,
+    )
     console.print(
         f'Training run "{console.escape(name)}" deleted.',
         style="green",

--- a/osmosis_ai/cli/commands/train.py
+++ b/osmosis_ai/cli/commands/train.py
@@ -215,14 +215,14 @@ def submit(
             credentials=credentials,
         )
 
-    url = console.escape(platform_entity_url(ws_name, "training", result.id))
+    url = platform_entity_url(ws_name, "training", result.id)
     console.print(
         f"Training run submitted: {console.escape(result.name)}",
         style="green",
         highlight=False,
     )
     console.print(f"  Status: {result.status}")
-    console.print(f"  View: {url}")
+    console.print("  View: ", console.format_url(url), sep="", soft_wrap=True)
 
 
 def _safe_name(name: str) -> str:
@@ -326,9 +326,15 @@ def metrics(
     is_in_progress = run.status in RUN_STATUSES_IN_PROGRESS
 
     # ── Platform URL (no metrics dependency) ─────────────────────
-    url = console.escape(platform_entity_url(ws_name, "training", run.id))
+    url = platform_entity_url(ws_name, "training", run.id)
     console.print()
-    console.print(f"View full details: {url}", style="cyan", highlight=False)
+    console.print(
+        "View full details: ",
+        console.format_url(url, style="cyan"),
+        sep="",
+        highlight=False,
+        soft_wrap=True,
+    )
     console.print()
 
     # ── Fetch metrics (best-effort) ──────────────────────────────

--- a/osmosis_ai/cli/commands/train.py
+++ b/osmosis_ai/cli/commands/train.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Any
 
 import typer
 
@@ -14,20 +15,53 @@ from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE
 app: typer.Typer = typer.Typer(help="Manage training runs.", no_args_is_help=True)
 
 
+def _detail_fields(rows: list[tuple[str, str]]) -> list[Any]:
+    from osmosis_ai.cli.output import DetailField
+
+    return [DetailField(label=label, value=value) for label, value in rows]
+
+
+def _require_confirmation(message: str, *, yes: bool) -> None:
+    if yes:
+        return
+
+    from osmosis_ai.cli.output import OutputFormat, get_output_context
+
+    output = get_output_context()
+    if output.format is not OutputFormat.rich or not output.interactive:
+        err = CLIError(
+            "Use --yes to confirm in non-interactive mode.",
+            code="INTERACTIVE_REQUIRED",
+        )
+        if output.format is OutputFormat.json:
+            from osmosis_ai.cli.output import emit_structured_error_to_stderr
+
+            emit_structured_error_to_stderr(err)
+            raise typer.Exit(1)
+        raise err
+
+    from osmosis_ai.cli.prompts import require_confirmation
+
+    require_confirmation(message, yes=yes)
+
+
 @app.command("list")
 def list_runs(
     limit: int = typer.Option(
         DEFAULT_PAGE_SIZE, "--limit", help="Maximum number of runs to show."
     ),
     all_: bool = typer.Option(False, "--all", help="Show all training runs."),
-) -> None:
+) -> Any:
     """List training runs in the current workspace."""
+    from osmosis_ai.cli.output import (
+        ListColumn,
+        ListResult,
+        get_output_context,
+        serialize_training_run,
+    )
     from osmosis_ai.platform.cli.utils import (
         _require_auth,
-        format_dim_date,
-        format_run_status,
-        paginated_fetch,
-        print_pagination_footer,
+        fetch_all_pages,
         validate_list_options,
     )
 
@@ -37,67 +71,71 @@ def list_runs(
 
     from osmosis_ai.platform.api.client import OsmosisClient
 
-    with console.spinner("Fetching training runs..."):
-        client = OsmosisClient()
-        training_runs, total_count, _has_more = paginated_fetch(
-            lambda lim, off: client.list_training_runs(
-                limit=lim, offset=off, credentials=credentials
-            ),
-            items_attr="training_runs",
-            limit=effective_limit,
-            fetch_all=fetch_all,
-        )
+    output = get_output_context()
+    client = OsmosisClient()
+    with output.status("Fetching training runs..."):
+        if fetch_all:
+            training_runs, total_count = fetch_all_pages(
+                lambda lim, off: client.list_training_runs(
+                    limit=lim, offset=off, credentials=credentials
+                ),
+                items_attr="training_runs",
+            )
+            has_more = False
+            next_offset = None
+        else:
+            page = client.list_training_runs(
+                limit=effective_limit, offset=0, credentials=credentials
+            )
+            training_runs = page.training_runs
+            total_count = page.total_count
+            has_more = page.has_more
+            next_offset = page.next_offset
 
-    if not training_runs:
-        console.print("No training runs found.")
-        return
-
-    console.print(f"Training Runs ({total_count}):", style="bold")
-    for r in training_runs:
-        status_str = format_run_status(r)
-        short_id = console.format_styled(r.id[:8], "dim")
-        name = (
-            console.escape(r.name)
-            if r.name
-            else console.format_styled("(unnamed)", "dim")
-        )
-        model = console.escape(r.model_name) if r.model_name else "—"
-        acc = f"acc:{r.eval_accuracy:.2f}" if r.eval_accuracy is not None else ""
-        date = format_dim_date(r.created_at)
-
-        console.print(
-            f"  {short_id}  {name}  {status_str}  {model}  {acc}  {date}",
-            highlight=False,
-        )
-
-    print_pagination_footer(len(training_runs), total_count, "training runs")
+    return ListResult(
+        title="Training Runs",
+        items=[serialize_training_run(r) for r in training_runs],
+        total_count=total_count,
+        has_more=has_more,
+        next_offset=next_offset,
+        columns=[
+            ListColumn(key="name", label="Name"),
+            ListColumn(key="status", label="Status"),
+            ListColumn(key="model_name", label="Model"),
+            ListColumn(key="eval_accuracy", label="Accuracy"),
+            ListColumn(key="created_at", label="Created"),
+            ListColumn(key="id", label="ID", no_wrap=True),
+        ],
+    )
 
 
 @app.command("status")
 def status(
     name: str = typer.Argument(..., help="Training run name."),
-) -> None:
+) -> Any:
     """Show training run details."""
+    from osmosis_ai.cli.output import (
+        DetailField,
+        DetailResult,
+        get_output_context,
+        serialize_checkpoint,
+        serialize_training_run,
+    )
     from osmosis_ai.platform.api.client import OsmosisClient
     from osmosis_ai.platform.api.models import RUN_STATUSES_TERMINAL
     from osmosis_ai.platform.auth.platform_client import PlatformAPIError
     from osmosis_ai.platform.cli.utils import (
         _require_auth,
         build_run_detail_rows,
-        entity_status_style,
         format_date,
-        format_dim_date,
-        platform_call,
     )
 
     _, credentials = _require_auth()
 
     client = OsmosisClient()
-    run = platform_call(
-        "Fetching training run...",
-        lambda: client.get_training_run(name, credentials=credentials),
-        output_console=console,
-    )
+    output = get_output_context()
+    with output.status("Fetching training run..."):
+        run = client.get_training_run(name, credentials=credentials)
 
     rows = build_run_detail_rows(run)
     if run.examples_processed_count is not None:
@@ -111,51 +149,59 @@ def status(
     if run.completed_at:
         rows.append(("Completed", format_date(run.completed_at)))
 
-    console.table(rows, title="Training Run")
+    checkpoints = []
 
     if run.status in RUN_STATUSES_TERMINAL:
         try:
-            ckpts = platform_call(
-                "Fetching checkpoints...",
-                lambda: client.list_training_run_checkpoints(
+            with output.status("Fetching checkpoints..."):
+                ckpts = client.list_training_run_checkpoints(
                     name, credentials=credentials
-                ),
-                output_console=console,
-            )
+                )
         except PlatformAPIError:
             ckpts = None
 
         if ckpts is not None and ckpts.checkpoints:
-            console.print()
-            console.print("Checkpoints:", style="bold")
-            for cp in ckpts.checkpoints:
-                name = (
-                    console.escape(cp.checkpoint_name)
-                    if cp.checkpoint_name
-                    else console.format_styled("(unnamed)", "dim")
-                )
-                step_str = f"step {cp.checkpoint_step}"
-                status_style = entity_status_style(cp.status) or "dim"
-                status_str = console.format_styled(f"[{cp.status}]", status_style)
-                date = format_dim_date(cp.created_at)
-                short_id = console.format_styled(cp.id[:8], "dim")
-                console.print(
-                    f"  {name}  {step_str}  {status_str}  {short_id}  {date}",
-                    highlight=False,
-                )
-            console.print()
-            console.print(
-                "Deploy with:  osmosis deploy <checkpoint-name>",
-                style="dim",
+            checkpoints = ckpts.checkpoints
+
+    fields = _detail_fields(rows)
+    for cp in checkpoints:
+        cp_name = cp.checkpoint_name or "(unnamed)"
+        fields.append(
+            DetailField(
+                label="Checkpoint",
+                value=(
+                    f"{cp_name}  step {cp.checkpoint_step}  [{cp.status}]"
+                    f"  {cp.id[:8]}  {format_date(cp.created_at)}"
+                ),
             )
+        )
+    if checkpoints:
+        fields.append(
+            DetailField(
+                label="Deploy",
+                value="osmosis deploy <checkpoint-name>",
+            )
+        )
+
+    data = serialize_training_run(run)
+    data.update(
+        {
+            "examples_processed_count": run.examples_processed_count,
+            "notes": run.notes,
+            "hf_status": run.hf_status,
+            "checkpoints": [serialize_checkpoint(cp) for cp in checkpoints],
+        }
+    )
+
+    return DetailResult(title="Training Run", data=data, fields=fields)
 
 
 @app.command("info", hidden=True)
 def info(
     name: str = typer.Argument(..., help="Training run name."),
-) -> None:
+) -> Any:
     """Deprecated alias for `osmosis train status`."""
-    status(name=name)
+    return status(name=name)
 
 
 @app.command("submit")
@@ -170,12 +216,12 @@ def submit(
         help="Path to training config TOML file.",
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
-) -> None:
+) -> Any:
     """Submit a new training run."""
+    from osmosis_ai.cli.output import OperationResult, get_output_context
     from osmosis_ai.platform.cli.training_config import load_training_config
     from osmosis_ai.platform.cli.utils import (
         _require_auth,
-        platform_call,
         platform_entity_url,
     )
     from osmosis_ai.platform.cli.workspace_contract import (
@@ -212,16 +258,14 @@ def submit(
         rows.append(("Commit", console.escape(config.experiment_commit_sha)))
     console.table(rows, title="Training Run")
 
-    from osmosis_ai.cli.prompts import require_confirmation
-
-    require_confirmation("Submit this training run?", yes=yes)
+    _require_confirmation("Submit this training run?", yes=yes)
 
     from osmosis_ai.platform.api.client import OsmosisClient
 
     client = OsmosisClient()
-    result = platform_call(
-        "Submitting training run...",
-        lambda: client.submit_training_run(
+    output = get_output_context()
+    with output.status("Submitting training run..."):
+        result = client.submit_training_run(
             model_path=config.experiment_model_path,
             dataset=config.experiment_dataset,
             rollout_name=config.experiment_rollout,
@@ -229,18 +273,36 @@ def submit(
             commit_sha=config.experiment_commit_sha,
             config=config.to_api_config(),
             credentials=credentials,
-        ),
-        output_console=console,
-    )
+        )
 
     url = platform_entity_url(ws_name, "training", result.id)
-    console.print(
-        f"Training run submitted: {console.escape(result.name)}",
-        style="green",
-        highlight=False,
+    return OperationResult(
+        operation="train.submit",
+        status="success",
+        resource={
+            "id": result.id,
+            "name": result.name,
+            "status": result.status,
+            "created_at": result.created_at,
+            "url": url,
+            "config": {
+                "rollout": config.experiment_rollout,
+                "entrypoint": config.experiment_entrypoint,
+                "model": config.experiment_model_path,
+                "dataset": config.experiment_dataset,
+                "commit_sha": config.experiment_commit_sha,
+            },
+        },
+        message=f"Training run submitted: {result.name}",
+        display_next_steps=[
+            f"Status: {result.status}",
+            f"View: {url}",
+        ],
+        next_steps_structured=[
+            {"action": "train_status", "name": result.name},
+            {"action": "open_url", "url": url},
+        ],
     )
-    console.print(f"  Status: {result.status}")
-    console.print_url("  View: ", url)
 
 
 def _safe_name(name: str) -> str:
@@ -319,28 +381,32 @@ def metrics(
             " filename inside it. (default: .osmosis/metrics/)"
         ),
     ),
-) -> None:
+) -> Any:
     """Export training run metrics to a JSON file."""
     import json
 
     from osmosis_ai.cli.metrics_export import build_export_dict
+    from osmosis_ai.cli.output import (
+        DetailField,
+        DetailResult,
+        OutputFormat,
+        get_output_context,
+        serialize_training_run,
+    )
     from osmosis_ai.platform.api.client import OsmosisClient
     from osmosis_ai.platform.api.models import RUN_STATUSES_IN_PROGRESS
     from osmosis_ai.platform.auth.platform_client import PlatformAPIError
     from osmosis_ai.platform.cli.utils import (
         _require_auth,
-        platform_call,
         platform_entity_url,
     )
 
     ws_name, credentials = _require_auth()
     client = OsmosisClient()
+    output_ctx = get_output_context()
 
-    run = platform_call(
-        "Fetching training run...",
-        lambda: client.get_training_run(name, credentials=credentials),
-        output_console=console,
-    )
+    with output_ctx.status("Fetching training run..."):
+        run = client.get_training_run(name, credentials=credentials)
 
     if run.status == "pending":
         raise CLIError("Metrics are not yet available for pending training runs.")
@@ -349,27 +415,17 @@ def metrics(
 
     # ── Platform URL (no metrics dependency) ─────────────────────
     url = platform_entity_url(ws_name, "training", run.id)
-    console.print()
-    console.print_url("View full details: ", url, style="cyan")
-    console.print()
 
     # ── Fetch metrics (best-effort) ──────────────────────────────
     metrics_data = None
+    metrics_error: str | None = None
     try:
-        metrics_data = platform_call(
-            "Fetching metrics...",
-            lambda: client.get_training_run_metrics(run.id, credentials=credentials),
-            output_console=console,
-        )
-    except (PlatformAPIError, KeyError):
-        console.print("Could not fetch metrics data.", style="yellow")
-
-    if is_in_progress:
-        console.print(
-            "Note: training is in progress. Metrics shown are a snapshot.",
-            style="yellow",
-        )
-        console.print()
+        with output_ctx.status("Fetching metrics..."):
+            metrics_data = client.get_training_run_metrics(
+                run.id, credentials=credentials
+            )
+    except (PlatformAPIError, KeyError) as exc:
+        metrics_error = str(exc) or "Could not fetch metrics data."
 
     # ── Summary table ─────────────────────────────────────────────
     rows: list[tuple[str, str]] = []
@@ -397,7 +453,8 @@ def metrics(
         if total_steps:
             rows.append(("Steps", f"{total_steps:,}"))
 
-    console.table(rows, title="Training Run Metrics")
+    fields = _detail_fields(rows)
+    fields.insert(0, DetailField(label="View", value=url))
 
     # ── Metric trends ─────────────────────────────────────────────
     if metrics_data is not None and metrics_data.metrics:
@@ -406,7 +463,7 @@ def metrics(
             should_render_metric_trends,
         )
 
-        if should_render_metric_trends(
+        if output_ctx.format is OutputFormat.rich and should_render_metric_trends(
             is_tty=console.is_tty,
             terminal_width=console.width,
             metrics=metrics_data.metrics,
@@ -415,34 +472,60 @@ def metrics(
                 metrics_data.metrics, terminal_width=console.width
             )
             if trends:
-                console.print()
-                console.separator("Metric Trends")
-                console.print(trends)
+                fields.append(DetailField(label="Metric Trends", value=trends))
     elif metrics_data is not None:
-        console.print("No metric data found.", style="dim")
+        fields.append(DetailField(label="Metrics", value="No metric data found."))
+
+    if metrics_error is not None:
+        fields.append(
+            DetailField(label="Metrics", value="Could not fetch metrics data.")
+        )
+
+    if is_in_progress:
+        fields.append(
+            DetailField(
+                label="Note",
+                value="Training is in progress. Metrics shown are a snapshot.",
+            )
+        )
 
     # ── Save to file (best-effort) ────────────────────────────────
+    export: dict[str, Any] | None = None
+    output_path: str | None = None
+    save_warning: str | None = None
     if metrics_data is not None:
         export = build_export_dict(run, metrics_data)
-        console.print()
-        try:
-            out_path = (
-                _resolve_output_path(output, run.name, run.id)
-                if output
-                else _resolve_default_output(run.name, run.id)
-            )
-            out_path.write_text(json.dumps(export, indent=2, ensure_ascii=False) + "\n")
-            console.print(
-                f"Saved to {console.escape(str(out_path))}",
-                style="green",
-                highlight=False,
-            )
-        except (CLIError, OSError) as exc:
-            console.print(
-                f"Could not save metrics: {console.escape(str(exc))}",
-                style="yellow",
-                highlight=False,
-            )
+        should_write_file = output is not None or output_ctx.format is OutputFormat.rich
+        if should_write_file:
+            try:
+                out_path = (
+                    _resolve_output_path(output, run.name, run.id)
+                    if output
+                    else _resolve_default_output(run.name, run.id)
+                )
+                out_path.write_text(
+                    json.dumps(export, indent=2, ensure_ascii=False) + "\n"
+                )
+                output_path = str(out_path)
+                fields.append(DetailField(label="Saved", value=output_path))
+            except (CLIError, OSError) as exc:
+                save_warning = f"Could not save metrics: {exc}"
+                fields.append(DetailField(label="Warning", value=save_warning))
+
+    return DetailResult(
+        title="Training Run Metrics",
+        data={
+            "training_run": serialize_training_run(run),
+            "platform_url": url,
+            "in_progress": is_in_progress,
+            "metrics_available": metrics_data is not None,
+            "metrics_error": metrics_error,
+            "metrics": export,
+            "output_path": output_path,
+            "save_warning": save_warning,
+        },
+        fields=fields,
+    )
 
 
 @app.command("traces")
@@ -455,9 +538,10 @@ def traces() -> None:
 def stop(
     name: str = typer.Argument(..., help="Training run name."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
-) -> None:
+) -> Any:
     """Stop a training run."""
-    from osmosis_ai.platform.cli.utils import _require_auth, platform_call
+    from osmosis_ai.cli.output import OperationResult, get_output_context
+    from osmosis_ai.platform.cli.utils import _require_auth
 
     _, credentials = _require_auth()
 
@@ -465,19 +549,16 @@ def stop(
 
     client = OsmosisClient()
 
-    from osmosis_ai.cli.prompts import require_confirmation
+    _require_confirmation(f'Stop training run "{name}"?', yes=yes)
 
-    require_confirmation(f'Stop training run "{name}"?', yes=yes)
-
-    platform_call(
-        "Stopping training run...",
-        lambda: client.stop_training_run(name, credentials=credentials),
-        output_console=console,
-    )
-    console.print(
-        f'Training run "{console.escape(name)}" stopped.',
-        style="green",
-        highlight=False,
+    output = get_output_context()
+    with output.status("Stopping training run..."):
+        client.stop_training_run(name, credentials=credentials)
+    return OperationResult(
+        operation="train.stop",
+        status="success",
+        resource={"name": name},
+        message=f'Training run "{name}" stopped.',
     )
 
 
@@ -485,9 +566,10 @@ def stop(
 def delete(
     name: str = typer.Argument(..., help="Training run name."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
-) -> None:
+) -> Any:
     """Delete a training run."""
-    from osmosis_ai.platform.cli.utils import _require_auth, platform_call
+    from osmosis_ai.cli.output import OperationResult, get_output_context
+    from osmosis_ai.platform.cli.utils import _require_auth
 
     _, credentials = _require_auth()
 
@@ -495,19 +577,16 @@ def delete(
 
     client = OsmosisClient()
 
-    from osmosis_ai.cli.prompts import require_confirmation
-
-    require_confirmation(
+    _require_confirmation(
         f'Delete training run "{name}"? This cannot be undone.', yes=yes
     )
 
-    platform_call(
-        "Deleting training run...",
-        lambda: client.delete_training_run(name, credentials=credentials),
-        output_console=console,
-    )
-    console.print(
-        f'Training run "{console.escape(name)}" deleted.',
-        style="green",
-        highlight=False,
+    output = get_output_context()
+    with output.status("Deleting training run..."):
+        client.delete_training_run(name, credentials=credentials)
+    return OperationResult(
+        operation="train.delete",
+        status="success",
+        resource={"name": name},
+        message=f'Training run "{name}" deleted.',
     )

--- a/osmosis_ai/cli/commands/workspace.py
+++ b/osmosis_ai/cli/commands/workspace.py
@@ -41,14 +41,18 @@ def create(
 ) -> None:
     """Create a new workspace."""
     from osmosis_ai.cli.console import console
-    from osmosis_ai.platform.cli.utils import _require_auth
+    from osmosis_ai.platform.cli.utils import _require_auth, platform_call
 
     _, credentials = _require_auth()
 
     from osmosis_ai.platform.api.client import OsmosisClient
 
     client = OsmosisClient()
-    result = client.create_workspace(name, timezone, credentials=credentials)
+    result = platform_call(
+        "Creating workspace...",
+        lambda: client.create_workspace(name, timezone, credentials=credentials),
+        output_console=console,
+    )
     console.print(
         f"Workspace '{console.escape(result['name'])}' created.",
         style="green",
@@ -64,7 +68,7 @@ def delete(
     """Delete a workspace."""
     from osmosis_ai.cli.console import console
     from osmosis_ai.cli.errors import CLIError
-    from osmosis_ai.platform.cli.utils import _require_auth
+    from osmosis_ai.platform.cli.utils import _require_auth, platform_call
 
     _, credentials = _require_auth()
 
@@ -72,7 +76,11 @@ def delete(
 
     client = OsmosisClient()
 
-    ws_data = client.list_workspaces(credentials=credentials)
+    ws_data = platform_call(
+        "Loading workspaces...",
+        lambda: client.list_workspaces(credentials=credentials),
+        output_console=console,
+    )
     workspace = None
     for ws in ws_data.get("workspaces", []):
         if ws.get("name") == name.lower():
@@ -83,8 +91,12 @@ def delete(
         raise CLIError(f"Workspace '{name}' not found.")
 
     try:
-        status = client.get_workspace_deletion_status(
-            workspace["id"], credentials=credentials
+        status = platform_call(
+            "Checking workspace deletion safety...",
+            lambda: client.get_workspace_deletion_status(
+                workspace["id"], credentials=credentials
+            ),
+            output_console=console,
         )
     except Exception as e:
         raise CLIError(f"Unable to verify workspace deletion safety: {e}") from e
@@ -120,7 +132,11 @@ def delete(
         yes=yes,
     )
 
-    client.delete_workspace(workspace["id"], credentials=credentials)
+    platform_call(
+        "Deleting workspace...",
+        lambda: client.delete_workspace(workspace["id"], credentials=credentials),
+        output_console=console,
+    )
     console.print(
         f"Workspace '{console.escape(workspace['name'])}' deleted.",
         style="green",
@@ -160,7 +176,7 @@ def validate(
     validate_workspace_contract(workspace_root)
     console.table(
         [
-            ("Root", str(workspace_root)),
+            ("Root", console.format_text(workspace_root)),
             ("Workspace metadata", ".osmosis/workspace.toml"),
             ("Research", ".osmosis/research/"),
             ("Rollouts", "rollouts/"),

--- a/osmosis_ai/cli/commands/workspace.py
+++ b/osmosis_ai/cli/commands/workspace.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import typer
 
@@ -17,17 +18,27 @@ app: typer.Typer = typer.Typer(
 def workspace_default(ctx: typer.Context) -> None:
     """Manage workspaces. Launches interactive mode when no subcommand is given."""
     if ctx.invoked_subcommand is None:
+        from osmosis_ai.cli.errors import CLIError
+        from osmosis_ai.cli.output import OutputFormat, get_output_context
         from osmosis_ai.platform.cli.workspace import workspace as interactive_workspace
 
+        output = get_output_context()
+        if output.format is not OutputFormat.rich:
+            raise CLIError(
+                "Interactive workspace UI is unavailable in this mode. "
+                "Use 'osmosis workspace list', 'osmosis workspace switch <name>', "
+                "or 'osmosis workspace create <name>'.",
+                code="INTERACTIVE_REQUIRED",
+            )
         interactive_workspace()
 
 
 @app.command("list")
-def list_workspaces() -> None:
+def list_workspaces() -> Any:
     """List available workspaces."""
     from osmosis_ai.platform.cli.workspace import list_workspaces as _list_workspaces
 
-    _list_workspaces()
+    return _list_workspaces()
 
 
 @app.command("create")
@@ -38,120 +49,32 @@ def create(
     timezone: str = typer.Option(
         "UTC", "--timezone", help="IANA timezone (e.g. America/New_York)."
     ),
-) -> None:
+) -> Any:
     """Create a new workspace."""
-    from osmosis_ai.cli.console import console
-    from osmosis_ai.platform.cli.utils import _require_auth, platform_call
+    from osmosis_ai.platform.cli.workspace import create_workspace
 
-    _, credentials = _require_auth()
-
-    from osmosis_ai.platform.api.client import OsmosisClient
-
-    client = OsmosisClient()
-    result = platform_call(
-        "Creating workspace...",
-        lambda: client.create_workspace(name, timezone, credentials=credentials),
-        output_console=console,
-    )
-    console.print(
-        f"Workspace '{console.escape(result['name'])}' created.",
-        style="green",
-        highlight=False,
-    )
+    return create_workspace(name=name, timezone=timezone)
 
 
 @app.command("delete")
 def delete(
     name: str = typer.Argument(..., help="Workspace name to delete."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
-) -> None:
+) -> Any:
     """Delete a workspace."""
-    from osmosis_ai.cli.console import console
-    from osmosis_ai.cli.errors import CLIError
-    from osmosis_ai.platform.cli.utils import _require_auth, platform_call
+    from osmosis_ai.platform.cli.workspace import delete_workspace
 
-    _, credentials = _require_auth()
-
-    from osmosis_ai.platform.api.client import OsmosisClient
-
-    client = OsmosisClient()
-
-    ws_data = platform_call(
-        "Loading workspaces...",
-        lambda: client.list_workspaces(credentials=credentials),
-        output_console=console,
-    )
-    workspace = None
-    for ws in ws_data.get("workspaces", []):
-        if ws.get("name") == name.lower():
-            workspace = ws
-            break
-
-    if not workspace:
-        raise CLIError(f"Workspace '{name}' not found.")
-
-    try:
-        status = platform_call(
-            "Checking workspace deletion safety...",
-            lambda: client.get_workspace_deletion_status(
-                workspace["id"], credentials=credentials
-            ),
-            output_console=console,
-        )
-    except Exception as e:
-        raise CLIError(f"Unable to verify workspace deletion safety: {e}") from e
-
-    if not status.is_owner:
-        raise CLIError("Only workspace owners can delete a workspace.")
-
-    if status.is_last_workspace:
-        raise CLIError("Cannot delete your only workspace.")
-
-    from osmosis_ai.cli.prompts import require_confirmation
-
-    if status.has_running_processes:
-        console.print(
-            "This workspace has running processes:",
-            style="yellow",
-        )
-        processes: list[str] = []
-        if not status.feature_pipelines.valid:
-            processes.append(f"{status.feature_pipelines.count} pipeline(s)")
-        if not status.training_runs.valid:
-            processes.append(f"{status.training_runs.count} training run(s)")
-        if not status.models.valid:
-            processes.append(f"{status.models.count} active model(s)")
-        if processes:
-            console.print(f"  {', '.join(processes)}")
-        console.print()
-
-    require_confirmation(
-        f"Delete workspace '{workspace['name']}'? "
-        "This will stop all running processes and delete all datasets and training "
-        "runs. This cannot be undone.",
-        yes=yes,
-    )
-
-    platform_call(
-        "Deleting workspace...",
-        lambda: client.delete_workspace(workspace["id"], credentials=credentials),
-        output_console=console,
-    )
-    console.print(
-        f"Workspace '{console.escape(workspace['name'])}' deleted.",
-        style="green",
-        highlight=False,
-    )
+    return delete_workspace(name=name, yes=yes)
 
 
 @app.command("switch")
 def switch(
     workspace: str = typer.Argument(..., help="Workspace name to switch to."),
-) -> None:
+) -> Any:
     """Switch to a different workspace."""
     from osmosis_ai.platform.cli.workspace import switch_workspace
 
-    switch_workspace(workspace=workspace)
+    return switch_workspace(workspace=workspace)
 
 
 @app.command("validate")
@@ -164,26 +87,8 @@ def validate(
         resolve_path=True,
         help="Workspace path (defaults to current directory).",
     ),
-) -> None:
+) -> Any:
     """Validate the canonical Osmosis workspace structure."""
-    from osmosis_ai.cli.console import console
-    from osmosis_ai.platform.cli.workspace_contract import (
-        resolve_workspace_root,
-        validate_workspace_contract,
-    )
+    from osmosis_ai.platform.cli.workspace import validate_workspace
 
-    workspace_root = resolve_workspace_root(path)
-    validate_workspace_contract(workspace_root)
-    console.table(
-        [
-            ("Root", console.format_text(workspace_root)),
-            ("Workspace metadata", ".osmosis/workspace.toml"),
-            ("Research", ".osmosis/research/"),
-            ("Rollouts", "rollouts/"),
-            ("Training configs", "configs/training/"),
-            ("Eval configs", "configs/eval/"),
-            ("Datasets", "data/"),
-        ],
-        title="Workspace Contract",
-    )
-    console.print("Workspace contract is valid.", style="green")
+    return validate_workspace(path)

--- a/osmosis_ai/cli/console.py
+++ b/osmosis_ai/cli/console.py
@@ -62,6 +62,7 @@ class Console:
             width: Fixed terminal width (for testing). None = auto-detect.
         """
         file = file or sys.stdout
+        self._no_color = no_color
 
         # When TERM=dumb, Rich's Console.size short-circuits to 80x25 unless both width and
         # height are set; width alone is ignored (see rich.console.Console.size).
@@ -250,7 +251,10 @@ class Console:
 
         Use this for dynamic values that should never be parsed as Rich markup.
         """
-        return Text("" if text is None else str(text), style=style)
+        value = "" if text is None else str(text)
+        if style is None:
+            return Text(value)
+        return Text(value, style=style)
 
     def format_url(
         self,
@@ -260,6 +264,8 @@ class Console:
         style: str | None = None,
     ) -> Text:
         """Return a Rich terminal hyperlink for a URL."""
+        if self._no_color:
+            return self.format_text(label or url, style=style)
         return _url_link_text(url, label=label, style=style)
 
     def print_url(

--- a/osmosis_ai/cli/console.py
+++ b/osmosis_ai/cli/console.py
@@ -226,6 +226,13 @@ class Console:
         """
         return f"[{style}]{rich_escape(text)}[/{style}]"
 
+    def format_text(self, text: Any, style: str | None = None) -> Text:
+        """Return plain text with optional Rich styling.
+
+        Use this for dynamic values that should never be parsed as Rich markup.
+        """
+        return Text("" if text is None else str(text), style=style)
+
     def format_url(
         self,
         url: str,
@@ -235,6 +242,22 @@ class Console:
     ) -> Text:
         """Return a Rich terminal hyperlink for a URL."""
         return _url_link_text(url, label=label, style=style)
+
+    def print_url(
+        self,
+        prefix: str,
+        url: str,
+        *,
+        label: str | None = None,
+        style: str | None = None,
+    ) -> None:
+        """Print a URL without inserting hard line breaks into the link target."""
+        self._rich.print(
+            self.format_text(prefix),
+            self.format_url(url, label=label, style=style),
+            sep="",
+            soft_wrap=True,
+        )
 
     @contextmanager
     def spinner(self, message: str) -> Generator[None, None, None]:

--- a/osmosis_ai/cli/console.py
+++ b/osmosis_ai/cli/console.py
@@ -1,4 +1,4 @@
-"""Console output with Rich and automatic TTY-aware rendering.
+"""Console output facade with Rich and output-context aware rendering.
 
 Rich automatically strips ANSI control codes when output is not directed
 to a terminal (e.g., piped to a file), and respects the NO_COLOR
@@ -52,7 +52,7 @@ class Console:
         force_terminal: bool | None = None,
         no_color: bool = False,
         width: int | None = None,
-    ):
+    ) -> None:
         """Initialize the console.
 
         Args:
@@ -105,6 +105,17 @@ class Console:
         """The underlying Rich Console instance."""
         return self._rich
 
+    @staticmethod
+    def _output_format() -> Any:
+        from osmosis_ai.cli.output.context import get_output_context
+
+        return get_output_context().format
+
+    def _is_rich_mode(self) -> bool:
+        from osmosis_ai.cli.output.context import OutputFormat
+
+        return self._output_format() is OutputFormat.rich
+
     def print(
         self,
         *args: Any,
@@ -120,6 +131,8 @@ class Console:
             end: String to print at end. Defaults to newline.
             **kwargs: Additional arguments passed to rich.print.
         """
+        if not self._is_rich_mode():
+            return
         self._rich.print(*args, style=style, end=end, **kwargs)
 
     def print_error(
@@ -147,6 +160,8 @@ class Console:
         Args:
             title: Optional title to display in the separator.
         """
+        if not self._is_rich_mode():
+            return
         from rich.rule import Rule
 
         self._rich.print(Rule(title, style="dim"))
@@ -167,6 +182,8 @@ class Console:
             style: Border style color.
             padding: Padding (vertical, horizontal).
         """
+        if not self._is_rich_mode():
+            return
         panel = Panel(content, title=title, border_style=style, padding=padding)
         self._rich.print(panel)
 
@@ -184,6 +201,8 @@ class Console:
             title: Optional table title.
             headers: Optional column headers.
         """
+        if not self._is_rich_mode():
+            return
         table = Table(
             title=title,
             box=box.ROUNDED,
@@ -252,6 +271,8 @@ class Console:
         style: str | None = None,
     ) -> None:
         """Print a URL without inserting hard line breaks into the link target."""
+        if not self._is_rich_mode():
+            return
         self._rich.print(
             self.format_text(prefix),
             self.format_url(url, label=label, style=style),
@@ -268,6 +289,18 @@ class Console:
             with console.spinner("Loading workspaces..."):
                 result = api_call()
         """
+        from osmosis_ai.cli.output.context import OutputFormat
+
+        fmt = self._output_format()
+        if fmt is OutputFormat.json:
+            yield
+            return
+        if fmt is OutputFormat.plain:
+            sys.stderr.write(message + "\n")
+            sys.stderr.flush()
+            yield
+            return
+
         if self.is_tty:
             from rich.status import Status
 
@@ -275,6 +308,14 @@ class Console:
                 yield
         else:
             self._rich.print(message)
+            yield
+
+    @contextmanager
+    def status(self, message: str) -> Generator[None, None, None]:
+        """Alias for spinner with output-context aware routing."""
+        from osmosis_ai.cli.output.context import get_output_context
+
+        with get_output_context().status(message):
             yield
 
     def input(self, prompt: str = "", style: str | None = None) -> str:

--- a/osmosis_ai/cli/console.py
+++ b/osmosis_ai/cli/console.py
@@ -24,7 +24,18 @@ from rich import box
 from rich.console import Console as RichConsole
 from rich.markup import escape as rich_escape
 from rich.panel import Panel
+from rich.style import Style
 from rich.table import Table
+from rich.text import Text
+
+
+def _url_link_text(
+    url: str, label: str | None = None, style: str | None = None
+) -> Text:
+    link_style = Style(link=url)
+    if style:
+        link_style = Style.parse(style) + link_style
+    return Text(label or url, style=link_style)
 
 
 class Console:
@@ -111,13 +122,24 @@ class Console:
         """
         self._rich.print(*args, style=style, end=end, **kwargs)
 
-    def print_error(self, message: str) -> None:
+    def print_error(
+        self,
+        message: str,
+        *,
+        soft_wrap: bool | None = None,
+        markup: bool = False,
+    ) -> None:
         """Print an error message to stderr.
 
         Args:
             message: Error message to print.
+            soft_wrap: Whether Rich should avoid inserting hard line breaks.
+            markup: Whether to interpret Rich markup in the message.
         """
-        self._rich_stderr.print(message, style="bold red")
+        kwargs: dict[str, Any] = {"markup": markup}
+        if soft_wrap is not None:
+            kwargs["soft_wrap"] = soft_wrap
+        self._rich_stderr.print(message, style="bold red", **kwargs)
 
     def separator(self, title: str = "") -> None:
         """Print a separator line with optional title.
@@ -150,7 +172,7 @@ class Console:
 
     def table(
         self,
-        rows: list[tuple[str, str]],
+        rows: list[tuple[Any, Any]],
         *,
         title: str | None = None,
         headers: tuple[str, str] | None = None,
@@ -203,6 +225,16 @@ class Console:
             Styled text string with Rich markup.
         """
         return f"[{style}]{rich_escape(text)}[/{style}]"
+
+    def format_url(
+        self,
+        url: str,
+        *,
+        label: str | None = None,
+        style: str | None = None,
+    ) -> Text:
+        """Return a Rich terminal hyperlink for a URL."""
+        return _url_link_text(url, label=label, style=style)
 
     @contextmanager
     def spinner(self, message: str) -> Generator[None, None, None]:

--- a/osmosis_ai/cli/errors.py
+++ b/osmosis_ai/cli/errors.py
@@ -1,8 +1,25 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import Any
+
 
 class CLIError(Exception):
     """Raised when the CLI encounters a recoverable error."""
+
+    def __init__(
+        self,
+        message: str = "",
+        *,
+        code: str = "VALIDATION",
+        details: Mapping[str, Any] | None = None,
+        request_id: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
+        self.details: dict[str, Any] = dict(details) if details else {}
+        self.request_id = request_id
 
 
 def not_implemented(group: str, cmd: str) -> None:
@@ -10,6 +27,11 @@ def not_implemented(group: str, cmd: str) -> None:
     import typer
 
     from osmosis_ai.cli.console import console
+    from osmosis_ai.cli.output.context import OutputFormat, get_output_context
 
-    console.print(f"'osmosis {group} {cmd}' is not yet implemented.", style="yellow")
+    message = f"'osmosis {group} {cmd}' is not yet implemented."
+    if get_output_context().format is not OutputFormat.rich:
+        raise CLIError(message, code="NOT_IMPLEMENTED")
+
+    console.print(message, style="yellow")
     raise typer.Exit(1)

--- a/osmosis_ai/cli/main.py
+++ b/osmosis_ai/cli/main.py
@@ -30,7 +30,6 @@ from osmosis_ai.platform.auth.platform_client import (
     AuthenticationExpiredError,
     PlatformAPIError,
 )
-from osmosis_ai.platform.constants import MSG_SESSION_EXPIRED
 
 
 class OsmosisGroup(typer.core.TyperGroup):
@@ -162,7 +161,7 @@ def _handle_cli_error(
         )
     else:
         if isinstance(exc, AuthenticationExpiredError):
-            _print_error(MSG_SESSION_EXPIRED)
+            _print_error(str(exc))
         else:
             _print_error(str(exc))
     return exit_code

--- a/osmosis_ai/cli/main.py
+++ b/osmosis_ai/cli/main.py
@@ -70,6 +70,12 @@ def _callback(
 _registered = False
 
 
+def _print_error(message: str) -> None:
+    from osmosis_ai.cli.console import Console
+
+    Console(file=sys.stderr).print_error(f"Error: {message}", soft_wrap=True)
+
+
 def _register_commands() -> None:
     """Register all subcommands. Called once before app() runs."""
     global _registered
@@ -143,21 +149,21 @@ def main(argv: list[str] | None = None) -> int:
         # after help is already printed — just exit cleanly.
         if not str(exc):
             return 0
-        print(f"Error: {exc}", file=sys.stderr)
+        _print_error(str(exc))
         return exc.exit_code
     except AuthenticationExpiredError:
-        print(f"Error: {MSG_SESSION_EXPIRED}", file=sys.stderr)
+        _print_error(MSG_SESSION_EXPIRED)
         return 1
     except PlatformAPIError as exc:
-        print(f"Error: {exc}", file=sys.stderr)
+        _print_error(str(exc))
         return 1
     except CLIError as exc:
-        print(f"Error: {exc}", file=sys.stderr)
+        _print_error(str(exc))
         return 1
     except KeyboardInterrupt:
         return 130
     except Exception as exc:
-        print(f"Error: {exc}", file=sys.stderr)
+        _print_error(str(exc))
         return 1
 
 

--- a/osmosis_ai/cli/main.py
+++ b/osmosis_ai/cli/main.py
@@ -131,8 +131,9 @@ def _output_context_for_error(
     exc: BaseException,
     argv: list[str] | None,
 ) -> OutputContext:
-    if isinstance(exc, click.ClickException) and exc.ctx is not None:
-        root_obj = exc.ctx.find_root().obj
+    ctx = getattr(exc, "ctx", None)
+    if isinstance(exc, click.ClickException) and isinstance(ctx, click.Context):
+        root_obj = ctx.find_root().obj
         if isinstance(root_obj, OutputContext):
             return root_obj
 
@@ -154,7 +155,8 @@ def _handle_cli_error(
 ) -> int:
     output = _output_context_for_error(exc, argv)
     if output.format is OutputFormat.json:
-        ctx = exc.ctx if isinstance(exc, click.ClickException) else None
+        raw_ctx = getattr(exc, "ctx", None)
+        ctx = raw_ctx if isinstance(raw_ctx, click.Context) else None
         emit_structured_error_to_stderr(
             classify_error(exc),
             command=command_path_for_error(ctx),

--- a/osmosis_ai/cli/main.py
+++ b/osmosis_ai/cli/main.py
@@ -10,6 +10,21 @@ import typer.core
 from dotenv import find_dotenv, load_dotenv
 
 from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.cli.output.context import (
+    OutputContext,
+    OutputFormat,
+    _argv_format_prescan,
+    _output_context_var,
+    get_output_context,
+    install_output_context,
+    resolve_format_selectors,
+)
+from osmosis_ai.cli.output.error import (
+    classify_error,
+    command_path_for_error,
+    emit_structured_error_to_stderr,
+)
+from osmosis_ai.cli.output.renderer import render_command_result, verify_output_emitted
 from osmosis_ai.consts import PACKAGE_VERSION, package_name
 from osmosis_ai.platform.auth.platform_client import (
     AuthenticationExpiredError,
@@ -45,6 +60,7 @@ app: typer.Typer = typer.Typer(
     no_args_is_help=True,
     add_completion=False,
     context_settings={"help_option_names": ["-h", "--help"]},
+    result_callback=render_command_result,
 )
 
 
@@ -58,12 +74,48 @@ def _callback(
         help="Show version and exit.",
         is_eager=True,
     ),
+    output_format: OutputFormat | None = typer.Option(
+        None,
+        "--format",
+        help=(
+            "Global output format: rich, json, or plain. Use json/plain for "
+            "AI agents, CI/CD, and scripts."
+        ),
+        case_sensitive=False,
+    ),
+    json_alias: bool = typer.Option(
+        False,
+        "--json",
+        help="Shortcut for --format json; recommended for AI agents and CI/CD.",
+    ),
+    plain_alias: bool = typer.Option(
+        False,
+        "--plain",
+        help="Shortcut for --format plain; low-noise text for shell pipelines.",
+    ),
 ) -> None:
-    """Osmosis AI CLI"""
+    """Osmosis AI CLI.
+
+    Rich output is the default for humans. For AI agents, CI/CD, and scripts,
+    prefer global output flags before the command, for example:
+    `osmosis --json dataset list` or `osmosis --format plain dataset list`.
+    """
     warnings.filterwarnings("ignore")
     if version:
         typer.echo(f"{package_name} {PACKAGE_VERSION}")
         raise typer.Exit()
+
+    selected_format = resolve_format_selectors(
+        output_format,
+        json_alias=json_alias,
+        plain_alias=plain_alias,
+    )
+    output = OutputContext(
+        format=selected_format,
+        interactive=selected_format is OutputFormat.rich and sys.stdin.isatty(),
+    )
+    install_output_context(ctx, output)
+    ctx.call_on_close(verify_output_emitted)
     load_dotenv(find_dotenv(usecwd=True))
 
 
@@ -74,6 +126,46 @@ def _print_error(message: str) -> None:
     from osmosis_ai.cli.console import Console
 
     Console(file=sys.stderr).print_error(f"Error: {message}", soft_wrap=True)
+
+
+def _output_context_for_error(
+    exc: BaseException,
+    argv: list[str] | None,
+) -> OutputContext:
+    if isinstance(exc, click.ClickException) and exc.ctx is not None:
+        root_obj = exc.ctx.find_root().obj
+        if isinstance(root_obj, OutputContext):
+            return root_obj
+
+    stored = _output_context_var.get()
+    if stored is not None:
+        return stored
+
+    pre = _argv_format_prescan(argv if argv is not None else sys.argv[1:])
+    if pre is not None:
+        return OutputContext(format=pre, interactive=False)
+    return get_output_context()
+
+
+def _handle_cli_error(
+    exc: BaseException,
+    *,
+    argv: list[str] | None,
+    exit_code: int = 1,
+) -> int:
+    output = _output_context_for_error(exc, argv)
+    if output.format is OutputFormat.json:
+        ctx = exc.ctx if isinstance(exc, click.ClickException) else None
+        emit_structured_error_to_stderr(
+            classify_error(exc),
+            command=command_path_for_error(ctx),
+        )
+    else:
+        if isinstance(exc, AuthenticationExpiredError):
+            _print_error(MSG_SESSION_EXPIRED)
+        else:
+            _print_error(str(exc))
+    return exit_code
 
 
 def _register_commands() -> None:
@@ -142,6 +234,8 @@ def main(argv: list[str] | None = None) -> int:
         if isinstance(result, int) and result != 0:
             return result
         return 0
+    except click.exceptions.Exit as e:
+        return e.exit_code
     except SystemExit as e:
         return int(e.code) if e.code is not None else 0
     except click.UsageError as exc:
@@ -149,22 +243,17 @@ def main(argv: list[str] | None = None) -> int:
         # after help is already printed — just exit cleanly.
         if not str(exc):
             return 0
-        _print_error(str(exc))
-        return exc.exit_code
-    except AuthenticationExpiredError:
-        _print_error(MSG_SESSION_EXPIRED)
-        return 1
+        return _handle_cli_error(exc, argv=argv, exit_code=exc.exit_code)
+    except AuthenticationExpiredError as exc:
+        return _handle_cli_error(exc, argv=argv)
     except PlatformAPIError as exc:
-        _print_error(str(exc))
-        return 1
+        return _handle_cli_error(exc, argv=argv)
     except CLIError as exc:
-        _print_error(str(exc))
-        return 1
+        return _handle_cli_error(exc, argv=argv)
     except KeyboardInterrupt:
         return 130
     except Exception as exc:
-        _print_error(str(exc))
-        return 1
+        return _handle_cli_error(exc, argv=argv)
 
 
 if __name__ == "__main__":

--- a/osmosis_ai/cli/output/__init__.py
+++ b/osmosis_ai/cli/output/__init__.py
@@ -1,0 +1,67 @@
+"""Public surface of the CLI output package."""
+
+from .context import (
+    OutputContext,
+    OutputFormat,
+    default_output_context,
+    get_output_context,
+    install_output_context,
+    override_output_context,
+    resolve_format_selectors,
+)
+from .error import (
+    classify_error,
+    command_path_for_error,
+    emit_structured_error_to_stderr,
+)
+from .renderer import render, render_command_result, verify_output_emitted
+from .result import (
+    CommandResult,
+    DetailField,
+    DetailResult,
+    ListColumn,
+    ListResult,
+    MessageResult,
+    OperationResult,
+)
+from .serializers import (
+    serialize_checkpoint,
+    serialize_dataset,
+    serialize_deployment,
+    serialize_eval_cache_entry,
+    serialize_model,
+    serialize_rollout,
+    serialize_training_run,
+    serialize_workspace,
+)
+
+__all__ = [
+    "CommandResult",
+    "DetailField",
+    "DetailResult",
+    "ListColumn",
+    "ListResult",
+    "MessageResult",
+    "OperationResult",
+    "OutputContext",
+    "OutputFormat",
+    "classify_error",
+    "command_path_for_error",
+    "default_output_context",
+    "emit_structured_error_to_stderr",
+    "get_output_context",
+    "install_output_context",
+    "override_output_context",
+    "render",
+    "render_command_result",
+    "resolve_format_selectors",
+    "serialize_checkpoint",
+    "serialize_dataset",
+    "serialize_deployment",
+    "serialize_eval_cache_entry",
+    "serialize_model",
+    "serialize_rollout",
+    "serialize_training_run",
+    "serialize_workspace",
+    "verify_output_emitted",
+]

--- a/osmosis_ai/cli/output/context.py
+++ b/osmosis_ai/cli/output/context.py
@@ -1,0 +1,166 @@
+"""Output format/context plumbing for the CLI."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+import click
+
+
+class OutputFormat(StrEnum):
+    """Top-level CLI output format."""
+
+    rich = "rich"
+    json = "json"
+    plain = "plain"
+
+
+@dataclass
+class OutputContext:
+    """Per-invocation output state."""
+
+    format: OutputFormat
+    interactive: bool
+    quiet: bool = False
+    schema_version: int = 1
+    output_emitted: bool = False
+    _close_callbacks: list[Callable[[], None]] = field(default_factory=list, repr=False)
+
+    @contextmanager
+    def status(self, message: str) -> Iterator[None]:
+        """Spinner-equivalent that respects the active output format."""
+        if self.format is OutputFormat.json:
+            yield
+            return
+
+        if self.format is OutputFormat.plain or not self.interactive:
+            sys.stderr.write(message + "\n")
+            sys.stderr.flush()
+            yield
+            return
+
+        from rich.console import Console as RichConsole
+        from rich.status import Status
+
+        rich_stderr = RichConsole(stderr=True)
+        with Status(message, console=rich_stderr, spinner="dots"):
+            yield
+
+
+_output_context_var: ContextVar[OutputContext | None] = ContextVar(
+    "osmosis_output_context",
+    default=None,
+)
+
+
+def default_output_context() -> OutputContext:
+    """Default rich + stdin-derived interactivity."""
+    return OutputContext(
+        format=OutputFormat.rich,
+        interactive=sys.stdin.isatty() if sys.stdin else False,
+    )
+
+
+def _argv_format_prescan(argv: list[str]) -> OutputFormat | None:
+    """Tolerantly scan root-level argv for output format selectors."""
+    i = 0
+    while i < len(argv):
+        token = argv[i]
+        if token == "--json":
+            return OutputFormat.json
+        if token == "--plain":
+            return OutputFormat.plain
+        if token == "--format":
+            if i + 1 >= len(argv):
+                return None
+            try:
+                return OutputFormat(argv[i + 1])
+            except ValueError:
+                return None
+        if token.startswith("--format="):
+            try:
+                return OutputFormat(token.split("=", 1)[1])
+            except ValueError:
+                return None
+        if not token.startswith("-"):
+            return None
+        i += 1
+    return None
+
+
+def get_output_context() -> OutputContext:
+    """Resolve the active OutputContext through the fallback stack."""
+    try:
+        ctx = click.get_current_context(silent=True)
+    except RuntimeError:
+        ctx = None
+
+    if ctx is not None:
+        root_obj = ctx.find_root().obj
+        if isinstance(root_obj, OutputContext):
+            return root_obj
+
+    stored = _output_context_var.get()
+    if stored is not None:
+        return stored
+
+    pre = _argv_format_prescan(sys.argv[1:])
+    if pre is not None:
+        return OutputContext(format=pre, interactive=False)
+
+    return default_output_context()
+
+
+def install_output_context(ctx: click.Context, output: OutputContext) -> None:
+    """Mirror `output` to Click.Context.obj and the ContextVar."""
+    ctx.obj = output
+    token: Token[OutputContext | None] = _output_context_var.set(output)
+    ctx.call_on_close(lambda: _output_context_var.reset(token))
+
+
+@contextmanager
+def override_output_context(
+    *,
+    format: OutputFormat = OutputFormat.rich,
+    interactive: bool = False,
+) -> Iterator[OutputContext]:
+    """Test helper. Installs an OutputContext for the duration of the block."""
+    output = OutputContext(format=format, interactive=interactive)
+    token = _output_context_var.set(output)
+    try:
+        yield output
+    finally:
+        _output_context_var.reset(token)
+
+
+def resolve_format_selectors(
+    format_value: OutputFormat | None,
+    *,
+    json_alias: bool,
+    plain_alias: bool,
+) -> OutputFormat:
+    """Reconcile --format / --json / --plain."""
+    from osmosis_ai.cli.errors import CLIError
+
+    selected: set[OutputFormat] = set()
+    if format_value is not None:
+        selected.add(format_value)
+    if json_alias:
+        selected.add(OutputFormat.json)
+    if plain_alias:
+        selected.add(OutputFormat.plain)
+
+    if len(selected) > 1:
+        raise CLIError(
+            "Conflicting output format selectors: "
+            f"{', '.join(sorted(f.value for f in selected))}. "
+            "Choose at most one of --format, --json, --plain.",
+            code="VALIDATION",
+        )
+
+    return next(iter(selected), OutputFormat.rich)

--- a/osmosis_ai/cli/output/context.py
+++ b/osmosis_ai/cli/output/context.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import StrEnum
 
 import click
@@ -29,7 +29,6 @@ class OutputContext:
     quiet: bool = False
     schema_version: int = 1
     output_emitted: bool = False
-    _close_callbacks: list[Callable[[], None]] = field(default_factory=list, repr=False)
 
     @contextmanager
     def status(self, message: str) -> Iterator[None]:

--- a/osmosis_ai/cli/output/error.py
+++ b/osmosis_ai/cli/output/error.py
@@ -69,7 +69,7 @@ def classify_error(exc: BaseException) -> CLIError:
 def _argv_command_path(argv: list[str]) -> str:
     skip_flags_with_value = {"--format"}
     skip_flags = {"--json", "--plain", "--version", "-V", "--help", "-h"}
-    result: list[str] = []
+    tokens: list[str] = []
     i = 0
     while i < len(argv):
         token = argv[i]
@@ -85,11 +85,39 @@ def _argv_command_path(argv: list[str]) -> str:
         if token.startswith("-"):
             i += 1
             continue
-        result.append(token)
-        if len(result) == 2:
-            break
+        tokens.append(token)
         i += 1
-    return " ".join(result) if result else "<root>"
+    if not tokens:
+        return "<root>"
+
+    top_level_commands = {
+        "deploy",
+        "init",
+        "login",
+        "logout",
+        "undeploy",
+        "upgrade",
+        "whoami",
+    }
+    command_groups = {
+        "auth",
+        "dataset",
+        "deployment",
+        "eval",
+        "model",
+        "rollout",
+        "train",
+        "workspace",
+    }
+
+    command = tokens[0]
+    if command in top_level_commands or len(tokens) == 1:
+        return command
+    if command == "eval" and tokens[1] == "cache" and len(tokens) >= 3:
+        return " ".join(tokens[:3])
+    if command in command_groups:
+        return " ".join(tokens[:2])
+    return command
 
 
 def command_path_for_error(ctx: click.Context | None) -> str:

--- a/osmosis_ai/cli/output/error.py
+++ b/osmosis_ai/cli/output/error.py
@@ -1,0 +1,133 @@
+"""Structured error envelope + PlatformAPIError to CLI code mapping."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.consts import PACKAGE_VERSION
+
+
+def _classify_platform_status(status: int | None) -> str:
+    if status == 401:
+        return "AUTH_REQUIRED"
+    if status == 404:
+        return "NOT_FOUND"
+    if status == 409:
+        return "CONFLICT"
+    if status == 429:
+        return "RATE_LIMITED"
+    if status == 400:
+        return "VALIDATION"
+    return "PLATFORM_ERROR"
+
+
+def classify_error(exc: BaseException) -> CLIError:
+    """Map any supported error type into a structured CLIError."""
+    if isinstance(exc, CLIError):
+        return exc
+
+    from osmosis_ai.platform.auth.platform_client import (
+        AuthenticationExpiredError,
+        PlatformAPIError,
+    )
+
+    if isinstance(exc, AuthenticationExpiredError):
+        return CLIError(str(exc) or "Session expired.", code="AUTH_REQUIRED")
+
+    if isinstance(exc, PlatformAPIError):
+        details: dict[str, Any] = {}
+        if exc.error_code:
+            details["platform_code"] = exc.error_code
+        if exc.field:
+            details["field"] = exc.field
+        if exc.details:
+            for key, value in exc.details.items():
+                details.setdefault(key, value)
+        if exc.status_code is not None:
+            details["status_code"] = exc.status_code
+        return CLIError(
+            str(exc),
+            code=_classify_platform_status(exc.status_code),
+            details=details,
+        )
+
+    if isinstance(exc, click.UsageError):
+        return CLIError(str(exc) or "Invalid usage.", code="VALIDATION")
+
+    return CLIError(
+        "An unexpected internal error occurred.",
+        code="INTERNAL",
+        details={"exception_type": type(exc).__name__},
+    )
+
+
+def _argv_command_path(argv: list[str]) -> str:
+    skip_flags_with_value = {"--format"}
+    skip_flags = {"--json", "--plain", "--version", "-V", "--help", "-h"}
+    result: list[str] = []
+    i = 0
+    while i < len(argv):
+        token = argv[i]
+        if token in skip_flags_with_value:
+            i += 2
+            continue
+        if any(token.startswith(f"{flag}=") for flag in skip_flags_with_value):
+            i += 1
+            continue
+        if token in skip_flags:
+            i += 1
+            continue
+        if token.startswith("-"):
+            i += 1
+            continue
+        result.append(token)
+        if len(result) == 2:
+            break
+        i += 1
+    return " ".join(result) if result else "<root>"
+
+
+def command_path_for_error(ctx: click.Context | None) -> str:
+    """Resolve the command path for the error envelope."""
+    if ctx is not None:
+        path = ctx.command_path
+        parts = path.split(" ", 1)
+        if len(parts) == 2:
+            return parts[1]
+        return path or "<root>"
+    return _argv_command_path(sys.argv[1:] if sys.argv[1:] else [])
+
+
+def emit_structured_error_to_stderr(
+    err: CLIError,
+    *,
+    command: str | None = None,
+    cli_version: str | None = None,
+) -> None:
+    """Write the JSON-mode error envelope to stderr."""
+    if command is None:
+        try:
+            ctx = click.get_current_context(silent=True)
+        except RuntimeError:
+            ctx = None
+        command = command_path_for_error(ctx)
+
+    envelope: dict[str, Any] = {
+        "schema_version": 1,
+        "command": command,
+        "cli_version": cli_version or PACKAGE_VERSION,
+        "error": {
+            "code": err.code,
+            "message": err.message,
+            "details": err.details,
+            "request_id": err.request_id,
+        },
+    }
+    sys.stderr.write(json.dumps(envelope, ensure_ascii=False))
+    sys.stderr.write("\n")
+    sys.stderr.flush()

--- a/osmosis_ai/cli/output/renderer.py
+++ b/osmosis_ai/cli/output/renderer.py
@@ -110,7 +110,10 @@ def _rich_text(value: Any, *, style: str | None = None) -> Any:
             value.stylize(style)
         return value
     text = "" if value is None else str(value)
-    return Text(text.replace("\\[", "[").replace("\\]", "]"), style=style)
+    text = text.replace("\\[", "[").replace("\\]", "]")
+    if style is None:
+        return Text(text)
+    return Text(text, style=style)
 
 
 def _render_plain(result: CommandResult, output: OutputContext) -> None:

--- a/osmosis_ai/cli/output/renderer.py
+++ b/osmosis_ai/cli/output/renderer.py
@@ -1,0 +1,258 @@
+"""Rich, JSON, and plain renderers + migration safety hooks."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from typing import Any
+
+from .context import OutputContext, OutputFormat
+from .result import (
+    CommandResult,
+    DetailResult,
+    ListResult,
+    MessageResult,
+    OperationResult,
+)
+
+_RICH_STYLE_TAG_RE = re.compile(
+    r"\[/?(?:bold|dim|italic|underline|blink|reverse|strike|"
+    r"black|red|green|yellow|blue|magenta|cyan|white)"
+    r"(?: [a-zA-Z0-9_#./ -]+)?\]"
+)
+
+
+def _envelope_list(result: ListResult, *, schema_version: int) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": schema_version,
+        "items": result.items,
+        "total_count": result.total_count,
+        "has_more": result.has_more,
+        "next_offset": result.next_offset,
+    }
+    payload.update(result.extra)
+    return payload
+
+
+def _envelope_detail(result: DetailResult, *, schema_version: int) -> dict[str, Any]:
+    return {
+        "schema_version": schema_version,
+        "data": result.data,
+    }
+
+
+def _envelope_operation(
+    result: OperationResult, *, schema_version: int
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": schema_version,
+        "status": result.status,
+        "operation": result.operation,
+    }
+    if result.resource is not None:
+        payload["resource"] = result.resource
+    if result.message is not None:
+        payload["message"] = result.message
+    if result.next_steps_structured:
+        payload["next_steps_structured"] = result.next_steps_structured
+    payload.update(result.extra)
+    return payload
+
+
+def _envelope_message(result: MessageResult, *, schema_version: int) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": schema_version,
+        "message": result.message,
+    }
+    payload.update(result.extra)
+    return payload
+
+
+def _build_json_envelope(
+    result: CommandResult, *, schema_version: int
+) -> dict[str, Any]:
+    if isinstance(result, ListResult):
+        return _envelope_list(result, schema_version=schema_version)
+    if isinstance(result, DetailResult):
+        return _envelope_detail(result, schema_version=schema_version)
+    if isinstance(result, OperationResult):
+        return _envelope_operation(result, schema_version=schema_version)
+    if isinstance(result, MessageResult):
+        return _envelope_message(result, schema_version=schema_version)
+    raise TypeError(f"Unsupported CommandResult: {type(result).__name__}")
+
+
+def _render_json(result: CommandResult, output: OutputContext) -> None:
+    envelope = _build_json_envelope(result, schema_version=output.schema_version)
+    sys.stdout.write(json.dumps(envelope, ensure_ascii=False))
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def _normalise_plain_value(value: Any, *, rich_display: bool = False) -> str:
+    text = "" if value is None else str(value)
+    if rich_display:
+        text = _RICH_STYLE_TAG_RE.sub("", text)
+        text = text.replace("\\[", "[").replace("\\]", "]")
+    return text.replace("\t", " ").replace("\n", " ").replace("\r", " ")
+
+
+def _display_items(result: ListResult) -> list[dict[str, Any]]:
+    return result.display_items if result.display_items is not None else result.items
+
+
+def _render_plain(result: CommandResult, output: OutputContext) -> None:
+    if isinstance(result, DetailResult):
+        for field in result.fields:
+            value = _normalise_plain_value(field.value, rich_display=True)
+            sys.stdout.write(f"{field.label}: {value}\n")
+        return
+
+    if isinstance(result, ListResult):
+        cols = [column for column in result.columns if column.plain]
+        display_items = _display_items(result)
+        for idx, item in enumerate(display_items):
+            raw_item = result.items[idx] if idx < len(result.items) else {}
+            row = "\t".join(
+                _normalise_plain_value(
+                    item.get(c.key),
+                    rich_display=(
+                        result.display_items is not None
+                        and item.get(c.key) != raw_item.get(c.key)
+                    ),
+                )
+                for c in cols
+            )
+            sys.stdout.write(row + "\n")
+        return
+
+    if isinstance(result, OperationResult):
+        line = result.message or f"{result.operation}: {result.status}"
+        sys.stdout.write(_normalise_plain_value(line) + "\n")
+        for hint in result.display_next_steps:
+            sys.stdout.write(_normalise_plain_value(hint) + "\n")
+        return
+
+    if isinstance(result, MessageResult):
+        sys.stdout.write(_normalise_plain_value(result.message) + "\n")
+        return
+
+    raise TypeError(f"Unsupported CommandResult: {type(result).__name__}")
+
+
+def _render_rich(result: CommandResult, output: OutputContext) -> None:
+    from osmosis_ai.cli.console import Console
+
+    console = Console()
+
+    if isinstance(result, DetailResult):
+        if result.title:
+            console.separator(result.title)
+        console.table([(field.label, field.value) for field in result.fields])
+        return
+
+    if isinstance(result, ListResult):
+        from rich.table import Table
+
+        table = Table(show_header=True, header_style="bold")
+        for column in result.columns:
+            table.add_column(column.label, no_wrap=column.no_wrap)
+        for item in _display_items(result):
+            table.add_row(
+                *[
+                    "" if item.get(column.key) is None else str(item.get(column.key))
+                    for column in result.columns
+                ]
+            )
+        console.rich.print(table)
+        if result.has_more:
+            console.print(
+                f"\nShowing {len(result.items)} of {result.total_count}. "
+                "Use --all to show all, or --limit to adjust.",
+                style="dim",
+            )
+        return
+
+    if isinstance(result, OperationResult):
+        if result.message:
+            style = "green" if result.status == "success" else "yellow"
+            console.print(result.message, style=style)
+        for hint in result.display_next_steps:
+            console.print(hint, style="dim")
+        return
+
+    if isinstance(result, MessageResult):
+        console.print(result.message)
+        return
+
+    raise TypeError(f"Unsupported CommandResult: {type(result).__name__}")
+
+
+def render(result: CommandResult, output: OutputContext) -> None:
+    """Dispatch to the format-specific renderer and mark output as emitted."""
+    if output.format is OutputFormat.json:
+        _render_json(result, output)
+    elif output.format is OutputFormat.plain:
+        _render_plain(result, output)
+    else:
+        _render_rich(result, output)
+    output.output_emitted = True
+
+
+def render_command_result(result: Any, **_: Any) -> None:
+    """Typer result callback that renders converted command results."""
+    from .context import get_output_context
+
+    if isinstance(result, CommandResult):
+        render(result, get_output_context())
+        exit_code = getattr(result, "exit_code", 0)
+        if exit_code:
+            import click
+
+            raise click.exceptions.Exit(exit_code)
+        return
+
+    output = get_output_context()
+    if result is None and output.format is OutputFormat.rich:
+        return
+
+    from osmosis_ai.cli.errors import CLIError
+
+    if result is None:
+        raise CLIError(
+            "Command exited without producing structured output. This usually "
+            "means the command has not been converted to return a CommandResult.",
+            code="INTERNAL",
+        )
+
+    raise CLIError(
+        f"Handler returned unsupported result type: {type(result).__name__}",
+        code="INTERNAL",
+    )
+
+
+def verify_output_emitted() -> None:
+    """Catch successful JSON/plain invocations that produced no structured output."""
+    from .context import _output_context_var
+    from .error import emit_structured_error_to_stderr
+
+    output = _output_context_var.get()
+    if output is None or output.format is OutputFormat.rich:
+        return
+    if output.output_emitted:
+        return
+    if sys.exc_info()[0] is not None:
+        return
+
+    import click
+
+    from osmosis_ai.cli.errors import CLIError
+
+    emit_structured_error_to_stderr(
+        CLIError(
+            "Command exited without producing structured output.",
+            code="INTERNAL",
+        )
+    )
+    raise click.exceptions.Exit(1)

--- a/osmosis_ai/cli/output/renderer.py
+++ b/osmosis_ai/cli/output/renderer.py
@@ -102,6 +102,17 @@ def _display_items(result: ListResult) -> list[dict[str, Any]]:
     return result.display_items if result.display_items is not None else result.items
 
 
+def _rich_text(value: Any, *, style: str | None = None) -> Any:
+    from rich.text import Text
+
+    if isinstance(value, Text):
+        if style is not None:
+            value.stylize(style)
+        return value
+    text = "" if value is None else str(value)
+    return Text(text.replace("\\[", "[").replace("\\]", "]"), style=style)
+
+
 def _render_plain(result: CommandResult, output: OutputContext) -> None:
     if isinstance(result, DetailResult):
         for field in result.fields:
@@ -149,7 +160,9 @@ def _render_rich(result: CommandResult, output: OutputContext) -> None:
     if isinstance(result, DetailResult):
         if result.title:
             console.separator(result.title)
-        console.table([(field.label, field.value) for field in result.fields])
+        console.table(
+            [(field.label, _rich_text(field.value)) for field in result.fields]
+        )
         return
 
     if isinstance(result, ListResult):
@@ -158,10 +171,14 @@ def _render_rich(result: CommandResult, output: OutputContext) -> None:
         table = Table(show_header=True, header_style="bold")
         for column in result.columns:
             table.add_column(column.label, no_wrap=column.no_wrap)
-        for item in _display_items(result):
+        for idx, item in enumerate(_display_items(result)):
+            raw_item = result.items[idx] if idx < len(result.items) else {}
             table.add_row(
                 *[
-                    "" if item.get(column.key) is None else str(item.get(column.key))
+                    ("" if item.get(column.key) is None else str(item.get(column.key)))
+                    if result.display_items is not None
+                    and item.get(column.key) != raw_item.get(column.key)
+                    else _rich_text(item.get(column.key))
                     for column in result.columns
                 ]
             )
@@ -177,13 +194,13 @@ def _render_rich(result: CommandResult, output: OutputContext) -> None:
     if isinstance(result, OperationResult):
         if result.message:
             style = "green" if result.status == "success" else "yellow"
-            console.print(result.message, style=style)
+            console.rich.print(_rich_text(result.message, style=style))
         for hint in result.display_next_steps:
-            console.print(hint, style="dim")
+            console.rich.print(_rich_text(hint, style="dim"))
         return
 
     if isinstance(result, MessageResult):
-        console.print(result.message)
+        console.rich.print(_rich_text(result.message))
         return
 
     raise TypeError(f"Unsupported CommandResult: {type(result).__name__}")

--- a/osmosis_ai/cli/output/renderer.py
+++ b/osmosis_ai/cli/output/renderer.py
@@ -23,6 +23,18 @@ _RICH_STYLE_TAG_RE = re.compile(
 )
 
 
+def _merge_extra(
+    payload: dict[str, Any],
+    extra: dict[str, Any],
+    *,
+    reserved: set[str],
+) -> dict[str, Any]:
+    for key, value in extra.items():
+        if key not in reserved:
+            payload[key] = value
+    return payload
+
+
 def _envelope_list(result: ListResult, *, schema_version: int) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "schema_version": schema_version,
@@ -31,8 +43,11 @@ def _envelope_list(result: ListResult, *, schema_version: int) -> dict[str, Any]
         "has_more": result.has_more,
         "next_offset": result.next_offset,
     }
-    payload.update(result.extra)
-    return payload
+    return _merge_extra(
+        payload,
+        result.extra,
+        reserved={"schema_version", "items", "total_count", "has_more", "next_offset"},
+    )
 
 
 def _envelope_detail(result: DetailResult, *, schema_version: int) -> dict[str, Any]:
@@ -56,8 +71,18 @@ def _envelope_operation(
         payload["message"] = result.message
     if result.next_steps_structured:
         payload["next_steps_structured"] = result.next_steps_structured
-    payload.update(result.extra)
-    return payload
+    return _merge_extra(
+        payload,
+        result.extra,
+        reserved={
+            "schema_version",
+            "status",
+            "operation",
+            "resource",
+            "message",
+            "next_steps_structured",
+        },
+    )
 
 
 def _envelope_message(result: MessageResult, *, schema_version: int) -> dict[str, Any]:
@@ -65,8 +90,7 @@ def _envelope_message(result: MessageResult, *, schema_version: int) -> dict[str
         "schema_version": schema_version,
         "message": result.message,
     }
-    payload.update(result.extra)
-    return payload
+    return _merge_extra(payload, result.extra, reserved={"schema_version", "message"})
 
 
 def _build_json_envelope(

--- a/osmosis_ai/cli/output/result.py
+++ b/osmosis_ai/cli/output/result.py
@@ -11,7 +11,7 @@ class DetailField:
     """Single label/value row for Rich + plain detail output."""
 
     label: str
-    value: str
+    value: Any
 
 
 @dataclass(frozen=True)

--- a/osmosis_ai/cli/output/result.py
+++ b/osmosis_ai/cli/output/result.py
@@ -1,0 +1,77 @@
+"""CommandResult types returned by command handlers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DetailField:
+    """Single label/value row for Rich + plain detail output."""
+
+    label: str
+    value: str
+
+
+@dataclass(frozen=True)
+class ListColumn:
+    """A column in a list result."""
+
+    key: str
+    label: str
+    plain: bool = True
+    no_wrap: bool = False
+    align: str | None = None
+
+
+class CommandResult:
+    """Marker base class for renderer-dispatchable results."""
+
+
+@dataclass
+class DetailResult(CommandResult):
+    """Single-resource detail output."""
+
+    title: str
+    data: dict[str, Any]
+    fields: list[DetailField] = field(default_factory=list)
+    exit_code: int = 0
+
+
+@dataclass
+class ListResult(CommandResult):
+    """Paginated list output."""
+
+    title: str
+    items: list[dict[str, Any]]
+    total_count: int
+    has_more: bool
+    next_offset: int | None
+    columns: list[ListColumn] = field(default_factory=list)
+    extra: dict[str, Any] = field(default_factory=dict)
+    display_items: list[dict[str, Any]] | None = None
+    exit_code: int = 0
+
+
+@dataclass
+class OperationResult(CommandResult):
+    """Mutation output."""
+
+    operation: str
+    status: str
+    resource: dict[str, Any] | None = None
+    message: str | None = None
+    display_next_steps: list[str] = field(default_factory=list)
+    next_steps_structured: list[dict[str, Any]] = field(default_factory=list)
+    extra: dict[str, Any] = field(default_factory=dict)
+    exit_code: int = 0
+
+
+@dataclass
+class MessageResult(CommandResult):
+    """Free-form message that does not map cleanly to a resource."""
+
+    message: str
+    extra: dict[str, Any] = field(default_factory=dict)
+    exit_code: int = 0

--- a/osmosis_ai/cli/output/serializers.py
+++ b/osmosis_ai/cli/output/serializers.py
@@ -1,0 +1,122 @@
+"""Public JSON serializers for CLI output."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from osmosis_ai.platform.api.models import (
+    BaseModelInfo,
+    DatasetFile,
+    DeploymentInfo,
+    LoraCheckpointInfo,
+    RolloutInfo,
+    TrainingRun,
+)
+
+
+def serialize_dataset(df: DatasetFile) -> dict[str, Any]:
+    """Serialize a dataset for the public JSON contract."""
+    return {
+        "id": df.id,
+        "file_name": df.file_name,
+        "file_size": df.file_size,
+        "status": df.status,
+        "processing_step": df.processing_step,
+        "processing_percent": df.processing_percent,
+        "error": df.error,
+        "created_at": df.created_at,
+        "updated_at": df.updated_at,
+    }
+
+
+def serialize_training_run(run: TrainingRun) -> dict[str, Any]:
+    """Serialize a training run for the public JSON contract."""
+    return {
+        "id": run.id,
+        "name": run.name,
+        "status": run.status,
+        "model_id": run.model_id,
+        "model_name": run.model_name,
+        "eval_accuracy": run.eval_accuracy,
+        "reward_increase_delta": run.reward_increase_delta,
+        "processing_step": run.processing_step,
+        "processing_percent": run.processing_percent,
+        "error_message": run.error_message,
+        "creator_name": run.creator_name,
+        "creator_email": run.creator_email,
+        "created_at": run.created_at,
+        "started_at": run.started_at,
+        "completed_at": run.completed_at,
+    }
+
+
+def serialize_checkpoint(ckpt: LoraCheckpointInfo) -> dict[str, Any]:
+    """Serialize a LoRA checkpoint for the public JSON contract."""
+    return {
+        "id": ckpt.id,
+        "checkpoint_name": ckpt.checkpoint_name,
+        "checkpoint_step": ckpt.checkpoint_step,
+        "status": ckpt.status,
+        "created_at": ckpt.created_at,
+    }
+
+
+def serialize_deployment(dep: DeploymentInfo) -> dict[str, Any]:
+    """Serialize a deployment for the public JSON contract."""
+    return {
+        "id": dep.id,
+        "checkpoint_name": dep.checkpoint_name,
+        "status": dep.status,
+        "base_model": dep.base_model,
+        "checkpoint_step": dep.checkpoint_step,
+        "training_run_id": dep.training_run_id,
+        "training_run_name": dep.training_run_name,
+        "creator_name": dep.creator_name,
+        "created_at": dep.created_at,
+    }
+
+
+def serialize_model(model: BaseModelInfo) -> dict[str, Any]:
+    """Serialize a base model for the public JSON contract."""
+    return {
+        "id": model.id,
+        "model_name": model.model_name,
+        "base_model": model.base_model,
+        "status": model.status,
+        "creator_name": model.creator_name,
+        "created_at": model.created_at,
+        "updated_at": model.updated_at,
+    }
+
+
+def serialize_workspace(workspace: dict[str, Any]) -> dict[str, Any]:
+    """Serialize a workspace dict."""
+    return {
+        "id": workspace["id"],
+        "name": workspace["name"],
+    }
+
+
+def serialize_rollout(rollout: RolloutInfo) -> dict[str, Any]:
+    """Serialize a rollout for the public JSON contract."""
+    return {
+        "id": rollout.id,
+        "name": rollout.name,
+        "is_active": rollout.is_active,
+        "repo_full_name": rollout.repo_full_name,
+        "last_synced_commit_sha": rollout.last_synced_commit_sha,
+        "created_at": rollout.created_at,
+    }
+
+
+def serialize_eval_cache_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    """Serialize an eval cache entry dict."""
+    config = entry.get("config", {}) or {}
+    return {
+        "task_id": entry.get("task_id", ""),
+        "model": config.get("llm_model") or config.get("model", ""),
+        "dataset": config.get("eval_dataset") or config.get("dataset", ""),
+        "status": entry.get("status", ""),
+        "runs_count": entry.get("runs_count", 0),
+        "created_at": entry.get("created_at", ""),
+    }

--- a/osmosis_ai/cli/upgrade.py
+++ b/osmosis_ai/cli/upgrade.py
@@ -7,10 +7,13 @@ import shutil
 import subprocess
 import sys
 import urllib.request
+from typing import Any
 
 import typer
 
 from osmosis_ai.cli.console import console
+from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.cli.output import OperationResult, OutputFormat, get_output_context
 from osmosis_ai.consts import PACKAGE_VERSION, package_name
 
 PYPI_URL = f"https://pypi.org/pypi/{package_name}/json"
@@ -86,15 +89,45 @@ def _get_upgrade_commands(method: str) -> list[list[str]]:
     return commands.get(method, commands["pip"])
 
 
-def upgrade() -> None:
+def _upgrade_resource(
+    *,
+    installed: str,
+    latest: str | None,
+    method: str | None = None,
+    command: list[str] | None = None,
+    stdout: str | None = None,
+    stderr: str | None = None,
+) -> dict[str, Any]:
+    resource: dict[str, Any] = {
+        "installed_version": installed,
+        "latest_version": latest,
+    }
+    if method is not None:
+        resource["method"] = method
+    if command is not None:
+        resource["command"] = command
+    if stdout:
+        resource["stdout"] = stdout
+    if stderr:
+        resource["stderr"] = stderr
+    return resource
+
+
+def upgrade() -> Any:
     """Upgrade the Osmosis CLI to the latest version."""
     installed = PACKAGE_VERSION
+    output = get_output_context()
+    structured_output = output.format is not OutputFormat.rich
 
     console.print(f"Installed version: {installed}")
     console.print("Checking for updates...", style="dim")
 
     latest = _fetch_latest_version()
     if latest is None:
+        if structured_output:
+            raise CLIError(
+                "Failed to check for updates from PyPI.", code="PLATFORM_ERROR"
+            )
         console.print_error("Failed to check for updates from PyPI.")
         raise typer.Exit(1)
 
@@ -102,6 +135,13 @@ def upgrade() -> None:
     console.print()
 
     if _is_up_to_date(installed, latest):
+        if structured_output:
+            return OperationResult(
+                operation="upgrade",
+                status="no_update",
+                resource=_upgrade_resource(installed=installed, latest=latest),
+                message="Already up to date.",
+            )
         console.print("Already up to date!", style="green")
         return
 
@@ -117,22 +157,103 @@ def upgrade() -> None:
     console.print(f"Detected install method: {method}")
     console.print()
 
+    last_failure: OperationResult | None = None
+
     for cmd in cmds:
         if shutil.which(cmd[0]) is None:
             continue
 
         console.print(f"Running: {' '.join(cmd)}", style="dim")
         try:
-            result = subprocess.run(cmd, timeout=120)
+            run_kwargs: dict[str, Any] = {"timeout": 120}
+            if structured_output:
+                run_kwargs.update({"capture_output": True, "text": True})
+            else:
+                run_kwargs["stdout"] = subprocess.DEVNULL
+            result = subprocess.run(cmd, **run_kwargs)
             if result.returncode == 0:
+                if structured_output:
+                    return OperationResult(
+                        operation="upgrade",
+                        status="success",
+                        resource=_upgrade_resource(
+                            installed=installed,
+                            latest=latest,
+                            method=method,
+                            command=cmd,
+                            stdout=getattr(result, "stdout", None),
+                            stderr=getattr(result, "stderr", None),
+                        ),
+                        message=f"Successfully upgraded to {latest}.",
+                    )
                 console.print()
                 console.print(f"Successfully upgraded to {latest}!", style="bold green")
                 return
+            if structured_output:
+                last_failure = OperationResult(
+                    operation="upgrade",
+                    status="failed",
+                    resource=_upgrade_resource(
+                        installed=installed,
+                        latest=latest,
+                        method=method,
+                        command=cmd,
+                        stdout=getattr(result, "stdout", None),
+                        stderr=getattr(result, "stderr", None),
+                    ),
+                    message="Upgrade failed.",
+                    exit_code=1,
+                )
+                continue
             console.print()
         except subprocess.TimeoutExpired:
+            if structured_output:
+                last_failure = OperationResult(
+                    operation="upgrade",
+                    status="failed",
+                    resource=_upgrade_resource(
+                        installed=installed,
+                        latest=latest,
+                        method=method,
+                        command=cmd,
+                    ),
+                    message="Upgrade command timed out.",
+                    exit_code=1,
+                )
+                continue
             console.print_error("Upgrade command timed out.")
         except Exception as exc:
+            if structured_output:
+                last_failure = OperationResult(
+                    operation="upgrade",
+                    status="failed",
+                    resource=_upgrade_resource(
+                        installed=installed,
+                        latest=latest,
+                        method=method,
+                        command=cmd,
+                        stderr=str(exc),
+                    ),
+                    message="Error running upgrade.",
+                    exit_code=1,
+                )
+                continue
             console.print_error(f"Error running upgrade: {exc}")
+
+    if structured_output:
+        if last_failure is not None:
+            return last_failure
+        return OperationResult(
+            operation="upgrade",
+            status="failed",
+            resource=_upgrade_resource(
+                installed=installed,
+                latest=latest,
+                method=method,
+            ),
+            message="Upgrade failed.",
+            exit_code=1,
+        )
 
     console.print()
     console.print_error("Upgrade failed. You can try manually:")

--- a/osmosis_ai/eval/evaluation/cli.py
+++ b/osmosis_ai/eval/evaluation/cli.py
@@ -8,12 +8,25 @@ from __future__ import annotations
 import asyncio
 import logging
 import shutil
+import sys
 import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 from osmosis_ai.cli.console import Console
+from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.cli.output import (
+    DetailField,
+    DetailResult,
+    ListColumn,
+    ListResult,
+    MessageResult,
+    OperationResult,
+    OutputFormat,
+    get_output_context,
+    serialize_eval_cache_entry,
+)
 
 if TYPE_CHECKING:
     from osmosis_ai.eval.evaluation.cache import BuildSummaryResult
@@ -25,10 +38,32 @@ class EvalCommand:
     def __init__(self) -> None:
         self.console: Console = Console()
 
-    def _run_cache_dir(self) -> int:
+    @staticmethod
+    def _structured_output() -> bool:
+        return get_output_context().format is not OutputFormat.rich
+
+    def _fail(self, message: str, *, code: str = "VALIDATION") -> int:
+        if self._structured_output():
+            raise CLIError(message.removeprefix("Error: "), code=code)
+        self.console.print_error(message)
+        return 1
+
+    @staticmethod
+    def _stderr_line(message: str) -> None:
+        sys.stderr.write(message + "\n")
+        sys.stderr.flush()
+
+    def _run_cache_dir(self) -> int | DetailResult:
         from osmosis_ai.eval.evaluation.cache import JsonFileCacheBackend
 
         backend = JsonFileCacheBackend()
+        if self._structured_output():
+            path = str(backend.cache_root)
+            return DetailResult(
+                title="Eval Cache",
+                data={"cache_root": path},
+                fields=[DetailField(label="Cache root", value=path)],
+            )
         self.console.print(str(backend.cache_root))
         return 0
 
@@ -73,7 +108,7 @@ class EvalCommand:
         cache_model: str | None = None,
         cache_dataset: str | None = None,
         cache_status: str | None = None,
-    ) -> int:
+    ) -> int | ListResult:
         from osmosis_ai.eval.evaluation.cache import JsonFileCacheBackend
 
         backend = JsonFileCacheBackend()
@@ -87,6 +122,23 @@ class EvalCommand:
 
         # Sort by created_at descending (newest first)
         entries.sort(key=lambda e: e.get("created_at", ""), reverse=True)
+
+        if self._structured_output():
+            return ListResult(
+                title="Eval Caches",
+                items=[serialize_eval_cache_entry(entry) for entry in entries],
+                total_count=len(entries),
+                has_more=False,
+                next_offset=None,
+                columns=[
+                    ListColumn(key="task_id", label="Task ID", no_wrap=True),
+                    ListColumn(key="model", label="Model"),
+                    ListColumn(key="dataset", label="Dataset"),
+                    ListColumn(key="status", label="Status"),
+                    ListColumn(key="runs_count", label="Runs", align="right"),
+                    ListColumn(key="created_at", label="Created"),
+                ],
+            )
 
         if not entries:
             self.console.print("No cached evaluations found.")
@@ -147,17 +199,16 @@ class EvalCommand:
         cache_dataset: str | None = None,
         cache_status: str | None = None,
         yes: bool = False,
-    ) -> int:
+    ) -> int | OperationResult | MessageResult:
         from osmosis_ai.eval.evaluation.cache import JsonFileCacheBackend
 
         has_filter = any([cache_model, cache_dataset, cache_status])
 
         if not task_id and not rm_all and not has_filter:
-            self.console.print_error(
+            return self._fail(
                 "Error: Provide a task_id, --all, or at least one filter "
-                "(--model, --dataset, --status)."
+                "(--model, --dataset, --status).",
             )
-            return 1
 
         backend = JsonFileCacheBackend()
         all_entries = backend.list_caches()
@@ -173,12 +224,22 @@ class EvalCommand:
             )
 
         if not targets:
+            if self._structured_output():
+                raise CLIError(
+                    "No matching cached evaluations found.",
+                    code="NOT_FOUND",
+                )
             self.console.print("No matching cached evaluations found.")
             return 1
 
         # Single task_id deletion: no confirmation needed
         is_batch = not task_id
         if is_batch and not yes:
+            if self._structured_output():
+                raise CLIError(
+                    "Use --yes to confirm cache deletion in non-interactive mode.",
+                    code="INTERACTIVE_REQUIRED",
+                )
             self.console.print(f"Will delete {len(targets)} cached evaluation(s):")
             for e in targets:
                 config = e.get("config", {})
@@ -220,9 +281,16 @@ class EvalCommand:
             deleted += 1
 
         self.console.print(f"Deleted {deleted} cached evaluation(s).")
+        if self._structured_output():
+            return OperationResult(
+                operation="eval.cache.rm",
+                status="success",
+                resource={"deleted_count": deleted},
+                message=f"Deleted {deleted} cached evaluation(s).",
+            )
         return 0
 
-    def run(self, **kwargs: Any) -> int:
+    def run(self, **kwargs: Any) -> int | DetailResult:
         args = SimpleNamespace(**kwargs)
         return asyncio.run(self._run_async(args))
 
@@ -327,15 +395,81 @@ class EvalCommand:
             if failed:
                 self.console.print(f"  Failed: {failed}")
 
-    async def _run_async(self, args: Any) -> int:
-        from osmosis_ai.cli.errors import CLIError
+    @staticmethod
+    def _partial_failures(cache_data: dict[str, Any]) -> list[dict[str, Any]]:
+        failures: list[dict[str, Any]] = []
+        for run in cache_data.get("runs", []):
+            if run.get("success", True):
+                continue
+            failures.append(
+                {
+                    "row_index": run.get("row_index"),
+                    "run_index": run.get("run_index"),
+                    "model_tag": run.get("model_tag"),
+                    "error": run.get("error"),
+                }
+            )
+        return failures
+
+    def _build_eval_run_result(
+        self,
+        *,
+        status: str,
+        summary: BuildSummaryResult | None,
+        total_completed: int,
+        total_expected: int,
+        cache_path: Path,
+        samples_path: Path | None,
+        output_path: Path | None,
+        cache_data: dict[str, Any],
+        dataset_fingerprint_warning: str | None = None,
+        exit_code: int = 0,
+    ) -> DetailResult:
+        summary_data: dict[str, Any] = dict(summary or {})
+        partial_failures = self._partial_failures(cache_data)
+        failed_runs = int(summary_data.get("failed", len(partial_failures)))
+        total_runs = int(summary_data.get("total_runs", total_expected))
+        data = {
+            "status": status,
+            "total_runs": total_runs,
+            "completed_runs": total_completed,
+            "expected_runs": total_expected,
+            "failed_runs": failed_runs,
+            "cache_path": str(cache_path),
+            "samples_path": str(samples_path) if samples_path else None,
+            "output_path": str(output_path) if output_path else None,
+            "partial_failures": partial_failures,
+            "summary": summary_data,
+        }
+        if dataset_fingerprint_warning:
+            data["dataset_fingerprint_warning"] = dataset_fingerprint_warning
+
+        return DetailResult(
+            title="Eval Run",
+            data=data,
+            fields=[
+                DetailField(label="Status", value=status),
+                DetailField(label="Total runs", value=str(total_runs)),
+                DetailField(label="Completed runs", value=str(total_completed)),
+                DetailField(label="Failed runs", value=str(failed_runs)),
+                DetailField(label="Cache", value=str(cache_path)),
+                DetailField(
+                    label="Output",
+                    value=str(output_path) if output_path else "",
+                ),
+            ],
+            exit_code=exit_code,
+        )
+
+    async def _run_async(self, args: Any) -> int | DetailResult:
+        output = get_output_context()
+        structured_output = output.format is not OutputFormat.rich
 
         # Reject conflicting CLI flags before config load so invalid fixtures cannot mask this error.
         if args.fresh and args.retry_failed:
-            self.console.print_error(
+            return self._fail(
                 "Error: --fresh and --retry-failed are mutually exclusive."
             )
-            return 1
 
         from osmosis_ai.eval.common.cli import (
             _resolve_grader,
@@ -356,8 +490,7 @@ class EvalCommand:
         try:
             config = load_eval_config(config_path)
         except CLIError as e:
-            self.console.print_error(f"Error: {e}")
-            return 1
+            return self._fail(f"Error: {e}")
 
         try:
             workspace_root = resolve_workspace_root(config_path)
@@ -369,8 +502,7 @@ class EvalCommand:
                 command_label="`osmosis eval run`",
             )
         except CLIError as e:
-            self.console.print_error(f"Error: {e}")
-            return 1
+            return self._fail(f"Error: {e}")
 
         # Apply CLI overrides (CLI flags take precedence over TOML).
         # Optional values: CLI wins when not None.
@@ -378,8 +510,7 @@ class EvalCommand:
         limit = args.limit if args.limit is not None else config.eval_limit
         offset = args.offset if args.offset is not None else config.eval_offset
         if offset is not None and offset < 0:
-            self.console.print_error("Error: --offset must be >= 0")
-            return 1
+            return self._fail("Error: --offset must be >= 0")
         fresh = args.fresh or config.eval_fresh
         retry_failed = args.retry_failed or config.eval_retry_failed
         batch_size = (
@@ -402,10 +533,9 @@ class EvalCommand:
             logging.getLogger("osmosis_ai.rollout.backend").setLevel(logging.CRITICAL)
 
         if fresh and retry_failed:
-            self.console.print_error(
+            return self._fail(
                 "Error: --fresh and --retry-failed are mutually exclusive."
             )
-            return 1
 
         if not quiet:
             from osmosis_ai.consts import PACKAGE_VERSION
@@ -421,8 +551,7 @@ class EvalCommand:
         try:
             api_key = self._resolve_api_key(config)
         except CLIError as e:
-            self.console.print_error(f"Error: {e}")
-            return 1
+            return self._fail(f"Error: {e}")
 
         # 3. Load dataset
         rows, error = load_dataset_rows(
@@ -435,8 +564,7 @@ class EvalCommand:
             action_label="evaluating",
         )
         if error:
-            self.console.print_error(f"Error: {error}")
-            return 1
+            return self._fail(f"Error: {error}")
         assert rows is not None
 
         # 4. Load workflow
@@ -448,8 +576,7 @@ class EvalCommand:
             workspace_root=workspace_root,
         )
         if error:
-            self.console.print_error(f"Error: {error}")
-            return 1
+            return self._fail(f"Error: {error}")
         assert workflow_cls is not None
         assert entrypoint_module is not None
 
@@ -461,17 +588,15 @@ class EvalCommand:
                 explicit_config=config.grader_config,
             )
         except (CLIError, ImportError, TypeError, ValueError) as e:
-            self.console.print_error(f"Error: {e}")
-            return 1
+            return self._fail(f"Error: {e}")
 
         if grader_cls is None:
-            self.console.print_error(
+            return self._fail(
                 "No Grader was found in the entrypoint module. "
                 "`osmosis eval run` requires a concrete Grader (and typically a "
                 "GraderConfig) alongside the workflow. Configure `[grader].module` "
                 "if the grader lives outside the entrypoint."
             )
-            return 1
 
         if not quiet:
             self.console.print(f"  Grader: {grader_cls.__name__}")
@@ -494,8 +619,7 @@ class EvalCommand:
         try:
             await proxy.preflight_check()
         except CLIError as e:
-            self.console.print_error(f"Error: {e}")
-            return 1
+            return self._fail(f"Error: {e}")
 
         # 8. Start proxy
         await proxy.start()
@@ -525,11 +649,10 @@ class EvalCommand:
 
                 baseline_api_key = os.environ.get(config.baseline_api_key_env)
                 if not baseline_api_key:
-                    self.console.print_error(
+                    await proxy.stop()
+                    return self._fail(
                         f"Error: Environment variable '{config.baseline_api_key_env}' is not set."
                     )
-                    await proxy.stop()
-                    return 1
 
             baseline_proxy = LiteLLMProxy(
                 model=config.baseline_model,
@@ -540,9 +663,8 @@ class EvalCommand:
             try:
                 await baseline_proxy.preflight_check()
             except CLIError as e:
-                self.console.print_error(f"Error (baseline): {e}")
                 await proxy.stop()
-                return 1
+                return self._fail(f"Error (baseline): {e}")
 
             await baseline_proxy.start()
             baseline_driver = InProcessDriver(backend=backend, proxy=baseline_proxy)
@@ -617,16 +739,17 @@ class EvalCommand:
             output_path_resolved = Path(output_path).resolve()
             cache_root_resolved = _get_cache_root().resolve()
             if output_path_resolved == cache_root_resolved:
-                self.console.print_error(
-                    "Error: --output-path cannot be the same as the cache root directory."
-                )
                 await proxy.stop()
                 if baseline_proxy:
                     await baseline_proxy.stop()
-                return 1
+                return self._fail(
+                    "Error: --output-path cannot be the same as the cache root directory."
+                )
 
         def on_progress(current: int, total: int, result: dict) -> None:
             if quiet:
+                return
+            if output.format is OutputFormat.json:
                 return
 
             status_style = "green" if result["success"] else "red"
@@ -646,20 +769,29 @@ class EvalCommand:
                 error_suffix = f" - {truncate_error(result['error'])}"
 
             tokens = result.get("tokens", 0)
+            line = (
+                f"[{current}/{total}] {tag_prefix}{status} "
+                f"({duration}, {tokens:,} tokens){reward_str}{error_suffix}"
+            )
+            if output.format is OutputFormat.plain:
+                self._stderr_line(line)
+                return
             status_styled = self.console.format_styled(status, status_style)
             self.console.print(
                 f"[{current}/{total}] {tag_prefix}{status_styled} "
                 f"({duration}, {tokens:,} tokens){reward_str}{error_suffix}"
             )
 
-        if not quiet:
+        if not quiet and output.format is not OutputFormat.json:
             self.console.print()
             n_info = f" x{config.runs_n} runs" if config.runs_n > 1 else ""
             batch_info = f", batch_size={batch_size}" if batch_size > 1 else ""
             model_info = " x2 models" if config.baseline_model else ""
-            self.console.print(
-                f"Running evaluation ({len(rows)} rows{n_info}{model_info}{batch_info})..."
-            )
+            message = f"Running evaluation ({len(rows)} rows{n_info}{model_info}{batch_info})..."
+            if output.format is OutputFormat.plain:
+                self._stderr_line(message)
+            else:
+                self.console.print(message)
 
         # 12. Run orchestrator
         from osmosis_ai.eval.evaluation.orchestrator import EvalOrchestrator
@@ -684,12 +816,12 @@ class EvalCommand:
         try:
             orch_result = await orchestrator.run()
         except Exception as e:
-            self.console.print_error(f"Error during evaluation: {e}")
+            result = self._fail(f"Error during evaluation: {e}", code="INTERNAL")
             if debug:
                 import traceback
 
                 traceback.print_exc()
-            return 1
+            return result
         finally:
             await proxy.stop()
             if baseline_proxy:
@@ -697,6 +829,7 @@ class EvalCommand:
 
         # 13. Handle result status
         if orch_result.status == "already_completed":
+            results_path: Path | None = None
             if not quiet:
                 self.console.print(
                     "\nEvaluation already completed (cached).", style="bold"
@@ -719,8 +852,21 @@ class EvalCommand:
                     samples_path=orch_result.samples_path,
                     task_id=task_id,
                 )
+                results_path = results_path
                 if not quiet:
                     self.console.print(f"Output written to: {results_path}")
+            if structured_output:
+                return self._build_eval_run_result(
+                    status=orch_result.status,
+                    summary=orch_result.summary,
+                    total_completed=orch_result.total_completed,
+                    total_expected=orch_result.total_expected,
+                    cache_path=orch_result.cache_path,
+                    samples_path=orch_result.samples_path,
+                    output_path=results_path,
+                    cache_data=orch_result.cache_data,
+                    dataset_fingerprint_warning=orch_result.dataset_fingerprint_warning,
+                )
             return 0
 
         if orch_result.status == "interrupted":
@@ -732,15 +878,26 @@ class EvalCommand:
                 )
                 self.console.print(f"Cache: {orch_result.cache_path}")
                 self.console.print("Re-run the same command to resume.")
+            if structured_output:
+                return self._build_eval_run_result(
+                    status=orch_result.status,
+                    summary=orch_result.summary,
+                    total_completed=orch_result.total_completed,
+                    total_expected=orch_result.total_expected,
+                    cache_path=orch_result.cache_path,
+                    samples_path=orch_result.samples_path,
+                    output_path=None,
+                    cache_data=orch_result.cache_data,
+                    exit_code=130,
+                )
             return 130
 
         if orch_result.status == "dataset_modified":
-            self.console.print_error(
+            return self._fail(
                 f"Error: Dataset was modified during evaluation"
                 f"{(' (' + orch_result.stop_reason + ')') if orch_result.stop_reason else ''}. "
                 f"Results may be inconsistent. Use --fresh to restart."
             )
-            return 1
 
         if orch_result.status == "systemic_error":
             if not quiet:
@@ -756,6 +913,18 @@ class EvalCommand:
                 self.console.print(
                     f"\nPartial results cached at: {orch_result.cache_path}"
                 )
+            if structured_output:
+                return self._build_eval_run_result(
+                    status=orch_result.status,
+                    summary=orch_result.summary,
+                    total_completed=orch_result.total_completed,
+                    total_expected=orch_result.total_expected,
+                    cache_path=orch_result.cache_path,
+                    samples_path=orch_result.samples_path,
+                    output_path=None,
+                    cache_data=orch_result.cache_data,
+                    exit_code=1,
+                )
             return 1
 
         # completed
@@ -769,6 +938,7 @@ class EvalCommand:
             if orch_result.samples_path:
                 self.console.print(f"Samples: {orch_result.samples_path}")
 
+        results_path = None
         if output_path:
             results_path = self._write_orchestrator_output(
                 output_path=output_path,
@@ -780,6 +950,18 @@ class EvalCommand:
             )
             if not quiet:
                 self.console.print(f"Output written to: {results_path}")
+
+        if structured_output:
+            return self._build_eval_run_result(
+                status=orch_result.status,
+                summary=orch_result.summary,
+                total_completed=orch_result.total_completed,
+                total_expected=orch_result.total_expected,
+                cache_path=orch_result.cache_path,
+                samples_path=orch_result.samples_path,
+                output_path=results_path,
+                cache_data=orch_result.cache_data,
+            )
 
         return 0
 

--- a/osmosis_ai/eval/evaluation/cli.py
+++ b/osmosis_ai/eval/evaluation/cli.py
@@ -816,12 +816,11 @@ class EvalCommand:
         try:
             orch_result = await orchestrator.run()
         except Exception as e:
-            result = self._fail(f"Error during evaluation: {e}", code="INTERNAL")
             if debug:
                 import traceback
 
                 traceback.print_exc()
-            return result
+            return self._fail(f"Error during evaluation: {e}", code="INTERNAL")
         finally:
             await proxy.stop()
             if baseline_proxy:

--- a/osmosis_ai/eval/rubric/cli.py
+++ b/osmosis_ai/eval/rubric/cli.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import asyncio
 import sys
 from pathlib import Path
+from typing import Any
 
 from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.cli.output import OperationResult, OutputFormat, get_output_context
 from osmosis_ai.cli.paths import parse_cli_path
 
 from .dataset import RubricRecord, load_rubric_dataset
@@ -34,7 +36,7 @@ class RubricCommand:
         timeout: float | None = None,
         score_min: float = 0.0,
         score_max: float = 1.0,
-    ) -> int:
+    ) -> int | OperationResult:
         if number < 1:
             raise CLIError("--number must be at least 1.")
 
@@ -70,18 +72,69 @@ class RubricCommand:
             overall_statistics=calculate_statistics(all_scores),
         )
 
-        ConsoleReportRenderer().render(report)
+        output = get_output_context()
+        if output.format is OutputFormat.rich:
+            ConsoleReportRenderer().render(report)
 
+        written: Path | None = None
         if output_path:
             parsed_output = parse_cli_path(output_path, expand_user=True)
             out = parsed_output.path
             if parsed_output.has_trailing_separator or out.is_dir():
                 out = out / "rubric_eval_result.json"
             written = JsonReportWriter().write(report, out)
-            print(f"Wrote results to {written}")
+            if output.format is OutputFormat.rich:
+                from osmosis_ai.cli.console import console
+
+                console.print(f"Wrote results to {written}")
 
         has_errors = any(r.errors for r in results)
+        if output.format is not OutputFormat.rich:
+            return OperationResult(
+                operation="eval.rubric",
+                status="failed" if has_errors else "success",
+                resource=self._report_resource(report, written),
+                message=(
+                    "Rubric evaluation completed with errors."
+                    if has_errors
+                    else "Rubric evaluation completed."
+                ),
+                exit_code=1 if has_errors else 0,
+            )
         return 1 if has_errors else 0
+
+    @staticmethod
+    def _record_payload(result: RecordResult) -> dict[str, Any]:
+        return {
+            "index": result.record_index,
+            "label": result.label,
+            "scores": result.scores,
+            "explanations": result.explanations,
+            "errors": result.errors,
+            "statistics": result.statistics,
+        }
+
+    @classmethod
+    def _report_resource(
+        cls,
+        report: RubricReport,
+        output_path: Path | None,
+    ) -> dict[str, Any]:
+        resource: dict[str, Any] = {
+            "model": report.model,
+            "data_path": str(report.data_path),
+            "number": report.number,
+            "statistics": report.overall_statistics,
+            "record_count": len(report.results),
+            "error_count": sum(len(result.errors) for result in report.results),
+        }
+        if output_path is not None:
+            resource["output_path"] = str(output_path)
+        else:
+            resource["records"] = [
+                cls._record_payload(result) for result in report.results
+            ]
+        return resource
 
     @staticmethod
     def _resolve_rubric_text(rubric: str) -> str:
@@ -113,7 +166,11 @@ class RubricCommand:
         score_max: float,
     ) -> list[RecordResult]:
         total = len(records) * number
-        show_progress = total > 1 and getattr(sys.stderr, "isatty", lambda: False)()
+        show_progress = (
+            get_output_context().format is OutputFormat.rich
+            and total > 1
+            and getattr(sys.stderr, "isatty", lambda: False)()
+        )
         progress = None
         if show_progress:
             from tqdm import tqdm

--- a/osmosis_ai/eval/rubric/cli.py
+++ b/osmosis_ai/eval/rubric/cli.py
@@ -86,7 +86,7 @@ class RubricCommand:
             if output.format is OutputFormat.rich:
                 from osmosis_ai.cli.console import console
 
-                console.print(f"Wrote results to {written}")
+                console.print(f"Wrote results to {console.escape(str(written))}")
 
         has_errors = any(r.errors for r in results)
         if output.format is not OutputFormat.rich:

--- a/osmosis_ai/eval/rubric/cli.py
+++ b/osmosis_ai/eval/rubric/cli.py
@@ -167,7 +167,7 @@ class RubricCommand:
     ) -> list[RecordResult]:
         total = len(records) * number
         show_progress = (
-            get_output_context().format is OutputFormat.rich
+            get_output_context().format is not OutputFormat.json
             and total > 1
             and getattr(sys.stderr, "isatty", lambda: False)()
         )

--- a/osmosis_ai/platform/api/upload.py
+++ b/osmosis_ai/platform/api/upload.py
@@ -411,19 +411,33 @@ def make_progress_bar(
     *,
     description: str = "Uploading",
 ) -> tuple[AbstractContextManager[Any], ProgressCallback]:
-    """Create a progress bar and a matching callback.
+    """Create an output-aware progress bar and a matching callback.
 
-    Returns (progress_context, callback) where progress_context is a
-    context manager wrapping a rich Progress bar (or a no-op nullcontext
-    for plain-text fallback).
-
-    The caller should use::
-
-        ctx, cb = make_progress_bar(size)
-        with ctx:
-            upload_fn(..., progress_callback=cb)
+    JSON mode stays fully silent. Plain mode emits coarse stderr updates. Rich
+    mode uses a stderr-bound Rich progress bar so stdout remains clean.
     """
+    from osmosis_ai.cli.output.context import OutputFormat, get_output_context
+
+    output = get_output_context()
+
+    if output.format is OutputFormat.json:
+        return nullcontext(), lambda uploaded, total: None
+
+    if output.format is OutputFormat.plain:
+        last_pct = -1
+
+        def _plain_cb(uploaded: int, total: int) -> None:
+            nonlocal last_pct
+            pct = uploaded * 100 // total if total else 0
+            if pct != last_pct and (pct - last_pct >= 10 or uploaded >= total):
+                sys.stderr.write(f"{description}: {pct}%\n")
+                sys.stderr.flush()
+                last_pct = pct
+
+        return nullcontext(), _plain_cb
+
     try:
+        from rich.console import Console as RichConsole
         from rich.progress import (
             BarColumn,
             DownloadColumn,
@@ -444,6 +458,9 @@ def make_progress_bar(
             BarColumn(),
             DownloadColumn(binary_units=True),
             _SpeedCol(),
+            console=RichConsole(stderr=True),
+            redirect_stdout=False,
+            redirect_stderr=False,
         )
         task_id = progress.add_task(description, total=file_size)
 
@@ -452,14 +469,14 @@ def make_progress_bar(
 
         return progress, _rich_cb
     except ImportError:
-        pass
+        last_pct = -1
 
-    # Plain-text fallback
-    def _plain_cb(uploaded: int, total: int) -> None:
-        pct = uploaded * 100 // total if total else 0
-        sys.stdout.write(f"\r{description}: {pct}%")
-        sys.stdout.flush()
-        if uploaded >= total:
-            sys.stdout.write("\n")
+        def _fallback(uploaded: int, total: int) -> None:
+            nonlocal last_pct
+            pct = uploaded * 100 // total if total else 0
+            if pct != last_pct and (pct - last_pct >= 10 or uploaded >= total):
+                sys.stderr.write(f"{description}: {pct}%\n")
+                sys.stderr.flush()
+                last_pct = pct
 
-    return nullcontext(), _plain_cb
+        return nullcontext(), _fallback

--- a/osmosis_ai/platform/api/upload.py
+++ b/osmosis_ai/platform/api/upload.py
@@ -424,15 +424,16 @@ def make_progress_bar(
         return nullcontext(), lambda uploaded, total: None
 
     if output.format is OutputFormat.plain:
-        last_pct = -1
+        last_pct = 0
 
         def _plain_cb(uploaded: int, total: int) -> None:
             nonlocal last_pct
-            pct = uploaded * 100 // total if total else 0
-            if pct != last_pct and (pct - last_pct >= 10 or uploaded >= total):
-                sys.stderr.write(f"{description}: {pct}%\n")
+            pct = uploaded * 100 // total if total else 100
+            next_pct = 100 if uploaded >= total else (pct // 10) * 10
+            if next_pct > last_pct:
+                sys.stderr.write(f"{description}: {next_pct}%\n")
                 sys.stderr.flush()
-                last_pct = pct
+                last_pct = next_pct
 
         return nullcontext(), _plain_cb
 

--- a/osmosis_ai/platform/auth/credentials.py
+++ b/osmosis_ai/platform/auth/credentials.py
@@ -238,14 +238,18 @@ def save_credentials(credentials: Credentials) -> str:
     return TOKEN_STORE_FILE
 
 
-def load_credentials() -> Credentials | None:
+def load_credentials(*, include_env: bool = True) -> Credentials | None:
     """Load credentials with priority: env var → keyring → plain-text file.
+
+    Args:
+        include_env: When ``False``, skip ``OSMOSIS_TOKEN`` and load only
+            credentials persisted by the CLI.
 
     Returns:
         The loaded credentials, or ``None`` if no credentials exist.
     """
     # 1. Environment variable
-    env_token = os.environ.get("OSMOSIS_TOKEN")
+    env_token = os.environ.get("OSMOSIS_TOKEN") if include_env else None
     if env_token:
         return Credentials(
             access_token=env_token,

--- a/osmosis_ai/platform/auth/flow.py
+++ b/osmosis_ai/platform/auth/flow.py
@@ -30,6 +30,17 @@ from .credentials import Credentials, UserInfo
 class LoginError(Exception):
     """Error during login flow."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str | None = None,
+        status_code: int | None = None,
+    ):
+        super().__init__(message)
+        self.code = code
+        self.status_code = status_code
+
 
 @dataclass
 class VerifyResult:
@@ -119,15 +130,22 @@ def _copy_to_clipboard(text: str) -> bool:
         return False
 
 
-def _read_error_detail(e: HTTPError) -> str:
-    """Extract error message from an HTTPError JSON response body."""
+def _read_error_body(e: HTTPError) -> dict[str, Any]:
+    """Extract a JSON error body from an HTTPError."""
     try:
         body = json.loads(e.read().decode())
         if isinstance(body, dict):
-            return body.get("error", "") or body.get("message", "")
+            return body
     except Exception:
         pass
-    return ""
+    return {}
+
+
+def _read_error_detail(e: HTTPError) -> str:
+    """Extract error message from an HTTPError JSON response body."""
+    body = _read_error_body(e)
+    detail = body.get("error", "") or body.get("message", "")
+    return detail if isinstance(detail, str) else ""
 
 
 # User-friendly messages keyed by HTTP status code.
@@ -139,6 +157,15 @@ _HTTP_ERROR_MESSAGES: dict[int, str] = {
     502: "Osmosis platform is temporarily unavailable. Please try again later.",
     503: "Osmosis platform is temporarily unavailable. Please try again later.",
     504: "Osmosis platform is temporarily unavailable. Please try again later.",
+}
+
+_CLI_TOKEN_ERROR_MESSAGES: dict[str, str] = {
+    "AUTH_HEADER_MISSING": "Token is missing.",
+    "TOKEN_MISSING": "Token is missing.",
+    "TOKEN_EXPIRED": "Token has expired.",
+    "TOKEN_INVALID": "Token is invalid.",
+    "TOKEN_REVOKED": "Token has been revoked.",
+    "UNKNOWN_AUTH_ERROR": "Authentication failed.",
 }
 
 
@@ -154,12 +181,14 @@ def _login_error_from_http(
     friendly = _HTTP_ERROR_MESSAGES.get(e.code)
 
     if detail and friendly:
-        return LoginError(f"{friendly} ({detail})")
+        return LoginError(f"{friendly} ({detail})", status_code=e.code)
     if friendly:
-        return LoginError(friendly)
+        return LoginError(friendly, status_code=e.code)
     if detail:
-        return LoginError(f"{fallback_prefix}: {detail} (HTTP {e.code})")
-    return LoginError(f"{fallback_prefix}: HTTP {e.code}")
+        return LoginError(
+            f"{fallback_prefix}: {detail} (HTTP {e.code})", status_code=e.code
+        )
+    return LoginError(f"{fallback_prefix}: HTTP {e.code}", status_code=e.code)
 
 
 # ---------------------------------------------------------------------------
@@ -216,7 +245,15 @@ def verify_token(token: str) -> VerifyResult:
 
     except HTTPError as e:
         if e.code == 401:
-            raise LoginError("Invalid or expired token") from e
+            error_body = _read_error_body(e)
+            error_code = error_body.get("code")
+            if isinstance(error_code, str) and error_code in _CLI_TOKEN_ERROR_MESSAGES:
+                raise LoginError(
+                    _CLI_TOKEN_ERROR_MESSAGES[error_code],
+                    code=error_code,
+                    status_code=e.code,
+                ) from e
+            raise LoginError(_HTTP_ERROR_MESSAGES[e.code], status_code=e.code) from e
         raise _login_error_from_http(e, "Verification failed") from e
     except URLError as e:
         raise LoginError(f"Could not connect to platform: {e.reason}") from e

--- a/osmosis_ai/platform/auth/flow.py
+++ b/osmosis_ai/platform/auth/flow.py
@@ -331,7 +331,8 @@ def device_login(timeout: float = 600.0) -> tuple[LoginResult, Credentials]:
     Returns:
         Tuple of (LoginResult, Credentials). Caller is responsible for saving credentials.
     """
-    device_code_resp = request_device_code()
+    with console.spinner("Requesting device code..."):
+        device_code_resp = request_device_code()
 
     console.print()
     copied = _copy_to_clipboard(device_code_resp.user_code)
@@ -347,9 +348,8 @@ def device_login(timeout: float = 600.0) -> tuple[LoginResult, Credentials]:
     console.print()
 
     verification_url = device_code_resp.verification_uri
-    console.print(
-        f"Open this URL in your browser: {verification_url}",
-        style="yellow",
+    console.print_url(
+        "Open this URL in your browser: ", verification_url, style="yellow"
     )
 
     if sys.stdin.isatty():

--- a/osmosis_ai/platform/auth/platform_client.py
+++ b/osmosis_ai/platform/auth/platform_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import os
 import sys
 from typing import TYPE_CHECKING, Any
 from urllib.error import HTTPError, URLError
@@ -11,7 +12,13 @@ from urllib.request import Request, urlopen
 
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.consts import PACKAGE_VERSION
-from osmosis_ai.platform.constants import MSG_NOT_LOGGED_IN
+from osmosis_ai.platform.constants import (
+    MSG_ENV_TOKEN_EXPIRED,
+    MSG_ENV_TOKEN_INVALID,
+    MSG_ENV_TOKEN_REVOKED,
+    MSG_NOT_LOGGED_IN,
+    MSG_SESSION_EXPIRED,
+)
 
 from .config import PLATFORM_URL
 from .credentials import load_credentials
@@ -28,6 +35,10 @@ if TYPE_CHECKING:
 
 class AuthenticationExpiredError(Exception):
     """Raised when the stored credentials are invalid, expired, or revoked."""
+
+    def __init__(self, message: str = MSG_SESSION_EXPIRED, *, code: str | None = None):
+        super().__init__(message)
+        self.code = code
 
 
 class PlatformAPIError(Exception):
@@ -67,6 +78,57 @@ class SubscriptionRequiredError(PlatformAPIError):
             field=field,
             details=details,
         )
+
+
+def _credentials_match_env_token(credentials: Credentials | None) -> bool:
+    env_token = os.environ.get("OSMOSIS_TOKEN")
+    return bool(
+        env_token and credentials is not None and credentials.access_token == env_token
+    )
+
+
+def _read_error_body(e: HTTPError) -> dict[str, Any]:
+    try:
+        raw = e.read()
+        text = raw.decode("utf-8", errors="replace").strip() if raw else ""
+        if not text:
+            return {}
+        parsed = json.loads(text)
+        return parsed if isinstance(parsed, dict) else {}
+    except Exception:
+        return {}
+
+
+def _auth_error_message(error_code: str | None, *, using_env_token: bool) -> str:
+    if using_env_token:
+        if error_code == "TOKEN_EXPIRED":
+            return MSG_ENV_TOKEN_EXPIRED
+        if error_code == "TOKEN_REVOKED":
+            return MSG_ENV_TOKEN_REVOKED
+        return MSG_ENV_TOKEN_INVALID
+
+    if error_code == "TOKEN_REVOKED":
+        return (
+            "Your session has been revoked. "
+            "Please run 'osmosis auth login' to re-authenticate."
+        )
+    return MSG_SESSION_EXPIRED
+
+
+_WORKSPACE_AUTH_ERROR_MESSAGES: dict[str, str] = {
+    "WORKSPACE_HEADER_MISSING": (
+        "No workspace selected. Run 'osmosis workspace' to select a workspace."
+    ),
+    "WORKSPACE_HEADER_INVALID": (
+        "Your workspace context is invalid. "
+        "Run 'osmosis auth login' or 'osmosis workspace' to re-select."
+    ),
+    "WORKSPACE_ACCESS_DENIED": (
+        "You do not have access to this workspace.\n"
+        "Your workspace context may be stale. "
+        "Run 'osmosis auth login' or 'osmosis workspace' to re-select."
+    ),
+}
 
 
 def revoke_cli_token(credentials: Credentials) -> bool:
@@ -191,6 +253,7 @@ def platform_request(
         credentials = load_credentials()
     if credentials is None:
         raise CLIError(MSG_NOT_LOGGED_IN)
+    using_env_token = _credentials_match_env_token(credentials)
 
     url = f"{PLATFORM_URL}{endpoint}"
 
@@ -232,11 +295,15 @@ def platform_request(
             return result
     except HTTPError as e:
         if e.code == 401:
-            if cleanup_on_401:
+            error_body = _read_error_body(e)
+            error_code = error_body.get("code")
+            if not isinstance(error_code, str):
+                error_code = None
+            if cleanup_on_401 and not using_env_token:
                 reset_session()
             raise AuthenticationExpiredError(
-                "Your session has expired or been revoked. "
-                "Please run 'osmosis auth login' to re-authenticate."
+                _auth_error_message(error_code, using_env_token=using_env_token),
+                code=error_code,
             ) from e
 
         # Best-effort capture of structured error message from response body
@@ -267,6 +334,15 @@ def platform_request(
                     detail = f" Response: {text}"
         except Exception:
             pass
+
+        if error_code in _WORKSPACE_AUTH_ERROR_MESSAGES:
+            raise PlatformAPIError(
+                _WORKSPACE_AUTH_ERROR_MESSAGES[error_code],
+                e.code,
+                error_code=error_code,
+                field=field,
+                details=error_body or None,
+            ) from e
 
         # Detect subscription-required responses (403 with subscription message)
         if e.code == 403 and isinstance(error_body, dict):

--- a/osmosis_ai/platform/cli/dataset.py
+++ b/osmosis_ai/platform/cli/dataset.py
@@ -31,6 +31,7 @@ from .utils import (
     format_dataset_status,
     format_dim_date,
     format_size,
+    platform_call,
     platform_entity_url,
 )
 
@@ -85,10 +86,14 @@ def _complete_with_retry(
             )
             time.sleep(delay)
         try:
-            return client.complete_upload(
-                dataset_id,
-                parts=parts,
-                credentials=credentials,
+            return platform_call(
+                "Finalizing upload...",
+                lambda: client.complete_upload(
+                    dataset_id,
+                    parts=parts,
+                    credentials=credentials,
+                ),
+                output_console=console,
             )
         except AuthenticationExpiredError:
             raise  # Not transient — surface immediately
@@ -174,11 +179,15 @@ def _perform_upload(
     client = OsmosisClient()
     dataset_name = _dataset_name_from_path(file_path)
 
-    dataset = client.create_dataset(
-        dataset_name,
-        file_size,
-        ext,
-        credentials=credentials,
+    dataset = platform_call(
+        "Creating dataset...",
+        lambda: client.create_dataset(
+            dataset_name,
+            file_size,
+            ext,
+            credentials=credentials,
+        ),
+        output_console=console,
     )
 
     upload_info = dataset.upload
@@ -286,11 +295,8 @@ def upload(
         highlight=False,
     )
     url = platform_entity_url(ws_name, "datasets", dataset.id)
-    console.print(
-        "Processing will continue on the platform. Check status at: ",
-        console.format_url(url),
-        sep="",
-        soft_wrap=True,
+    console.print_url(
+        "Processing will continue on the platform. Check status at: ", url
     )
 
 
@@ -344,7 +350,11 @@ def info(
     from osmosis_ai.platform.api.client import OsmosisClient
 
     client = OsmosisClient()
-    ds = client.get_dataset(name, credentials=credentials)
+    ds = platform_call(
+        "Fetching dataset...",
+        lambda: client.get_dataset(name, credentials=credentials),
+        output_console=console,
+    )
 
     rows = build_dataset_detail_rows(ds)
     console.table(rows, title="Dataset")
@@ -359,7 +369,11 @@ def preview(
     from osmosis_ai.platform.api.client import OsmosisClient
 
     client = OsmosisClient()
-    ds = client.get_dataset(name, credentials=credentials)
+    ds = platform_call(
+        "Fetching dataset...",
+        lambda: client.get_dataset(name, credentials=credentials),
+        output_console=console,
+    )
 
     if ds.data_preview is None:
         if ds.status in STATUSES_IN_PROGRESS:
@@ -402,7 +416,11 @@ def download(
     from osmosis_ai.platform.api.download import download_file
 
     client = OsmosisClient()
-    ds = client.get_dataset(name, credentials=credentials)
+    ds = platform_call(
+        "Fetching dataset...",
+        lambda: client.get_dataset(name, credentials=credentials),
+        output_console=console,
+    )
     if ds.status != "uploaded":
         if ds.status in STATUSES_IN_PROGRESS:
             raise CLIError(
@@ -411,7 +429,11 @@ def download(
             )
         raise CLIError(f"Dataset is not available for download (status: {ds.status}).")
 
-    info = client.get_dataset_download_url(name, credentials=credentials)
+    info = platform_call(
+        "Preparing download...",
+        lambda: client.get_dataset_download_url(name, credentials=credentials),
+        output_console=console,
+    )
     default_filename = _default_download_filename(
         info.file_name or ds.file_name,
         info.presigned_url,
@@ -454,7 +476,13 @@ def delete(
 
     # Blocking preflight: abort if active training runs use this dataset
     try:
-        affected = client.get_dataset_affected_resources(name, credentials=credentials)
+        affected = platform_call(
+            "Checking dataset dependencies...",
+            lambda: client.get_dataset_affected_resources(
+                name, credentials=credentials
+            ),
+            output_console=console,
+        )
     except Exception as e:
         raise CLIError(f"Unable to verify dataset dependencies: {e}") from e
 
@@ -471,7 +499,11 @@ def delete(
         raise CLIError("\n".join(lines))
 
     if not yes:
-        ds = client.get_dataset(name, credentials=credentials)
+        ds = platform_call(
+            "Fetching dataset...",
+            lambda: client.get_dataset(name, credentials=credentials),
+            output_console=console,
+        )
         console.print(
             f"  Dataset: {console.escape(ds.file_name)} ({format_size(ds.file_size)})"
         )
@@ -480,7 +512,11 @@ def delete(
 
     require_confirmation(f'Delete dataset "{name}"? This cannot be undone.', yes=yes)
 
-    client.delete_dataset(name, credentials=credentials)
+    platform_call(
+        "Deleting dataset...",
+        lambda: client.delete_dataset(name, credentials=credentials),
+        output_console=console,
+    )
     console.print(
         f'Dataset "{console.escape(name)}" deleted.',
         style="green",

--- a/osmosis_ai/platform/cli/dataset.py
+++ b/osmosis_ai/platform/cli/dataset.py
@@ -285,8 +285,13 @@ def upload(
         style="green",
         highlight=False,
     )
-    url = console.escape(platform_entity_url(ws_name, "datasets", dataset.id))
-    console.print(f"Processing will continue on the platform. Check status at: {url}")
+    url = platform_entity_url(ws_name, "datasets", dataset.id)
+    console.print(
+        "Processing will continue on the platform. Check status at: ",
+        console.format_url(url),
+        sep="",
+        soft_wrap=True,
+    )
 
 
 def list_datasets(limit: int = DEFAULT_PAGE_SIZE, all_: bool = False) -> None:

--- a/osmosis_ai/platform/cli/dataset.py
+++ b/osmosis_ai/platform/cli/dataset.py
@@ -10,8 +10,19 @@ from urllib.parse import unquote, urlparse
 
 from osmosis_ai.cli.console import console
 from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.cli.output import (
+    CommandResult,
+    DetailField,
+    DetailResult,
+    ListColumn,
+    ListResult,
+    OperationResult,
+    OutputFormat,
+    get_output_context,
+    serialize_dataset,
+)
 from osmosis_ai.cli.paths import parse_cli_path
-from osmosis_ai.cli.prompts import confirm, is_interactive
+from osmosis_ai.cli.prompts import confirm
 from osmosis_ai.platform.api.models import STATUSES_IN_PROGRESS
 from osmosis_ai.platform.auth import (
     AuthenticationExpiredError,
@@ -63,6 +74,11 @@ def _abort_upload(
 # primary client-side defense, not the only one.
 
 from osmosis_ai.platform.api.upload import BACKOFF_BASE, BACKOFF_CAP, MAX_RETRIES
+
+PARQUET_VALIDATION_SKIPPED_WARNING = (
+    "pyarrow not installed; parquet content validation skipped. "
+    "Install with: pip install 'osmosis-ai[platform]'"
+)
 
 
 def _complete_with_retry(
@@ -122,7 +138,11 @@ def _complete_with_retry(
         style="yellow",
     )
     console.print()
-    raise CLIError(f"Failed to complete upload: {last_error}") from last_error
+    raise CLIError(
+        f"Failed to complete upload: {last_error}",
+        code="PLATFORM_ERROR",
+        details={"dataset_id": dataset_id},
+    ) from last_error
 
 
 def _check_file_basics(file: str) -> tuple[Path, str, int]:
@@ -155,6 +175,11 @@ def _check_file_basics(file: str) -> tuple[Path, str, int]:
 def _dataset_name_from_path(file_path: Path) -> str:
     """Derive the platform dataset name from a local file path."""
     return file_path.stem
+
+
+def _detail_fields(rows: list[tuple[str, str]]) -> list[DetailField]:
+    """Convert existing label/value rows into renderer detail fields."""
+    return [DetailField(label=label, value=value) for label, value in rows]
 
 
 def _perform_upload(
@@ -222,7 +247,7 @@ def _perform_upload(
         except Exception as e:
             _abort_upload(client, dataset.id, credentials=credentials)
             raise CLIError(f"Upload failed: {e}") from e
-        _complete_with_retry(
+        completed = _complete_with_retry(
             client,
             dataset.id,
             parts=parts,
@@ -241,21 +266,22 @@ def _perform_upload(
         except Exception as e:
             _abort_upload(client, dataset.id, credentials=credentials)
             raise CLIError(f"Upload failed: {e}") from e
-        _complete_with_retry(
+        completed = _complete_with_retry(
             client,
             dataset.id,
             credentials=credentials,
         )
 
-    return dataset
+    return completed or dataset
 
 
 def upload(
     file: str,
-) -> None:
+) -> CommandResult:
     """Upload a dataset file."""
     ws_name, credentials = _require_auth()
     _require_subscription(workspace_name=ws_name)
+    output = get_output_context()
 
     file_path, ext, file_size = _check_file_basics(file)
 
@@ -276,11 +302,14 @@ def upload(
         title="Upload Target",
     )
     console.print()
-    if is_interactive():
+    if output.interactive:
         proceed = confirm("Proceed with upload?", default=True)
         if proceed is None or not proceed:
-            console.print("Upload cancelled.", style="dim")
-            return
+            return OperationResult(
+                operation="dataset.upload",
+                status="cancelled",
+                message="Upload cancelled.",
+            )
 
     dataset = _perform_upload(
         file_path=file_path,
@@ -289,22 +318,28 @@ def upload(
         credentials=credentials,
     )
 
-    console.print(
-        f"Dataset uploaded: {console.escape(dataset.file_name)}",
-        style="green",
-        highlight=False,
-    )
     url = platform_entity_url(ws_name, "datasets", dataset.id)
-    console.print_url(
-        "Processing will continue on the platform. Check status at: ", url
+    return OperationResult(
+        operation="dataset.upload",
+        status="success",
+        resource=serialize_dataset(dataset),
+        message=f"Dataset uploaded: {dataset.file_name}",
+        display_next_steps=[
+            f"Processing will continue on the platform. Check status at: {url}"
+        ],
+        next_steps_structured=[
+            {
+                "label": "View dataset",
+                "url": url,
+            }
+        ],
     )
 
 
-def list_datasets(limit: int = DEFAULT_PAGE_SIZE, all_: bool = False) -> None:
+def list_datasets(limit: int = DEFAULT_PAGE_SIZE, all_: bool = False) -> CommandResult:
     """List datasets."""
     from osmosis_ai.platform.cli.utils import (
-        paginated_fetch,
-        print_pagination_footer,
+        fetch_all_pages,
         validate_list_options,
     )
 
@@ -316,35 +351,54 @@ def list_datasets(limit: int = DEFAULT_PAGE_SIZE, all_: bool = False) -> None:
     client = OsmosisClient()
 
     with console.spinner("Fetching datasets..."):
-        datasets, total_count, _has_more = paginated_fetch(
-            lambda lim, off: client.list_datasets(
-                limit=lim, offset=off, credentials=credentials
-            ),
-            items_attr="datasets",
-            limit=effective_limit,
-            fetch_all=fetch_all,
-        )
+        if fetch_all:
+            datasets, total_count = fetch_all_pages(
+                lambda lim, off: client.list_datasets(
+                    limit=lim, offset=off, credentials=credentials
+                ),
+                items_attr="datasets",
+            )
+            has_more = False
+            next_offset = None
+        else:
+            page = client.list_datasets(
+                limit=effective_limit,
+                offset=0,
+                credentials=credentials,
+            )
+            datasets = page.datasets
+            total_count = page.total_count
+            has_more = page.has_more
+            next_offset = page.next_offset
 
-    if not datasets:
-        console.print("No datasets found.")
-        return
-
-    console.print(f"Datasets ({total_count}):", style="bold")
-    for d in datasets:
-        status_info = format_dataset_status(d)
-        name = console.escape(d.file_name)
-        date = format_dim_date(d.created_at)
-        console.print(
-            f"  {name}  {format_size(d.file_size)}  {status_info}  {date}",
-            highlight=False,
-        )
-
-    print_pagination_footer(len(datasets), total_count, "datasets")
+    return ListResult(
+        title="Datasets",
+        items=[serialize_dataset(d) for d in datasets],
+        total_count=total_count,
+        has_more=has_more,
+        next_offset=next_offset,
+        columns=[
+            ListColumn(key="file_name", label="File"),
+            ListColumn(key="status", label="Status"),
+            ListColumn(key="file_size", label="Size"),
+            ListColumn(key="created_at", label="Created"),
+            ListColumn(key="id", label="ID", no_wrap=True),
+        ],
+        display_items=[
+            {
+                **serialize_dataset(d),
+                "status": format_dataset_status(d),
+                "file_size": format_size(d.file_size),
+                "created_at": format_dim_date(d.created_at),
+            }
+            for d in datasets
+        ],
+    )
 
 
 def info(
     name: str,
-) -> None:
+) -> CommandResult:
     """Show dataset details and processing status."""
     _ws_name, credentials = _require_auth()
     from osmosis_ai.platform.api.client import OsmosisClient
@@ -357,13 +411,17 @@ def info(
     )
 
     rows = build_dataset_detail_rows(ds)
-    console.table(rows, title="Dataset")
+    return DetailResult(
+        title="Dataset",
+        data=serialize_dataset(ds),
+        fields=_detail_fields(rows),
+    )
 
 
 def preview(
     name: str,
     rows: int = 5,
-) -> None:
+) -> CommandResult:
     """Preview dataset rows."""
     _ws_name, credentials = _require_auth()
     from osmosis_ai.platform.api.client import OsmosisClient
@@ -377,21 +435,56 @@ def preview(
 
     if ds.data_preview is None:
         if ds.status in STATUSES_IN_PROGRESS:
-            console.print(
-                f"Dataset is still processing (status: {ds.status}).",
-                style="yellow",
-            )
+            message = f"Dataset is still processing (status: {ds.status})."
         else:
-            console.print("No preview available for this dataset.", style="dim")
-        return
+            message = "No preview available for this dataset."
+        return DetailResult(
+            title="Dataset Preview",
+            data={
+                "dataset": serialize_dataset(ds),
+                "rows": None,
+                "requested_rows": rows,
+                "returned_rows": 0,
+                "available": False,
+                "message": message,
+            },
+            fields=[
+                DetailField(label="Dataset", value=ds.file_name),
+                DetailField(label="Status", value=ds.status),
+                DetailField(label="Preview", value=message),
+            ],
+        )
 
     data_rows = ds.data_preview
     if isinstance(data_rows, list):
         limit = min(rows, len(data_rows))
-        for row in data_rows[:limit]:
-            console.print(str(row))
+        preview_rows = data_rows[:limit]
+        fields = [
+            DetailField(label="Dataset", value=ds.file_name),
+            DetailField(label="Rows", value=f"{len(preview_rows)} of {len(data_rows)}"),
+        ]
+        fields.extend(
+            DetailField(label=f"Row {idx}", value=str(row))
+            for idx, row in enumerate(preview_rows, 1)
+        )
     else:
-        console.print(str(data_rows))
+        preview_rows = data_rows
+        fields = [
+            DetailField(label="Dataset", value=ds.file_name),
+            DetailField(label="Preview", value=str(data_rows)),
+        ]
+
+    return DetailResult(
+        title="Dataset Preview",
+        data={
+            "dataset": serialize_dataset(ds),
+            "rows": preview_rows,
+            "requested_rows": rows,
+            "returned_rows": len(preview_rows) if isinstance(preview_rows, list) else 1,
+            "available": True,
+        },
+        fields=fields,
+    )
 
 
 def _default_download_filename(file_name: str, presigned_url: str) -> str:
@@ -409,7 +502,7 @@ def download(
     name: str,
     output: str | None = None,
     overwrite: bool = False,
-) -> None:
+) -> CommandResult:
     """Download a dataset file."""
     _ws_name, credentials = _require_auth()
     from osmosis_ai.platform.api.client import OsmosisClient
@@ -457,18 +550,28 @@ def download(
     except Exception as exc:
         raise CLIError(f"Download failed: {exc}") from exc
 
-    console.print(
-        f"Dataset downloaded: {console.escape(str(destination))}",
-        style="green",
-        highlight=False,
+    resource = serialize_dataset(ds)
+    resource["output_path"] = str(destination)
+    return OperationResult(
+        operation="dataset.download",
+        status="success",
+        resource=resource,
+        message=f"Dataset downloaded: {destination}",
     )
 
 
 def delete(
     name: str,
     yes: bool = False,
-) -> None:
+) -> CommandResult:
     """Delete a dataset."""
+    output = get_output_context()
+    if not yes and (output.format is not OutputFormat.rich or not output.interactive):
+        raise CLIError(
+            "Use --yes to confirm in non-interactive mode.",
+            code="INTERACTIVE_REQUIRED",
+        )
+
     _ws_name, credentials = _require_auth()
     from osmosis_ai.platform.api.client import OsmosisClient
 
@@ -487,6 +590,19 @@ def delete(
         raise CLIError(f"Unable to verify dataset dependencies: {e}") from e
 
     if affected.has_blocking_runs:
+        blocking_runs = [
+            {
+                "id": run.id,
+                "training_run_name": run.training_run_name,
+            }
+            for run in affected.affected_training_runs
+        ]
+        if output.format is not OutputFormat.rich:
+            raise CLIError(
+                "Cannot delete this dataset because training runs depend on it.",
+                code="CONFLICT",
+                details={"training_runs": blocking_runs},
+            )
         lines = ["Cannot delete — active training runs depend on this dataset:"]
         for run in affected.affected_training_runs:
             run_name = (
@@ -517,30 +633,57 @@ def delete(
         lambda: client.delete_dataset(name, credentials=credentials),
         output_console=console,
     )
-    console.print(
-        f'Dataset "{console.escape(name)}" deleted.',
-        style="green",
-        highlight=False,
+    return OperationResult(
+        operation="dataset.delete",
+        status="success",
+        resource={"id": name},
+        message=f'Dataset "{name}" deleted.',
     )
 
 
 def validate(
     file: str,
-) -> None:
+) -> CommandResult:
     """Validate a dataset file locally."""
     file_path, ext, file_size = _check_file_basics(file)
 
     # Format validation
-    errors = _validate_file(file_path, ext)
+    errors, warnings = _validate_file_with_warnings(file_path, ext)
 
     if errors:
         raise CLIError("Validation failed:\n" + "\n".join(f"  - {e}" for e in errors))
 
-    console.print(
-        f"Valid {ext} file: {console.escape(file_path.name)} ({format_size(file_size)})",
-        style="green",
-        highlight=False,
+    return DetailResult(
+        title="Dataset Validation",
+        data={
+            "valid": True,
+            "file": str(file_path),
+            "file_name": file_path.name,
+            "extension": ext,
+            "file_size": file_size,
+            "errors": [],
+            "warnings": warnings,
+        },
+        fields=[
+            DetailField(label="File", value=file_path.name),
+            DetailField(label="Size", value=format_size(file_size)),
+            DetailField(label="Status", value=f"Valid {ext} file"),
+            *[DetailField(label="Warning", value=warning) for warning in warnings],
+        ],
     )
+
+
+def _validate_file_with_warnings(
+    file_path: Path, ext: str
+) -> tuple[list[str], list[str]]:
+    """Validate file contents and surface non-fatal validation skips."""
+    warnings: list[str] = []
+    if ext == "parquet":
+        try:
+            import pyarrow.parquet  # noqa: F401
+        except ImportError:
+            warnings.append(PARQUET_VALIDATION_SKIPPED_WARNING)
+    return _validate_file(file_path, ext), warnings
 
 
 def _validate_file(file_path: Path, ext: str) -> list[str]:
@@ -611,8 +754,7 @@ def _validate_parquet(file_path: Path) -> list[str]:
         import pyarrow.parquet as pq
     except ImportError:
         console.print(
-            "Note: pyarrow not installed — parquet content validation skipped. "
-            "Install with: pip install 'osmosis-ai[platform]'",
+            f"Note: {PARQUET_VALIDATION_SKIPPED_WARNING}",
             style="dim yellow",
         )
         return []

--- a/osmosis_ai/platform/cli/dataset.py
+++ b/osmosis_ai/platform/cli/dataset.py
@@ -683,6 +683,7 @@ def _validate_file_with_warnings(
             import pyarrow.parquet  # noqa: F401
         except ImportError:
             warnings.append(PARQUET_VALIDATION_SKIPPED_WARNING)
+            return [], warnings
     return _validate_file(file_path, ext), warnings
 
 

--- a/osmosis_ai/platform/cli/init.py
+++ b/osmosis_ai/platform/cli/init.py
@@ -270,6 +270,7 @@ def _selected_workspace_git_context() -> dict[str, str | bool | None]:
     from osmosis_ai.platform.cli.utils import platform_call
 
     empty_context: dict[str, str | bool | None] = {
+        "workspace_id": None,
         "workspace_name": None,
         "git_sync_url": None,
         "has_github_app_installation": False,
@@ -281,6 +282,7 @@ def _selected_workspace_git_context() -> dict[str, str | bool | None]:
         if not local_name:
             return empty_context
         return {
+            "workspace_id": get_active_workspace_id(),
             "workspace_name": local_name,
             "git_sync_url": f"{PLATFORM_URL}/{local_name}/integrations/git",
             "has_github_app_installation": False,
@@ -343,6 +345,9 @@ def _selected_workspace_git_context() -> dict[str, str | bool | None]:
             connected_repo_url = repo_url
 
     return {
+        "workspace_id": matched.get("id")
+        if isinstance(matched.get("id"), str)
+        else None,
         "workspace_name": selected_name,
         "git_sync_url": f"{PLATFORM_URL}/{selected_name}/integrations/git",
         "has_github_app_installation": bool(matched.get("has_github_app_installation")),
@@ -428,7 +433,7 @@ def _print_next_steps(
 
     cmd_table = Table.grid(padding=(0, 1))
     cmd_table.add_column(no_wrap=True)
-    cmd_table.add_column(no_wrap=True)
+    cmd_table.add_column()
     if not here:
         cmd_table.add_row(
             "[bold green]$[/bold green]", console.format_text(f"cd {ws_name}")
@@ -535,14 +540,109 @@ def _print_next_steps(
     )
 
 
+def _created_paths_for_result(target: Path) -> list[str]:
+    """Return scaffold paths to expose in machine-readable init output."""
+    paths: list[Path] = [target]
+    paths.extend(
+        target / entry.dest for entry in SCAFFOLD if (target / entry.dest).exists()
+    )
+    if (target / ".git").exists():
+        paths.append(target / ".git")
+    return [str(path.resolve()) for path in paths]
+
+
+def _workspace_for_result(
+    git_context: dict[str, str | bool | None],
+) -> dict[str, str] | None:
+    workspace_id = git_context.get("workspace_id")
+    workspace_name = git_context.get("workspace_name")
+    if (
+        isinstance(workspace_id, str)
+        and workspace_id
+        and isinstance(workspace_name, str)
+    ):
+        return {"id": workspace_id, "name": workspace_name}
+    if isinstance(workspace_name, str) and workspace_name:
+        return {"name": workspace_name}
+    return None
+
+
+def _init_next_steps_structured(
+    ws_name: str,
+    *,
+    here: bool,
+    git_context: dict[str, str | bool | None],
+) -> list[dict[str, Any]]:
+    steps: list[dict[str, Any]] = []
+    if not here:
+        steps.append({"action": "cd", "path": ws_name, "command": f"cd {ws_name}"})
+    steps.extend(
+        [
+            {
+                "action": "create_github_repo",
+                "command": "gh repo create --private --source=. --push",
+            },
+            {
+                "action": "add_git_remote",
+                "command": "git remote add origin <your-repo-url>",
+            },
+            {"action": "push_git", "command": "git push -u origin main"},
+        ]
+    )
+
+    connected_repo_url = git_context.get("connected_repo_url")
+    if isinstance(connected_repo_url, str) and connected_repo_url:
+        steps.append({"action": "clone_connected_repo", "url": connected_repo_url})
+    else:
+        git_sync_url = git_context.get("git_sync_url")
+        if isinstance(git_sync_url, str) and git_sync_url:
+            steps.append({"action": "configure_git_sync", "url": git_sync_url})
+
+    plugin_repo = _plugin_repo()
+    plugin_marketplace = _plugin_marketplace()
+    steps.extend(
+        [
+            {
+                "action": "install_cursor_rule",
+                "source": plugin_repo,
+            },
+            {
+                "action": "install_codex_plugin",
+                "commands": [
+                    f"codex plugin marketplace add {plugin_repo}",
+                    f"codex plugin install {plugin_marketplace}",
+                ],
+            },
+        ]
+    )
+    return steps
+
+
+def _init_display_next_steps(ws_name: str, *, here: bool) -> list[str]:
+    steps: list[str] = []
+    if not here:
+        steps.append(f"cd {ws_name}")
+    steps.extend(
+        [
+            "gh repo create --private --source=. --push",
+            "git remote add origin <your-repo-url>",
+            "git push -u origin main",
+        ]
+    )
+    return steps
+
+
 # ── Main entry point ─────────────────────────────────────────────
 
 
-def init(name: str, here: bool = False) -> None:
+def init(name: str, here: bool = False) -> Any:
     """Initialise a new local workspace directory.
 
     This is the main entry point for ``osmosis init <name>``.
     """
+    from osmosis_ai.cli.output import OperationResult, OutputFormat, get_output_context
+
+    output = get_output_context()
     _check_git_installed()
 
     name_error = validate_name(name, label="Workspace name")
@@ -575,9 +675,10 @@ def init(name: str, here: bool = False) -> None:
         if target.exists():
             if (target / ".osmosis" / "workspace.toml").is_file():
                 # Re-entry: update mode
-                console.print(
-                    f"Updating existing workspace in [cyan]./{name}[/cyan]...",
-                )
+                if output.format is OutputFormat.rich:
+                    console.print(
+                        f"Updating existing workspace in [cyan]./{name}[/cyan]...",
+                    )
             else:
                 raise CLIError(
                     f"Directory ./{name} already exists. "
@@ -602,4 +703,32 @@ def init(name: str, here: bool = False) -> None:
             shutil.rmtree(target)
         raise
 
-    _print_next_steps(name, here=here, git_context=_ensure_git_context())
+    final_git_context = _ensure_git_context()
+    if output.format is OutputFormat.rich:
+        _print_next_steps(name, here=here, git_context=final_git_context)
+        return None
+
+    resource = {
+        "path": str(target.resolve()),
+        "created_paths": _created_paths_for_result(target),
+        "workspace": _workspace_for_result(final_git_context),
+        "git_sync_url": final_git_context.get("git_sync_url"),
+        "connected_repo_url": final_git_context.get("connected_repo_url"),
+        "mode": "update" if is_update else "create",
+    }
+    return OperationResult(
+        operation="init",
+        status="success",
+        resource=resource,
+        message=(
+            f"Updated workspace in {target.resolve()}."
+            if is_update
+            else f"Initialized workspace in {target.resolve()}."
+        ),
+        display_next_steps=_init_display_next_steps(name, here=here),
+        next_steps_structured=_init_next_steps_structured(
+            name,
+            here=here,
+            git_context=final_git_context,
+        ),
+    )

--- a/osmosis_ai/platform/cli/init.py
+++ b/osmosis_ai/platform/cli/init.py
@@ -267,6 +267,7 @@ def _selected_workspace_git_context() -> dict[str, str | bool | None]:
         load_credentials,
         platform_request,
     )
+    from osmosis_ai.platform.cli.utils import platform_call
 
     empty_context: dict[str, str | bool | None] = {
         "workspace_name": None,
@@ -291,11 +292,15 @@ def _selected_workspace_git_context() -> dict[str, str | bool | None]:
         return _offline_fallback()
 
     try:
-        data = platform_request(
-            "/api/cli/workspaces",
-            credentials=credentials,
-            require_workspace=False,
-            cleanup_on_401=False,
+        data = platform_call(
+            "Loading workspace Git Sync status...",
+            lambda: platform_request(
+                "/api/cli/workspaces",
+                credentials=credentials,
+                require_workspace=False,
+                cleanup_on_401=False,
+            ),
+            output_console=console,
         )
     except (AuthenticationExpiredError, PlatformAPIError):
         return _offline_fallback()
@@ -422,8 +427,12 @@ def _print_next_steps(
     from rich.text import Text
 
     cmd_table = Table.grid(padding=(0, 1))
+    cmd_table.add_column(no_wrap=True)
+    cmd_table.add_column(no_wrap=True)
     if not here:
-        cmd_table.add_row("[bold green]$[/bold green]", f"cd {ws_name}")
+        cmd_table.add_row(
+            "[bold green]$[/bold green]", console.format_text(f"cd {ws_name}")
+        )
     cmd_table.add_row(
         "[bold green]$[/bold green]",
         "gh repo create --private --source=. --push",
@@ -456,17 +465,24 @@ def _print_next_steps(
     plugin_repo = _plugin_repo()
     plugin_marketplace = _plugin_marketplace()
     plugin_table = Table.grid(padding=(0, 1))
+    plugin_table.add_column(no_wrap=True)
+    plugin_table.add_column(no_wrap=True)
     plugin_table.add_row(
         "[bold cyan]Claude Code[/bold cyan]",
         "open this folder — it'll prompt to install [cyan]osmosis[/cyan]",
     )
     plugin_table.add_row(
         "[bold cyan]Cursor[/bold cyan]",
-        f"Settings → Rules → Add Remote Rule → [cyan]{plugin_repo}[/cyan]",
+        Text.assemble(
+            "Settings → Rules → Add Remote Rule → ",
+            console.format_text(plugin_repo, style="cyan"),
+        ),
     )
     plugin_table.add_row(
         "[bold cyan]Codex[/bold cyan]",
-        f"[cyan]codex plugin marketplace add {plugin_repo}[/cyan]",
+        console.format_text(
+            f"codex plugin marketplace add {plugin_repo}", style="cyan"
+        ),
     )
     plugin_table.add_row(
         "[dim] [/dim]",
@@ -474,7 +490,7 @@ def _print_next_steps(
     )
     plugin_table.add_row(
         "[bold cyan] [/bold cyan]",
-        f"[cyan]codex plugin install {plugin_marketplace}[/cyan]",
+        console.format_text(f"codex plugin install {plugin_marketplace}", style="cyan"),
     )
 
     content = Group(

--- a/osmosis_ai/platform/cli/init.py
+++ b/osmosis_ai/platform/cli/init.py
@@ -347,14 +347,19 @@ def _selected_workspace_git_context() -> dict[str, str | bool | None]:
 
 def _git_sync_cta_text(
     git_context: dict[str, str | bool | None] | None = None,
-) -> str:
+) -> Any:
     """Build the Git Sync CTA shown after workspace scaffolding."""
+    from rich.text import Text
+
     if git_context is None:
         git_context = _selected_workspace_git_context()
 
     connected_repo_url = git_context.get("connected_repo_url")
     if isinstance(connected_repo_url, str) and connected_repo_url:
-        return f"Connected repo: [cyan]{connected_repo_url}[/cyan]"
+        return Text.assemble(
+            "Connected repo: ",
+            console.format_url(connected_repo_url, style="cyan"),
+        )
 
     git_sync_url = git_context.get("git_sync_url")
     if isinstance(git_sync_url, str) and git_sync_url:
@@ -363,9 +368,15 @@ def _git_sync_cta_text(
             if git_context.get("has_github_app_installation")
             else "connect your repo"
         )
-        return f"Go to [cyan]{git_sync_url}[/cyan] to {action}"
+        return Text.assemble(
+            f"{action}: ",
+            console.format_url(git_sync_url, style="cyan"),
+        )
 
-    return f"Go to [cyan]{PLATFORM_URL}[/cyan] → Git Sync to connect your repo"
+    return Text.assemble(
+        "connect your repo with Git Sync: ",
+        console.format_url(PLATFORM_URL, style="cyan"),
+    )
 
 
 def _raise_if_selected_workspace_has_connected_repo(

--- a/osmosis_ai/platform/cli/init.py
+++ b/osmosis_ai/platform/cli/init.py
@@ -464,7 +464,7 @@ def _print_next_steps(
         "I want to train a model for <my task domain>. "
         "Read .osmosis/research/program.md, create a baseline rollout in the "
         "canonical workspace structure, iterate locally with evals, and prepare "
-        "a training config."
+        "a training config. Use `osmosis --json` for Osmosis CLI commands."
     )
 
     plugin_repo = _plugin_repo()

--- a/osmosis_ai/platform/cli/templates/AGENTS.md.tpl
+++ b/osmosis_ai/platform/cli/templates/AGENTS.md.tpl
@@ -27,7 +27,7 @@ top-level layout.
   explicit grader override where supported).
 - Tools should be async Python functions with type hints and docstrings.
 - `Grader.grade` must be async and return a float in `[0.0, 1.0]`.
-- Before `osmosis train submit`, validate the workspace and run a local eval.
+- Before `osmosis --json train submit`, validate the workspace and run a local eval.
 
 ## AI skills
 
@@ -53,13 +53,19 @@ Detailed workflow guidance lives in the **`osmosis` agent plugin**:
 The plugin repo is configured in `.claude/settings.json`. Check that file
 before modifying plugin state.
 
+## CLI output
+
+- When you run `osmosis` commands as an AI agent or in automation, use the
+  global `--json` flag before the command.
+- Use the default rich output only for interactive human sessions.
+
 ## Common commands
 
 ```bash
-osmosis workspace validate
-osmosis rollout validate configs/eval/<name>.toml
-osmosis rollout validate configs/training/<run>.toml
-osmosis eval run configs/eval/<name>.toml
-osmosis train submit configs/training/<run>.toml
-osmosis train status <run-name>
+osmosis --json workspace validate
+osmosis --json rollout validate configs/eval/<name>.toml
+osmosis --json rollout validate configs/training/<run>.toml
+osmosis --json eval run configs/eval/<name>.toml
+osmosis --json train submit configs/training/<run>.toml
+osmosis --json train status <run-name>
 ```

--- a/osmosis_ai/platform/cli/templates/README.md.tpl
+++ b/osmosis_ai/platform/cli/templates/README.md.tpl
@@ -12,7 +12,7 @@ pip install -e .
 osmosis auth login
 
 # Verify the canonical workspace layout
-osmosis workspace validate
+osmosis --json workspace validate
 ```
 
 ## Ask your agent
@@ -20,5 +20,5 @@ osmosis workspace validate
 ```text
 I want to train a model for <task>. Read .osmosis/research/program.md,
 create a baseline rollout in this workspace, iterate locally with evals,
-and prepare a training config.
+and prepare a training config. Use `osmosis --json` for Osmosis CLI commands.
 ```

--- a/osmosis_ai/platform/cli/templates/configs/AGENTS.md.tpl
+++ b/osmosis_ai/platform/cli/templates/configs/AGENTS.md.tpl
@@ -8,6 +8,8 @@ Configs are workspace-scoped and must stay in their canonical directories.
 - Eval: `configs/eval/<name>.toml`
 
 Do not place these configs elsewhere. The CLI validates these locations.
+When running `osmosis` commands as an AI agent or in automation, use the global
+`--json` flag before the command.
 
 ## Training configs (`training/*.toml`)
 
@@ -45,10 +47,10 @@ batch_size = 2
 ## Commands
 
 ```bash
-osmosis workspace validate
-osmosis rollout validate configs/training/<config>.toml
-osmosis rollout validate configs/eval/<config>.toml
-osmosis train submit configs/training/<config>.toml
-osmosis eval run configs/eval/<config>.toml
-osmosis train status <run-name>
+osmosis --json workspace validate
+osmosis --json rollout validate configs/training/<config>.toml
+osmosis --json rollout validate configs/eval/<config>.toml
+osmosis --json train submit configs/training/<config>.toml
+osmosis --json eval run configs/eval/<config>.toml
+osmosis --json train status <run-name>
 ```

--- a/osmosis_ai/platform/cli/templates/configs/eval/default.toml.tpl
+++ b/osmosis_ai/platform/cli/templates/configs/eval/default.toml.tpl
@@ -1,5 +1,5 @@
 # Osmosis Eval Configuration
-# Usage: osmosis eval run configs/eval/<your-config>.toml
+# Usage: osmosis --json eval run configs/eval/<your-config>.toml
 
 [eval]
 rollout = "<your-rollout>"                 # Rollout name (directory under rollouts/)

--- a/osmosis_ai/platform/cli/templates/configs/training/default.toml.tpl
+++ b/osmosis_ai/platform/cli/templates/configs/training/default.toml.tpl
@@ -1,7 +1,7 @@
 # Osmosis Training Configuration
 # Copy and customize this file for your training run.
 #
-# Usage: osmosis train submit configs/training/<your-config>.toml
+# Usage: osmosis --json train submit configs/training/<your-config>.toml
 #
 # Supported models:
 #   - Qwen/Qwen3.5-35B-A3B
@@ -11,7 +11,7 @@
 rollout = "<your-rollout>"        # Rollout name (directory under rollouts/)
 entrypoint = "<your-entrypoint-file>" # Entrypoint file name
 model_path = "<your-model-path>"     # Must be a supported model (see above)
-dataset = "<your-dataset-name>"        # Dataset name from `osmosis dataset list`
+dataset = "<your-dataset-name>"        # Dataset name from `osmosis --json dataset list`
 # commit_sha =                       # Pin to a specific commit (default: latest on default branch)
 
 [training]

--- a/osmosis_ai/platform/cli/templates/research/program.md.tpl
+++ b/osmosis_ai/platform/cli/templates/research/program.md.tpl
@@ -19,7 +19,7 @@ rollout to improve.
 1. Read the current rollout, grader, dataset, and config files.
 2. Pick one hypothesis for improvement.
 3. Make the smallest change that tests that hypothesis.
-4. Run `osmosis eval run configs/eval/<name>.toml`.
+4. Run `osmosis --json eval run configs/eval/<name>.toml`.
 5. Compare results to the previous baseline.
 6. Keep or revert the change based on the result.
 7. Log the experiment under `.osmosis/research/experiments/`.

--- a/osmosis_ai/platform/cli/utils.py
+++ b/osmosis_ai/platform/cli/utils.py
@@ -55,7 +55,7 @@ def require_credentials() -> Credentials:
     if credentials is None:
         raise CLIError(MSG_NOT_LOGGED_IN)
     if credentials.is_expired():
-        raise AuthenticationExpiredError("Session has expired.")
+        raise AuthenticationExpiredError()
     return credentials
 
 

--- a/osmosis_ai/platform/cli/utils.py
+++ b/osmosis_ai/platform/cli/utils.py
@@ -6,7 +6,7 @@ import contextlib
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from osmosis_ai.cli.console import console
+from osmosis_ai.cli.console import Console, console
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.platform.api.models import (
     RUN_STATUSES_ERROR,
@@ -33,6 +33,18 @@ from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE
 
 if TYPE_CHECKING:
     from osmosis_ai.platform.auth.credentials import Credentials
+
+
+def platform_call[T](
+    message: str,
+    call: Callable[[], T],
+    *,
+    output_console: Console | None = None,
+) -> T:
+    """Run a platform request while showing a consistent CLI loading status."""
+    status_console = output_console or console
+    with status_console.spinner(message):
+        return call()
 
 
 def require_credentials() -> Credentials:
@@ -275,7 +287,10 @@ def _get_active_workspace_name(
     """Return the active workspace name, or raise if none is selected."""
     workspace_name = get_active_workspace_name()
     if workspace_name is None:
-        active_workspace = ensure_active_workspace(credentials=credentials)
+        active_workspace = platform_call(
+            "Loading workspace...",
+            lambda: ensure_active_workspace(credentials=credentials),
+        )
         if active_workspace is not None:
             workspace_name = active_workspace["name"]
     if workspace_name is None:
@@ -320,8 +335,11 @@ def _require_subscription(*, workspace_name: str) -> None:
         from osmosis_ai.platform.api.client import OsmosisClient
 
         client = OsmosisClient()
-        info = client.refresh_workspace_info(
-            credentials=credentials, workspace_name=workspace_name
+        info = platform_call(
+            "Checking subscription...",
+            lambda: client.refresh_workspace_info(
+                credentials=credentials, workspace_name=workspace_name
+            ),
         )
         api_reached = True
         workspace_found = info.get("found", False)

--- a/osmosis_ai/platform/cli/workspace.py
+++ b/osmosis_ai/platform/cli/workspace.py
@@ -591,16 +591,13 @@ def delete_workspace(name: str, *, yes: bool = False) -> Any:
     if not workspace:
         raise CLIError(f"Workspace '{name}' not found.", code="NOT_FOUND")
 
-    try:
-        status = platform_call(
-            "Checking workspace deletion safety...",
-            lambda: client.get_workspace_deletion_status(
-                workspace["id"], credentials=credentials
-            ),
-            output_console=console,
-        )
-    except Exception as e:
-        raise CLIError(f"Unable to verify workspace deletion safety: {e}") from e
+    status = platform_call(
+        "Checking workspace deletion safety...",
+        lambda: client.get_workspace_deletion_status(
+            workspace["id"], credentials=credentials
+        ),
+        output_console=console,
+    )
 
     if not status.is_owner:
         raise CLIError("Only workspace owners can delete a workspace.")

--- a/osmosis_ai/platform/cli/workspace.py
+++ b/osmosis_ai/platform/cli/workspace.py
@@ -565,7 +565,6 @@ def delete_workspace(name: str, *, yes: bool = False) -> Any:
         serialize_workspace,
     )
     from osmosis_ai.platform.api.client import OsmosisClient
-    from osmosis_ai.platform.cli.utils import _require_auth
 
     output = get_output_context()
     if not yes and (output.format is not OutputFormat.rich or not output.interactive):
@@ -574,7 +573,7 @@ def delete_workspace(name: str, *, yes: bool = False) -> Any:
             code="INTERACTIVE_REQUIRED",
         )
 
-    _, credentials = _require_auth()
+    credentials = require_credentials()
     client = OsmosisClient()
 
     ws_data = platform_call(
@@ -584,7 +583,7 @@ def delete_workspace(name: str, *, yes: bool = False) -> Any:
     )
     workspace = None
     for ws in ws_data.get("workspaces", []):
-        if ws.get("name") == name.lower():
+        if ws.get("name", "").lower() == name.lower():
             workspace = ws
             break
 

--- a/osmosis_ai/platform/cli/workspace.py
+++ b/osmosis_ai/platform/cli/workspace.py
@@ -68,8 +68,11 @@ def _show_context(ws_name: str | None) -> None:
     )
     url = platform_entity_url(ws_name)
     console.print(
-        f"{console.format_styled('URL:', 'bold')}     "
-        f"{console.format_styled(url, 'dim')}"
+        console.format_styled("URL:", "bold"),
+        "     ",
+        console.format_url(url, style="dim"),
+        sep="",
+        soft_wrap=True,
     )
     console.print()
 
@@ -202,8 +205,8 @@ def _upload_dataset_interactive(
         style="green",
         highlight=False,
     )
-    url = console.escape(platform_entity_url(ws_name, "datasets", dataset.id))
-    console.print(f"Check status at: {url}")
+    url = platform_entity_url(ws_name, "datasets", dataset.id)
+    console.print("Check status at: ", console.format_url(url), sep="", soft_wrap=True)
     return True
 
 
@@ -267,9 +270,9 @@ def _show_dataset_detail(ds: Any, ws_name: str) -> None:
     if ds.created_at:
         rows.append(("Created", format_date(ds.created_at)))
     url = platform_entity_url(ws_name, "datasets", ds.id)
-    rows.append(("URL", url))
 
     console.table(rows, title="Dataset Detail")
+    _print_platform_link(url)
     console.print()
 
 
@@ -322,9 +325,9 @@ def _show_run_detail(r: Any, ws_name: str) -> None:
     """Display detailed info for a single training run."""
     rows = build_run_detail_rows(r)
     url = platform_entity_url(ws_name, "training", r.id)
-    rows.append(("URL", url))
 
     console.table(rows, title="Training Run")
+    _print_platform_link(url)
     console.print()
 
 
@@ -384,16 +387,32 @@ def _show_model_detail(m: Any, ws_name: str) -> None:
     if m.created_at:
         rows.append(("Created", format_date(m.created_at)))
     url = platform_entity_url(ws_name, "models", m.id)
-    rows.append(("URL", url))
 
     console.table(rows, title="Model Detail")
+    _print_platform_link(url)
     console.print()
+
+
+def _print_platform_link(url: str) -> None:
+    """Print a copyable platform URL outside tables so Rich won't truncate it."""
+    console.print(
+        "View on platform: ",
+        console.format_url(url, style="cyan"),
+        sep="",
+        soft_wrap=True,
+    )
 
 
 def _open_in_browser(ws_name: str) -> None:
     """Open the workspace URL in the default browser."""
     url = platform_entity_url(ws_name)
-    console.print(f"Opening {console.format_styled(url, 'dim')} ...")
+    console.print(
+        "Opening ",
+        console.format_url(url, style="dim"),
+        " ...",
+        sep="",
+        soft_wrap=True,
+    )
     webbrowser.open(url)
     console.print()
 

--- a/osmosis_ai/platform/cli/workspace.py
+++ b/osmosis_ai/platform/cli/workspace.py
@@ -372,7 +372,7 @@ def _browse_models(ws_name: str) -> None:
 
 def _show_model_detail(m: Any, ws_name: str) -> None:
     """Display detailed info for a single model."""
-    rows: list[tuple[str, str]] = [
+    rows: list[tuple[Any, Any]] = [
         ("Model", console.format_text(m.model_name)),
         ("ID", console.format_text(m.id)),
         ("Status", console.format_text(m.status)),

--- a/osmosis_ai/platform/cli/workspace.py
+++ b/osmosis_ai/platform/cli/workspace.py
@@ -34,6 +34,7 @@ from .utils import (
     format_date,
     format_run_status,
     format_size,
+    platform_call,
     platform_entity_url,
     require_credentials,
 )
@@ -67,13 +68,7 @@ def _show_context(ws_name: str | None) -> None:
         f"{console.format_styled(ws_name, 'cyan')}"
     )
     url = platform_entity_url(ws_name)
-    console.print(
-        console.format_styled("URL:", "bold"),
-        "     ",
-        console.format_url(url, style="dim"),
-        sep="",
-        soft_wrap=True,
-    )
+    console.print_url("URL:     ", url, style="dim")
     console.print()
 
 
@@ -206,7 +201,7 @@ def _upload_dataset_interactive(
         highlight=False,
     )
     url = platform_entity_url(ws_name, "datasets", dataset.id)
-    console.print("Check status at: ", console.format_url(url), sep="", soft_wrap=True)
+    console.print_url("Check status at: ", url)
     return True
 
 
@@ -258,7 +253,11 @@ def _browse_datasets(ws_name: str) -> bool:
             if uploaded:
                 # Refresh the list after successful upload
                 with contextlib.suppress(PlatformAPIError):
-                    result = client.list_datasets(credentials=credentials)
+                    result = platform_call(
+                        "Refreshing datasets...",
+                        lambda: client.list_datasets(credentials=credentials),
+                        output_console=console,
+                    )
             continue
 
         _show_dataset_detail(selected, ws_name)
@@ -374,16 +373,16 @@ def _browse_models(ws_name: str) -> None:
 def _show_model_detail(m: Any, ws_name: str) -> None:
     """Display detailed info for a single model."""
     rows: list[tuple[str, str]] = [
-        ("Model", m.model_name),
-        ("ID", m.id),
-        ("Status", m.status),
+        ("Model", console.format_text(m.model_name)),
+        ("ID", console.format_text(m.id)),
+        ("Status", console.format_text(m.status)),
     ]
     if m.base_model:
-        rows.append(("Base Model", m.base_model))
+        rows.append(("Base Model", console.format_text(m.base_model)))
     if m.description:
-        rows.append(("Description", m.description))
+        rows.append(("Description", console.format_text(m.description)))
     if m.creator_name:
-        rows.append(("Creator", m.creator_name))
+        rows.append(("Creator", console.format_text(m.creator_name)))
     if m.created_at:
         rows.append(("Created", format_date(m.created_at)))
     url = platform_entity_url(ws_name, "models", m.id)
@@ -395,24 +394,13 @@ def _show_model_detail(m: Any, ws_name: str) -> None:
 
 def _print_platform_link(url: str) -> None:
     """Print a copyable platform URL outside tables so Rich won't truncate it."""
-    console.print(
-        "View on platform: ",
-        console.format_url(url, style="cyan"),
-        sep="",
-        soft_wrap=True,
-    )
+    console.print_url("View on platform: ", url, style="cyan")
 
 
 def _open_in_browser(ws_name: str) -> None:
     """Open the workspace URL in the default browser."""
     url = platform_entity_url(ws_name)
-    console.print(
-        "Opening ",
-        console.format_url(url, style="dim"),
-        " ...",
-        sep="",
-        soft_wrap=True,
-    )
+    console.print_url("Opening ", url, style="dim")
     webbrowser.open(url)
     console.print()
 
@@ -420,9 +408,17 @@ def _open_in_browser(ws_name: str) -> None:
 def list_workspaces() -> None:
     """List all workspaces (non-interactive)."""
     credentials = require_credentials()
-    active_ws = ensure_active_workspace(credentials=credentials)
-    result = platform_request(
-        "/api/cli/workspaces", require_workspace=False, credentials=credentials
+    active_ws = platform_call(
+        "Loading workspaces...",
+        lambda: ensure_active_workspace(credentials=credentials),
+        output_console=console,
+    )
+    result = platform_call(
+        "Loading workspaces...",
+        lambda: platform_request(
+            "/api/cli/workspaces", require_workspace=False, credentials=credentials
+        ),
+        output_console=console,
     )
     workspaces = result.get("workspaces", [])
 
@@ -444,8 +440,12 @@ def list_workspaces() -> None:
 def switch_workspace(workspace: str) -> None:
     """Switch to a different workspace."""
     credentials = require_credentials()
-    result = platform_request(
-        "/api/cli/workspaces", require_workspace=False, credentials=credentials
+    result = platform_call(
+        "Loading workspaces...",
+        lambda: platform_request(
+            "/api/cli/workspaces", require_workspace=False, credentials=credentials
+        ),
+        output_console=console,
     )
     workspaces = result.get("workspaces", [])
 
@@ -473,7 +473,11 @@ def workspace() -> None:
     if credentials is None:
         raise CLIError(MSG_NOT_LOGGED_IN)
 
-    active_ws = ensure_active_workspace(credentials=credentials)
+    active_ws = platform_call(
+        "Loading workspace...",
+        lambda: ensure_active_workspace(credentials=credentials),
+        output_console=console,
+    )
     ws_name = active_ws["name"] if active_ws else None
 
     _show_context(ws_name)

--- a/osmosis_ai/platform/cli/workspace.py
+++ b/osmosis_ai/platform/cli/workspace.py
@@ -502,10 +502,9 @@ def create_workspace(name: str, timezone: str) -> Any:
         serialize_workspace,
     )
     from osmosis_ai.platform.api.client import OsmosisClient
-    from osmosis_ai.platform.cli.utils import _require_auth
 
     output = get_output_context()
-    _, credentials = _require_auth()
+    credentials = require_credentials()
 
     client = OsmosisClient()
     result = platform_call(

--- a/osmosis_ai/platform/cli/workspace.py
+++ b/osmosis_ai/platform/cli/workspace.py
@@ -405,8 +405,33 @@ def _open_in_browser(ws_name: str) -> None:
     console.print()
 
 
-def list_workspaces() -> None:
+def _interactive_workspace_error() -> CLIError:
+    return CLIError(
+        "Interactive workspace UI is unavailable in this mode. "
+        "Use 'osmosis workspace list', 'osmosis workspace switch <name>', or "
+        "'osmosis workspace create <name>'.",
+        code="INTERACTIVE_REQUIRED",
+    )
+
+
+def _workspace_summary(ws: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": ws["id"],
+        "name": ws["name"],
+    }
+
+
+def list_workspaces() -> Any:
     """List all workspaces (non-interactive)."""
+    from osmosis_ai.cli.output import (
+        ListColumn,
+        ListResult,
+        OutputFormat,
+        get_output_context,
+        serialize_workspace,
+    )
+
+    output = get_output_context()
     credentials = require_credentials()
     active_ws = platform_call(
         "Loading workspaces...",
@@ -423,10 +448,40 @@ def list_workspaces() -> None:
     workspaces = result.get("workspaces", [])
 
     if not workspaces:
-        console.print("No workspaces found.")
-        return
+        if output.format is OutputFormat.rich:
+            console.print("No workspaces found.")
+            return None
+        return ListResult(
+            title="Workspaces",
+            items=[],
+            total_count=0,
+            has_more=False,
+            next_offset=None,
+            columns=[ListColumn(key="name", label="Name")],
+        )
 
     active_name = active_ws["name"] if active_ws else None
+
+    if output.format is not OutputFormat.rich:
+        items = []
+        for ws in workspaces:
+            item = serialize_workspace(_workspace_summary(ws))
+            item["is_active"] = ws.get("name") == active_name
+            if "has_subscription" in ws:
+                item["has_subscription"] = bool(ws.get("has_subscription"))
+            items.append(item)
+        return ListResult(
+            title="Workspaces",
+            items=items,
+            total_count=len(items),
+            has_more=False,
+            next_offset=None,
+            columns=[
+                ListColumn(key="name", label="Name"),
+                ListColumn(key="id", label="ID", plain=False),
+                ListColumn(key="is_active", label="Active", plain=False),
+            ],
+        )
 
     console.print(f"Workspaces ({len(workspaces)}):", style="bold")
     for ws in workspaces:
@@ -435,10 +490,175 @@ def list_workspaces() -> None:
         marker = " (current)" if raw_name == active_name else ""
         sub_label = "active" if ws.get("has_subscription") else "no subscription"
         console.print(f"  {name}{marker}  {console.escape(f'[{sub_label}]')}")
+    return None
 
 
-def switch_workspace(workspace: str) -> None:
+def create_workspace(name: str, timezone: str) -> Any:
+    """Create a new workspace."""
+    from osmosis_ai.cli.output import (
+        OperationResult,
+        OutputFormat,
+        get_output_context,
+        serialize_workspace,
+    )
+    from osmosis_ai.platform.api.client import OsmosisClient
+    from osmosis_ai.platform.cli.utils import _require_auth
+
+    output = get_output_context()
+    _, credentials = _require_auth()
+
+    client = OsmosisClient()
+    result = platform_call(
+        "Creating workspace...",
+        lambda: client.create_workspace(name, timezone, credentials=credentials),
+        output_console=console,
+    )
+
+    resource = serialize_workspace(_workspace_summary(result))
+    resource["timezone"] = timezone
+
+    if output.format is OutputFormat.rich:
+        console.print(
+            f"Workspace '{console.escape(result['name'])}' created.",
+            style="green",
+            highlight=False,
+        )
+        return None
+
+    return OperationResult(
+        operation="workspace.create",
+        status="success",
+        resource=resource,
+        message=f"Workspace '{result['name']}' created.",
+        display_next_steps=[f"Switch with: osmosis workspace switch {result['name']}"],
+        next_steps_structured=[
+            {"action": "workspace.switch", "name": result["name"]},
+        ],
+    )
+
+
+def _require_delete_confirmation(*, workspace_name: str, yes: bool) -> None:
+    from osmosis_ai.cli.output import OutputFormat, get_output_context
+    from osmosis_ai.cli.prompts import require_confirmation
+
+    if yes:
+        return
+    output = get_output_context()
+    if output.format is not OutputFormat.rich or not output.interactive:
+        raise CLIError(
+            "Use --yes to confirm in non-interactive mode.",
+            code="INTERACTIVE_REQUIRED",
+        )
+    require_confirmation(
+        f"Delete workspace '{workspace_name}'? "
+        "This will stop all running processes and delete all datasets and training "
+        "runs. This cannot be undone.",
+        yes=False,
+    )
+
+
+def delete_workspace(name: str, *, yes: bool = False) -> Any:
+    """Delete a workspace."""
+    from osmosis_ai.cli.output import (
+        OperationResult,
+        OutputFormat,
+        get_output_context,
+        serialize_workspace,
+    )
+    from osmosis_ai.platform.api.client import OsmosisClient
+    from osmosis_ai.platform.cli.utils import _require_auth
+
+    output = get_output_context()
+    if not yes and (output.format is not OutputFormat.rich or not output.interactive):
+        raise CLIError(
+            "Use --yes to confirm in non-interactive mode.",
+            code="INTERACTIVE_REQUIRED",
+        )
+
+    _, credentials = _require_auth()
+    client = OsmosisClient()
+
+    ws_data = platform_call(
+        "Loading workspaces...",
+        lambda: client.list_workspaces(credentials=credentials),
+        output_console=console,
+    )
+    workspace = None
+    for ws in ws_data.get("workspaces", []):
+        if ws.get("name") == name.lower():
+            workspace = ws
+            break
+
+    if not workspace:
+        raise CLIError(f"Workspace '{name}' not found.", code="NOT_FOUND")
+
+    try:
+        status = platform_call(
+            "Checking workspace deletion safety...",
+            lambda: client.get_workspace_deletion_status(
+                workspace["id"], credentials=credentials
+            ),
+            output_console=console,
+        )
+    except Exception as e:
+        raise CLIError(f"Unable to verify workspace deletion safety: {e}") from e
+
+    if not status.is_owner:
+        raise CLIError("Only workspace owners can delete a workspace.")
+
+    if status.is_last_workspace:
+        raise CLIError("Cannot delete your only workspace.")
+
+    if output.format is OutputFormat.rich and status.has_running_processes:
+        console.print(
+            "This workspace has running processes:",
+            style="yellow",
+        )
+        processes: list[str] = []
+        if not status.feature_pipelines.valid:
+            processes.append(f"{status.feature_pipelines.count} pipeline(s)")
+        if not status.training_runs.valid:
+            processes.append(f"{status.training_runs.count} training run(s)")
+        if not status.models.valid:
+            processes.append(f"{status.models.count} active model(s)")
+        if processes:
+            console.print(f"  {', '.join(processes)}")
+        console.print()
+
+    _require_delete_confirmation(workspace_name=workspace["name"], yes=yes)
+
+    platform_call(
+        "Deleting workspace...",
+        lambda: client.delete_workspace(workspace["id"], credentials=credentials),
+        output_console=console,
+    )
+
+    if output.format is OutputFormat.rich:
+        console.print(
+            f"Workspace '{console.escape(workspace['name'])}' deleted.",
+            style="green",
+            highlight=False,
+        )
+        return None
+
+    return OperationResult(
+        operation="workspace.delete",
+        status="success",
+        resource=serialize_workspace(_workspace_summary(workspace)),
+        message=f"Workspace '{workspace['name']}' deleted.",
+    )
+
+
+def switch_workspace(workspace: str) -> Any:
     """Switch to a different workspace."""
+    from osmosis_ai.cli.output import (
+        OperationResult,
+        OutputFormat,
+        get_output_context,
+        serialize_workspace,
+    )
+
+    output = get_output_context()
     credentials = require_credentials()
     result = platform_call(
         "Loading workspaces...",
@@ -462,12 +682,80 @@ def switch_workspace(workspace: str) -> None:
     ws_name = ws["name"]
 
     set_active_workspace(ws_id, ws_name)
+    resource = serialize_workspace(_workspace_summary(ws))
+    if output.format is not OutputFormat.rich:
+        return OperationResult(
+            operation="workspace.switch",
+            status="success",
+            resource=resource,
+            message=f"Switched to workspace: {ws_name}",
+        )
+
     console.print(f"Switched to workspace: {console.format_styled(ws_name, 'cyan')}")
+    return None
+
+
+def validate_workspace(path: Any) -> Any:
+    """Validate the canonical Osmosis workspace structure."""
+    from osmosis_ai.cli.output import (
+        DetailField,
+        DetailResult,
+        OutputFormat,
+        get_output_context,
+    )
+    from osmosis_ai.platform.cli.workspace_contract import (
+        resolve_workspace_root,
+        validate_workspace_contract,
+    )
+
+    output = get_output_context()
+    workspace_root = resolve_workspace_root(path)
+    validate_workspace_contract(workspace_root)
+    rows = [
+        ("Root", str(workspace_root)),
+        ("Workspace metadata", ".osmosis/workspace.toml"),
+        ("Research", ".osmosis/research/"),
+        ("Rollouts", "rollouts/"),
+        ("Training configs", "configs/training/"),
+        ("Eval configs", "configs/eval/"),
+        ("Datasets", "data/"),
+    ]
+    if output.format is OutputFormat.rich:
+        console.table(
+            [
+                ("Root", console.format_text(workspace_root)),
+                ("Workspace metadata", ".osmosis/workspace.toml"),
+                ("Research", ".osmosis/research/"),
+                ("Rollouts", "rollouts/"),
+                ("Training configs", "configs/training/"),
+                ("Eval configs", "configs/eval/"),
+                ("Datasets", "data/"),
+            ],
+            title="Workspace Contract",
+        )
+        console.print("Workspace contract is valid.", style="green")
+        return None
+
+    return DetailResult(
+        title="Workspace Contract",
+        data={
+            "root": str(workspace_root),
+            "required_paths": [value for label, value in rows if label != "Root"],
+            "valid": True,
+        },
+        fields=[DetailField(label=label, value=value) for label, value in rows],
+    )
 
 
 @app.callback(invoke_without_command=True)
 def workspace() -> None:
     """Manage workspace context."""
+    from osmosis_ai.cli.output import OutputFormat, get_output_context
+
+    output = get_output_context()
+    if output.format is not OutputFormat.rich:
+        raise _interactive_workspace_error()
+
     credentials = load_credentials()
 
     if credentials is None:

--- a/osmosis_ai/platform/constants.py
+++ b/osmosis_ai/platform/constants.py
@@ -11,6 +11,21 @@ DEFAULT_PAGE_SIZE = 50
 MSG_SESSION_EXPIRED = (
     "Your session has expired. Please run 'osmosis auth login' to re-authenticate."
 )
+MSG_ENV_TOKEN_INVALID = (
+    "The OSMOSIS_TOKEN environment variable is invalid or expired. "
+    "Run 'unset OSMOSIS_TOKEN' to use saved credentials or interactive login, "
+    "or set OSMOSIS_TOKEN to a valid token."
+)
+MSG_ENV_TOKEN_EXPIRED = (
+    "The OSMOSIS_TOKEN environment variable has expired. "
+    "Set OSMOSIS_TOKEN to a new token, or run 'unset OSMOSIS_TOKEN' "
+    "to use saved credentials or interactive login."
+)
+MSG_ENV_TOKEN_REVOKED = (
+    "The OSMOSIS_TOKEN environment variable has been revoked. "
+    "Set OSMOSIS_TOKEN to a new token, or run 'unset OSMOSIS_TOKEN' "
+    "to use saved credentials or interactive login."
+)
 MSG_NOT_LOGGED_IN = "Not logged in. Run 'osmosis auth login' first."
 
 # ── Inference endpoint ───────────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Project-wide pytest fixtures."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_output_context_var() -> None:
+    """Keep CLI output context state isolated across tests."""
+    from osmosis_ai.cli.output.context import _output_context_var
+
+    token = _output_context_var.set(None)
+    try:
+        yield
+    finally:
+        _output_context_var.reset(token)

--- a/tests/golden/cli_output/checkpoint_serializer.json
+++ b/tests/golden/cli_output/checkpoint_serializer.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "keys": [
+    "id",
+    "checkpoint_name",
+    "checkpoint_step",
+    "status",
+    "created_at"
+  ]
+}

--- a/tests/golden/cli_output/dataset_serializer.json
+++ b/tests/golden/cli_output/dataset_serializer.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "keys": [
+    "id",
+    "file_name",
+    "file_size",
+    "status",
+    "processing_step",
+    "processing_percent",
+    "error",
+    "created_at",
+    "updated_at"
+  ]
+}

--- a/tests/golden/cli_output/deployment_serializer.json
+++ b/tests/golden/cli_output/deployment_serializer.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "keys": [
+    "id",
+    "checkpoint_name",
+    "status",
+    "base_model",
+    "checkpoint_step",
+    "training_run_id",
+    "training_run_name",
+    "creator_name",
+    "created_at"
+  ]
+}

--- a/tests/golden/cli_output/detail_envelope.json
+++ b/tests/golden/cli_output/detail_envelope.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "keys": ["schema_version", "data"]
+}

--- a/tests/golden/cli_output/error_envelope.json
+++ b/tests/golden/cli_output/error_envelope.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "keys": ["schema_version", "command", "cli_version", "error"]
+}

--- a/tests/golden/cli_output/eval_cache_entry_serializer.json
+++ b/tests/golden/cli_output/eval_cache_entry_serializer.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "keys": [
+    "task_id",
+    "model",
+    "dataset",
+    "status",
+    "runs_count",
+    "created_at"
+  ]
+}

--- a/tests/golden/cli_output/list_envelope.json
+++ b/tests/golden/cli_output/list_envelope.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "keys": [
+    "schema_version",
+    "items",
+    "total_count",
+    "has_more",
+    "next_offset"
+  ]
+}

--- a/tests/golden/cli_output/model_serializer.json
+++ b/tests/golden/cli_output/model_serializer.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "keys": [
+    "id",
+    "model_name",
+    "base_model",
+    "status",
+    "creator_name",
+    "created_at",
+    "updated_at"
+  ]
+}

--- a/tests/golden/cli_output/operation_envelope.json
+++ b/tests/golden/cli_output/operation_envelope.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": 1,
+  "keys": {
+    "required": ["schema_version", "status", "operation"],
+    "optional": ["resource", "message", "next_steps_structured"]
+  }
+}

--- a/tests/golden/cli_output/rollout_serializer.json
+++ b/tests/golden/cli_output/rollout_serializer.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "keys": [
+    "id",
+    "name",
+    "is_active",
+    "repo_full_name",
+    "last_synced_commit_sha",
+    "created_at"
+  ]
+}

--- a/tests/golden/cli_output/training_run_serializer.json
+++ b/tests/golden/cli_output/training_run_serializer.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "keys": [
+    "id",
+    "name",
+    "status",
+    "model_id",
+    "model_name",
+    "eval_accuracy",
+    "reward_increase_delta",
+    "processing_step",
+    "processing_percent",
+    "error_message",
+    "creator_name",
+    "creator_email",
+    "created_at",
+    "started_at",
+    "completed_at"
+  ]
+}

--- a/tests/golden/cli_output/workspace_serializer.json
+++ b/tests/golden/cli_output/workspace_serializer.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "keys": ["id", "name"]
+}

--- a/tests/integration/test_cli_no_direct_stdout_writes.py
+++ b/tests/integration/test_cli_no_direct_stdout_writes.py
@@ -1,0 +1,62 @@
+"""Lint guardrail: converted CLI paths must not write directly to stdout."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCAN_PATHS = [
+    ROOT / "osmosis_ai" / "cli" / "commands" / "eval.py",
+    ROOT / "osmosis_ai" / "eval" / "rubric" / "cli.py",
+    ROOT / "osmosis_ai" / "eval" / "evaluation" / "cli.py",
+    ROOT / "osmosis_ai" / "cli" / "upgrade.py",
+]
+
+
+def _is_sys_stdout_write(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "write"
+        and isinstance(node.func.value, ast.Attribute)
+        and node.func.value.attr == "stdout"
+        and isinstance(node.func.value.value, ast.Name)
+        and node.func.value.value.id == "sys"
+    )
+
+
+def _is_typer_echo(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "echo"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "typer"
+    )
+
+
+def _is_builtin_print(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "print"
+    )
+
+
+@pytest.mark.parametrize("path", SCAN_PATHS, ids=lambda p: str(p.relative_to(ROOT)))
+def test_no_direct_stdout_writes(path: Path) -> None:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if (
+            _is_builtin_print(node)
+            or _is_sys_stdout_write(node)
+            or _is_typer_echo(node)
+        ):
+            line = getattr(node, "lineno", "?")
+            pytest.fail(
+                f"Direct stdout write at {path.relative_to(ROOT)}:{line}. "
+                "Return CommandResult or use stderr for progress."
+            )

--- a/tests/integration/test_cli_subprocess_contract.py
+++ b/tests/integration/test_cli_subprocess_contract.py
@@ -35,7 +35,9 @@ def test_eval_cache_dir_json_is_single_stdout_envelope(tmp_path: Path) -> None:
     assert proc.stderr == ""
     payload = json.loads(proc.stdout)
     assert payload["schema_version"] == 1
-    assert payload["data"]["cache_root"].endswith("/eval")
+    assert (
+        Path(payload["data"]["cache_root"]) == (tmp_path / "cache" / "eval").resolve()
+    )
 
 
 def test_eval_cache_ls_json_is_single_stdout_envelope(tmp_path: Path) -> None:

--- a/tests/integration/test_cli_subprocess_contract.py
+++ b/tests/integration/test_cli_subprocess_contract.py
@@ -1,0 +1,59 @@
+"""Subprocess guardrails for JSON-mode CLI output."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_json_command(
+    args: list[str], tmp_path: Path
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "OSMOSIS_CACHE_DIR": str(tmp_path / "cache"),
+    }
+    return subprocess.run(
+        [sys.executable, "-m", "osmosis_ai.cli.main", "--json", *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+def test_eval_cache_dir_json_is_single_stdout_envelope(tmp_path: Path) -> None:
+    proc = _run_json_command(["eval", "cache", "dir"], tmp_path)
+
+    assert proc.returncode == 0
+    assert proc.stderr == ""
+    payload = json.loads(proc.stdout)
+    assert payload["schema_version"] == 1
+    assert payload["data"]["cache_root"].endswith("/eval")
+
+
+def test_eval_cache_ls_json_is_single_stdout_envelope(tmp_path: Path) -> None:
+    proc = _run_json_command(["eval", "cache", "ls"], tmp_path)
+
+    assert proc.returncode == 0
+    assert proc.stderr == ""
+    payload = json.loads(proc.stdout)
+    assert payload["schema_version"] == 1
+    assert payload["items"] == []
+
+
+def test_eval_run_json_error_is_structured_stderr(tmp_path: Path) -> None:
+    proc = _run_json_command(["eval", "run", str(tmp_path / "missing.toml")], tmp_path)
+
+    assert proc.returncode != 0
+    assert proc.stdout == ""
+    payload = json.loads(proc.stderr)
+    assert payload["schema_version"] == 1
+    assert payload["error"]["code"] == "VALIDATION"
+    assert "Config file not found" in payload["error"]["message"]

--- a/tests/unit/auth/test_credentials.py
+++ b/tests/unit/auth/test_credentials.py
@@ -330,6 +330,27 @@ def test_load_credentials_from_env(monkeypatch) -> None:
     assert creds.user.id == ""  # minimal user info for env token
 
 
+def test_load_credentials_can_skip_env_token(tmp_path, monkeypatch) -> None:
+    creds_file = tmp_path / "creds.json"
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.CREDENTIALS_FILE", creds_file
+    )
+    monkeypatch.setenv("OSMOSIS_TOKEN", "env-token-abc")
+
+    stored = _make_credentials(token_id="tok_stored")
+    data = stored.to_dict()
+    data["token_store"] = TOKEN_STORE_FILE
+    creds_file.write_text(json.dumps(data))
+
+    from osmosis_ai.platform.auth.credentials import load_credentials
+
+    assert load_credentials().access_token == "env-token-abc"
+    loaded = load_credentials(include_env=False)
+    assert loaded is not None
+    assert loaded.access_token == "test-token"
+    assert loaded.token_id == "tok_stored"
+
+
 # ---------------------------------------------------------------------------
 # load: version mismatch
 # ---------------------------------------------------------------------------

--- a/tests/unit/auth/test_error_messages.py
+++ b/tests/unit/auth/test_error_messages.py
@@ -230,6 +230,21 @@ class TestMainExceptionHandlerMessages:
         assert "No workspace selected" in capsys.readouterr().err
 
     @patch("osmosis_ai.cli.main._registered", True)
+    def test_cli_error_preserves_bracketed_section_names(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from osmosis_ai.cli.main import main
+
+        with patch(
+            "osmosis_ai.cli.main.app",
+            side_effect=CLIError("Missing [experiment] section in train.toml"),
+        ):
+            code = main([])
+
+        assert code == 1
+        assert "Missing [experiment] section" in capsys.readouterr().err
+
+    @patch("osmosis_ai.cli.main._registered", True)
     def test_auth_expired_shows_session_expired(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/unit/auth/test_error_messages.py
+++ b/tests/unit/auth/test_error_messages.py
@@ -18,6 +18,7 @@ from osmosis_ai.platform.auth.platform_client import (
     AuthenticationExpiredError,
     PlatformAPIError,
 )
+from osmosis_ai.platform.constants import MSG_ENV_TOKEN_INVALID
 
 
 def _make_credentials(*, expired: bool = False) -> Credentials:
@@ -49,8 +50,11 @@ class TestRequireCredentialsMessages:
 
         mock_load.return_value = _make_credentials(expired=True)
 
-        with pytest.raises(AuthenticationExpiredError):
+        with pytest.raises(AuthenticationExpiredError) as exc_info:
             require_credentials()
+
+        assert "session has expired" in str(exc_info.value)
+        assert "osmosis auth login" in str(exc_info.value)
 
     @patch("osmosis_ai.platform.cli.utils.load_credentials")
     def test_valid_credentials_returns_them(self, mock_load: object) -> None:
@@ -252,12 +256,27 @@ class TestMainExceptionHandlerMessages:
 
         with patch(
             "osmosis_ai.cli.main.app",
-            side_effect=AuthenticationExpiredError("expired"),
+            side_effect=AuthenticationExpiredError(),
         ):
             code = main([])
 
         assert code == 1
         captured = capsys.readouterr().err
-        assert (
-            "session has expired" in captured.lower() or "expired" in captured.lower()
-        )
+        assert "session has expired" in captured.lower()
+
+    @patch("osmosis_ai.cli.main._registered", True)
+    def test_auth_expired_preserves_env_token_guidance(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from osmosis_ai.cli.main import main
+
+        with patch(
+            "osmosis_ai.cli.main.app",
+            side_effect=AuthenticationExpiredError(MSG_ENV_TOKEN_INVALID),
+        ):
+            code = main([])
+
+        assert code == 1
+        captured = capsys.readouterr().err
+        assert "OSMOSIS_TOKEN environment variable is invalid or expired" in captured
+        assert "unset OSMOSIS_TOKEN" in captured

--- a/tests/unit/auth/test_flow.py
+++ b/tests/unit/auth/test_flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import socket
 from datetime import UTC, datetime, timedelta
+from io import BytesIO
 from typing import Any
 from unittest.mock import MagicMock, patch
 from urllib.error import HTTPError, URLError
@@ -107,8 +108,37 @@ class TestVerifyAndGetUserInfo:
             fp=None,  # type: ignore[arg-type]
         )
         with patch("osmosis_ai.platform.auth.flow.urlopen", side_effect=error):
-            with pytest.raises(LoginError, match="Invalid or expired token"):
+            with pytest.raises(LoginError, match="Authentication failed") as exc_info:
                 verify_token("expired-token")
+
+        assert exc_info.value.code is None
+
+    @pytest.mark.parametrize(
+        ("error_code", "expected_message"),
+        [
+            ("AUTH_HEADER_MISSING", "Token is missing."),
+            ("TOKEN_MISSING", "Token is missing."),
+            ("TOKEN_EXPIRED", "Token has expired."),
+            ("TOKEN_INVALID", "Token is invalid."),
+            ("TOKEN_REVOKED", "Token has been revoked."),
+            ("UNKNOWN_AUTH_ERROR", "Authentication failed."),
+        ],
+    )
+    def test_http_401_uses_structured_cli_token_code(
+        self, error_code: str, expected_message: str
+    ) -> None:
+        error = HTTPError(
+            url="http://test",
+            code=401,
+            msg="Unauthorized",
+            hdrs=None,
+            fp=BytesIO(json.dumps({"code": error_code}).encode()),
+        )
+        with patch("osmosis_ai.platform.auth.flow.urlopen", side_effect=error):
+            with pytest.raises(LoginError, match=expected_message) as exc_info:
+                verify_token("expired-token")
+
+        assert exc_info.value.code == error_code
 
     def test_http_500_raises_login_error(self) -> None:
         error = HTTPError(
@@ -119,8 +149,10 @@ class TestVerifyAndGetUserInfo:
             fp=None,  # type: ignore[arg-type]
         )
         with patch("osmosis_ai.platform.auth.flow.urlopen", side_effect=error):
-            with pytest.raises(LoginError, match="internal error"):
+            with pytest.raises(LoginError, match="internal error") as exc_info:
                 verify_token("token")
+
+        assert exc_info.value.status_code == 500
 
     def test_network_error_raises_login_error(self) -> None:
         error = URLError(reason="Connection refused")

--- a/tests/unit/auth/test_platform_client.py
+++ b/tests/unit/auth/test_platform_client.py
@@ -425,7 +425,7 @@ class TestPlatformRequest:
         mock_urlopen.side_effect = _make_http_error(401, "Unauthorized")
         creds = _make_credentials()
 
-        with pytest.raises(AuthenticationExpiredError, match="expired or been revoked"):
+        with pytest.raises(AuthenticationExpiredError, match="session has expired"):
             platform_request("/api/test", credentials=creds)
 
         mock_reset.assert_called_once()
@@ -439,10 +439,77 @@ class TestPlatformRequest:
         mock_urlopen.side_effect = _make_http_error(401, "Unauthorized")
         creds = _make_credentials()
 
-        with pytest.raises(AuthenticationExpiredError, match="expired or been revoked"):
+        with pytest.raises(AuthenticationExpiredError, match="session has expired"):
             platform_request("/api/test", credentials=creds, cleanup_on_401=False)
 
         mock_reset.assert_not_called()
+
+    def test_401_with_env_token_skips_cleanup_and_mentions_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify an invalid OSMOSIS_TOKEN does not wipe saved credentials."""
+        monkeypatch.setenv("OSMOSIS_TOKEN", "env-token")
+        creds = _make_credentials(access_token="env-token")
+
+        with (
+            patch(
+                "osmosis_ai.platform.auth.platform_client.urlopen",
+                side_effect=_make_http_error(
+                    401, json.dumps({"code": "TOKEN_EXPIRED"})
+                ),
+            ),
+            patch(
+                "osmosis_ai.platform.auth.platform_client.reset_session"
+            ) as mock_reset,
+        ):
+            with pytest.raises(AuthenticationExpiredError) as exc_info:
+                platform_request("/api/test", credentials=creds)
+
+        assert "OSMOSIS_TOKEN environment variable has expired" in str(exc_info.value)
+        assert "unset OSMOSIS_TOKEN" in str(exc_info.value)
+        mock_reset.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("status_code", "error_code", "expected_message"),
+        [
+            (
+                400,
+                "WORKSPACE_HEADER_MISSING",
+                "No workspace selected",
+            ),
+            (
+                400,
+                "WORKSPACE_HEADER_INVALID",
+                "workspace context is invalid",
+            ),
+            (
+                403,
+                "WORKSPACE_ACCESS_DENIED",
+                "do not have access to this workspace",
+            ),
+        ],
+    )
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_workspace_auth_codes_use_sdk_guidance(
+        self,
+        mock_urlopen: MagicMock,
+        status_code: int,
+        error_code: str,
+        expected_message: str,
+    ) -> None:
+        """Verify monolith workspace auth codes map to actionable CLI errors."""
+        mock_urlopen.side_effect = _make_http_error(
+            status_code, json.dumps({"code": error_code})
+        )
+        creds = _make_credentials()
+
+        with pytest.raises(PlatformAPIError) as exc_info:
+            platform_request("/api/test", credentials=creds)
+
+        assert exc_info.value.status_code == status_code
+        assert exc_info.value.error_code == error_code
+        assert exc_info.value.details == {"code": error_code}
+        assert expected_message in str(exc_info.value)
 
     @patch("osmosis_ai.platform.auth.platform_client.urlopen")
     def test_non_401_http_error_raises_platform_api_error(

--- a/tests/unit/cli/output/test_console_facade.py
+++ b/tests/unit/cli/output/test_console_facade.py
@@ -1,0 +1,78 @@
+"""Tests for the Console facade lazy binding."""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stderr, redirect_stdout
+
+from osmosis_ai.cli.console import Console
+from osmosis_ai.cli.output.context import (
+    OutputContext,
+    OutputFormat,
+    override_output_context,
+)
+
+
+def test_console_print_is_silent_in_json_mode() -> None:
+    out, err = io.StringIO(), io.StringIO()
+    with override_output_context(format=OutputFormat.json):
+        with redirect_stdout(out), redirect_stderr(err):
+            console = Console()
+            console.print("This must not pollute JSON stdout.")
+    assert out.getvalue() == ""
+    assert err.getvalue() == ""
+
+
+def test_console_print_routes_to_stdout_in_rich_mode() -> None:
+    out = io.StringIO()
+    with override_output_context(format=OutputFormat.rich):
+        with redirect_stdout(out):
+            console = Console(file=out, force_terminal=False)
+            console.print("Visible in rich mode.")
+    assert "Visible in rich mode." in out.getvalue()
+
+
+def test_console_print_error_always_writes_to_stderr() -> None:
+    err = io.StringIO()
+    with override_output_context(format=OutputFormat.json):
+        with redirect_stderr(err):
+            Console().print_error("Something went wrong.")
+    assert "Something went wrong." in err.getvalue()
+
+
+def test_console_spinner_is_silent_in_json_mode() -> None:
+    out, err = io.StringIO(), io.StringIO()
+    with override_output_context(format=OutputFormat.json):
+        with redirect_stdout(out), redirect_stderr(err):
+            with Console().spinner("Loading workspaces..."):
+                pass
+    assert out.getvalue() == ""
+    assert err.getvalue() == ""
+
+
+def test_console_spinner_writes_to_stderr_in_plain_mode() -> None:
+    out, err = io.StringIO(), io.StringIO()
+    with override_output_context(format=OutputFormat.plain):
+        with redirect_stdout(out), redirect_stderr(err):
+            with Console().spinner("Loading..."):
+                pass
+    assert out.getvalue() == ""
+    assert "Loading..." in err.getvalue()
+
+
+def test_output_context_status_no_op_in_json() -> None:
+    out, err = io.StringIO(), io.StringIO()
+    output = OutputContext(format=OutputFormat.json, interactive=False)
+    with redirect_stdout(out), redirect_stderr(err):
+        with output.status("fetching..."):
+            pass
+    assert out.getvalue() == ""
+    assert err.getvalue() == ""
+
+
+def test_console_table_is_silent_in_json_mode() -> None:
+    out = io.StringIO()
+    with override_output_context(format=OutputFormat.json):
+        with redirect_stdout(out):
+            Console().table([("ID", "ds_1")])
+    assert out.getvalue() == ""

--- a/tests/unit/cli/output/test_context.py
+++ b/tests/unit/cli/output/test_context.py
@@ -1,0 +1,165 @@
+"""Tests for OutputFormat, OutputContext, and context resolution."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import click
+import pytest
+
+from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.cli.output.context import (
+    OutputContext,
+    OutputFormat,
+    _argv_format_prescan,
+    _output_context_var,
+    default_output_context,
+    get_output_context,
+    install_output_context,
+    override_output_context,
+    resolve_format_selectors,
+)
+
+
+def test_output_format_values() -> None:
+    assert OutputFormat.rich.value == "rich"
+    assert OutputFormat.json.value == "json"
+    assert OutputFormat.plain.value == "plain"
+
+
+def test_default_output_context_is_rich_and_uses_stdin_isatty(monkeypatch) -> None:
+    monkeypatch.setattr("sys.stdin", StringIO())
+    output = default_output_context()
+    assert output.format is OutputFormat.rich
+    assert output.interactive is False
+    assert output.schema_version == 1
+    assert output.output_emitted is False
+
+
+def test_get_output_context_layer_1_uses_active_click_context() -> None:
+    output = OutputContext(format=OutputFormat.plain, interactive=False)
+    cmd = click.Command("dummy", callback=lambda: None)
+    with click.Context(cmd) as ctx:
+        ctx.obj = output
+        assert get_output_context() is output
+
+
+def test_get_output_context_layer_3_falls_back_to_contextvar() -> None:
+    forced = OutputContext(format=OutputFormat.json, interactive=False)
+    token = _output_context_var.set(forced)
+    try:
+        assert get_output_context() is forced
+    finally:
+        _output_context_var.reset(token)
+
+
+def test_get_output_context_layer_4_uses_argv_prescan(monkeypatch) -> None:
+    monkeypatch.setattr("sys.argv", ["osmosis", "--json", "dataset", "list"])
+    output = get_output_context()
+    assert output.format is OutputFormat.json
+    assert output.interactive is False
+
+
+def test_get_output_context_layer_5_default_when_unset(monkeypatch) -> None:
+    monkeypatch.setattr("sys.argv", ["osmosis"])
+    output = get_output_context()
+    assert output.format is OutputFormat.rich
+
+
+def test_install_output_context_sets_obj_and_contextvar() -> None:
+    output = OutputContext(format=OutputFormat.plain, interactive=False)
+    cmd = click.Command("dummy", callback=lambda: None)
+    with click.Context(cmd) as ctx:
+        install_output_context(ctx, output)
+        assert ctx.obj is output
+        assert _output_context_var.get() is output
+    assert _output_context_var.get() is None
+
+
+def test_argv_prescan_recognises_format_flags() -> None:
+    assert _argv_format_prescan(["--json", "dataset", "list"]) is OutputFormat.json
+    assert _argv_format_prescan(["--plain", "dataset", "list"]) is OutputFormat.plain
+    assert (
+        _argv_format_prescan(["--format", "json", "dataset", "list"])
+        is OutputFormat.json
+    )
+    assert (
+        _argv_format_prescan(["--format=plain", "dataset", "list"])
+        is OutputFormat.plain
+    )
+
+
+def test_argv_prescan_ignores_command_local_output() -> None:
+    assert (
+        _argv_format_prescan(["dataset", "download", "ds1", "--output", "./file"])
+        is None
+    )
+
+
+def test_argv_prescan_ignores_unknown_flags() -> None:
+    assert _argv_format_prescan(["--bogus", "dataset", "list"]) is None
+
+
+def test_get_output_context_layer_2_uses_usage_error_ctx() -> None:
+    output = OutputContext(format=OutputFormat.json, interactive=False)
+    root_cmd = click.Command("root", callback=lambda: None)
+    with click.Context(root_cmd) as ctx:
+        ctx.obj = output
+        exc = click.UsageError("Bad subcommand", ctx=ctx)
+        assert exc.ctx is not None
+        assert exc.ctx.find_root().obj is output
+
+
+def test_resolve_format_selectors_default_is_rich() -> None:
+    assert (
+        resolve_format_selectors(None, json_alias=False, plain_alias=False)
+        is OutputFormat.rich
+    )
+
+
+def test_resolve_format_selectors_json_alias() -> None:
+    assert (
+        resolve_format_selectors(None, json_alias=True, plain_alias=False)
+        is OutputFormat.json
+    )
+
+
+def test_resolve_format_selectors_plain_alias() -> None:
+    assert (
+        resolve_format_selectors(None, json_alias=False, plain_alias=True)
+        is OutputFormat.plain
+    )
+
+
+def test_resolve_format_selectors_explicit_value_wins_over_unset_aliases() -> None:
+    assert (
+        resolve_format_selectors(OutputFormat.json, json_alias=False, plain_alias=False)
+        is OutputFormat.json
+    )
+
+
+def test_resolve_format_selectors_consistent_alias_and_value_is_ok() -> None:
+    assert (
+        resolve_format_selectors(OutputFormat.json, json_alias=True, plain_alias=False)
+        is OutputFormat.json
+    )
+
+
+def test_resolve_format_selectors_json_and_plain_conflict() -> None:
+    with pytest.raises(CLIError) as exc:
+        resolve_format_selectors(None, json_alias=True, plain_alias=True)
+    assert exc.value.code == "VALIDATION"
+
+
+def test_resolve_format_selectors_format_and_alias_conflict() -> None:
+    with pytest.raises(CLIError) as exc:
+        resolve_format_selectors(OutputFormat.plain, json_alias=True, plain_alias=False)
+    assert exc.value.code == "VALIDATION"
+
+
+def test_override_output_context_helper_round_trip() -> None:
+    assert _output_context_var.get() is None
+    with override_output_context(format=OutputFormat.json) as output:
+        assert output.format is OutputFormat.json
+        assert _output_context_var.get() is output
+    assert _output_context_var.get() is None

--- a/tests/unit/cli/output/test_error.py
+++ b/tests/unit/cli/output/test_error.py
@@ -1,0 +1,115 @@
+"""Structured error envelope and classification tests."""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stderr
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.cli.output.error import (
+    classify_error,
+    command_path_for_error,
+    emit_structured_error_to_stderr,
+)
+from osmosis_ai.platform.auth.platform_client import (
+    AuthenticationExpiredError,
+    PlatformAPIError,
+)
+
+GOLDEN = Path(__file__).resolve().parents[3] / "golden" / "cli_output"
+
+
+def _capture_envelope(err: CLIError) -> dict[str, Any]:
+    buf = io.StringIO()
+    with redirect_stderr(buf):
+        emit_structured_error_to_stderr(err, command="dataset list")
+    return json.loads(buf.getvalue())
+
+
+def test_envelope_keys_match_golden() -> None:
+    envelope = _capture_envelope(CLIError("Bad input.", code="VALIDATION"))
+    expected = json.loads((GOLDEN / "error_envelope.json").read_text(encoding="utf-8"))
+    assert sorted(envelope.keys()) == sorted(expected["keys"])
+    assert envelope["schema_version"] == 1
+    assert envelope["command"] == "dataset list"
+    assert envelope["cli_version"]
+    assert envelope["error"]["code"] == "VALIDATION"
+    assert envelope["error"]["details"] == {}
+    assert envelope["error"]["request_id"] is None
+
+
+def test_envelope_includes_platform_details() -> None:
+    err = PlatformAPIError(
+        "Validation failed.",
+        status_code=400,
+        error_code="invalid_dataset_name",
+        details={"field": "name"},
+    )
+    envelope = _capture_envelope(classify_error(err))
+    assert envelope["error"]["code"] == "VALIDATION"
+    assert envelope["error"]["details"]["platform_code"] == "invalid_dataset_name"
+    assert envelope["error"]["details"]["field"] == "name"
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_code"),
+    [
+        (400, "VALIDATION"),
+        (401, "AUTH_REQUIRED"),
+        (403, "PLATFORM_ERROR"),
+        (404, "NOT_FOUND"),
+        (409, "CONFLICT"),
+        (429, "RATE_LIMITED"),
+        (500, "PLATFORM_ERROR"),
+        (502, "PLATFORM_ERROR"),
+    ],
+)
+def test_platform_error_status_mapping(status: int, expected_code: str) -> None:
+    cli_err = classify_error(PlatformAPIError("x", status_code=status))
+    assert cli_err.code == expected_code
+
+
+def test_authentication_expired_error_maps_to_auth_required() -> None:
+    cli_err = classify_error(AuthenticationExpiredError("expired"))
+    assert cli_err.code == "AUTH_REQUIRED"
+
+
+def test_unknown_exception_maps_to_internal_with_safe_details() -> None:
+    cli_err = classify_error(RuntimeError("traceback contains secrets"))
+    assert cli_err.code == "INTERNAL"
+    assert cli_err.details == {"exception_type": "RuntimeError"}
+    assert "secrets" not in cli_err.message
+
+
+def test_cli_error_is_returned_unchanged() -> None:
+    original = CLIError("Bad", code="NOT_FOUND")
+    assert classify_error(original) is original
+
+
+def test_command_path_falls_back_to_argv_when_no_context(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "sys.argv", ["osmosis", "--json", "dataset", "list", "--limit", "5"]
+    )
+    assert command_path_for_error(None) == "dataset list"
+
+
+def test_command_path_uses_click_context_when_available() -> None:
+    import click
+
+    parent = click.Context(click.Command("osmosis"))
+    parent.info_name = "osmosis"
+    middle = click.Context(click.Command("dataset"), parent=parent)
+    middle.info_name = "dataset"
+    nested = click.Context(click.Command("list"), parent=middle)
+    nested.info_name = "list"
+    assert command_path_for_error(nested) == "dataset list"
+
+
+def test_command_path_root_when_argv_empty(monkeypatch) -> None:
+    monkeypatch.setattr("sys.argv", ["osmosis"])
+    assert command_path_for_error(None) == "<root>"

--- a/tests/unit/cli/output/test_error.py
+++ b/tests/unit/cli/output/test_error.py
@@ -98,6 +98,18 @@ def test_command_path_falls_back_to_argv_when_no_context(monkeypatch) -> None:
     assert command_path_for_error(None) == "dataset list"
 
 
+def test_command_path_fallback_excludes_top_level_argument(monkeypatch) -> None:
+    monkeypatch.setattr("sys.argv", ["osmosis", "--json", "deploy", "ckpt-name"])
+    assert command_path_for_error(None) == "deploy"
+
+
+def test_command_path_fallback_keeps_eval_cache_subcommand(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "sys.argv", ["osmosis", "--json", "eval", "cache", "rm", "task-1"]
+    )
+    assert command_path_for_error(None) == "eval cache rm"
+
+
 def test_command_path_uses_click_context_when_available() -> None:
     import click
 

--- a/tests/unit/cli/output/test_progress.py
+++ b/tests/unit/cli/output/test_progress.py
@@ -35,6 +35,23 @@ def test_plain_mode_emits_only_to_stderr() -> None:
     assert err.getvalue().count("100%") == 1
 
 
+def test_plain_mode_reports_ten_percent_buckets() -> None:
+    out, err = io.StringIO(), io.StringIO()
+    with override_output_context(format=OutputFormat.plain):
+        with redirect_stdout(out), redirect_stderr(err):
+            ctx, callback = make_progress_bar(100)
+            with ctx:
+                callback(9, 100)
+                callback(19, 100)
+                callback(100, 100)
+    stderr = err.getvalue()
+    assert out.getvalue() == ""
+    assert "9%" not in stderr
+    assert "10%" in stderr
+    assert "19%" not in stderr
+    assert "100%" in stderr
+
+
 def test_rich_mode_emits_to_stderr_only() -> None:
     out, err = io.StringIO(), io.StringIO()
     with override_output_context(format=OutputFormat.rich):

--- a/tests/unit/cli/output/test_progress.py
+++ b/tests/unit/cli/output/test_progress.py
@@ -1,0 +1,45 @@
+"""Output-aware make_progress_bar tests."""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stderr, redirect_stdout
+
+from osmosis_ai.cli.output.context import OutputFormat, override_output_context
+from osmosis_ai.platform.api.upload import make_progress_bar
+
+
+def test_json_mode_emits_no_progress_anywhere() -> None:
+    out, err = io.StringIO(), io.StringIO()
+    with override_output_context(format=OutputFormat.json):
+        with redirect_stdout(out), redirect_stderr(err):
+            ctx, callback = make_progress_bar(1024)
+            with ctx:
+                callback(256, 1024)
+                callback(1024, 1024)
+    assert out.getvalue() == ""
+    assert err.getvalue() == ""
+
+
+def test_plain_mode_emits_only_to_stderr() -> None:
+    out, err = io.StringIO(), io.StringIO()
+    with override_output_context(format=OutputFormat.plain):
+        with redirect_stdout(out), redirect_stderr(err):
+            ctx, callback = make_progress_bar(1024)
+            with ctx:
+                callback(512, 1024)
+                callback(1024, 1024)
+                callback(1024, 1024)
+    assert out.getvalue() == ""
+    assert err.getvalue() != ""
+    assert err.getvalue().count("100%") == 1
+
+
+def test_rich_mode_emits_to_stderr_only() -> None:
+    out, err = io.StringIO(), io.StringIO()
+    with override_output_context(format=OutputFormat.rich):
+        with redirect_stdout(out), redirect_stderr(err):
+            ctx, callback = make_progress_bar(1024)
+            with ctx:
+                callback(1024, 1024)
+    assert out.getvalue() == ""

--- a/tests/unit/cli/output/test_renderer_json.py
+++ b/tests/unit/cli/output/test_renderer_json.py
@@ -64,6 +64,28 @@ def test_list_envelope_supports_extra_keys() -> None:
     assert payload["workspace"] == "ws-a"
 
 
+def test_list_envelope_extra_cannot_override_reserved_keys() -> None:
+    result = ListResult(
+        title="Datasets",
+        items=[{"id": "ds_1"}],
+        total_count=1,
+        has_more=False,
+        next_offset=None,
+        columns=[],
+        extra={
+            "schema_version": 999,
+            "items": [],
+            "has_more": True,
+            "workspace": "ws-a",
+        },
+    )
+    payload, _ = _render_to_json(result)
+    assert payload["schema_version"] == 1
+    assert payload["items"] == [{"id": "ds_1"}]
+    assert payload["has_more"] is False
+    assert payload["workspace"] == "ws-a"
+
+
 def test_detail_envelope_required_keys() -> None:
     result = DetailResult(
         title="Dataset",
@@ -107,10 +129,41 @@ def test_operation_envelope_includes_structured_next_steps_only() -> None:
     assert "display_next_steps" not in payload
 
 
+def test_operation_envelope_extra_cannot_override_reserved_keys() -> None:
+    result = OperationResult(
+        operation="deploy",
+        status="success",
+        extra={
+            "status": "failed",
+            "operation": "delete",
+            "message": "from extra",
+            "workspace": "ws-a",
+        },
+    )
+    payload, _ = _render_to_json(result)
+    assert payload["status"] == "success"
+    assert payload["operation"] == "deploy"
+    assert "message" not in payload
+    assert payload["workspace"] == "ws-a"
+
+
 def test_message_envelope_includes_schema_version() -> None:
     result = MessageResult(message="Logged out.")
     payload, _ = _render_to_json(result)
     assert payload == {"schema_version": 1, "message": "Logged out."}
+
+
+def test_message_envelope_extra_cannot_override_reserved_keys() -> None:
+    result = MessageResult(
+        message="Logged out.",
+        extra={"schema_version": 999, "message": "from extra", "workspace": "ws-a"},
+    )
+    payload, _ = _render_to_json(result)
+    assert payload == {
+        "schema_version": 1,
+        "message": "Logged out.",
+        "workspace": "ws-a",
+    }
 
 
 def test_no_ansi_or_rich_box_on_json_stdout() -> None:

--- a/tests/unit/cli/output/test_renderer_json.py
+++ b/tests/unit/cli/output/test_renderer_json.py
@@ -1,0 +1,138 @@
+"""JSON renderer envelope and parseability tests."""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from typing import Any
+
+from osmosis_ai.cli.output.context import OutputFormat, override_output_context
+from osmosis_ai.cli.output.renderer import render
+from osmosis_ai.cli.output.result import (
+    DetailField,
+    DetailResult,
+    ListColumn,
+    ListResult,
+    MessageResult,
+    OperationResult,
+)
+
+GOLDEN = Path(__file__).resolve().parents[3] / "golden" / "cli_output"
+
+
+def _render_to_json(result: Any) -> tuple[dict[str, Any], str]:
+    out, err = io.StringIO(), io.StringIO()
+    with override_output_context(format=OutputFormat.json) as ctx:
+        with redirect_stdout(out), redirect_stderr(err):
+            render(result, ctx)
+    return json.loads(out.getvalue()), err.getvalue()
+
+
+def test_list_envelope_required_keys() -> None:
+    result = ListResult(
+        title="Datasets",
+        items=[{"id": "ds_1"}],
+        total_count=1,
+        has_more=False,
+        next_offset=None,
+        columns=[ListColumn(key="id", label="ID")],
+    )
+    payload, stderr = _render_to_json(result)
+    expected_keys = json.loads(
+        (GOLDEN / "list_envelope.json").read_text(encoding="utf-8")
+    )["keys"]
+    assert sorted(payload.keys()) == sorted(expected_keys)
+    assert payload["schema_version"] == 1
+    assert payload["items"] == [{"id": "ds_1"}]
+    assert payload["next_offset"] is None
+    assert stderr == ""
+
+
+def test_list_envelope_supports_extra_keys() -> None:
+    result = ListResult(
+        title="Eval caches",
+        items=[],
+        total_count=0,
+        has_more=False,
+        next_offset=None,
+        columns=[],
+        extra={"workspace": "ws-a"},
+    )
+    payload, _ = _render_to_json(result)
+    assert payload["workspace"] == "ws-a"
+
+
+def test_detail_envelope_required_keys() -> None:
+    result = DetailResult(
+        title="Dataset",
+        data={"id": "ds_1"},
+        fields=[DetailField(label="ID", value="ds_1")],
+    )
+    payload, _ = _render_to_json(result)
+    expected_keys = json.loads(
+        (GOLDEN / "detail_envelope.json").read_text(encoding="utf-8")
+    )["keys"]
+    assert sorted(payload.keys()) == sorted(expected_keys)
+    assert payload["data"] == {"id": "ds_1"}
+
+
+def test_operation_envelope_required_keys() -> None:
+    result = OperationResult(
+        operation="deploy",
+        status="success",
+        resource={"id": "dep_1", "checkpoint_name": "run-step-40", "status": "active"},
+    )
+    payload, _ = _render_to_json(result)
+    expected_keys = json.loads(
+        (GOLDEN / "operation_envelope.json").read_text(encoding="utf-8")
+    )["keys"]
+    assert set(expected_keys["required"]).issubset(payload.keys())
+    assert payload["status"] == "success"
+    assert payload["operation"] == "deploy"
+
+
+def test_operation_envelope_includes_structured_next_steps_only() -> None:
+    result = OperationResult(
+        operation="init",
+        status="success",
+        next_steps_structured=[{"action": "open", "target": "https://x.io"}],
+        display_next_steps=["Open the dashboard."],
+    )
+    payload, _ = _render_to_json(result)
+    assert payload["next_steps_structured"] == [
+        {"action": "open", "target": "https://x.io"}
+    ]
+    assert "display_next_steps" not in payload
+
+
+def test_message_envelope_includes_schema_version() -> None:
+    result = MessageResult(message="Logged out.")
+    payload, _ = _render_to_json(result)
+    assert payload == {"schema_version": 1, "message": "Logged out."}
+
+
+def test_no_ansi_or_rich_box_on_json_stdout() -> None:
+    result = DetailResult(
+        title="Dataset",
+        data={"id": "ds_1"},
+        fields=[DetailField(label="ID", value="ds_1")],
+    )
+    out = io.StringIO()
+    with override_output_context(format=OutputFormat.json) as ctx:
+        with redirect_stdout(out):
+            render(result, ctx)
+    raw = out.getvalue()
+    assert "\x1b[" not in raw
+    assert "\u2500" not in raw
+    json.loads(raw)
+
+
+def test_render_marks_output_emitted() -> None:
+    result = MessageResult(message="ok")
+    out = io.StringIO()
+    with override_output_context(format=OutputFormat.json) as ctx:
+        with redirect_stdout(out):
+            render(result, ctx)
+        assert ctx.output_emitted is True

--- a/tests/unit/cli/output/test_renderer_plain.py
+++ b/tests/unit/cli/output/test_renderer_plain.py
@@ -1,0 +1,167 @@
+"""Plain renderer behavior tests."""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stderr, redirect_stdout
+from typing import Any
+
+from osmosis_ai.cli.output.context import OutputFormat, override_output_context
+from osmosis_ai.cli.output.renderer import render
+from osmosis_ai.cli.output.result import (
+    DetailField,
+    DetailResult,
+    ListColumn,
+    ListResult,
+    MessageResult,
+    OperationResult,
+)
+
+
+def _render(result: Any) -> tuple[str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    with override_output_context(format=OutputFormat.plain) as ctx:
+        with redirect_stdout(out), redirect_stderr(err):
+            render(result, ctx)
+    return out.getvalue(), err.getvalue()
+
+
+def test_detail_renders_label_value_lines() -> None:
+    result = DetailResult(
+        title="Dataset",
+        data={"id": "ds_1", "file_name": "train.jsonl"},
+        fields=[
+            DetailField(label="ID", value="ds_1"),
+            DetailField(label="File", value="train.jsonl"),
+        ],
+    )
+    stdout, stderr = _render(result)
+    assert stdout == "ID: ds_1\nFile: train.jsonl\n"
+    assert stderr == ""
+
+
+def test_list_renders_tab_separated_without_heading() -> None:
+    result = ListResult(
+        title="Datasets",
+        items=[
+            {"id": "ds_1", "status": "uploaded"},
+            {"id": "ds_2", "status": "pending"},
+        ],
+        total_count=2,
+        has_more=False,
+        next_offset=None,
+        columns=[
+            ListColumn(key="id", label="ID"),
+            ListColumn(key="status", label="Status"),
+        ],
+    )
+    stdout, _ = _render(result)
+    assert stdout.splitlines() == ["ds_1\tuploaded", "ds_2\tpending"]
+
+
+def test_list_uses_display_items_for_plain_human_values() -> None:
+    result = ListResult(
+        title="Datasets",
+        items=[
+            {
+                "file_name": "train[ok].jsonl",
+                "file_size": 12345,
+                "created_at": "2026-04-26T00:00:00Z",
+            }
+        ],
+        total_count=1,
+        has_more=False,
+        next_offset=None,
+        columns=[
+            ListColumn(key="file_name", label="File"),
+            ListColumn(key="file_size", label="Size"),
+            ListColumn(key="created_at", label="Created"),
+        ],
+        display_items=[
+            {
+                "file_name": "train[ok].jsonl",
+                "file_size": "12.1 KB",
+                "created_at": "[dim]2026-04-26[/dim]",
+            }
+        ],
+    )
+    stdout, _ = _render(result)
+    assert stdout == "train[ok].jsonl\t12.1 KB\t2026-04-26\n"
+
+
+def test_list_skips_columns_marked_plain_false() -> None:
+    result = ListResult(
+        title="Datasets",
+        items=[{"id": "ds_1", "status": "uploaded", "internal_id": "int_1"}],
+        total_count=1,
+        has_more=False,
+        next_offset=None,
+        columns=[
+            ListColumn(key="id", label="ID"),
+            ListColumn(key="status", label="Status"),
+            ListColumn(key="internal_id", label="Internal ID", plain=False),
+        ],
+    )
+    stdout, _ = _render(result)
+    assert stdout.strip() == "ds_1\tuploaded"
+
+
+def test_list_normalises_tabs_and_newlines_in_values() -> None:
+    result = ListResult(
+        title="X",
+        items=[{"name": "first\tline\nbroken", "id": "1"}],
+        total_count=1,
+        has_more=False,
+        next_offset=None,
+        columns=[
+            ListColumn(key="name", label="Name"),
+            ListColumn(key="id", label="ID"),
+        ],
+    )
+    stdout, _ = _render(result)
+    assert "\t" in stdout
+    assert stdout.count("\t") == 1
+    assert "\n" in stdout
+    assert stdout.count("\n") == 1
+
+
+def test_detail_unescapes_rich_escaped_display_values() -> None:
+    result = DetailResult(
+        title="Dataset",
+        data={"file_name": "train[ok].jsonl"},
+        fields=[
+            DetailField(label="File", value="train\\[ok].jsonl"),
+        ],
+    )
+    stdout, _ = _render(result)
+    assert stdout == "File: train[ok].jsonl\n"
+
+
+def test_operation_renders_concise_success_line() -> None:
+    result = OperationResult(
+        operation="deploy",
+        status="success",
+        resource={"id": "dep_1", "checkpoint_name": "run-step-40"},
+        message="Checkpoint deployed.",
+        display_next_steps=["Test it: osmosis deployment info run-step-40"],
+    )
+    stdout, _ = _render(result)
+    lines = stdout.splitlines()
+    assert lines[0] == "Checkpoint deployed."
+    assert any("Test it:" in line for line in lines)
+
+
+def test_message_renders_text_only() -> None:
+    stdout, _ = _render(MessageResult(message="Logged out."))
+    assert stdout == "Logged out.\n"
+
+
+def test_no_ansi_in_plain_stdout() -> None:
+    result = DetailResult(
+        title="Dataset",
+        data={"id": "ds_1"},
+        fields=[DetailField(label="ID", value="ds_1")],
+    )
+    stdout, _ = _render(result)
+    assert "\x1b[" not in stdout
+    assert "\u2500" not in stdout

--- a/tests/unit/cli/output/test_renderer_rich.py
+++ b/tests/unit/cli/output/test_renderer_rich.py
@@ -57,6 +57,19 @@ def test_rich_list_includes_column_headers() -> None:
     assert "ds_1" in stdout and "uploaded" in stdout
 
 
+def test_rich_list_renders_raw_cell_markup_as_text() -> None:
+    result = ListResult(
+        title="Models",
+        items=[{"name": "[red]model[/red]"}],
+        total_count=1,
+        has_more=False,
+        next_offset=None,
+        columns=[ListColumn(key="name", label="Name")],
+    )
+    stdout, _ = _render(result)
+    assert "[red]model[/red]" in stdout
+
+
 def test_rich_message_renders_message_text() -> None:
     stdout, _ = _render(MessageResult(message="Logged out."))
     assert "Logged out." in stdout
@@ -72,3 +85,13 @@ def test_rich_operation_renders_message() -> None:
     stdout, _ = _render(result)
     assert "Deployed." in stdout
     assert "Try it now" in stdout
+
+
+def test_rich_operation_renders_message_markup_as_text() -> None:
+    result = OperationResult(
+        operation="model.delete",
+        status="success",
+        message='Model "[red]danger[/red]" deleted.',
+    )
+    stdout, _ = _render(result)
+    assert 'Model "[red]danger[/red]" deleted.' in stdout

--- a/tests/unit/cli/output/test_renderer_rich.py
+++ b/tests/unit/cli/output/test_renderer_rich.py
@@ -1,0 +1,74 @@
+"""Rich renderer integration tests."""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stderr, redirect_stdout
+from typing import Any
+
+from osmosis_ai.cli.output.context import OutputFormat, override_output_context
+from osmosis_ai.cli.output.renderer import render
+from osmosis_ai.cli.output.result import (
+    DetailField,
+    DetailResult,
+    ListColumn,
+    ListResult,
+    MessageResult,
+    OperationResult,
+)
+
+
+def _render(result: Any) -> tuple[str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    with override_output_context(format=OutputFormat.rich) as ctx:
+        with redirect_stdout(out), redirect_stderr(err):
+            render(result, ctx)
+    return out.getvalue(), err.getvalue()
+
+
+def test_rich_detail_uses_label_value_table() -> None:
+    result = DetailResult(
+        title="Dataset",
+        data={"id": "ds_1"},
+        fields=[
+            DetailField(label="ID", value="ds_1"),
+            DetailField(label="File", value="train.jsonl"),
+        ],
+    )
+    stdout, _ = _render(result)
+    assert "ID" in stdout and "ds_1" in stdout
+    assert "File" in stdout and "train.jsonl" in stdout
+
+
+def test_rich_list_includes_column_headers() -> None:
+    result = ListResult(
+        title="Datasets",
+        items=[{"id": "ds_1", "status": "uploaded"}],
+        total_count=1,
+        has_more=False,
+        next_offset=None,
+        columns=[
+            ListColumn(key="id", label="ID"),
+            ListColumn(key="status", label="Status"),
+        ],
+    )
+    stdout, _ = _render(result)
+    assert "ID" in stdout and "Status" in stdout
+    assert "ds_1" in stdout and "uploaded" in stdout
+
+
+def test_rich_message_renders_message_text() -> None:
+    stdout, _ = _render(MessageResult(message="Logged out."))
+    assert "Logged out." in stdout
+
+
+def test_rich_operation_renders_message() -> None:
+    result = OperationResult(
+        operation="deploy",
+        status="success",
+        message="Deployed.",
+        display_next_steps=["Try it now"],
+    )
+    stdout, _ = _render(result)
+    assert "Deployed." in stdout
+    assert "Try it now" in stdout

--- a/tests/unit/cli/output/test_result.py
+++ b/tests/unit/cli/output/test_result.py
@@ -1,0 +1,86 @@
+"""Tests for the CommandResult shapes."""
+
+from __future__ import annotations
+
+from osmosis_ai.cli.output.result import (
+    DetailField,
+    DetailResult,
+    ListColumn,
+    ListResult,
+    MessageResult,
+    OperationResult,
+)
+
+
+def test_detail_result_basic() -> None:
+    result = DetailResult(
+        title="Dataset",
+        data={"id": "ds_1", "file_name": "train.jsonl"},
+        fields=[
+            DetailField(label="ID", value="ds_1"),
+            DetailField(label="File", value="train.jsonl"),
+        ],
+    )
+    assert result.title == "Dataset"
+    assert result.data["id"] == "ds_1"
+    assert len(result.fields) == 2
+
+
+def test_list_result_carries_pagination() -> None:
+    result = ListResult(
+        title="Datasets",
+        items=[{"id": "ds_1"}, {"id": "ds_2"}],
+        total_count=42,
+        has_more=True,
+        next_offset=2,
+        columns=[
+            ListColumn(key="id", label="ID"),
+            ListColumn(key="status", label="Status"),
+        ],
+    )
+    assert result.total_count == 42
+    assert result.has_more is True
+    assert result.next_offset == 2
+    assert [column.key for column in result.columns] == ["id", "status"]
+
+
+def test_list_result_next_offset_required_even_when_unsupported() -> None:
+    result = ListResult(
+        title="Caches",
+        items=[],
+        total_count=0,
+        has_more=False,
+        next_offset=None,
+        columns=[],
+    )
+    assert result.next_offset is None
+
+
+def test_operation_result_minimal() -> None:
+    result = OperationResult(
+        operation="deploy",
+        status="success",
+        resource={"id": "ckpt_1", "checkpoint_name": "run-step-40"},
+    )
+    assert result.operation == "deploy"
+    assert result.status == "success"
+    assert result.resource is not None
+
+
+def test_operation_result_with_structured_next_steps() -> None:
+    result = OperationResult(
+        operation="init",
+        status="success",
+        message="Workspace created.",
+        next_steps_structured=[
+            {"action": "open", "target": "https://app.osmosis.ai/ws"},
+        ],
+        display_next_steps=["Open the dashboard."],
+    )
+    assert result.next_steps_structured[0]["action"] == "open"
+    assert result.display_next_steps == ["Open the dashboard."]
+
+
+def test_message_result() -> None:
+    result = MessageResult(message="Logged out successfully.")
+    assert result.message == "Logged out successfully."

--- a/tests/unit/cli/output/test_root_callback.py
+++ b/tests/unit/cli/output/test_root_callback.py
@@ -1,0 +1,41 @@
+"""Root callback tests for --format/--json/--plain parsing."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from osmosis_ai.cli import main as cli
+
+
+def test_help_is_plain_text_even_with_json(capsys) -> None:
+    exit_code = cli.main(["--json", "--help"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Osmosis" in captured.out
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(captured.out)
+
+
+def test_version_is_plain_text_even_with_json(capsys) -> None:
+    exit_code = cli.main(["--json", "--version"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.strip().startswith("osmosis-ai")
+
+
+def test_conflicting_selectors_emit_validation_error(capsys) -> None:
+    exit_code = cli.main(["--json", "--plain", "dataset", "list"])
+    captured = capsys.readouterr()
+    assert exit_code != 0
+    assert captured.out == ""
+    assert "conflict" in captured.err.lower() or "format" in captured.err.lower()
+
+
+def test_json_mode_contextvar_resets_after_eager_help(capsys) -> None:
+    from osmosis_ai.cli.output.context import _output_context_var
+
+    cli.main(["--json", "--help"])
+    capsys.readouterr()
+    assert _output_context_var.get() is None

--- a/tests/unit/cli/output/test_safety.py
+++ b/tests/unit/cli/output/test_safety.py
@@ -1,0 +1,83 @@
+"""Tests for render_command_result and verify_output_emitted safety hooks."""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+
+import click
+import pytest
+
+from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.cli.output.context import OutputFormat, override_output_context
+from osmosis_ai.cli.output.renderer import (
+    render_command_result,
+    verify_output_emitted,
+)
+from osmosis_ai.cli.output.result import MessageResult
+
+
+def test_render_command_result_renders_command_result_in_json() -> None:
+    out = io.StringIO()
+    with override_output_context(format=OutputFormat.json) as ctx:
+        with redirect_stdout(out):
+            render_command_result(MessageResult(message="ok"))
+        assert ctx.output_emitted is True
+    payload = json.loads(out.getvalue())
+    assert payload == {"schema_version": 1, "message": "ok"}
+
+
+def test_render_command_result_passes_none_through_in_rich_mode() -> None:
+    with override_output_context(format=OutputFormat.rich):
+        render_command_result(None)
+
+
+def test_render_command_result_rejects_none_in_json_mode() -> None:
+    with override_output_context(format=OutputFormat.json):
+        with pytest.raises(CLIError) as exc:
+            render_command_result(None)
+        assert exc.value.code == "INTERNAL"
+        assert "structured output" in exc.value.message
+
+
+def test_render_command_result_rejects_unsupported_type() -> None:
+    with override_output_context(format=OutputFormat.json):
+        with pytest.raises(CLIError) as exc:
+            render_command_result(42)
+        assert exc.value.code == "INTERNAL"
+
+
+def test_verify_output_emitted_passes_when_emitted() -> None:
+    with override_output_context(format=OutputFormat.json) as ctx:
+        ctx.output_emitted = True
+        verify_output_emitted()
+
+
+def test_verify_output_emitted_passes_in_rich_mode() -> None:
+    with override_output_context(format=OutputFormat.rich):
+        verify_output_emitted()
+
+
+def test_verify_output_emitted_emits_internal_error_when_silent_in_json() -> None:
+    with override_output_context(format=OutputFormat.json) as ctx:
+        assert ctx.output_emitted is False
+        err = io.StringIO()
+        with pytest.raises(click.exceptions.Exit) as exit_info:
+            with redirect_stderr(err):
+                verify_output_emitted()
+        assert exit_info.value.exit_code == 1
+        envelope = json.loads(err.getvalue())
+        assert envelope["error"]["code"] == "INTERNAL"
+        assert "structured output" in envelope["error"]["message"]
+
+
+def test_verify_output_emitted_no_op_when_exception_in_flight() -> None:
+    err = io.StringIO()
+    try:
+        raise RuntimeError("simulated")
+    except RuntimeError:
+        with override_output_context(format=OutputFormat.json):
+            with redirect_stderr(err):
+                verify_output_emitted()
+    assert err.getvalue() == ""

--- a/tests/unit/cli/output/test_serializers.py
+++ b/tests/unit/cli/output/test_serializers.py
@@ -1,0 +1,178 @@
+"""Tests for public JSON serializers and golden snapshots."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from osmosis_ai.cli.output.serializers import (
+    serialize_checkpoint,
+    serialize_dataset,
+    serialize_deployment,
+    serialize_eval_cache_entry,
+    serialize_model,
+    serialize_rollout,
+    serialize_training_run,
+    serialize_workspace,
+)
+from osmosis_ai.platform.api.models import (
+    BaseModelInfo,
+    DatasetFile,
+    DeploymentInfo,
+    LoraCheckpointInfo,
+    RolloutInfo,
+    TrainingRun,
+)
+
+GOLDEN_DIR = Path(__file__).resolve().parents[3] / "golden" / "cli_output"
+
+
+def _assert_keys_match_golden(payload: dict, golden_name: str) -> None:
+    expected = json.loads((GOLDEN_DIR / golden_name).read_text(encoding="utf-8"))
+    assert sorted(payload.keys()) == sorted(expected["keys"])
+
+
+def test_serialize_dataset_keys() -> None:
+    dataset = DatasetFile.from_dict(
+        {
+            "id": "ds_1",
+            "file_name": "train.jsonl",
+            "file_size": 12345,
+            "status": "uploaded",
+            "processing_step": None,
+            "processing_percent": None,
+            "error": None,
+            "created_at": "2026-04-26T00:00:00Z",
+            "updated_at": "2026-04-26T00:00:01Z",
+        }
+    )
+    payload = serialize_dataset(dataset)
+    _assert_keys_match_golden(payload, "dataset_serializer.json")
+    assert payload["id"] == "ds_1"
+    assert payload["file_size"] == 12345
+    assert "upload" not in payload
+
+
+def test_serialize_dataset_keeps_none_optional_contract_fields() -> None:
+    dataset = DatasetFile.from_dict(
+        {
+            "id": "ds_1",
+            "file_name": "x.jsonl",
+            "file_size": 0,
+            "status": "pending",
+        }
+    )
+    payload = serialize_dataset(dataset)
+    assert payload["error"] is None
+    assert payload["processing_step"] is None
+
+
+def test_serialize_training_run_keys() -> None:
+    run = TrainingRun.from_dict(
+        {
+            "id": "run_1",
+            "name": "qwen3-run1",
+            "status": "running",
+            "model_id": "model_1",
+            "model": {"model_name": "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8"},
+            "eval_accuracy": 0.4,
+            "reward_increase_delta": 0.02,
+            "processing_step": "training",
+            "processing_percent": 50.0,
+            "error_message": None,
+            "creator_name": "brian",
+            "creator_email": "b@example.com",
+            "created_at": "2026-04-26T00:00:00Z",
+            "started_at": "2026-04-26T00:00:01Z",
+            "completed_at": None,
+        }
+    )
+    payload = serialize_training_run(run)
+    _assert_keys_match_golden(payload, "training_run_serializer.json")
+    assert payload["model_name"] == "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8"
+
+
+def test_serialize_checkpoint_keys() -> None:
+    checkpoint = LoraCheckpointInfo.from_dict(
+        {
+            "id": "ckpt_1",
+            "checkpoint_step": 100,
+            "checkpoint_name": "qwen3-run1-step-100",
+            "status": "uploaded",
+            "created_at": "2026-04-26T00:00:00Z",
+        }
+    )
+    payload = serialize_checkpoint(checkpoint)
+    _assert_keys_match_golden(payload, "checkpoint_serializer.json")
+
+
+def test_serialize_deployment_keys() -> None:
+    deployment = DeploymentInfo.from_dict(
+        {
+            "id": "dep_1",
+            "checkpoint_name": "qwen3-run1-step-100",
+            "status": "active",
+            "checkpoint_step": 100,
+            "base_model": "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8",
+            "training_run_id": "run_1",
+            "training_run_name": "qwen3-run1",
+            "creator_name": "brian",
+            "created_at": "2026-04-26T00:00:00Z",
+        }
+    )
+    payload = serialize_deployment(deployment)
+    _assert_keys_match_golden(payload, "deployment_serializer.json")
+
+
+def test_serialize_model_keys() -> None:
+    model = BaseModelInfo.from_dict(
+        {
+            "id": "model_1",
+            "model_name": "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8",
+            "base_model": "Qwen/Qwen3",
+            "status": "ready",
+            "creator_name": "brian",
+            "created_at": "2026-04-26T00:00:00Z",
+            "updated_at": "2026-04-26T00:00:01Z",
+        }
+    )
+    payload = serialize_model(model)
+    _assert_keys_match_golden(payload, "model_serializer.json")
+
+
+def test_serialize_workspace_minimal() -> None:
+    payload = serialize_workspace({"id": "ws_1", "name": "default"})
+    _assert_keys_match_golden(payload, "workspace_serializer.json")
+    assert payload == {"id": "ws_1", "name": "default"}
+
+
+def test_serialize_rollout_keys() -> None:
+    rollout = RolloutInfo.from_dict(
+        {
+            "id": "ro_1",
+            "name": "my-rollout",
+            "is_active": True,
+            "repo_full_name": "org/repo",
+            "last_synced_commit_sha": "abc123",
+            "created_at": "2026-04-26T00:00:00Z",
+        }
+    )
+    payload = serialize_rollout(rollout)
+    _assert_keys_match_golden(payload, "rollout_serializer.json")
+
+
+def test_serialize_eval_cache_entry_keys() -> None:
+    entry = {
+        "task_id": "task_1",
+        "config": {
+            "llm_model": "openai/gpt-5.4",
+            "eval_dataset": "data.jsonl",
+        },
+        "status": "completed",
+        "runs_count": 3,
+        "created_at": "2026-04-26T00:00:00Z",
+    }
+    payload = serialize_eval_cache_entry(entry)
+    _assert_keys_match_golden(payload, "eval_cache_entry_serializer.json")
+    assert payload["model"] == "openai/gpt-5.4"
+    assert payload["dataset"] == "data.jsonl"

--- a/tests/unit/cli/test_auth_login_json.py
+++ b/tests/unit/cli/test_auth_login_json.py
@@ -21,14 +21,21 @@ def fake_verify_result() -> VerifyResult:
     )
 
 
-def _credentials() -> Credentials:
+def _credentials(
+    *,
+    access_token: str = "t",
+    user_id: str = "u",
+    email: str = "x@example.com",
+    token_id: str = "tok",
+    include_env: bool = True,
+) -> Credentials:
     return Credentials(
-        access_token="t",
+        access_token=access_token,
         token_type="Bearer",
         expires_at=datetime.now(UTC) + timedelta(days=1),
         created_at=datetime.now(UTC),
-        user=UserInfo(id="u", email="x@example.com", name=None),
-        token_id="tok",
+        user=UserInfo(id=user_id, email=email, name=None),
+        token_id=token_id,
     )
 
 
@@ -36,7 +43,10 @@ def test_login_json_with_token_returns_operation_result(
     monkeypatch, capsys, fake_verify_result
 ) -> None:
     monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
-    monkeypatch.setattr("osmosis_ai.platform.auth.load_credentials", lambda: None)
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.load_credentials",
+        lambda **kwargs: None,
+    )
     monkeypatch.setattr(
         "osmosis_ai.platform.auth.verify_token", lambda token: fake_verify_result
     )
@@ -114,7 +124,10 @@ def test_login_json_with_platform_verify_error_is_platform_error(
     monkeypatch, capsys
 ) -> None:
     monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
-    monkeypatch.setattr("osmosis_ai.platform.auth.load_credentials", lambda: None)
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.load_credentials",
+        lambda **kwargs: None,
+    )
     monkeypatch.setattr(
         "osmosis_ai.platform.auth.verify_token",
         lambda token: (_ for _ in ()).throw(
@@ -140,7 +153,10 @@ def test_login_json_with_malformed_verify_response_is_platform_error(
     monkeypatch, capsys
 ) -> None:
     monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
-    monkeypatch.setattr("osmosis_ai.platform.auth.load_credentials", lambda: None)
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.load_credentials",
+        lambda **kwargs: None,
+    )
     monkeypatch.setattr(
         "osmosis_ai.platform.auth.verify_token",
         lambda token: (_ for _ in ()).throw(
@@ -194,6 +210,60 @@ def test_login_json_replaces_session_before_revoking_old_token(
     assert exit_code == 0
     assert json.loads(captured.out)["status"] == "success"
     assert calls[:2] == ["save_credentials", "revoke_cli_token"]
+
+
+def test_login_json_with_token_loads_stored_credentials_when_env_is_set(
+    monkeypatch, capsys, fake_verify_result
+) -> None:
+    monkeypatch.setenv("OSMOSIS_TOKEN", "env-token")
+    calls = []
+    old_credentials = _credentials(
+        access_token="stored-token",
+        user_id=fake_verify_result.user.id,
+        token_id="tok_old",
+    )
+
+    def load_credentials(*, include_env: bool = True):
+        calls.append(("load_credentials", include_env))
+        return old_credentials
+
+    monkeypatch.setattr("osmosis_ai.platform.auth.load_credentials", load_credentials)
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.verify_token", lambda token: fake_verify_result
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.save_credentials",
+        lambda creds: (
+            calls.append(("save_credentials", creds.access_token)) or "keyring"
+        ),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.platform_client.revoke_cli_token",
+        lambda creds: (
+            calls.append(("revoke_cli_token", creds.access_token, creds.token_id))
+            or True
+        ),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.local_config.clear_all_local_data",
+        lambda: calls.append(("clear_all_local_data",)),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.cli.commands.auth._load_login_workspaces", lambda creds: ([], None)
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.cli.commands.auth._ensure_login_workspace_selection",
+        lambda workspaces: (None, False),
+    )
+
+    exit_code = cli.main(["--json", "auth", "login", "--token", "new-token"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert json.loads(captured.out)["status"] == "success"
+    assert ("load_credentials", False) in calls
+    assert ("revoke_cli_token", "stored-token", "tok_old") in calls
+    assert ("clear_all_local_data",) not in calls
 
 
 def test_login_json_with_env_token_is_verify_only(

--- a/tests/unit/cli/test_auth_login_json.py
+++ b/tests/unit/cli/test_auth_login_json.py
@@ -290,6 +290,27 @@ def test_login_json_with_invalid_env_token_mentions_unset(
     assert "unset OSMOSIS_TOKEN" in envelope["error"]["message"]
 
 
+def test_login_json_with_generic_401_env_token_mentions_unset(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.setenv("OSMOSIS_TOKEN", "bad-env-token")
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.verify_token",
+        lambda token: (_ for _ in ()).throw(
+            LoginError("Authentication failed.", status_code=401)
+        ),
+    )
+
+    exit_code = cli.main(["--json", "auth", "login"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    envelope = json.loads(captured.err)
+    assert envelope["error"]["code"] == "AUTH_REQUIRED"
+    assert "OSMOSIS_TOKEN environment variable" in envelope["error"]["message"]
+    assert "unset OSMOSIS_TOKEN" in envelope["error"]["message"]
+
+
 def test_login_json_without_token_or_env_fails_interactive_required(
     monkeypatch, capsys
 ) -> None:

--- a/tests/unit/cli/test_auth_login_json.py
+++ b/tests/unit/cli/test_auth_login_json.py
@@ -108,6 +108,32 @@ def test_login_json_force_with_invalid_token_preserves_existing_session(
     assert side_effects == []
 
 
+def test_login_json_with_platform_verify_error_is_platform_error(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
+    monkeypatch.setattr("osmosis_ai.platform.auth.load_credentials", lambda: None)
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.verify_token",
+        lambda token: (_ for _ in ()).throw(
+            LoginError(
+                "Osmosis platform encountered an internal error. Please try again later.",
+                status_code=500,
+            )
+        ),
+    )
+
+    exit_code = cli.main(["--json", "auth", "login", "--token", "secret"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    envelope = json.loads(captured.err)
+    assert envelope["error"]["code"] == "PLATFORM_ERROR"
+    assert envelope["error"]["details"]["status_code"] == 500
+    assert "internal error" in envelope["error"]["message"]
+
+
 def test_login_json_replaces_session_before_revoking_old_token(
     monkeypatch, capsys, fake_verify_result
 ) -> None:
@@ -208,6 +234,60 @@ def test_login_rich_with_env_token_is_verify_only(
     assert verify_calls == ["env-token"]
     assert save_calls == []
     assert delete_calls == []
+
+
+@pytest.mark.parametrize(
+    "error_code",
+    ["AUTH_HEADER_MISSING", "TOKEN_MISSING", "TOKEN_INVALID", "UNKNOWN_AUTH_ERROR"],
+)
+def test_login_rich_with_invalid_env_token_mentions_unset(
+    monkeypatch, capsys, error_code: str
+) -> None:
+    monkeypatch.setenv("OSMOSIS_TOKEN", "bad-env-token")
+    errors = []
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.verify_token",
+        lambda token: (_ for _ in ()).throw(
+            LoginError("Token is invalid.", code=error_code)
+        ),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.cli.commands.auth.console.print_error",
+        lambda message: errors.append(message),
+    )
+
+    exit_code = cli.main(["auth", "login"])
+
+    capsys.readouterr()
+    message = errors[0]
+    assert exit_code == 1
+    assert "OSMOSIS_TOKEN environment variable is invalid or expired" in message
+    assert "unset OSMOSIS_TOKEN" in message
+
+
+@pytest.mark.parametrize(
+    "error_code",
+    ["AUTH_HEADER_MISSING", "TOKEN_MISSING", "TOKEN_INVALID", "UNKNOWN_AUTH_ERROR"],
+)
+def test_login_json_with_invalid_env_token_mentions_unset(
+    monkeypatch, capsys, error_code: str
+) -> None:
+    monkeypatch.setenv("OSMOSIS_TOKEN", "bad-env-token")
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.verify_token",
+        lambda token: (_ for _ in ()).throw(
+            LoginError("Token is invalid.", code=error_code)
+        ),
+    )
+
+    exit_code = cli.main(["--json", "auth", "login"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    envelope = json.loads(captured.err)
+    assert envelope["error"]["code"] == "AUTH_REQUIRED"
+    assert "OSMOSIS_TOKEN environment variable" in envelope["error"]["message"]
+    assert "unset OSMOSIS_TOKEN" in envelope["error"]["message"]
 
 
 def test_login_json_without_token_or_env_fails_interactive_required(

--- a/tests/unit/cli/test_auth_login_json.py
+++ b/tests/unit/cli/test_auth_login_json.py
@@ -73,7 +73,9 @@ def test_login_json_force_with_invalid_token_preserves_existing_session(
     monkeypatch.setattr("osmosis_ai.platform.auth.load_credentials", _credentials)
     monkeypatch.setattr(
         "osmosis_ai.platform.auth.verify_token",
-        lambda token: (_ for _ in ()).throw(LoginError("Authentication failed.")),
+        lambda token: (_ for _ in ()).throw(
+            LoginError("Authentication failed.", status_code=401)
+        ),
     )
     monkeypatch.setattr(
         "osmosis_ai.platform.auth.credentials.delete_credentials",
@@ -132,6 +134,29 @@ def test_login_json_with_platform_verify_error_is_platform_error(
     assert envelope["error"]["code"] == "PLATFORM_ERROR"
     assert envelope["error"]["details"]["status_code"] == 500
     assert "internal error" in envelope["error"]["message"]
+
+
+def test_login_json_with_malformed_verify_response_is_platform_error(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
+    monkeypatch.setattr("osmosis_ai.platform.auth.load_credentials", lambda: None)
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.verify_token",
+        lambda token: (_ for _ in ()).throw(
+            LoginError("Invalid response from platform")
+        ),
+    )
+
+    exit_code = cli.main(["--json", "auth", "login", "--token", "secret"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    envelope = json.loads(captured.err)
+    assert envelope["error"]["code"] == "PLATFORM_ERROR"
+    assert envelope["error"]["details"] == {}
+    assert envelope["error"]["message"] == "Invalid response from platform"
 
 
 def test_login_json_replaces_session_before_revoking_old_token(

--- a/tests/unit/cli/test_auth_login_json.py
+++ b/tests/unit/cli/test_auth_login_json.py
@@ -1,0 +1,255 @@
+"""auth login + logout JSON/plain contracts."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from osmosis_ai.cli import main as cli
+from osmosis_ai.platform.auth.credentials import Credentials, UserInfo
+from osmosis_ai.platform.auth.flow import LoginError, VerifyResult
+
+
+@pytest.fixture
+def fake_verify_result() -> VerifyResult:
+    return VerifyResult(
+        user=UserInfo(id="u1", email="brian@example.com", name="Brian"),
+        expires_at=datetime.now(UTC) + timedelta(days=30),
+        token_id="tok_1",
+    )
+
+
+def _credentials() -> Credentials:
+    return Credentials(
+        access_token="t",
+        token_type="Bearer",
+        expires_at=datetime.now(UTC) + timedelta(days=1),
+        created_at=datetime.now(UTC),
+        user=UserInfo(id="u", email="x@example.com", name=None),
+        token_id="tok",
+    )
+
+
+def test_login_json_with_token_returns_operation_result(
+    monkeypatch, capsys, fake_verify_result
+) -> None:
+    monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
+    monkeypatch.setattr("osmosis_ai.platform.auth.load_credentials", lambda: None)
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.verify_token", lambda token: fake_verify_result
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.save_credentials", lambda creds: "keyring"
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.cli.commands.auth._load_login_workspaces",
+        lambda creds: ([{"id": "ws_1", "name": "default"}], None),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.cli.commands.auth._ensure_login_workspace_selection",
+        lambda workspaces: (workspaces[0], True),
+    )
+
+    exit_code = cli.main(["--json", "auth", "login", "--token", "secret"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["status"] == "success"
+    assert payload["operation"] == "auth.login"
+    assert payload["resource"]["email"] == "brian@example.com"
+    assert payload["resource"]["workspace"] == {"id": "ws_1", "name": "default"}
+    assert payload["resource"]["verified"] is True
+    assert payload["resource"]["saved"] is True
+
+
+def test_login_json_force_with_invalid_token_preserves_existing_session(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
+    side_effects = []
+    monkeypatch.setattr("osmosis_ai.platform.auth.load_credentials", _credentials)
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.verify_token",
+        lambda token: (_ for _ in ()).throw(LoginError("Authentication failed.")),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.delete_credentials",
+        lambda: side_effects.append("delete_credentials"),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.save_credentials",
+        lambda creds: side_effects.append("save_credentials"),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.local_config.clear_all_local_data",
+        lambda: side_effects.append("clear_all_local_data"),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.platform_client.revoke_cli_token",
+        lambda creds: side_effects.append("revoke_cli_token"),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.cli.commands.auth._load_login_workspaces",
+        lambda creds: pytest.fail(
+            "workspace lookup should not run after verify failure"
+        ),
+    )
+
+    exit_code = cli.main(["--json", "auth", "login", "--force", "--token", "bad"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert captured.out == ""
+    envelope = json.loads(captured.err)
+    assert envelope["error"]["code"] == "AUTH_REQUIRED"
+    assert side_effects == []
+
+
+def test_login_json_replaces_session_before_revoking_old_token(
+    monkeypatch, capsys, fake_verify_result
+) -> None:
+    monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
+    calls = []
+    monkeypatch.setattr("osmosis_ai.platform.auth.load_credentials", _credentials)
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.verify_token", lambda token: fake_verify_result
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.save_credentials",
+        lambda creds: calls.append("save_credentials") or "keyring",
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.platform_client.revoke_cli_token",
+        lambda creds: calls.append("revoke_cli_token") or True,
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.local_config.clear_all_local_data",
+        lambda: calls.append("clear_all_local_data"),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.cli.commands.auth._load_login_workspaces", lambda creds: ([], None)
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.cli.commands.auth._ensure_login_workspace_selection",
+        lambda workspaces: (None, False),
+    )
+
+    exit_code = cli.main(["--json", "auth", "login", "--force", "--token", "secret"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert json.loads(captured.out)["status"] == "success"
+    assert calls[:2] == ["save_credentials", "revoke_cli_token"]
+
+
+def test_login_json_with_env_token_is_verify_only(
+    monkeypatch, capsys, fake_verify_result
+) -> None:
+    monkeypatch.setenv("OSMOSIS_TOKEN", "env-token")
+    save_calls = []
+    delete_calls = []
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.verify_token", lambda token: fake_verify_result
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.save_credentials",
+        lambda creds: save_calls.append(creds),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.delete_credentials",
+        lambda: delete_calls.append(True),
+    )
+
+    exit_code = cli.main(["--json", "auth", "login"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["resource"]["source"] == "environment"
+    assert payload["resource"]["verified"] is True
+    assert payload["resource"]["saved"] is False
+    assert save_calls == []
+    assert delete_calls == []
+
+
+def test_login_rich_with_env_token_is_verify_only(
+    monkeypatch, capsys, fake_verify_result
+) -> None:
+    monkeypatch.setenv("OSMOSIS_TOKEN", "env-token")
+    verify_calls = []
+    save_calls = []
+    delete_calls = []
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.verify_token",
+        lambda token: verify_calls.append(token) or fake_verify_result,
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.save_credentials",
+        lambda creds: save_calls.append(creds),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.delete_credentials",
+        lambda: delete_calls.append(True),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.device_login",
+        lambda: pytest.fail("device login should not run when OSMOSIS_TOKEN is set"),
+    )
+
+    exit_code = cli.main(["auth", "login"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Verified OSMOSIS_TOKEN for brian@example.com." in captured.out
+    assert "OSMOSIS_TOKEN was not saved to local credentials." in captured.out
+    assert verify_calls == ["env-token"]
+    assert save_calls == []
+    assert delete_calls == []
+
+
+def test_login_json_without_token_or_env_fails_interactive_required(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
+
+    exit_code = cli.main(["--json", "auth", "login"])
+
+    captured = capsys.readouterr()
+    assert exit_code != 0
+    assert captured.out == ""
+    envelope = json.loads(captured.err)
+    assert envelope["error"]["code"] == "INTERACTIVE_REQUIRED"
+
+
+def test_logout_json_without_yes_fails_fast(monkeypatch, capsys) -> None:
+    monkeypatch.setattr("osmosis_ai.platform.auth.load_credentials", _credentials)
+
+    exit_code = cli.main(["--json", "auth", "logout"])
+
+    captured = capsys.readouterr()
+    assert exit_code != 0
+    assert captured.out == ""
+    envelope = json.loads(captured.err)
+    assert envelope["error"]["code"] == "INTERACTIVE_REQUIRED"
+
+
+def test_logout_json_with_yes_returns_operation_result(monkeypatch, capsys) -> None:
+    monkeypatch.setattr("osmosis_ai.platform.auth.load_credentials", _credentials)
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.local_config.reset_session", lambda: None
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.platform_client.revoke_cli_token", lambda c: True
+    )
+
+    exit_code = cli.main(["--json", "auth", "logout", "--yes"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["status"] == "success"
+    assert payload["operation"] == "auth.logout"
+    assert payload["resource"]["revoked"] is True

--- a/tests/unit/cli/test_command_result_migration_train_model_deployment_rollout.py
+++ b/tests/unit/cli/test_command_result_migration_train_model_deployment_rollout.py
@@ -1,0 +1,332 @@
+"""CommandResult smoke tests for train/model/deployment/rollout commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from osmosis_ai.cli import main as cli
+from osmosis_ai.platform.api.models import (
+    BaseModelInfo,
+    DeploymentInfo,
+    DeploymentSummary,
+    MetricDataPoint,
+    MetricHistory,
+    PaginatedBaseModels,
+    PaginatedDeployments,
+    PaginatedRollouts,
+    PaginatedTrainingRuns,
+    RolloutInfo,
+    TrainingRun,
+    TrainingRunDetail,
+    TrainingRunMetrics,
+    TrainingRunMetricsOverview,
+)
+
+
+def _stub_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.utils._require_auth",
+        lambda: ("ws-test", object()),
+    )
+
+
+def _make_rollout_workspace(root: Path) -> Path:
+    for rel_path in (
+        ".osmosis/research",
+        "rollouts/demo",
+        "configs/training",
+        "configs/eval",
+        "data",
+    ):
+        (root / rel_path).mkdir(parents=True, exist_ok=True)
+    (root / ".osmosis" / "workspace.toml").write_text(
+        "[workspace]\nsetup_source = 'test'\n", encoding="utf-8"
+    )
+    (root / "rollouts" / "demo" / "main.py").write_text(
+        """
+from osmosis_ai.rollout.agent_workflow import AgentWorkflow
+from osmosis_ai.rollout.grader import Grader
+
+
+class DemoWorkflow(AgentWorkflow):
+    async def run(self, ctx):
+        return None
+
+
+class DemoGrader(Grader):
+    async def grade(self, ctx):
+        return 1.0
+""".strip(),
+        encoding="utf-8",
+    )
+    return root
+
+
+def test_train_list_json_returns_single_list_envelope(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _stub_auth(monkeypatch)
+
+    class FakeClient:
+        def list_training_runs(self, limit=30, offset=0, *, credentials=None):
+            return PaginatedTrainingRuns(
+                training_runs=[
+                    TrainingRun(
+                        id="run_1",
+                        name="reward-run",
+                        status="running",
+                        model_name="Qwen/Qwen3",
+                        created_at="2026-04-26T00:00:00Z",
+                    )
+                ],
+                total_count=1,
+                has_more=False,
+            )
+
+    monkeypatch.setattr("osmosis_ai.platform.api.client.OsmosisClient", FakeClient)
+
+    exit_code = cli.main(["--json", "train", "list"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["schema_version"] == 1
+    assert payload["items"][0]["name"] == "reward-run"
+    assert payload["total_count"] == 1
+    assert captured.out.count("\n") == 1
+
+
+def test_train_metrics_json_does_not_write_default_file(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    _stub_auth(monkeypatch)
+    osmosis_dir = tmp_path / ".osmosis"
+    osmosis_dir.mkdir()
+    (osmosis_dir / "workspace.toml").write_text("[workspace]\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    class FakeClient:
+        def get_training_run(self, name, *, credentials=None):
+            return TrainingRunDetail(
+                id="run_1",
+                name=name,
+                status="finished",
+                model_name="Qwen/Qwen3",
+            )
+
+        def get_training_run_metrics(self, run_id, *, credentials=None):
+            return TrainingRunMetrics(
+                training_run_id=run_id,
+                status="finished",
+                overview=TrainingRunMetricsOverview(
+                    mlflow_run_id="mlflow_1",
+                    mlflow_status="FINISHED",
+                    duration_ms=1000,
+                    duration_formatted="1s",
+                    reward=1.0,
+                    reward_delta=0.5,
+                    examples_processed_count=10,
+                ),
+                metrics=[
+                    MetricHistory(
+                        metric_key="rollout/raw_reward",
+                        title="Reward",
+                        data_points=[MetricDataPoint(step=1, value=1.0, timestamp=0)],
+                    )
+                ],
+            )
+
+    monkeypatch.setattr("osmosis_ai.platform.api.client.OsmosisClient", FakeClient)
+
+    exit_code = cli.main(["--json", "train", "metrics", "reward-run"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["data"]["metrics_available"] is True
+    assert payload["data"]["output_path"] is None
+    assert not (osmosis_dir / "metrics").exists()
+
+
+def test_train_traces_json_returns_structured_not_implemented_error(capsys) -> None:
+    exit_code = cli.main(["--json", "train", "traces"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert captured.out == ""
+    payload = json.loads(captured.err)
+    assert payload["error"]["code"] == "NOT_IMPLEMENTED"
+    assert "train traces" in payload["error"]["message"]
+
+
+def test_model_list_plain_is_tab_separated_rows(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _stub_auth(monkeypatch)
+
+    class FakeClient:
+        def list_base_models(self, limit=30, offset=0, *, credentials=None):
+            return PaginatedBaseModels(
+                models=[
+                    BaseModelInfo(
+                        id="model_1",
+                        model_name="Qwen/Qwen3",
+                        base_model="Qwen/Qwen3",
+                        status="ready",
+                        creator_name="brian",
+                        created_at="2026-04-26T00:00:00Z",
+                    )
+                ],
+                total_count=1,
+                has_more=False,
+            )
+
+    monkeypatch.setattr("osmosis_ai.platform.api.client.OsmosisClient", FakeClient)
+
+    exit_code = cli.main(["--plain", "model", "list"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert captured.out.splitlines() == [
+        "Qwen/Qwen3\tQwen/Qwen3\tready\tbrian\t2026-04-26T00:00:00Z\tmodel_1"
+    ]
+
+
+def test_deployment_commands_json_return_results(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _stub_auth(monkeypatch)
+
+    class FakeClient:
+        def list_deployments(self, limit=30, offset=0, *, credentials=None):
+            return PaginatedDeployments(
+                deployments=[
+                    DeploymentInfo(
+                        id="dep_1",
+                        checkpoint_name="run-step-1",
+                        status="active",
+                        checkpoint_step=1,
+                        base_model="Qwen/Qwen3",
+                    )
+                ],
+                total_count=1,
+                has_more=False,
+            )
+
+        def deploy_checkpoint(self, checkpoint, *, credentials=None):
+            return DeploymentSummary(
+                id="dep_1", checkpoint_name=checkpoint, status="active"
+            )
+
+    monkeypatch.setattr("osmosis_ai.platform.api.client.OsmosisClient", FakeClient)
+
+    exit_code = cli.main(["--json", "deployment", "list"])
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["items"][0]["checkpoint_name"] == "run-step-1"
+
+    exit_code = cli.main(["--json", "deploy", "run-step-1"])
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["operation"] == "deploy"
+    assert payload["resource"]["checkpoint_name"] == "run-step-1"
+
+
+def test_failed_deploy_json_exits_nonzero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _stub_auth(monkeypatch)
+
+    class FakeClient:
+        def deploy_checkpoint(self, checkpoint, *, credentials=None):
+            return DeploymentSummary(
+                id="dep_1",
+                checkpoint_name=checkpoint,
+                status="failed",
+            )
+
+    monkeypatch.setattr("osmosis_ai.platform.api.client.OsmosisClient", FakeClient)
+
+    exit_code = cli.main(["--json", "deploy", "run-step-1"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["operation"] == "deploy"
+    assert payload["status"] == "failed"
+
+
+def test_destructive_command_requires_yes_in_json(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _stub_auth(monkeypatch)
+
+    exit_code = cli.main(["--json", "deployment", "delete", "run-step-1"])
+    captured = capsys.readouterr()
+
+    assert exit_code != 0
+    assert captured.out == ""
+    payload = json.loads(captured.err)
+    assert payload["error"]["code"] == "INTERACTIVE_REQUIRED"
+
+
+def test_rollout_list_json_returns_envelope(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _stub_auth(monkeypatch)
+
+    class FakeClient:
+        def list_rollouts(self, limit=30, offset=0, *, credentials=None):
+            return PaginatedRollouts(
+                rollouts=[
+                    RolloutInfo(
+                        id="rollout_1",
+                        name="demo",
+                        is_active=True,
+                        repo_full_name="osmosis/demo",
+                        last_synced_commit_sha="abc123",
+                        created_at="2026-04-26T00:00:00Z",
+                    )
+                ],
+                total_count=1,
+                has_more=False,
+            )
+
+    monkeypatch.setattr("osmosis_ai.platform.api.client.OsmosisClient", FakeClient)
+
+    exit_code = cli.main(["--json", "rollout", "list"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["items"][0]["name"] == "demo"
+    assert payload["next_offset"] is None
+
+
+def test_rollout_validate_json_returns_detail_result(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    workspace = _make_rollout_workspace(tmp_path)
+    config_path = workspace / "configs" / "training" / "demo.toml"
+    config_path.write_text(
+        """
+[experiment]
+rollout = "demo"
+entrypoint = "main.py"
+model_path = "Qwen/Qwen3"
+dataset = "demo-dataset"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    exit_code = cli.main(["--json", "rollout", "validate", str(config_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["data"]["valid"] is True
+    assert payload["data"]["kind"] == "training"

--- a/tests/unit/cli/test_console.py
+++ b/tests/unit/cli/test_console.py
@@ -128,6 +128,102 @@ def test_print_respects_sep() -> None:
     assert "a|b|c" in output.getvalue()
 
 
+def test_print_soft_wrap_preserves_url_without_rich_line_breaks() -> None:
+    """URL output should not get hard line breaks inserted by Rich wrapping."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=True, no_color=True, width=92)
+    url = (
+        "https://platform.osmosis.ai/osmosis-shared/training/"
+        "328be61c-ef39-45e1-9b33-1e3c7c482e97"
+    )
+
+    console.print("  View: ", console.format_url(url), sep="", soft_wrap=True)
+
+    assert output.getvalue() == f"  View: {url}\n"
+
+
+def test_format_url_emits_terminal_hyperlink(monkeypatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    output = StringIO()
+    console = Console(file=output, force_terminal=True, width=120)
+    url = "https://platform.osmosis.ai/osmosis-shared/training/run-1"
+
+    console.print("View: ", console.format_url(url), sep="")
+
+    rendered = output.getvalue()
+    assert "\x1b]8;" in rendered
+    assert url in rendered
+
+
+def test_format_url_handles_brackets_in_url(monkeypatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    output = StringIO()
+    console = Console(file=output, force_terminal=True, width=120)
+    url = "https://platform.osmosis.ai/osmosis-shared/training/run-1?filter[]=ok"
+
+    console.print("View: ", console.format_url(url), sep="")
+
+    rendered = output.getvalue()
+    assert "\x1b]8;" in rendered
+    assert url in rendered
+
+
+def test_print_error_preserves_url_without_rich_line_breaks(monkeypatch) -> None:
+    """URL-bearing error messages should stay copyable in captured output."""
+    error_output = StringIO()
+    monkeypatch.setattr(sys, "stderr", error_output)
+    console = Console(file=StringIO(), force_terminal=True, no_color=True, width=92)
+    url = (
+        "https://platform.osmosis.ai/osmosis-shared/settings/billing/"
+        "328be61c-ef39-45e1-9b33-1e3c7c482e97"
+    )
+
+    console.print_error(f"Upgrade at: {url}", soft_wrap=True)
+
+    assert error_output.getvalue() == f"Upgrade at: {url}\n"
+
+
+def test_print_error_does_not_parse_rich_markup(monkeypatch) -> None:
+    error_output = StringIO()
+    monkeypatch.setattr(sys, "stderr", error_output)
+    console = Console(file=StringIO(), force_terminal=True, no_color=True, width=120)
+
+    console.print_error("Missing [experiment] section", soft_wrap=True)
+
+    assert error_output.getvalue() == "Missing [experiment] section\n"
+
+
+def test_table_url_emits_terminal_hyperlink(monkeypatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    output = StringIO()
+    console = Console(file=output, force_terminal=True, width=120)
+    url = "https://platform.osmosis.ai/osmosis-shared/datasets/dataset-1"
+
+    console.table([("URL", console.format_url(url))], title="Dataset")
+
+    rendered = output.getvalue()
+    assert "\x1b]8;" in rendered
+    assert url in rendered
+
+
+def test_format_url_uses_label_for_visible_text(monkeypatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    output = StringIO()
+    console = Console(file=output, force_terminal=True, width=120)
+    url = "https://platform.osmosis.ai/osmosis-shared/integrations/git"
+
+    console.print("Open ", console.format_url(url, label="Git Sync"), sep="")
+
+    rendered = output.getvalue()
+    assert "\x1b]8;" in rendered
+    assert url in rendered
+    assert "Git Sync" in rendered
+
+
 def test_non_tty_output_has_no_ansi() -> None:
     """Non-TTY output should not contain ANSI escape codes."""
     output = StringIO()

--- a/tests/unit/cli/test_console.py
+++ b/tests/unit/cli/test_console.py
@@ -356,3 +356,28 @@ def test_format_styled_escapes_brackets() -> None:
     result = c.format_styled("[bold]text", "cyan")
     assert "\\[bold]" in result  # opening bracket escaped
     assert "cyan" in result
+
+
+# ── format_text / print_url ──────────────────────────────────────────
+
+
+def test_format_text_does_not_parse_markup() -> None:
+    output = StringIO()
+    console = Console(file=output, force_terminal=True, no_color=True, width=120)
+
+    console.print(console.format_text("[red]model-123[/red]", style="green"))
+
+    assert output.getvalue() == "[red]model-123[/red]\n"
+
+
+def test_print_url_preserves_url_without_rich_line_breaks() -> None:
+    output = StringIO()
+    console = Console(file=output, force_terminal=True, no_color=True, width=92)
+    url = (
+        "https://platform.osmosis.ai/osmosis-shared/training/"
+        "328be61c-ef39-45e1-9b33-1e3c7c482e97?filter[]=ok"
+    )
+
+    console.print_url("  View: ", url)
+
+    assert output.getvalue() == f"  View: {url}\n"

--- a/tests/unit/cli/test_dataset_commands_json.py
+++ b/tests/unit/cli/test_dataset_commands_json.py
@@ -1,0 +1,353 @@
+"""Tests for dataset commands in JSON/plain output modes."""
+
+from __future__ import annotations
+
+import builtins
+import json
+from contextlib import nullcontext
+from pathlib import Path
+
+import osmosis_ai.cli.main as cli
+import osmosis_ai.platform.api.client as api_client_module
+import osmosis_ai.platform.api.download as download_module
+import osmosis_ai.platform.api.upload as upload_module
+import osmosis_ai.platform.cli.dataset as dataset_module
+from osmosis_ai.platform.api.models import (
+    AffectedTrainingRun,
+    DatasetAffectedResources,
+    DatasetDownloadInfo,
+    DatasetFile,
+    PaginatedDatasets,
+    UploadInfo,
+)
+
+
+def _stub_auth(monkeypatch) -> object:
+    fake_credentials = object()
+    monkeypatch.setattr(
+        dataset_module,
+        "_require_auth",
+        lambda: ("ws-a", fake_credentials),
+    )
+    monkeypatch.setattr(
+        dataset_module,
+        "_require_subscription",
+        lambda *, workspace_name: None,
+    )
+    return fake_credentials
+
+
+def _dataset(
+    *,
+    id: str = "ds_1",
+    file_name: str = "train.jsonl",
+    file_size: int = 100,
+    status: str = "uploaded",
+    data_preview=None,
+) -> DatasetFile:
+    return DatasetFile(
+        id=id,
+        file_name=file_name,
+        file_size=file_size,
+        status=status,
+        data_preview=data_preview,
+        created_at="2026-04-26T00:00:00Z",
+        updated_at="2026-04-26T00:00:01Z",
+    )
+
+
+def test_dataset_list_json_envelope(monkeypatch, capsys) -> None:
+    fake_credentials = _stub_auth(monkeypatch)
+
+    class FakeClient:
+        def list_datasets(self, *, limit, offset, credentials=None):
+            assert credentials is fake_credentials
+            assert limit == 10
+            assert offset == 0
+            return PaginatedDatasets(
+                datasets=[_dataset()],
+                total_count=20,
+                has_more=True,
+                next_offset=10,
+            )
+
+    monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+
+    exit_code = cli.main(["--json", "dataset", "list", "--limit", "10"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["schema_version"] == 1
+    assert payload["items"][0]["id"] == "ds_1"
+    assert payload["total_count"] == 20
+    assert payload["has_more"] is True
+    assert payload["next_offset"] == 10
+
+
+def test_dataset_list_plain_emits_tab_separated_rows(monkeypatch, capsys) -> None:
+    _stub_auth(monkeypatch)
+
+    class FakeClient:
+        def list_datasets(self, *, limit, offset, credentials=None):
+            return PaginatedDatasets(
+                datasets=[
+                    _dataset(id="ds_1", file_name="a.jsonl", status="uploaded"),
+                    _dataset(id="ds_2", file_name="b.jsonl", status="pending"),
+                ],
+                total_count=2,
+                has_more=False,
+            )
+
+    monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+
+    exit_code = cli.main(["--plain", "dataset", "list"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert captured.out.splitlines() == [
+        "a.jsonl\t[uploaded]\t100 B\t2026-04-26\tds_1",
+        "b.jsonl\t[pending]\t100 B\t2026-04-26\tds_2",
+    ]
+
+
+def test_dataset_info_json_envelope(monkeypatch, capsys) -> None:
+    _stub_auth(monkeypatch)
+
+    class FakeClient:
+        def get_dataset(self, name, *, credentials=None):
+            assert name == "ds_1"
+            return _dataset(file_size=12345)
+
+    monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+
+    exit_code = cli.main(["--json", "dataset", "info", "ds_1"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["schema_version"] == 1
+    assert payload["data"]["id"] == "ds_1"
+    assert payload["data"]["file_size"] == 12345
+
+
+def test_dataset_preview_json_includes_rows(monkeypatch, capsys) -> None:
+    _stub_auth(monkeypatch)
+    rows = [{"system_prompt": "s", "user_prompt": "u", "ground_truth": "g"}]
+
+    class FakeClient:
+        def get_dataset(self, name, *, credentials=None):
+            return _dataset(data_preview=rows)
+
+    monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+
+    exit_code = cli.main(["--json", "dataset", "preview", "ds_1", "--rows", "1"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["data"]["available"] is True
+    assert payload["data"]["rows"] == rows
+
+
+def test_dataset_validate_json_envelope(tmp_path: Path, capsys) -> None:
+    file_path = tmp_path / "train.jsonl"
+    file_path.write_text(
+        json.dumps({"system_prompt": "s", "user_prompt": "u", "ground_truth": "g"})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = cli.main(["--json", "dataset", "validate", str(file_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["data"]["valid"] is True
+    assert payload["data"]["file_name"] == "train.jsonl"
+
+
+def test_dataset_validate_json_includes_parquet_warning_when_pyarrow_missing(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    real_import = builtins.__import__
+
+    def _block_pyarrow(name: str, *args, **kwargs):
+        if name == "pyarrow.parquet" or name == "pyarrow":
+            raise ImportError("mocked missing pyarrow")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _block_pyarrow)
+    file_path = tmp_path / "train.parquet"
+    file_path.write_bytes(b"fake parquet data")
+
+    exit_code = cli.main(["--json", "dataset", "validate", str(file_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["data"]["valid"] is True
+    assert payload["data"]["warnings"]
+    assert "pyarrow not installed" in payload["data"]["warnings"][0]
+
+
+def test_dataset_upload_json_stdout_is_one_envelope(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    fake_credentials = _stub_auth(monkeypatch)
+    file_path = tmp_path / "train.jsonl"
+    file_path.write_text(
+        json.dumps({"system_prompt": "s", "user_prompt": "u", "ground_truth": "g"})
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        upload_module,
+        "make_progress_bar",
+        lambda _size, **_kwargs: (nullcontext(), lambda _done, _total: None),
+    )
+    monkeypatch.setattr(
+        upload_module,
+        "upload_file_simple",
+        lambda _file_path, _upload_info, progress_callback=None: None,
+    )
+
+    class FakeClient:
+        def create_dataset(self, file_name, file_size, extension, *, credentials=None):
+            assert credentials is fake_credentials
+            return DatasetFile(
+                id="ds_1",
+                file_name=file_name,
+                file_size=file_size,
+                status="created",
+                upload=UploadInfo(
+                    method="simple",
+                    s3_key="uploads/train",
+                    presigned_url="https://example.com/upload",
+                ),
+            )
+
+        def complete_upload(self, file_id, parts=None, *, credentials=None):
+            assert file_id == "ds_1"
+            assert credentials is fake_credentials
+            return _dataset(id=file_id)
+
+    monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+
+    exit_code = cli.main(["--json", "dataset", "upload", str(file_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["operation"] == "dataset.upload"
+    assert payload["resource"]["id"] == "ds_1"
+    assert "Uploading" not in captured.out
+
+
+def test_dataset_download_json_includes_output_path(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    _stub_auth(monkeypatch)
+    output_path = tmp_path / "out.jsonl"
+
+    class FakeClient:
+        def get_dataset(self, name, *, credentials=None):
+            return _dataset()
+
+        def get_dataset_download_url(self, name, *, credentials=None):
+            return DatasetDownloadInfo(
+                presigned_url="https://example.com/train.jsonl",
+                expires_in=3600,
+            )
+
+    def fake_download_file(
+        url,
+        *,
+        output,
+        default_filename,
+        expected_size,
+        overwrite,
+        output_is_directory,
+    ):
+        return output_path
+
+    monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+    monkeypatch.setattr(download_module, "download_file", fake_download_file)
+
+    exit_code = cli.main(
+        [
+            "--json",
+            "dataset",
+            "download",
+            "ds_1",
+            "--output",
+            str(output_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["operation"] == "dataset.download"
+    assert payload["resource"]["output_path"] == str(output_path)
+
+
+def test_dataset_delete_json_with_yes_returns_operation(
+    monkeypatch,
+    capsys,
+) -> None:
+    _stub_auth(monkeypatch)
+
+    class FakeClient:
+        def get_dataset_affected_resources(self, name, *, credentials=None):
+            return DatasetAffectedResources(affected_training_runs=[])
+
+        def delete_dataset(self, name, *, credentials=None):
+            return True
+
+    monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+
+    exit_code = cli.main(["--json", "dataset", "delete", "ds_1", "--yes"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["operation"] == "dataset.delete"
+    assert payload["status"] == "success"
+    assert payload["resource"]["id"] == "ds_1"
+
+
+def test_dataset_delete_json_conflict_includes_blocking_runs(
+    monkeypatch,
+    capsys,
+) -> None:
+    _stub_auth(monkeypatch)
+
+    class FakeClient:
+        def get_dataset_affected_resources(self, name, *, credentials=None):
+            return DatasetAffectedResources(
+                affected_training_runs=[
+                    AffectedTrainingRun(
+                        id="run_1",
+                        training_run_name="active-run",
+                    )
+                ]
+            )
+
+    monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+
+    exit_code = cli.main(["--json", "dataset", "delete", "ds_1", "--yes"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    payload = json.loads(captured.err)
+    assert payload["error"]["code"] == "CONFLICT"
+    assert payload["error"]["details"]["training_runs"] == [
+        {"id": "run_1", "training_run_name": "active-run"}
+    ]

--- a/tests/unit/cli/test_deployment_commands.py
+++ b/tests/unit/cli/test_deployment_commands.py
@@ -11,6 +11,13 @@ import osmosis_ai.cli.commands.deployment as deployment_module
 import osmosis_ai.platform.api.client as api_client_module
 import osmosis_ai.platform.cli.utils as utils_module
 from osmosis_ai.cli.console import Console
+from osmosis_ai.cli.output import (
+    DetailResult,
+    ListResult,
+    OperationResult,
+    OutputFormat,
+    override_output_context,
+)
 from osmosis_ai.platform.api.models import (
     DeploymentInfo,
     DeploymentSummary,
@@ -49,8 +56,13 @@ class TestListDeployments:
                 )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        deployment_module.list_deployments(limit=30, all_=False)
-        assert "No deployments found" in console_capture.getvalue()
+        result = deployment_module.list_deployments(limit=30, all_=False)
+
+        assert isinstance(result, ListResult)
+        assert result.title == "Deployments"
+        assert result.items == []
+        assert result.total_count == 0
+        assert result.has_more is False
 
     def test_list_with_deployments(
         self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
@@ -75,16 +87,16 @@ class TestListDeployments:
                 )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        deployment_module.list_deployments(limit=10, all_=False)
-        out = console_capture.getvalue()
+        result = deployment_module.list_deployments(limit=10, all_=False)
         assert captured == {
             "limit": 10,
             "offset": 0,
             "credentials": AUTH_CREDENTIALS,
         }
-        assert "Deployments" in out
-        assert "qwen3-run1-step-100" in out
-        assert "Qwen/Qwen3" in out
+        assert isinstance(result, ListResult)
+        assert result.title == "Deployments"
+        assert result.items[0]["checkpoint_name"] == "qwen3-run1-step-100"
+        assert result.items[0]["base_model"] == "Qwen/Qwen3"
 
 
 class TestInfo:
@@ -110,21 +122,20 @@ class TestInfo:
                 )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        deployment_module.info(checkpoint=checkpoint_id)
-        out = console_capture.getvalue()
+        result = deployment_module.info(checkpoint=checkpoint_id)
         assert captured == {
             "checkpoint": checkpoint_id,
             "credentials": AUTH_CREDENTIALS,
         }
-        assert "qwen3-run1-step-100" in out
-        assert "Qwen/Qwen3" in out
-        assert "qwen3-run1" in out
+        assert isinstance(result, DetailResult)
+        assert result.title == "Deployment"
+        assert result.data["checkpoint_name"] == "qwen3-run1-step-100"
+        assert result.data["base_model"] == "Qwen/Qwen3"
+        assert result.data["training_run_name"] == "qwen3-run1"
 
     def test_info_escapes_status_for_rich_table(
         self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
     ) -> None:
-        captured_rows: list[tuple[str, str]] = []
-
         class FakeClient:
             def get_deployment(self, checkpoint, *, credentials=None):
                 return DeploymentInfo(
@@ -135,15 +146,14 @@ class TestInfo:
                     base_model="Qwen/Qwen3",
                 )
 
-        def record_table(rows, *args, **kwargs):
-            captured_rows.extend(rows)
-
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        monkeypatch.setattr(deployment_module.console, "table", record_table)
 
-        deployment_module.info(checkpoint="qwen3-run1-step-100")
+        result = deployment_module.info(checkpoint="qwen3-run1-step-100")
 
-        assert ("Status", "\\[red]failed\\[/red]") in captured_rows
+        assert isinstance(result, DetailResult)
+        assert ("Status", "\\[red]failed\\[/red]") in [
+            (field.label, field.value) for field in result.fields
+        ]
 
 
 class TestDeploy:
@@ -163,12 +173,20 @@ class TestDeploy:
                 )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        deployment_module.deploy(checkpoint="qwen3-run1-step-100")
+        result = deployment_module.deploy(checkpoint="qwen3-run1-step-100")
         assert captured == {
             "checkpoint": "qwen3-run1-step-100",
             "credentials": AUTH_CREDENTIALS,
         }
-        assert "qwen3-run1-step-100" in console_capture.getvalue()
+        assert isinstance(result, OperationResult)
+        assert result.operation == "deploy"
+        assert result.status == "success"
+        assert result.resource == {
+            "id": "dep_1",
+            "checkpoint_name": "qwen3-run1-step-100",
+            "status": "active",
+        }
+        assert result.message == "Deployment qwen3-run1-step-100 active"
 
     def test_deploy_escapes_checkpoint_in_spinner(
         self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
@@ -190,29 +208,20 @@ class TestDeploy:
                 )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        monkeypatch.setattr(deployment_module.console, "spinner", record_spinner)
 
-        deployment_module.deploy(checkpoint="[red]bad[/red]")
+        with override_output_context(
+            format=OutputFormat.rich, interactive=True
+        ) as output:
+            monkeypatch.setattr(output, "status", record_spinner)
+            result = deployment_module.deploy(checkpoint="[red]bad[/red]")
 
         assert captured["checkpoint"] == "[red]bad[/red]"
         assert captured["message"] == 'Deploying checkpoint "\\[red]bad\\[/red]"...'
+        assert isinstance(result, OperationResult)
 
     def test_deploy_failed_result_does_not_force_message_green(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        output = StringIO()
-        tty_console = Console(file=output, force_terminal=True, width=120)
-        print_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
-
-        original_print = tty_console.print
-
-        def record_print(*args, **kwargs):
-            print_calls.append((args, kwargs))
-            original_print(*args, **kwargs)
-
-        monkeypatch.setattr(tty_console, "print", record_print)
-        monkeypatch.setattr(deployment_module, "console", tty_console)
-
         class FakeClient:
             def deploy_checkpoint(self, checkpoint, *, credentials=None):
                 return DeploymentSummary(
@@ -222,12 +231,12 @@ class TestDeploy:
                 )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        deployment_module.deploy(checkpoint="qwen3-run1-step-100")
+        result = deployment_module.deploy(checkpoint="qwen3-run1-step-100")
 
-        args, kwargs = print_calls[-1]
-        assert args == ("Deployment qwen3-run1-step-100 [red]\\[failed][/red]",)
-        assert kwargs.get("style") is None
-        assert kwargs["highlight"] is False
+        assert isinstance(result, OperationResult)
+        assert result.status == "failed"
+        assert result.message == "Deployment qwen3-run1-step-100 failed"
+        assert result.exit_code == 1
 
 
 class TestUndeploy:
@@ -248,14 +257,20 @@ class TestUndeploy:
                 )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        deployment_module.undeploy(checkpoint=checkpoint_id)
-        out = console_capture.getvalue()
+        result = deployment_module.undeploy(checkpoint=checkpoint_id)
         assert captured == {
             "checkpoint": checkpoint_id,
             "credentials": AUTH_CREDENTIALS,
         }
-        assert "qwen3-run1-step-100" in out
-        assert "inactive" in out
+        assert isinstance(result, OperationResult)
+        assert result.operation == "undeploy"
+        assert result.status == "success"
+        assert result.resource == {
+            "id": checkpoint_id,
+            "checkpoint_name": "qwen3-run1-step-100",
+            "status": "inactive",
+        }
+        assert result.message == "Deployment qwen3-run1-step-100 inactive"
 
     def test_undeploy_escapes_checkpoint_in_spinner(
         self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
@@ -277,12 +292,34 @@ class TestUndeploy:
                 )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        monkeypatch.setattr(deployment_module.console, "spinner", record_spinner)
 
-        deployment_module.undeploy(checkpoint="[red]bad[/red]")
+        with override_output_context(
+            format=OutputFormat.rich, interactive=True
+        ) as output:
+            monkeypatch.setattr(output, "status", record_spinner)
+            result = deployment_module.undeploy(checkpoint="[red]bad[/red]")
 
         assert captured["checkpoint"] == "[red]bad[/red]"
         assert captured["message"] == 'Undeploying checkpoint "\\[red]bad\\[/red]"...'
+        assert isinstance(result, OperationResult)
+
+    def test_undeploy_failed_result_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class FakeClient:
+            def undeploy_checkpoint(self, checkpoint, *, credentials=None):
+                return DeploymentSummary(
+                    id="dep_1",
+                    checkpoint_name="qwen3-run1-step-100",
+                    status="failed",
+                )
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        result = deployment_module.undeploy(checkpoint="qwen3-run1-step-100")
+
+        assert isinstance(result, OperationResult)
+        assert result.status == "failed"
+        assert result.exit_code == 1
 
 
 class TestRename:
@@ -304,13 +341,22 @@ class TestRename:
                 )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        deployment_module.rename(checkpoint="old-name", new_name="new-name")
+        result = deployment_module.rename(checkpoint="old-name", new_name="new-name")
         assert captured == {
             "checkpoint": "old-name",
             "new_name": "new-name",
             "credentials": AUTH_CREDENTIALS,
         }
-        assert "Renamed old-name -> new-name" in console_capture.getvalue()
+        assert isinstance(result, OperationResult)
+        assert result.operation == "deployment.rename"
+        assert result.status == "success"
+        assert result.resource == {
+            "id": "dep_1",
+            "old_checkpoint_name": "old-name",
+            "checkpoint_name": "new-name",
+            "status": "active",
+        }
+        assert result.message == "Renamed old-name -> new-name"
 
     def test_rename_warns_when_reregistration_fails(
         self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
@@ -325,8 +371,14 @@ class TestRename:
                 )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        deployment_module.rename(checkpoint="old-name", new_name="new-name")
-        assert "re-registration failed" in console_capture.getvalue()
+        result = deployment_module.rename(checkpoint="old-name", new_name="new-name")
+
+        assert isinstance(result, OperationResult)
+        assert result.status == "failed"
+        assert result.display_next_steps == [
+            "Warning: inference re-registration failed; deployment is marked as failed."
+        ]
+        assert result.exit_code == 1
 
 
 class TestDelete:
@@ -342,9 +394,13 @@ class TestDelete:
                 return True
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        deployment_module.delete(checkpoint="qwen3-run1-step-100", yes=True)
+        result = deployment_module.delete(checkpoint="qwen3-run1-step-100", yes=True)
         assert captured == {
             "checkpoint": "qwen3-run1-step-100",
             "credentials": AUTH_CREDENTIALS,
         }
-        assert "deleted" in console_capture.getvalue()
+        assert isinstance(result, OperationResult)
+        assert result.operation == "deployment.delete"
+        assert result.status == "success"
+        assert result.resource == {"checkpoint": "qwen3-run1-step-100"}
+        assert result.message == 'Deployment for "qwen3-run1-step-100" deleted.'

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -1,0 +1,42 @@
+"""Tests for the structured CLIError signature."""
+
+from __future__ import annotations
+
+from osmosis_ai.cli.errors import CLIError
+
+
+def test_positional_message_defaults_to_validation() -> None:
+    err = CLIError("Something went wrong.")
+    assert err.message == "Something went wrong."
+    assert str(err) == "Something went wrong."
+    assert err.code == "VALIDATION"
+    assert err.details == {}
+    assert err.request_id is None
+
+
+def test_explicit_code_is_preserved() -> None:
+    err = CLIError("Not found.", code="NOT_FOUND")
+    assert err.code == "NOT_FOUND"
+
+
+def test_details_coerced_to_dict() -> None:
+    err = CLIError("Bad", details={"field": "name"})
+    assert err.details == {"field": "name"}
+
+
+def test_details_default_is_empty_dict() -> None:
+    err = CLIError("Bad")
+    assert err.details == {}
+    err.details["x"] = 1
+    assert CLIError("Other").details == {}
+
+
+def test_request_id_is_optional() -> None:
+    err = CLIError("Bad", request_id="req_abc")
+    assert err.request_id == "req_abc"
+
+
+def test_empty_message_is_allowed() -> None:
+    err = CLIError(code="INTERACTIVE_REQUIRED")
+    assert err.message == ""
+    assert err.code == "INTERACTIVE_REQUIRED"

--- a/tests/unit/cli/test_eval_rubric_json.py
+++ b/tests/unit/cli/test_eval_rubric_json.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import AsyncMock
+
+import pytest
+
+from osmosis_ai.cli import main as cli
+from osmosis_ai.eval.rubric.types import RubricResult
+
+
+def test_eval_rubric_json_returns_operation_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    capsys,
+) -> None:
+    data_path = tmp_path / "records.jsonl"
+    data_path.write_text(
+        json.dumps(
+            {
+                "messages": [
+                    {"role": "user", "content": "Help me"},
+                    {"role": "assistant", "content": "Sure."},
+                ]
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    mock_eval = AsyncMock(
+        return_value=RubricResult(score=0.8, explanation="good", raw={})
+    )
+    monkeypatch.setattr("osmosis_ai.eval.rubric.cli.evaluate_rubric", mock_eval)
+
+    exit_code = cli.main(
+        [
+            "--json",
+            "eval",
+            "rubric",
+            "-d",
+            str(data_path),
+            "--rubric",
+            "Score quality.",
+            "--model",
+            "openai/gpt-5.4",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.err == ""
+    payload = json.loads(captured.out)
+    assert payload["schema_version"] == 1
+    assert payload["status"] == "success"
+    assert payload["operation"] == "eval.rubric"
+    assert payload["resource"]["statistics"]["average"] == pytest.approx(0.8)
+    assert payload["resource"]["records"][0]["scores"] == [0.8]
+
+
+def test_eval_rubric_json_output_file_omits_records(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    capsys,
+) -> None:
+    data_path = tmp_path / "records.jsonl"
+    data_path.write_text(
+        json.dumps({"solution_str": "answer", "id": "row-1"}) + "\n",
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "result.json"
+    monkeypatch.setattr(
+        "osmosis_ai.eval.rubric.cli.evaluate_rubric",
+        AsyncMock(return_value=RubricResult(score=1.0, explanation="ok", raw={})),
+    )
+
+    exit_code = cli.main(
+        [
+            "--json",
+            "eval",
+            "rubric",
+            "-d",
+            str(data_path),
+            "--rubric",
+            "Score quality.",
+            "--model",
+            "openai/gpt-5.4",
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["resource"]["output_path"] == str(output_path)
+    assert "records" not in payload["resource"]
+    assert output_path.exists()
+
+
+def test_eval_rubric_json_suppresses_tty_progress(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    capsys,
+) -> None:
+    data_path = tmp_path / "records.jsonl"
+    data_path.write_text(
+        json.dumps({"solution_str": "answer", "id": "row-1"}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: True)
+    monkeypatch.setattr(
+        "osmosis_ai.eval.rubric.cli.evaluate_rubric",
+        AsyncMock(return_value=RubricResult(score=1.0, explanation="ok", raw={})),
+    )
+
+    exit_code = cli.main(
+        [
+            "--json",
+            "eval",
+            "rubric",
+            "-d",
+            str(data_path),
+            "--rubric",
+            "Score quality.",
+            "--model",
+            "openai/gpt-5.4",
+            "--number",
+            "2",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.err == ""
+    payload = json.loads(captured.out)
+    assert payload["status"] == "success"

--- a/tests/unit/cli/test_eval_rubric_json.py
+++ b/tests/unit/cli/test_eval_rubric_json.py
@@ -135,3 +135,40 @@ def test_eval_rubric_json_suppresses_tty_progress(
     assert captured.err == ""
     payload = json.loads(captured.out)
     assert payload["status"] == "success"
+
+
+def test_eval_rubric_plain_allows_tty_progress(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    capsys,
+) -> None:
+    data_path = tmp_path / "records.jsonl"
+    data_path.write_text(
+        json.dumps({"solution_str": "answer", "id": "row-1"}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: True)
+    monkeypatch.setattr(
+        "osmosis_ai.eval.rubric.cli.evaluate_rubric",
+        AsyncMock(return_value=RubricResult(score=1.0, explanation="ok", raw={})),
+    )
+
+    exit_code = cli.main(
+        [
+            "--plain",
+            "eval",
+            "rubric",
+            "-d",
+            str(data_path),
+            "--rubric",
+            "Score quality.",
+            "--model",
+            "openai/gpt-5.4",
+            "--number",
+            "2",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.err != ""

--- a/tests/unit/cli/test_eval_run_json.py
+++ b/tests/unit/cli/test_eval_run_json.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from osmosis_ai.cli import main as cli
+from osmosis_ai.eval.config import EvalConfig
+from osmosis_ai.eval.evaluation.orchestrator import OrchestratorResult
+
+
+class _FakeProxy:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.started = False
+
+    async def preflight_check(self) -> None:
+        return None
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.started = False
+
+
+class _FakeOrchestrator:
+    def __init__(self, **kwargs: Any) -> None:
+        self.on_progress = kwargs["on_progress"]
+        self.cache_config = kwargs["cache_config"]
+
+    async def run(self) -> OrchestratorResult:
+        self.on_progress(
+            1,
+            2,
+            {
+                "success": True,
+                "duration_ms": 10.0,
+                "tokens": 12,
+                "reward": 0.9,
+            },
+        )
+        cache_path = Path("/tmp/eval-cache.json")
+        return OrchestratorResult(
+            status="completed",
+            cache_path=cache_path,
+            samples_path=None,
+            summary={
+                "total_runs": 2,
+                "passed": 1,
+                "failed": 1,
+                "total_tokens": 24,
+                "total_duration_ms": 20.0,
+                "reward_stats": {"mean": 0.9},
+            },
+            total_completed=2,
+            total_expected=2,
+            cache_data={
+                "runs": [
+                    {"row_index": 0, "run_index": 0, "success": True, "reward": 0.9},
+                    {
+                        "row_index": 1,
+                        "run_index": 0,
+                        "success": False,
+                        "error": "boom",
+                    },
+                ]
+            },
+        )
+
+
+def test_eval_run_json_returns_final_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    capsys,
+) -> None:
+    config_path = tmp_path / "eval.toml"
+    dataset_path = tmp_path / "data.jsonl"
+    config_path.write_text("[eval]\n", encoding="utf-8")
+    dataset_path.write_text('{"input": "x"}\n', encoding="utf-8")
+
+    config = EvalConfig(
+        eval_dataset=str(dataset_path),
+        eval_rollout="demo_rollout",
+        eval_entrypoint="workflow.py",
+        llm_model="openai/gpt-5.4",
+        output_quiet=False,
+    )
+
+    fake_workflow = type("FakeWorkflow", (), {})
+    fake_grader = type("FakeGrader", (), {})
+
+    monkeypatch.setattr("osmosis_ai.eval.config.load_eval_config", lambda path: config)
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.workspace_contract.resolve_workspace_root",
+        lambda path: path.parent,
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.workspace_contract.validate_workspace_contract",
+        lambda workspace_root: None,
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.workspace_contract.ensure_workspace_config_path",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.eval.common.cli.load_dataset_rows",
+        lambda **kwargs: ([{"input": "x"}, {"input": "y"}], None),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.eval.common.cli.load_workflow",
+        lambda **kwargs: (fake_workflow, None, "fake_entrypoint", None),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.eval.common.cli._resolve_grader",
+        lambda *args, **kwargs: (fake_grader, None),
+    )
+    monkeypatch.setattr("osmosis_ai.eval.llm_proxy.LiteLLMProxy", _FakeProxy)
+    monkeypatch.setattr(
+        "osmosis_ai.rollout.backend.local.backend.LocalBackend",
+        lambda **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.rollout.driver.InProcessDriver",
+        lambda **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.eval.evaluation.cache.compute_module_fingerprint",
+        lambda module: "module-fingerprint",
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.eval.evaluation.orchestrator.EvalOrchestrator",
+        _FakeOrchestrator,
+    )
+
+    exit_code = cli.main(["--json", "eval", "run", str(config_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.err == ""
+    payload = json.loads(captured.out)
+    assert payload["schema_version"] == 1
+    assert payload["data"]["total_runs"] == 2
+    assert payload["data"]["completed_runs"] == 2
+    assert payload["data"]["failed_runs"] == 1
+    assert payload["data"]["cache_path"] == "/tmp/eval-cache.json"
+    assert payload["data"]["output_path"] is None
+    assert payload["data"]["partial_failures"] == [
+        {
+            "row_index": 1,
+            "run_index": 0,
+            "model_tag": None,
+            "error": "boom",
+        }
+    ]

--- a/tests/unit/cli/test_init_json.py
+++ b/tests/unit/cli/test_init_json.py
@@ -1,0 +1,77 @@
+"""Init command JSON/plain contracts."""
+
+from __future__ import annotations
+
+import json
+
+from osmosis_ai.cli import main as cli
+
+
+def test_init_json_returns_created_paths_and_next_steps(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    import osmosis_ai.platform.cli.init as init_module
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
+    monkeypatch.setattr(init_module, "_write_scaffold", lambda *args, **kwargs: None)
+    monkeypatch.setattr(init_module, "_git_init", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        init_module, "_git_initial_commit", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        init_module,
+        "_selected_workspace_git_context",
+        lambda: {
+            "workspace_id": "ws_1",
+            "workspace_name": "default",
+            "git_sync_url": "https://platform.osmosis.ai/default/integrations/git",
+            "has_github_app_installation": False,
+            "connected_repo_url": None,
+        },
+    )
+
+    exit_code = cli.main(["--json", "init", "demo"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.err == ""
+    payload = json.loads(captured.out)
+    assert payload["status"] == "success"
+    assert payload["operation"] == "init"
+    assert payload["resource"]["workspace"] == {"id": "ws_1", "name": "default"}
+    assert payload["resource"]["created_paths"] == [str((tmp_path / "demo").resolve())]
+    assert payload["resource"]["git_sync_url"].endswith("/default/integrations/git")
+    assert payload["next_steps_structured"]
+
+
+def test_init_plain_uses_renderer_without_rich_panels(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    import osmosis_ai.platform.cli.init as init_module
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
+    monkeypatch.setattr(init_module, "_write_scaffold", lambda *args, **kwargs: None)
+    monkeypatch.setattr(init_module, "_git_init", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        init_module, "_git_initial_commit", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        init_module,
+        "_selected_workspace_git_context",
+        lambda: {
+            "workspace_id": None,
+            "workspace_name": None,
+            "git_sync_url": None,
+            "has_github_app_installation": False,
+            "connected_repo_url": None,
+        },
+    )
+
+    exit_code = cli.main(["--plain", "init", "demo"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.startswith("Initialized workspace in ")
+    assert "get started" not in captured.out

--- a/tests/unit/cli/test_model_commands.py
+++ b/tests/unit/cli/test_model_commands.py
@@ -10,6 +10,7 @@ import osmosis_ai.cli.commands.model as model_module
 import osmosis_ai.platform.api.client as api_client_module
 import osmosis_ai.platform.cli.utils as utils_module
 from osmosis_ai.cli.console import Console
+from osmosis_ai.cli.output import ListResult, OperationResult
 from osmosis_ai.platform.api.models import (
     AffectedTrainingRun,
     BaseModelInfo,
@@ -44,8 +45,13 @@ class TestListModels:
                 return PaginatedBaseModels(models=[], total_count=0, has_more=False)
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        model_module.list_models(limit=30, all_=False)
-        assert "No models found" in console_capture.getvalue()
+        result = model_module.list_models(limit=30, all_=False)
+
+        assert isinstance(result, ListResult)
+        assert result.title == "Base Models"
+        assert result.items == []
+        assert result.total_count == 0
+        assert result.has_more is False
 
     def test_list_with_base_models(
         self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
@@ -63,10 +69,12 @@ class TestListModels:
                 return PaginatedBaseModels(models=[base], total_count=1, has_more=False)
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        model_module.list_models(limit=30, all_=False)
-        out = console_capture.getvalue()
-        assert "gpt-2" in out
-        assert "Base Models" in out
+        result = model_module.list_models(limit=30, all_=False)
+
+        assert isinstance(result, ListResult)
+        assert result.title == "Base Models"
+        assert result.items[0]["model_name"] == "gpt-2"
+        assert result.items[0]["status"] == "available"
 
     def test_list_has_more_truncation(
         self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
@@ -83,10 +91,12 @@ class TestListModels:
                 return PaginatedBaseModels(models=[base], total_count=5, has_more=True)
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        model_module.list_models(limit=1, all_=False)
-        out = console_capture.getvalue()
-        assert "Showing 1 of 5 base models" in out
-        assert "--all" in out
+        result = model_module.list_models(limit=1, all_=False)
+
+        assert isinstance(result, ListResult)
+        assert len(result.items) == 1
+        assert result.total_count == 5
+        assert result.has_more is True
 
 
 class TestDeleteModel:
@@ -104,9 +114,14 @@ class TestDeleteModel:
                 return True
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        model_module.delete(name="Qwen/Qwen3", yes=True)
+        result = model_module.delete(name="Qwen/Qwen3", yes=True)
+
         assert captured["deleted"] == "Qwen/Qwen3"
-        assert 'Model "Qwen/Qwen3" deleted' in console_capture.getvalue()
+        assert isinstance(result, OperationResult)
+        assert result.operation == "model.delete"
+        assert result.status == "success"
+        assert result.resource == {"name": "Qwen/Qwen3"}
+        assert result.message == 'Model "Qwen/Qwen3" deleted.'
 
     def test_blocked_by_training_runs(
         self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO

--- a/tests/unit/cli/test_train_commands.py
+++ b/tests/unit/cli/test_train_commands.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from contextlib import nullcontext
 from io import StringIO
 from pathlib import Path
 
@@ -13,6 +12,7 @@ import osmosis_ai.platform.api.client as api_client_module
 import osmosis_ai.platform.cli.utils as utils_module
 from osmosis_ai.cli.console import Console
 from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.cli.output import DetailResult, ListResult, OperationResult
 from osmosis_ai.platform.api.models import (
     DeleteTrainingRunResult,
     PaginatedTrainingRuns,
@@ -56,8 +56,13 @@ class TestListRuns:
                 )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        train_module.list_runs(limit=30, all_=False)
-        assert "No training runs found" in console_capture.getvalue()
+        result = train_module.list_runs(limit=30, all_=False)
+
+        assert isinstance(result, ListResult)
+        assert result.title == "Training Runs"
+        assert result.items == []
+        assert result.total_count == 0
+        assert result.has_more is False
 
     def test_list_with_runs(
         self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
@@ -78,11 +83,12 @@ class TestListRuns:
                 )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        train_module.list_runs(limit=30, all_=False)
-        out = console_capture.getvalue()
-        assert "my-run" in out
-        assert "gpt-2" in out
-        assert "acc:0.95" in out
+        result = train_module.list_runs(limit=30, all_=False)
+
+        assert isinstance(result, ListResult)
+        assert result.items[0]["name"] == "my-run"
+        assert result.items[0]["model_name"] == "gpt-2"
+        assert result.items[0]["eval_accuracy"] == 0.95
 
     def test_list_unnamed_run(
         self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
@@ -100,8 +106,11 @@ class TestListRuns:
                 )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        train_module.list_runs(limit=30, all_=False)
-        assert "(unnamed)" in console_capture.getvalue()
+        result = train_module.list_runs(limit=30, all_=False)
+
+        assert isinstance(result, ListResult)
+        assert result.items[0]["name"] is None
+        assert result.items[0]["status"] == "running"
 
     def test_list_has_more(
         self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
@@ -119,10 +128,12 @@ class TestListRuns:
                 )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        train_module.list_runs(limit=30, all_=False)
-        out = console_capture.getvalue()
-        assert "Showing 1 of 5 training runs" in out
-        assert "--all" in out
+        result = train_module.list_runs(limit=30, all_=False)
+
+        assert isinstance(result, ListResult)
+        assert len(result.items) == 1
+        assert result.total_count == 5
+        assert result.has_more is True
 
 
 # ---------------------------------------------------------------------------
@@ -146,10 +157,12 @@ class TestStatus:
                 return detail
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        train_module.status(name="run-1")
-        out = console_capture.getvalue()
-        assert "run-1" in out
-        assert "completed" in out
+        result = train_module.status(name="run-1")
+
+        assert isinstance(result, DetailResult)
+        assert result.title == "Training Run"
+        assert result.data["name"] == "run-1"
+        assert result.data["status"] == "completed"
 
     def test_status_with_all_optional_fields(
         self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
@@ -176,13 +189,18 @@ class TestStatus:
                 return detail
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        train_module.status(name="full-run")
-        out = console_capture.getvalue()
-        assert "100" in out
-        assert "experiment notes" in out
-        assert "uploaded" in out
-        assert "2026-01-01" in out
-        assert "2026-01-02" in out
+        result = train_module.status(name="full-run")
+
+        assert isinstance(result, DetailResult)
+        fields = {field.label: field.value for field in result.fields}
+        assert fields["Examples"] == "100"
+        assert fields["Notes"] == "experiment notes"
+        assert fields["HF Status"] == "uploaded"
+        assert fields["Started"] == "2026-01-01"
+        assert fields["Completed"] == "2026-01-02"
+        assert result.data["examples_processed_count"] == 100
+        assert result.data["notes"] == "experiment notes"
+        assert result.data["hf_status"] == "uploaded"
 
 
 # ---------------------------------------------------------------------------
@@ -265,12 +283,17 @@ total_epochs = 1
                 return result
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        train_module.submit(config_path=config_path, yes=True)
-        out = console_capture.getvalue()
-        assert "my-training-run" in out
-        assert "550e8400" in out
-        assert "pending" in out
-        assert "training" in out  # URL contains "training"
+        command_result = train_module.submit(config_path=config_path, yes=True)
+
+        assert isinstance(command_result, OperationResult)
+        assert command_result.operation == "train.submit"
+        assert command_result.status == "success"
+        assert command_result.resource is not None
+        assert command_result.resource["name"] == "my-training-run"
+        assert command_result.resource["id"] == "550e8400-e29b-41d4-a716-446655440000"
+        assert command_result.resource["status"] == "pending"
+        assert "/training/" in command_result.resource["url"]
+        assert command_result.message == "Training run submitted: my-training-run"
 
     def test_submit_url_does_not_insert_rich_line_breaks(
         self,
@@ -279,31 +302,23 @@ total_epochs = 1
     ) -> None:
         config_path = self._write_config(tmp_path)
         result = self.SUBMIT_RESULT
-        output = StringIO()
-        tty_console = Console(
-            file=output,
-            force_terminal=True,
-            no_color=True,
-            width=92,
-        )
-        monkeypatch.setattr(tty_console, "spinner", lambda message: nullcontext())
-        monkeypatch.setattr(train_module, "console", tty_console)
-        monkeypatch.setattr(utils_module, "console", tty_console)
 
         class FakeClient:
             def submit_training_run(self, **kwargs):
                 return result
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        train_module.submit(config_path=config_path, yes=True)
+        command_result = train_module.submit(config_path=config_path, yes=True)
 
         expected_url = utils_module.platform_entity_url(
             "ws-test",
             "training",
             result.id,
         )
-        out = output.getvalue()
-        assert f"  View: {expected_url}" in out
+        assert isinstance(command_result, OperationResult)
+        assert command_result.resource is not None
+        assert command_result.resource["url"] == expected_url
+        assert f"View: {expected_url}" in command_result.display_next_steps
 
     def test_submit_shows_summary_table(
         self,
@@ -319,12 +334,21 @@ total_epochs = 1
 
         FakeClient.SUBMIT_RESULT = self.SUBMIT_RESULT
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        train_module.submit(config_path=config_path, yes=True)
+        result = train_module.submit(config_path=config_path, yes=True)
         out = console_capture.getvalue()
         assert "calculator" in out
         assert "main.py" in out
         assert "Qwen/Qwen3.5-35B-A3B" in out
         assert "abc-123" in out
+        assert isinstance(result, OperationResult)
+        assert result.resource is not None
+        assert result.resource["config"] == {
+            "rollout": "calculator",
+            "entrypoint": "main.py",
+            "model": "Qwen/Qwen3.5-35B-A3B",
+            "dataset": "abc-123",
+            "commit_sha": None,
+        }
 
     def test_submit_with_commit_sha(
         self,
@@ -354,9 +378,12 @@ commit_sha = "deadbeef"
                 return TestSubmit.SUBMIT_RESULT
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        train_module.submit(config_path=path, yes=True)
+        result = train_module.submit(config_path=path, yes=True)
         assert captured_kwargs["commit_sha"] == "deadbeef"
         assert "deadbeef" in console_capture.getvalue()
+        assert isinstance(result, OperationResult)
+        assert result.resource is not None
+        assert result.resource["config"]["commit_sha"] == "deadbeef"
 
     def test_submit_passes_config_to_api(
         self,
@@ -446,7 +473,10 @@ class TestDelete:
                 return DeleteTrainingRunResult(deleted=True)
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        train_module.delete(name="my-run", yes=True)
-        out = console_capture.getvalue()
-        assert "deleted" in out
-        assert "my-run" in out
+        result = train_module.delete(name="my-run", yes=True)
+
+        assert isinstance(result, OperationResult)
+        assert result.operation == "train.delete"
+        assert result.status == "success"
+        assert result.resource == {"name": "my-run"}
+        assert result.message == 'Training run "my-run" deleted.'

--- a/tests/unit/cli/test_train_commands.py
+++ b/tests/unit/cli/test_train_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from io import StringIO
 from pathlib import Path
 
@@ -270,6 +271,39 @@ total_epochs = 1
         assert "550e8400" in out
         assert "pending" in out
         assert "training" in out  # URL contains "training"
+
+    def test_submit_url_does_not_insert_rich_line_breaks(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        config_path = self._write_config(tmp_path)
+        result = self.SUBMIT_RESULT
+        output = StringIO()
+        tty_console = Console(
+            file=output,
+            force_terminal=True,
+            no_color=True,
+            width=92,
+        )
+        monkeypatch.setattr(tty_console, "spinner", lambda message: nullcontext())
+        monkeypatch.setattr(train_module, "console", tty_console)
+        monkeypatch.setattr(utils_module, "console", tty_console)
+
+        class FakeClient:
+            def submit_training_run(self, **kwargs):
+                return result
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        train_module.submit(config_path=config_path, yes=True)
+
+        expected_url = utils_module.platform_entity_url(
+            "ws-test",
+            "training",
+            result.id,
+        )
+        out = output.getvalue()
+        assert f"  View: {expected_url}" in out
 
     def test_submit_shows_summary_table(
         self,

--- a/tests/unit/cli/test_train_info_checkpoints.py
+++ b/tests/unit/cli/test_train_info_checkpoints.py
@@ -10,6 +10,7 @@ import osmosis_ai.cli.commands.train as train_module
 import osmosis_ai.platform.api.client as api_client_module
 import osmosis_ai.platform.cli.utils as utils_module
 from osmosis_ai.cli.console import Console
+from osmosis_ai.cli.output import DetailResult
 from osmosis_ai.platform.api.models import (
     LoraCheckpointInfo,
     TrainingRunCheckpoints,
@@ -88,13 +89,22 @@ class TestStatusCheckpoints:
                 )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        train_module.status(name="qwen3-run1")
-        out = console_capture.getvalue()
-        assert "Checkpoints" in out
-        assert "qwen3-run1-step-100" in out
-        assert "step 100" in out
-        assert "cp_1"[:8] in out
-        assert "osmosis deploy <checkpoint-name>" in out
+        result = train_module.status(name="qwen3-run1")
+
+        assert isinstance(result, DetailResult)
+        checkpoint = result.data["checkpoints"][0]
+        assert checkpoint["checkpoint_name"] == "qwen3-run1-step-100"
+        assert checkpoint["checkpoint_step"] == 100
+        assert checkpoint["id"] == "cp_1"
+        checkpoint_fields = [
+            field.value for field in result.fields if field.label == "Checkpoint"
+        ]
+        assert checkpoint_fields == [
+            "qwen3-run1-step-100  step 100  [uploaded]  cp_1  2026-04-20"
+        ]
+        assert ("Deploy", "osmosis deploy <checkpoint-name>") in [
+            (field.label, field.value) for field in result.fields
+        ]
 
     def test_running_run_skips_checkpoints(
         self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
@@ -112,9 +122,11 @@ class TestStatusCheckpoints:
                 raise AssertionError("should not call for running run")
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        train_module.status(name="qwen3-run1")
-        out = console_capture.getvalue()
-        assert "Checkpoints" not in out
+        result = train_module.status(name="qwen3-run1")
+
+        assert isinstance(result, DetailResult)
+        assert result.data["checkpoints"] == []
+        assert all(field.label != "Checkpoint" for field in result.fields)
         assert called["ckpts"] is False
 
     def test_stopped_run_shows_uploaded_checkpoints(
@@ -140,11 +152,13 @@ class TestStatusCheckpoints:
                 )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        train_module.status(name="qwen3-run1")
-        out = console_capture.getvalue()
-        assert "stopped" in out
-        assert "Checkpoints" in out
-        assert "qwen3-run1-step-100" in out
+        result = train_module.status(name="qwen3-run1")
+
+        assert isinstance(result, DetailResult)
+        assert result.data["status"] == "stopped"
+        assert result.data["checkpoints"][0]["checkpoint_name"] == (
+            "qwen3-run1-step-100"
+        )
 
     def test_endpoint_error_is_non_fatal(
         self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
@@ -159,10 +173,12 @@ class TestStatusCheckpoints:
                 raise PlatformAPIError("Internal server error", 500)
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        train_module.status(name="qwen3-run1")
-        out = console_capture.getvalue()
-        assert "Checkpoints" not in out
-        assert "Training Run" in out
+        result = train_module.status(name="qwen3-run1")
+
+        assert isinstance(result, DetailResult)
+        assert result.title == "Training Run"
+        assert result.data["checkpoints"] == []
+        assert all(field.label != "Checkpoint" for field in result.fields)
 
     def test_finished_but_no_checkpoints(
         self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
@@ -179,7 +195,10 @@ class TestStatusCheckpoints:
                 )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
-        train_module.status(name="qwen3-run1")
-        out = console_capture.getvalue()
-        assert "Checkpoints" not in out
-        assert "Deploy with:" not in out
+        result = train_module.status(name="qwen3-run1")
+
+        assert isinstance(result, DetailResult)
+        assert result.data["checkpoints"] == []
+        assert all(
+            field.label not in {"Checkpoint", "Deploy"} for field in result.fields
+        )

--- a/tests/unit/cli/test_train_metrics_cmd.py
+++ b/tests/unit/cli/test_train_metrics_cmd.py
@@ -8,9 +8,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from rich.console import Console as RichConsole
 
 from osmosis_ai.cli.console import Console
 from osmosis_ai.cli.metrics_graph import MIN_TREND_TERMINAL_WIDTH, SPARKLINE_BLOCKS
+from osmosis_ai.cli.output import DetailResult
 from osmosis_ai.platform.api.models import (
     MetricDataPoint,
     MetricHistory,
@@ -88,6 +90,20 @@ def _patch_train_console(
     )
 
 
+def _field_value(result: DetailResult, label: str) -> str:
+    for field in result.fields:
+        if field.label == label:
+            return field.value
+    raise AssertionError(f"Missing field {label!r}")
+
+
+def _render_rich_text(value: object) -> str:
+    buffer = io.StringIO()
+    rich = RichConsole(file=buffer, force_terminal=False, no_color=True, width=120)
+    rich.print(value)
+    return buffer.getvalue()
+
+
 class TestMetricsCommandPlatformUrl:
     """Platform URL is printed at the top of output."""
 
@@ -106,15 +122,15 @@ class TestMetricsCommandPlatformUrl:
         with _patch_train_console(buf, force_terminal=False, width=120):
             from osmosis_ai.cli.commands.train import metrics
 
-            metrics(
+            result = metrics(
                 name="reward-tuning-v3",
                 output=str(output),
             )
 
-        text = buf.getvalue()
-        assert "View full details:" in text
-        assert "ws/training/" in text
-        assert "550e8400-e29b-41d4-a716-446655440000" in text
+        assert isinstance(result, DetailResult)
+        view = _field_value(result, "View")
+        assert "ws/training/" in view
+        assert "550e8400-e29b-41d4-a716-446655440000" in view
 
 
 class TestMetricsCommandTrendGraphs:
@@ -137,16 +153,16 @@ class TestMetricsCommandTrendGraphs:
         ):
             from osmosis_ai.cli.commands.train import metrics
 
-            metrics(
+            result = metrics(
                 name="reward-tuning-v3",
                 output=str(output),
             )
 
-        text = buf.getvalue()
-        assert "Training Run Metrics" in text
-        assert "Metric Trends" in text  # Rule separator header
-        assert "Training Reward" in text
-        assert any(c in text for c in SPARKLINE_BLOCKS)
+        assert isinstance(result, DetailResult)
+        assert result.title == "Training Run Metrics"
+        trends = _render_rich_text(_field_value(result, "Metric Trends"))
+        assert "Training Reward" in trends
+        assert any(c in trends for c in SPARKLINE_BLOCKS)
 
     @patch(_PATCH_CLIENT)
     @patch(_PATCH_AUTH)
@@ -178,14 +194,14 @@ class TestMetricsCommandTrendGraphs:
         ):
             from osmosis_ai.cli.commands.train import metrics
 
-            metrics(
+            result = metrics(
                 name="reward-tuning-v3",
                 output=str(output),
             )
 
-        text = buf.getvalue()
-        assert bracket_title in text
-        assert "Metric Trends" in text
+        assert isinstance(result, DetailResult)
+        trends = _render_rich_text(_field_value(result, "Metric Trends"))
+        assert bracket_title in trends
 
     @patch(_PATCH_CLIENT)
     @patch(_PATCH_AUTH)
@@ -252,16 +268,16 @@ class TestMetricsCommandTrendGraphs:
         ):
             from osmosis_ai.cli.commands.train import metrics
 
-            metrics(
+            result = metrics(
                 name="reward-tuning-v3",
                 output=str(output),
             )
 
-        text = buf.getvalue()
-        assert "No metric data found." in text
-        assert "Metric Trends" not in text
+        assert isinstance(result, DetailResult)
+        assert _field_value(result, "Metrics") == "No metric data found."
+        assert all(field.label != "Metric Trends" for field in result.fields)
         # Summary table is always shown (run metadata is valuable even without metrics)
-        assert "Training Run Metrics" in text
+        assert result.title == "Training Run Metrics"
 
 
 class TestMetricsCommandWritesFile:
@@ -424,13 +440,13 @@ class TestMetricsCommandErrors:
         with _patch_train_console(buf, force_terminal=False, width=120):
             from osmosis_ai.cli.commands.train import metrics
 
-            metrics(
+            result = metrics(
                 name="reward-tuning-v3",
                 output=str(output),
             )
 
-        text = buf.getvalue()
-        assert "training is in progress" in text
+        assert isinstance(result, DetailResult)
+        assert "Training is in progress" in _field_value(result, "Note")
         assert output.exists()
 
     def test_no_workspace_no_output_raises(self, tmp_path: Path) -> None:
@@ -456,13 +472,13 @@ class TestMetricsCommandErrors:
         with _patch_train_console(buf, force_terminal=False, width=80):
             from osmosis_ai.cli.commands.train import metrics
 
-            metrics(
+            result = metrics(
                 name="reward-tuning-v3",
                 output="/nonexistent/dir/metrics.json",
             )
 
-        text = buf.getvalue()
-        assert "Could not save metrics" in text
+        assert isinstance(result, DetailResult)
+        assert "Could not save metrics" in _field_value(result, "Warning")
 
     @patch(_PATCH_CLIENT)
     @patch(_PATCH_AUTH)
@@ -485,11 +501,11 @@ class TestMetricsCommandErrors:
         with _patch_train_console(buf, force_terminal=False, width=80):
             from osmosis_ai.cli.commands.train import metrics
 
-            metrics(
+            result = metrics(
                 name="reward-tuning-v3",
                 output=None,
             )
 
-        text = buf.getvalue()
-        assert "Training Run Metrics" in text
-        assert "Could not save metrics" in text
+        assert isinstance(result, DetailResult)
+        assert result.title == "Training Run Metrics"
+        assert "Could not save metrics" in _field_value(result, "Warning")

--- a/tests/unit/cli/test_upgrade_json.py
+++ b/tests/unit/cli/test_upgrade_json.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from osmosis_ai.cli import main as cli
+
+
+def test_upgrade_json_no_update(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    monkeypatch.setattr("osmosis_ai.cli.upgrade._fetch_latest_version", lambda: "0.0.0")
+
+    exit_code = cli.main(["--json", "upgrade"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.err == ""
+    payload = json.loads(captured.out)
+    assert payload["schema_version"] == 1
+    assert payload["operation"] == "upgrade"
+    assert payload["status"] == "no_update"
+    assert payload["resource"]["latest_version"] == "0.0.0"
+
+
+def test_upgrade_json_captures_subprocess_output(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(
+        "osmosis_ai.cli.upgrade._fetch_latest_version", lambda: "99.0.0"
+    )
+    monkeypatch.setattr("osmosis_ai.cli.upgrade._detect_install_method", lambda: "pipx")
+    monkeypatch.setattr("shutil.which", lambda command: f"/usr/bin/{command}")
+
+    def fake_run(cmd, **kwargs):
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="installed ok\n",
+            stderr="warning only\n",
+        )
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    exit_code = cli.main(["--json", "upgrade"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.err == ""
+    payload = json.loads(captured.out)
+    assert payload["status"] == "success"
+    assert payload["resource"]["method"] == "pipx"
+    assert payload["resource"]["command"] == ["pipx", "upgrade", "osmosis-ai"]
+    assert payload["resource"]["stdout"] == "installed ok\n"
+    assert payload["resource"]["stderr"] == "warning only\n"
+
+
+def test_upgrade_json_failed_subprocess_is_parseable_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(
+        "osmosis_ai.cli.upgrade._fetch_latest_version", lambda: "99.0.0"
+    )
+    monkeypatch.setattr("osmosis_ai.cli.upgrade._detect_install_method", lambda: "pipx")
+    monkeypatch.setattr("shutil.which", lambda command: f"/usr/bin/{command}")
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd,
+            1,
+            stdout="",
+            stderr="failed\n",
+        ),
+    )
+
+    exit_code = cli.main(["--json", "upgrade"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.err == ""
+    payload = json.loads(captured.out)
+    assert payload["status"] == "failed"
+    assert payload["resource"]["stderr"] == "failed\n"
+
+
+def test_upgrade_json_tries_next_fallback_after_failed_command(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(
+        "osmosis_ai.cli.upgrade._fetch_latest_version", lambda: "99.0.0"
+    )
+    monkeypatch.setattr("osmosis_ai.cli.upgrade._detect_install_method", lambda: "pip")
+    monkeypatch.setattr("shutil.which", lambda command: f"/usr/bin/{command}")
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(
+            cmd,
+            1 if len(calls) == 1 else 0,
+            stdout="",
+            stderr="first failed\n" if len(calls) == 1 else "second ok\n",
+        )
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    exit_code = cli.main(["--json", "upgrade"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["status"] == "success"
+    assert len(calls) == 2
+    assert payload["resource"]["command"] == calls[1]

--- a/tests/unit/cli/test_whoami.py
+++ b/tests/unit/cli/test_whoami.py
@@ -1,0 +1,253 @@
+"""Tests for `osmosis auth whoami` across rich/json/plain."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from osmosis_ai.cli import main as cli
+from osmosis_ai.platform.auth.credentials import Credentials, UserInfo
+from osmosis_ai.platform.auth.flow import VerifyResult
+
+
+@pytest.fixture
+def fake_credentials() -> Credentials:
+    return Credentials(
+        access_token="token",
+        token_type="Bearer",
+        expires_at=datetime.now(UTC) + timedelta(days=30),
+        created_at=datetime.now(UTC),
+        user=UserInfo(id="u1", email="brian@example.com", name="Brian"),
+        token_id="tok_1",
+    )
+
+
+def _patch_auth(monkeypatch, creds: Credentials | None, workspace=None) -> None:
+    monkeypatch.setattr("osmosis_ai.platform.auth.load_credentials", lambda: creds)
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.ensure_active_workspace",
+        lambda *args, **kwargs: workspace,
+    )
+
+
+@pytest.fixture
+def fake_verify_result() -> VerifyResult:
+    return VerifyResult(
+        user=UserInfo(id="env_u1", email="env@example.com", name="Env User"),
+        expires_at=datetime.now(UTC) + timedelta(days=30),
+        token_id="env_tok_1",
+    )
+
+
+def test_whoami_json_envelope(monkeypatch, capsys, fake_credentials) -> None:
+    _patch_auth(
+        monkeypatch,
+        fake_credentials,
+        {"id": "ws_1", "name": "default"},
+    )
+    exit_code = cli.main(["--json", "auth", "whoami"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.err == ""
+    payload = json.loads(captured.out)
+    assert payload["schema_version"] == 1
+    data = payload["data"]
+    assert data["email"] == "brian@example.com"
+    assert data["name"] == "Brian"
+    assert data["workspace"] == {"id": "ws_1", "name": "default"}
+    assert data["source"] == "credentials"
+    assert "expires_at" in data
+
+
+def test_whoami_json_with_env_token_uses_verified_identity(
+    monkeypatch, capsys, fake_verify_result
+) -> None:
+    monkeypatch.setenv("OSMOSIS_TOKEN", "env-token")
+    verify_calls = []
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.verify_token",
+        lambda token: verify_calls.append(token) or fake_verify_result,
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.load_credentials",
+        lambda: pytest.fail("env token whoami should not use stored credentials"),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.get_active_workspace",
+        lambda: {"id": "stored_ws", "name": "stored"},
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.platform_request",
+        lambda *args, **kwargs: {"workspaces": [{"id": "env_ws", "name": "env"}]},
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.ensure_active_workspace",
+        lambda *args, **kwargs: pytest.fail(
+            "env token whoami should not use cached workspace resolution"
+        ),
+    )
+
+    exit_code = cli.main(["--json", "auth", "whoami"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    data = payload["data"]
+    assert data["email"] == "env@example.com"
+    assert data["name"] == "Env User"
+    assert data["workspace"] == {"id": "env_ws", "name": "env"}
+    assert data["source"] == "environment"
+    assert verify_calls == ["env-token"]
+
+
+def test_whoami_json_with_env_token_keeps_matching_local_workspace(
+    monkeypatch, capsys, fake_verify_result
+) -> None:
+    monkeypatch.setenv("OSMOSIS_TOKEN", "env-token")
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.verify_token", lambda token: fake_verify_result
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.get_active_workspace",
+        lambda: {"id": "env_ws_2", "name": "env-2"},
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.platform_request",
+        lambda *args, **kwargs: {
+            "workspaces": [
+                {"id": "env_ws_1", "name": "env-1"},
+                {"id": "env_ws_2", "name": "env-2"},
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.load_credentials",
+        lambda: Credentials(
+            access_token="stored-token",
+            token_type="Bearer",
+            expires_at=datetime.now(UTC) + timedelta(days=30),
+            created_at=datetime.now(UTC),
+            user=UserInfo(id="stored_u1", email="stored@example.com", name="Stored"),
+            token_id="stored_tok_1",
+        ),
+    )
+
+    exit_code = cli.main(["--json", "auth", "whoami"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    data = payload["data"]
+    assert data["email"] == "env@example.com"
+    assert data["workspace"] == {"id": "env_ws_2", "name": "env-2"}
+    assert data["source"] == "environment"
+
+
+def test_whoami_json_with_env_token_ignores_mismatched_local_workspace(
+    monkeypatch, capsys, fake_verify_result
+) -> None:
+    monkeypatch.setenv("OSMOSIS_TOKEN", "env-token")
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.verify_token", lambda token: fake_verify_result
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.get_active_workspace",
+        lambda: {"id": "stored_ws", "name": "stored"},
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.platform_request",
+        lambda *args, **kwargs: {
+            "workspaces": [
+                {"id": "env_ws_1", "name": "env-1"},
+                {"id": "env_ws_2", "name": "env-2"},
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.load_credentials",
+        lambda: Credentials(
+            access_token="stored-token",
+            token_type="Bearer",
+            expires_at=datetime.now(UTC) + timedelta(days=30),
+            created_at=datetime.now(UTC),
+            user=UserInfo(id="stored_u1", email="stored@example.com", name="Stored"),
+            token_id="stored_tok_1",
+        ),
+    )
+
+    exit_code = cli.main(["--json", "auth", "whoami"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    data = payload["data"]
+    assert data["email"] == "env@example.com"
+    assert data["workspace"] is None
+    assert data["source"] == "environment"
+
+
+def test_whoami_json_with_env_token_verify_failure_emits_auth_required(
+    monkeypatch, capsys
+) -> None:
+    from osmosis_ai.platform.auth import LoginError
+
+    monkeypatch.setenv("OSMOSIS_TOKEN", "env-token")
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.verify_token",
+        lambda token: (_ for _ in ()).throw(LoginError("Authentication failed.")),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.load_credentials",
+        lambda: pytest.fail(
+            "env token whoami should not fall back to stored credentials"
+        ),
+    )
+
+    exit_code = cli.main(["--json", "auth", "whoami"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert captured.out == ""
+    envelope = json.loads(captured.err)
+    assert envelope["error"]["code"] == "AUTH_REQUIRED"
+
+
+def test_whoami_json_when_logged_out_emits_auth_required(monkeypatch, capsys) -> None:
+    _patch_auth(monkeypatch, None)
+    exit_code = cli.main(["--json", "auth", "whoami"])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    envelope = json.loads(captured.err)
+    assert envelope["error"]["code"] == "AUTH_REQUIRED"
+
+
+def test_whoami_plain_renders_label_value_lines(
+    monkeypatch, capsys, fake_credentials
+) -> None:
+    _patch_auth(
+        monkeypatch,
+        fake_credentials,
+        {"id": "ws_1", "name": "default"},
+    )
+    exit_code = cli.main(["--plain", "auth", "whoami"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    lines = captured.out.splitlines()
+    assert "Email: brian@example.com" in lines
+    assert "Workspace: default" in lines
+
+
+def test_whoami_rich_still_uses_table(monkeypatch, capsys, fake_credentials) -> None:
+    _patch_auth(
+        monkeypatch,
+        fake_credentials,
+        {"id": "ws_1", "name": "default"},
+    )
+    exit_code = cli.main(["auth", "whoami"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Email" in captured.out
+    assert "brian@example.com" in captured.out

--- a/tests/unit/cli/test_whoami.py
+++ b/tests/unit/cli/test_whoami.py
@@ -111,7 +111,7 @@ def test_whoami_json_with_env_token_keeps_matching_local_workspace(
     )
     monkeypatch.setattr(
         "osmosis_ai.platform.auth.get_active_workspace",
-        lambda: {"id": "env_ws_2", "name": "env-2"},
+        lambda: {"id": "env_ws_2", "name": "old-env-2"},
     )
     monkeypatch.setattr(
         "osmosis_ai.platform.auth.platform_request",

--- a/tests/unit/cli/test_whoami.py
+++ b/tests/unit/cli/test_whoami.py
@@ -196,7 +196,9 @@ def test_whoami_json_with_env_token_verify_failure_emits_auth_required(
     monkeypatch.setenv("OSMOSIS_TOKEN", "env-token")
     monkeypatch.setattr(
         "osmosis_ai.platform.auth.verify_token",
-        lambda token: (_ for _ in ()).throw(LoginError("Authentication failed.")),
+        lambda token: (_ for _ in ()).throw(
+            LoginError("Authentication failed.", status_code=401)
+        ),
     )
     monkeypatch.setattr(
         "osmosis_ai.platform.auth.load_credentials",
@@ -212,6 +214,34 @@ def test_whoami_json_with_env_token_verify_failure_emits_auth_required(
     assert captured.out == ""
     envelope = json.loads(captured.err)
     assert envelope["error"]["code"] == "AUTH_REQUIRED"
+
+
+def test_whoami_json_with_env_token_malformed_response_emits_platform_error(
+    monkeypatch, capsys
+) -> None:
+    from osmosis_ai.platform.auth import LoginError
+
+    monkeypatch.setenv("OSMOSIS_TOKEN", "env-token")
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.verify_token",
+        lambda token: (_ for _ in ()).throw(
+            LoginError("Invalid response from platform")
+        ),
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.load_credentials",
+        lambda: pytest.fail(
+            "env token whoami should not fall back to stored credentials"
+        ),
+    )
+
+    exit_code = cli.main(["--json", "auth", "whoami"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert captured.out == ""
+    envelope = json.loads(captured.err)
+    assert envelope["error"]["code"] == "PLATFORM_ERROR"
 
 
 def test_whoami_json_when_logged_out_emits_auth_required(monkeypatch, capsys) -> None:

--- a/tests/unit/cli/test_workspace_json.py
+++ b/tests/unit/cli/test_workspace_json.py
@@ -87,13 +87,15 @@ def test_workspace_switch_plain_returns_renderer_output(monkeypatch, capsys) -> 
 
 
 def test_workspace_create_json_returns_operation_result(monkeypatch, capsys) -> None:
+    creds = object()
     monkeypatch.setattr(
-        "osmosis_ai.platform.cli.utils._require_auth",
-        lambda **kwargs: ("default", object()),
+        "osmosis_ai.platform.cli.workspace.require_credentials",
+        lambda: creds,
     )
 
     class FakeClient:
         def create_workspace(self, name, timezone, *, credentials=None):
+            assert credentials is creds
             return {"id": "ws_new", "name": name, "timezone": timezone}
 
     monkeypatch.setattr("osmosis_ai.platform.api.client.OsmosisClient", FakeClient)

--- a/tests/unit/cli/test_workspace_json.py
+++ b/tests/unit/cli/test_workspace_json.py
@@ -126,13 +126,13 @@ def test_workspace_delete_json_with_yes_returns_operation_result(
     monkeypatch, capsys
 ) -> None:
     monkeypatch.setattr(
-        "osmosis_ai.platform.cli.utils._require_auth",
-        lambda **kwargs: ("default", object()),
+        "osmosis_ai.platform.cli.workspace.require_credentials",
+        lambda: object(),
     )
 
     class FakeClient:
         def list_workspaces(self, *, credentials=None):
-            return {"workspaces": [{"id": "ws_1", "name": "default"}]}
+            return {"workspaces": [{"id": "ws_1", "name": "Default"}]}
 
         def get_workspace_deletion_status(self, workspace_id, *, credentials=None):
             return SimpleNamespace(
@@ -155,7 +155,7 @@ def test_workspace_delete_json_with_yes_returns_operation_result(
     assert exit_code == 0
     payload = json.loads(captured.out)
     assert payload["operation"] == "workspace.delete"
-    assert payload["resource"] == {"id": "ws_1", "name": "default"}
+    assert payload["resource"] == {"id": "ws_1", "name": "Default"}
 
 
 def test_workspace_delete_json_preserves_platform_error_code(
@@ -164,8 +164,8 @@ def test_workspace_delete_json_preserves_platform_error_code(
     from osmosis_ai.platform.auth.platform_client import PlatformAPIError
 
     monkeypatch.setattr(
-        "osmosis_ai.platform.cli.utils._require_auth",
-        lambda **kwargs: ("default", object()),
+        "osmosis_ai.platform.cli.workspace.require_credentials",
+        lambda: object(),
     )
 
     class FakeClient:

--- a/tests/unit/cli/test_workspace_json.py
+++ b/tests/unit/cli/test_workspace_json.py
@@ -158,6 +158,33 @@ def test_workspace_delete_json_with_yes_returns_operation_result(
     assert payload["resource"] == {"id": "ws_1", "name": "default"}
 
 
+def test_workspace_delete_json_preserves_platform_error_code(
+    monkeypatch, capsys
+) -> None:
+    from osmosis_ai.platform.auth.platform_client import PlatformAPIError
+
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.utils._require_auth",
+        lambda **kwargs: ("default", object()),
+    )
+
+    class FakeClient:
+        def list_workspaces(self, *, credentials=None):
+            return {"workspaces": [{"id": "ws_1", "name": "default"}]}
+
+        def get_workspace_deletion_status(self, workspace_id, *, credentials=None):
+            raise PlatformAPIError("Authentication failed.", status_code=401)
+
+    monkeypatch.setattr("osmosis_ai.platform.api.client.OsmosisClient", FakeClient)
+
+    exit_code = cli.main(["--json", "workspace", "delete", "default", "--yes"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    payload = json.loads(captured.err)
+    assert payload["error"]["code"] == "AUTH_REQUIRED"
+
+
 def test_workspace_validate_json_returns_detail_result(tmp_path, capsys) -> None:
     workspace_root = _workspace_root(tmp_path)
 

--- a/tests/unit/cli/test_workspace_json.py
+++ b/tests/unit/cli/test_workspace_json.py
@@ -1,0 +1,168 @@
+"""Workspace command JSON/plain contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from osmosis_ai.cli import main as cli
+
+
+def _workspace_root(root: Path) -> Path:
+    for rel_path in (
+        ".osmosis/research",
+        "rollouts",
+        "configs/training",
+        "configs/eval",
+        "data",
+    ):
+        (root / rel_path).mkdir(parents=True, exist_ok=True)
+    (root / ".osmosis" / "workspace.toml").write_text("[workspace]\n", encoding="utf-8")
+    return root
+
+
+def test_bare_workspace_in_json_fails_interactive_required(capsys) -> None:
+    exit_code = cli.main(["--json", "workspace"])
+
+    captured = capsys.readouterr()
+    assert exit_code != 0
+    assert captured.out == ""
+    envelope = json.loads(captured.err)
+    assert envelope["error"]["code"] == "INTERACTIVE_REQUIRED"
+    assert "workspace list" in envelope["error"]["message"]
+
+
+def test_workspace_list_json_returns_list_result(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.workspace.require_credentials", lambda: object()
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.workspace.ensure_active_workspace",
+        lambda credentials=None: {"id": "ws_1", "name": "default"},
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.workspace.platform_request",
+        lambda *args, **kwargs: {
+            "workspaces": [
+                {"id": "ws_1", "name": "default", "has_subscription": True},
+                {"id": "ws_2", "name": "research", "has_subscription": False},
+            ]
+        },
+    )
+
+    exit_code = cli.main(["--json", "workspace", "list"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["schema_version"] == 1
+    assert payload["total_count"] == 2
+    assert payload["items"][0]["name"] == "default"
+    assert payload["items"][0]["is_active"] is True
+
+
+def test_workspace_switch_plain_returns_renderer_output(monkeypatch, capsys) -> None:
+    persisted = {}
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.workspace.require_credentials", lambda: object()
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.workspace.platform_request",
+        lambda *args, **kwargs: {"workspaces": [{"id": "ws_2", "name": "research"}]},
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.workspace.set_active_workspace",
+        lambda workspace_id, workspace_name: persisted.update(
+            {"id": workspace_id, "name": workspace_name}
+        ),
+    )
+
+    exit_code = cli.main(["--plain", "workspace", "switch", "research"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out == "Switched to workspace: research\n"
+    assert persisted == {"id": "ws_2", "name": "research"}
+
+
+def test_workspace_create_json_returns_operation_result(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.utils._require_auth",
+        lambda **kwargs: ("default", object()),
+    )
+
+    class FakeClient:
+        def create_workspace(self, name, timezone, *, credentials=None):
+            return {"id": "ws_new", "name": name, "timezone": timezone}
+
+    monkeypatch.setattr("osmosis_ai.platform.api.client.OsmosisClient", FakeClient)
+
+    exit_code = cli.main(
+        ["--json", "workspace", "create", "new-team", "--timezone", "UTC"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["operation"] == "workspace.create"
+    assert payload["resource"]["id"] == "ws_new"
+    assert payload["resource"]["name"] == "new-team"
+
+
+def test_workspace_delete_json_without_yes_fails_interactive_required(capsys) -> None:
+    exit_code = cli.main(["--json", "workspace", "delete", "default"])
+
+    captured = capsys.readouterr()
+    assert exit_code != 0
+    assert captured.out == ""
+    envelope = json.loads(captured.err)
+    assert envelope["error"]["code"] == "INTERACTIVE_REQUIRED"
+
+
+def test_workspace_delete_json_with_yes_returns_operation_result(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.utils._require_auth",
+        lambda **kwargs: ("default", object()),
+    )
+
+    class FakeClient:
+        def list_workspaces(self, *, credentials=None):
+            return {"workspaces": [{"id": "ws_1", "name": "default"}]}
+
+        def get_workspace_deletion_status(self, workspace_id, *, credentials=None):
+            return SimpleNamespace(
+                is_owner=True,
+                is_last_workspace=False,
+                has_running_processes=False,
+                feature_pipelines=SimpleNamespace(valid=True, count=0),
+                training_runs=SimpleNamespace(valid=True, count=0),
+                models=SimpleNamespace(valid=True, count=0),
+            )
+
+        def delete_workspace(self, workspace_id, *, credentials=None):
+            return True
+
+    monkeypatch.setattr("osmosis_ai.platform.api.client.OsmosisClient", FakeClient)
+
+    exit_code = cli.main(["--json", "workspace", "delete", "default", "--yes"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["operation"] == "workspace.delete"
+    assert payload["resource"] == {"id": "ws_1", "name": "default"}
+
+
+def test_workspace_validate_json_returns_detail_result(tmp_path, capsys) -> None:
+    workspace_root = _workspace_root(tmp_path)
+
+    exit_code = cli.main(["--json", "workspace", "validate", str(workspace_root)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["data"]["valid"] is True
+    assert payload["data"]["root"] == str(workspace_root)

--- a/tests/unit/eval/evaluation/test_cache.py
+++ b/tests/unit/eval/evaluation/test_cache.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import io
 import json
 import types
+from contextlib import redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1501,6 +1503,31 @@ class TestCacheRm:
         assert ret == 0
         assert not cache_path.exists()
         assert not jsonl_path.exists()
+
+    def test_rm_structured_returns_operation_without_stdout(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """Structured cache rm returns data without pre-rendering stdout."""
+        from osmosis_ai.cli.output import OperationResult, OutputFormat
+        from osmosis_ai.cli.output.context import override_output_context
+
+        cache_path = _make_cache_entry(tmp_path, "abc123", "gpt-4", "data.jsonl")
+        monkeypatch.setattr(
+            "osmosis_ai.eval.evaluation.cache._get_cache_root",
+            lambda: tmp_path,
+        )
+        cmd = self._make_command()
+
+        out = io.StringIO()
+        with override_output_context(format=OutputFormat.json):
+            with redirect_stdout(out):
+                ret = cmd._run_cache_rm(task_id="abc123")
+
+        assert out.getvalue() == ""
+        assert isinstance(ret, OperationResult)
+        assert ret.operation == "eval.cache.rm"
+        assert ret.resource == {"deleted_count": 1}
+        assert not cache_path.exists()
 
     def test_rm_nonexistent_task_id(self, tmp_path: Path, monkeypatch):
         """Non-existent task_id prints message and returns 1."""

--- a/tests/unit/platform/cli/test_dataset_validation.py
+++ b/tests/unit/platform/cli/test_dataset_validation.py
@@ -11,9 +11,11 @@ from pathlib import Path
 import pytest
 
 from osmosis_ai.platform.cli.dataset import (
+    PARQUET_VALIDATION_SKIPPED_WARNING,
     _check_required_columns,
     _read_tail_lines,
     _validate_csv,
+    _validate_file_with_warnings,
     _validate_jsonl,
     _validate_parquet,
 )
@@ -245,6 +247,39 @@ class TestValidateCsv:
 
 
 class TestValidateParquet:
+    def test_validate_file_with_warnings_skips_parquet_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Structured validation should surface one warning without console output."""
+        import builtins
+        from io import StringIO
+
+        from osmosis_ai.cli.console import Console
+
+        real_import = builtins.__import__
+
+        def _block_pyarrow(name: str, *args, **kwargs):
+            if name == "pyarrow.parquet" or name == "pyarrow":
+                raise ImportError("mocked missing pyarrow")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _block_pyarrow)
+
+        import osmosis_ai.platform.cli.dataset as dataset_mod
+
+        buf = StringIO()
+        fake_console = Console(file=buf, force_terminal=False)
+        monkeypatch.setattr(dataset_mod, "console", fake_console)
+
+        f = tmp_path / "test.parquet"
+        f.write_bytes(b"fake parquet data")
+
+        errors, warnings = _validate_file_with_warnings(f, "parquet")
+
+        assert errors == []
+        assert warnings == [PARQUET_VALIDATION_SKIPPED_WARNING]
+        assert buf.getvalue() == ""
+
     def test_missing_pyarrow_prints_warning(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):

--- a/tests/unit/platform/cli/test_dataset_workspace_context.py
+++ b/tests/unit/platform/cli/test_dataset_workspace_context.py
@@ -42,11 +42,12 @@ def test_list_datasets_uses_active_workspace(monkeypatch) -> None:
 
     monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
 
-    dataset_module.list_datasets()
+    result = dataset_module.list_datasets()
 
     assert calls == {
         "credentials": fake_credentials,
     }
+    assert result.total_count == 0
 
 
 def test_upload_passes_active_workspace_context_to_subscription_and_api_calls(
@@ -71,7 +72,6 @@ def test_upload_passes_active_workspace_context_to_subscription_and_api_calls(
         dataset_module, "_require_subscription", fake_require_subscription
     )
     monkeypatch.setattr(dataset_module, "_validate_file", lambda _path, _ext: [])
-    monkeypatch.setattr(dataset_module, "is_interactive", lambda: False)
     monkeypatch.setattr(
         dataset_module, "console", Console(file=output, force_terminal=False)
     )
@@ -137,16 +137,18 @@ def test_upload_passes_active_workspace_context_to_subscription_and_api_calls(
 
     monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
 
-    dataset_module.upload(str(file_path))
+    result = dataset_module.upload(str(file_path))
 
     assert calls == {
         "workspace_name": "ws-b",
         "create_credentials": fake_credentials,
         "complete_credentials": fake_credentials,
     }
-    rendered = output.getvalue()
-    assert "Dataset uploaded: data" in rendered
-    assert "https://example.com/ws-b/datasets/dataset-1" in rendered
+    assert result.operation == "dataset.upload"
+    assert result.status == "success"
+    assert result.resource["id"] == "dataset-1"
+    assert result.resource["status"] == "uploaded"
+    assert "https://example.com/ws-b/datasets/dataset-1" in result.display_next_steps[0]
 
 
 def test_download_uses_active_workspace_context_and_saves_file(
@@ -215,7 +217,7 @@ def test_download_uses_active_workspace_context_and_saves_file(
     monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
     monkeypatch.setattr(download_module, "download_file", fake_download_file)
 
-    dataset_module.download("dataset-1", output=str(tmp_path), overwrite=True)
+    result = dataset_module.download("dataset-1", output=str(tmp_path), overwrite=True)
 
     assert calls == {
         "get_credentials": fake_credentials,
@@ -227,7 +229,9 @@ def test_download_uses_active_workspace_context_and_saves_file(
         "overwrite": True,
         "output_is_directory": False,
     }
-    assert "Dataset downloaded:" in output.getvalue()
+    assert result.operation == "dataset.download"
+    assert result.status == "success"
+    assert result.resource["output_path"] == str(tmp_path / "data.jsonl")
 
 
 def test_download_preserves_trailing_separator_as_directory_intent(

--- a/tests/unit/platform/cli/test_status_formatting.py
+++ b/tests/unit/platform/cli/test_status_formatting.py
@@ -27,7 +27,7 @@ def test_list_datasets_preserves_uncategorized_status_brackets(
     monkeypatch: pytest.MonkeyPatch,
     status: str,
 ) -> None:
-    console, output = _make_rich_console()
+    console, _output = _make_rich_console()
     fake_credentials = object()
 
     monkeypatch.setattr(dataset_module, "console", console)
@@ -60,9 +60,10 @@ def test_list_datasets_preserves_uncategorized_status_brackets(
 
     monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
 
-    dataset_module.list_datasets()
+    result = dataset_module.list_datasets()
 
-    assert f"[{status}]" in strip_ansi(output.getvalue())
+    assert result.display_items is not None
+    assert f"\\[{status}]" == result.display_items[0]["status"]
 
 
 @pytest.mark.parametrize("status", ["cancelled", "deleted"])

--- a/tests/unit/platform/cli/test_utils.py
+++ b/tests/unit/platform/cli/test_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from io import StringIO
 from types import SimpleNamespace
 
@@ -15,6 +16,7 @@ from osmosis_ai.platform.cli.utils import (
     format_processing_step,
     format_run_status,
     format_size,
+    platform_call,
     validate_list_options,
 )
 from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE
@@ -274,3 +276,28 @@ def test_validate_list_options_custom_limit() -> None:
 def test_validate_list_options_mutual_exclusion() -> None:
     with pytest.raises(CLIError, match="mutually exclusive"):
         validate_list_options(limit=10, all_=True)
+
+
+# ── platform_call ────────────────────────────────────────────────────
+
+
+def test_platform_call_uses_injected_console() -> None:
+    output = StringIO()
+    status_console = Console(file=output, force_terminal=False)
+    messages: list[str] = []
+
+    @contextmanager
+    def record_spinner(message: str):
+        messages.append(message)
+        yield
+
+    status_console.spinner = record_spinner  # type: ignore[method-assign]
+
+    result = platform_call(
+        "Fetching things...",
+        lambda: "ok",
+        output_console=status_console,
+    )
+
+    assert result == "ok"
+    assert messages == ["Fetching things..."]

--- a/tests/unit/platform/cli/test_workspace_setup.py
+++ b/tests/unit/platform/cli/test_workspace_setup.py
@@ -528,7 +528,7 @@ class TestWriteScaffold:
 
         content = (target / "README.md").read_text(encoding="utf-8")
         assert "my-awesome-ws" in content
-        assert "osmosis workspace validate" in content
+        assert "osmosis --json workspace validate" in content
         assert ".osmosis/research/program.md" in content
 
     def test_is_idempotent(self, tmp_path: Path) -> None:

--- a/tests/unit/platform/cli/test_workspace_upload.py
+++ b/tests/unit/platform/cli/test_workspace_upload.py
@@ -8,7 +8,12 @@ from io import StringIO
 import pytest
 
 from osmosis_ai.cli.console import Console
-from osmosis_ai.platform.api.models import DatasetFile, UploadInfo
+from osmosis_ai.platform.api.models import (
+    BaseModelInfo,
+    DatasetFile,
+    TrainingRun,
+    UploadInfo,
+)
 
 # ---------------------------------------------------------------------------
 # _clean_file_path — drag-and-drop path normalization
@@ -48,6 +53,94 @@ class TestCleanFilePath:
         from osmosis_ai.platform.cli.workspace import _clean_file_path
 
         assert _clean_file_path("/path/to/file.jsonl") == "/path/to/file.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Detail views — platform links
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceDetailLinks:
+    def _assert_copyable_platform_link(
+        self, output: StringIO, expected_url: str
+    ) -> None:
+        rendered = output.getvalue()
+        assert "View on platform:" in rendered
+        assert expected_url in rendered
+        assert "…" not in rendered
+
+    def test_dataset_detail_prints_copyable_url_outside_table(self, monkeypatch):
+        import osmosis_ai.platform.cli.workspace as workspace_module
+
+        output = StringIO()
+        monkeypatch.setattr(
+            workspace_module,
+            "console",
+            Console(file=output, force_terminal=True, no_color=True, width=60),
+        )
+        dataset = DatasetFile(
+            id="328be61c-ef39-45e1-9b33-1e3c7c482e97",
+            file_name="data",
+            file_size=2,
+            status="uploaded",
+        )
+
+        workspace_module._show_dataset_detail(dataset, "osmosis-shared")
+
+        expected_url = workspace_module.platform_entity_url(
+            "osmosis-shared",
+            "datasets",
+            "328be61c-ef39-45e1-9b33-1e3c7c482e97",
+        )
+        self._assert_copyable_platform_link(output, expected_url)
+
+    def test_run_detail_prints_copyable_url_outside_table(self, monkeypatch):
+        import osmosis_ai.platform.cli.workspace as workspace_module
+
+        output = StringIO()
+        monkeypatch.setattr(
+            workspace_module,
+            "console",
+            Console(file=output, force_terminal=True, no_color=True, width=60),
+        )
+        run = TrainingRun(
+            id="328be61c-ef39-45e1-9b33-1e3c7c482e97",
+            name="run-1",
+            status="finished",
+        )
+
+        workspace_module._show_run_detail(run, "osmosis-shared")
+
+        expected_url = workspace_module.platform_entity_url(
+            "osmosis-shared",
+            "training",
+            "328be61c-ef39-45e1-9b33-1e3c7c482e97",
+        )
+        self._assert_copyable_platform_link(output, expected_url)
+
+    def test_model_detail_prints_copyable_url_outside_table(self, monkeypatch):
+        import osmosis_ai.platform.cli.workspace as workspace_module
+
+        output = StringIO()
+        monkeypatch.setattr(
+            workspace_module,
+            "console",
+            Console(file=output, force_terminal=True, no_color=True, width=60),
+        )
+        model = BaseModelInfo(
+            id="328be61c-ef39-45e1-9b33-1e3c7c482e97",
+            model_name="model-1",
+            status="ready",
+        )
+
+        workspace_module._show_model_detail(model, "osmosis-shared")
+
+        expected_url = workspace_module.platform_entity_url(
+            "osmosis-shared",
+            "models",
+            "328be61c-ef39-45e1-9b33-1e3c7c482e97",
+        )
+        self._assert_copyable_platform_link(output, expected_url)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

- Add global `--format`, `--json`, and `--plain` output modes with shared `CommandResult` renderers for JSON, plain text, and Rich output.
- Migrate public CLI commands across auth, dataset, train, model, deployment, rollout, eval, workspace, init, and upgrade to return structured results.
- Emit structured JSON error envelopes on stderr and fail fast for interactive or unconverted commands in machine-readable modes.
- Harden auth flows around `OSMOSIS_TOKEN`, token login, logout, workspace selection, and platform authentication errors.
- Add golden fixtures, unit tests, and subprocess guardrails for the CLI output contract.

## Why

AI agents, CI jobs, and shell automation need parseable CLI output instead of Rich-only terminal rendering. This PR keeps Rich as the default human experience while adding stable JSON envelopes and low-noise plain text for automated consumers.

The auth updates make machine-mode login safer and clearer by treating `OSMOSIS_TOKEN` as verify-only, preserving existing sessions on failed token login, and surfacing actionable token/workspace errors.

## How to Test

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest`
- `uv run pyright osmosis_ai/` currently fails with existing type errors in `osmosis_ai/cli/commands/auth.py`, `osmosis_ai/cli/commands/train.py`, `osmosis_ai/cli/console.py`, `osmosis_ai/cli/main.py`, and `osmosis_ai/platform/cli/workspace.py`.

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured CLI output modes (JSON and plain) with Rich as default, and tightens the output contract with single-envelope JSON, consistent error envelopes, and clickable/copyable platform links. Extends structured results across more commands (incl. auth whoami and eval rubric) and hardens auth token guidance and progress output so automation can parse results reliably.

- **New Features**
  - Global `--format`, `--json`, `--plain` with conflict checks; `--help`/`--version` stay plain.
  - Single JSON stdout envelope (`schema_version: 1`) for lists, details, and operations; errors always to stderr with stable codes and command/CLI version metadata; safety hook verifies output was emitted.
  - Output-aware UX: JSON is silent; plain logs progress to stderr; Rich shows spinners/progress; shared `platform_call` wrapper and upload progress bars standardize loading feedback to stderr; terminal hyperlinks via `console.print_url` keep links clickable and copyable with soft wrapping.
  - Non-interactive safeguards and `--yes` confirmations; interactive-only paths return `INTERACTIVE_REQUIRED` in JSON/plain.
  - Structured results and serializers across auth (incl. `whoami`), dataset, model, train, deployment, rollout, eval (run/rubric/cache), workspace, init, and upgrade (captures subprocess stdout/stderr).
  - Auth hardening: explicit mapping for `OSMOSIS_TOKEN` states with `INVALID`/`EXPIRED`/`REVOKED` guidance; `AuthenticationExpiredError` carries a code; no session wipe on failed token login; login/workspace loading show spinners.
  - Guardrails/tests: golden JSON fixtures; subprocess tests enforce a single stdout JSON envelope; lints block direct stdout writes in converted paths.

- **Migration**
  - Use `--json` for agents, CI, and scripts. Example: `osmosis --json dataset list`.
  - Use `--format plain` for low-noise shell pipelines.
  - Interactive workspace UI is Rich-only; in JSON/plain it returns `INTERACTIVE_REQUIRED`.
  - `OSMOSIS_TOKEN` is verify-only; failed token login no longer clears existing sessions; invalid/expired/revoked env tokens return actionable messages.
  - JSON output is the stable machine contract (`schema_version: 1`).

<sup>Written for commit 8dcf2a2d7613d26c2d44bbf1e94fad3f01478497. Summary will update on new commits. <a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/145?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

