### PR TITLE
Seperated concerns

### DIFF
--- a/osmosis_ai/__init__.py
+++ b/osmosis_ai/__init__.py
@@ -41,7 +41,13 @@ _RUBRIC_EXPORTS: frozenset[str] = frozenset(
 
 def __getattr__(name: str) -> object:
     if name in _RUBRIC_EXPORTS:
-        from .eval import rubric
+        try:
+            from .eval import rubric
+        except ImportError:
+            raise ImportError(
+                f"'{name}' requires additional dependencies: "
+                "pip install osmosis-ai[cli]"
+            ) from None
 
         value = getattr(rubric, name)
         globals()[name] = value  # cache so future access skips __getattr__

--- a/osmosis_ai/cli/__init__.py
+++ b/osmosis_ai/cli/__init__.py
@@ -1,12 +1,6 @@
-"""Osmosis CLI framework: shared errors and console utilities.
+"""Osmosis CLI framework: console utilities and command entry point.
 
 The CLI entry point (main) is accessed via osmosis_ai.cli.main:main
 and is NOT eagerly imported here to avoid circular imports with
-modules that only need the shared infrastructure (CLIError, Console).
+modules that only need the shared infrastructure.
 """
-
-from .errors import CLIError
-
-__all__ = [
-    "CLIError",
-]

--- a/osmosis_ai/cli/commands/auth.py
+++ b/osmosis_ai/cli/commands/auth.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 import typer
 
 from osmosis_ai.cli.console import console
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 
 if TYPE_CHECKING:
     from osmosis_ai.platform.auth.credentials import Credentials

--- a/osmosis_ai/cli/commands/model.py
+++ b/osmosis_ai/cli/commands/model.py
@@ -116,8 +116,8 @@ def delete(
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
 ) -> None:
     """Delete a base model."""
-    from osmosis_ai.cli.errors import CLIError
     from osmosis_ai.cli.prompts import require_confirmation
+    from osmosis_ai.errors import CLIError
     from osmosis_ai.platform.api.client import OsmosisClient
     from osmosis_ai.platform.auth.platform_client import PlatformAPIError
     from osmosis_ai.platform.cli.utils import _require_auth

--- a/osmosis_ai/cli/commands/rollout.py
+++ b/osmosis_ai/cli/commands/rollout.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import typer
 
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE
 
 if TYPE_CHECKING:

--- a/osmosis_ai/cli/commands/train.py
+++ b/osmosis_ai/cli/commands/train.py
@@ -8,7 +8,8 @@ from pathlib import Path
 import typer
 
 from osmosis_ai.cli.console import console
-from osmosis_ai.cli.errors import CLIError, not_implemented
+from osmosis_ai.cli.errors import not_implemented
+from osmosis_ai.errors import CLIError
 from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE
 
 app: typer.Typer = typer.Typer(help="Manage training runs.", no_args_is_help=True)

--- a/osmosis_ai/cli/commands/workspace.py
+++ b/osmosis_ai/cli/commands/workspace.py
@@ -63,7 +63,7 @@ def delete(
 ) -> None:
     """Delete a workspace."""
     from osmosis_ai.cli.console import console
-    from osmosis_ai.cli.errors import CLIError
+    from osmosis_ai.errors import CLIError
     from osmosis_ai.platform.cli.utils import _require_auth
 
     _, credentials = _require_auth()

--- a/osmosis_ai/cli/errors.py
+++ b/osmosis_ai/cli/errors.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
 
-class CLIError(Exception):
-    """Raised when the CLI encounters a recoverable error."""
-
-
 def not_implemented(group: str, cmd: str) -> None:
     """Print a 'not yet implemented' message and exit."""
     import typer

--- a/osmosis_ai/cli/main.py
+++ b/osmosis_ai/cli/main.py
@@ -9,8 +9,8 @@ import typer
 import typer.core
 from dotenv import find_dotenv, load_dotenv
 
-from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.consts import PACKAGE_VERSION, package_name
+from osmosis_ai.errors import CLIError
 from osmosis_ai.platform.auth.platform_client import (
     AuthenticationExpiredError,
     PlatformAPIError,

--- a/osmosis_ai/cli/prompts.py
+++ b/osmosis_ai/cli/prompts.py
@@ -388,7 +388,7 @@ def require_confirmation(message: str, *, yes: bool = False) -> None:
     if yes:
         return
     if not is_interactive():
-        from osmosis_ai.cli.errors import CLIError
+        from osmosis_ai.errors import CLIError
 
         raise CLIError("Use --yes to confirm in non-interactive mode.")
     if not confirm(message):

--- a/osmosis_ai/consts.py
+++ b/osmosis_ai/consts.py
@@ -1,3 +1,3 @@
 # package metadata
 package_name = "osmosis-ai"
-PACKAGE_VERSION = "0.2.18"
+PACKAGE_VERSION = "0.3.0"

--- a/osmosis_ai/consts.py
+++ b/osmosis_ai/consts.py
@@ -1,3 +1,3 @@
 # package metadata
 package_name = "osmosis-ai"
-PACKAGE_VERSION = "0.3.0"
+PACKAGE_VERSION = "0.2.18"

--- a/osmosis_ai/errors.py
+++ b/osmosis_ai/errors.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+class CLIError(Exception):
+    """Raised when the CLI encounters a recoverable error."""

--- a/osmosis_ai/eval/common/cli.py
+++ b/osmosis_ai/eval/common/cli.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from osmosis_ai.cli.console import Console
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 from osmosis_ai.eval.common.dataset import DatasetReader
 from osmosis_ai.eval.common.errors import (
     DatasetParseError,

--- a/osmosis_ai/eval/config.py
+++ b/osmosis_ai/eval/config.py
@@ -8,7 +8,7 @@ from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 
 
 class _EvalSection(BaseModel):

--- a/osmosis_ai/eval/evaluation/cli.py
+++ b/osmosis_ai/eval/evaluation/cli.py
@@ -234,7 +234,7 @@ class EvalCommand:
             return None
         value = os.environ.get(config.llm_api_key_env)
         if not value:
-            from osmosis_ai.cli.errors import CLIError
+            from osmosis_ai.errors import CLIError
 
             raise CLIError(
                 f"Environment variable '{config.llm_api_key_env}' "
@@ -328,7 +328,7 @@ class EvalCommand:
                 self.console.print(f"  Failed: {failed}")
 
     async def _run_async(self, args: Any) -> int:
-        from osmosis_ai.cli.errors import CLIError
+        from osmosis_ai.errors import CLIError
 
         # Reject conflicting CLI flags before config load so invalid fixtures cannot mask this error.
         if args.fresh and args.retry_failed:

--- a/osmosis_ai/eval/llm_proxy.py
+++ b/osmosis_ai/eval/llm_proxy.py
@@ -104,7 +104,7 @@ class LiteLLMProxy:
 
     async def preflight_check(self) -> None:
         """Send a minimal 1-token request to verify LLM connectivity."""
-        from osmosis_ai.cli.errors import CLIError
+        from osmosis_ai.errors import CLIError
 
         litellm = _get_litellm()
 
@@ -298,7 +298,7 @@ def _get_litellm():
             litellm._async_client_cleanup_registered = True
         return litellm
     except ImportError as exc:
-        from osmosis_ai.cli.errors import CLIError
+        from osmosis_ai.errors import CLIError
 
         raise CLIError(
             "LiteLLM is required. Install with: pip install litellm"

--- a/osmosis_ai/eval/rubric/cli.py
+++ b/osmosis_ai/eval/rubric/cli.py
@@ -4,8 +4,8 @@ import asyncio
 import sys
 from pathlib import Path
 
-from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.cli.paths import parse_cli_path
+from osmosis_ai.errors import CLIError
 
 from .dataset import RubricRecord, load_rubric_dataset
 from .engine import evaluate_rubric

--- a/osmosis_ai/eval/rubric/dataset.py
+++ b/osmosis_ai/eval/rubric/dataset.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 
 
 def extract_assistant_content(messages: list[dict[str, Any]]) -> str:

--- a/osmosis_ai/platform/auth/flow.py
+++ b/osmosis_ai/platform/auth/flow.py
@@ -20,7 +20,6 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-from osmosis_ai.cli.console import console
 from osmosis_ai.consts import PACKAGE_VERSION
 
 from .config import PLATFORM_URL
@@ -331,6 +330,8 @@ def device_login(timeout: float = 600.0) -> tuple[LoginResult, Credentials]:
     Returns:
         Tuple of (LoginResult, Credentials). Caller is responsible for saving credentials.
     """
+    from osmosis_ai.cli.console import console
+
     device_code_resp = request_device_code()
 
     console.print()

--- a/osmosis_ai/platform/auth/platform_client.py
+++ b/osmosis_ai/platform/auth/platform_client.py
@@ -9,8 +9,8 @@ from typing import TYPE_CHECKING, Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.consts import PACKAGE_VERSION
+from osmosis_ai.errors import CLIError
 from osmosis_ai.platform.constants import MSG_NOT_LOGGED_IN
 
 from .config import PLATFORM_URL

--- a/osmosis_ai/platform/cli/dataset.py
+++ b/osmosis_ai/platform/cli/dataset.py
@@ -9,9 +9,9 @@ from typing import Any
 from urllib.parse import unquote, urlparse
 
 from osmosis_ai.cli.console import console
-from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.cli.paths import parse_cli_path
 from osmosis_ai.cli.prompts import confirm, is_interactive
+from osmosis_ai.errors import CLIError
 from osmosis_ai.platform.api.models import STATUSES_IN_PROGRESS
 from osmosis_ai.platform.auth import (
     AuthenticationExpiredError,

--- a/osmosis_ai/platform/cli/init.py
+++ b/osmosis_ai/platform/cli/init.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from osmosis_ai.cli.console import console
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 from osmosis_ai.platform.auth.config import PLATFORM_URL
 from osmosis_ai.platform.auth.local_config import (
     get_active_workspace_id,

--- a/osmosis_ai/platform/cli/training_config.py
+++ b/osmosis_ai/platform/cli/training_config.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 
 
 class _ExperimentSection(BaseModel):

--- a/osmosis_ai/platform/cli/utils.py
+++ b/osmosis_ai/platform/cli/utils.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from osmosis_ai.cli.console import console
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 from osmosis_ai.platform.api.models import (
     RUN_STATUSES_ERROR,
     RUN_STATUSES_IN_PROGRESS,

--- a/osmosis_ai/platform/cli/workspace.py
+++ b/osmosis_ai/platform/cli/workspace.py
@@ -7,7 +7,6 @@ from typing import Any
 import typer
 
 from osmosis_ai.cli.console import console
-from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.cli.prompts import (
     Choice,
     Separator,
@@ -17,6 +16,7 @@ from osmosis_ai.cli.prompts import (
     select_list,
     text,
 )
+from osmosis_ai.errors import CLIError
 from osmosis_ai.platform.auth import (
     PlatformAPIError,
     ensure_active_workspace,

--- a/osmosis_ai/platform/cli/workspace_contract.py
+++ b/osmosis_ai/platform/cli/workspace_contract.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 
 _REQUIRED_DIRS = (
     ".osmosis",

--- a/osmosis_ai/rollout/__init__.py
+++ b/osmosis_ai/rollout/__init__.py
@@ -1,5 +1,7 @@
 """Public API for the rollout SDK."""
 
+import importlib
+
 from osmosis_ai.rollout.agent_workflow import AgentWorkflow
 from osmosis_ai.rollout.backend import ExecutionBackend, LocalBackend
 from osmosis_ai.rollout.context import (
@@ -10,11 +12,7 @@ from osmosis_ai.rollout.context import (
     get_rollout_context,
 )
 from osmosis_ai.rollout.grader import Grader
-from osmosis_ai.rollout.integrations.agents.strands import (
-    OsmosisRolloutModel,
-    OsmosisStrandsAgent,
-)
-from osmosis_ai.rollout.server import ControllerAuth, create_rollout_server
+from osmosis_ai.rollout.server.auth import ControllerAuth
 from osmosis_ai.rollout.types import (
     AgentWorkflowConfig,
     ConcurrencyConfig,
@@ -31,6 +29,34 @@ from osmosis_ai.rollout.types import (
     RolloutSample,
     RolloutStatus,
 )
+
+_LAZY_IMPORTS: dict[str, str] = {
+    "create_rollout_server": "osmosis_ai.rollout.server.app",
+    "OsmosisRolloutModel": "osmosis_ai.rollout.integrations.agents.strands",
+    "OsmosisStrandsAgent": "osmosis_ai.rollout.integrations.agents.strands",
+}
+
+_EXTRA_HINTS: dict[str, str] = {
+    "create_rollout_server": "pip install osmosis-ai[server]",
+    "OsmosisRolloutModel": "pip install osmosis-ai[server]",
+    "OsmosisStrandsAgent": "pip install osmosis-ai[server]",
+}
+
+
+def __getattr__(name: str) -> object:
+    if name in _LAZY_IMPORTS:
+        try:
+            module = importlib.import_module(_LAZY_IMPORTS[name])
+        except ImportError:
+            hint = _EXTRA_HINTS.get(name, "")
+            raise ImportError(
+                f"'{name}' requires additional dependencies: {hint}"
+            ) from None
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "AgentWorkflow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,47 +20,52 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "PyYAML>=6.0,<7.0",
-    "python-dotenv>=0.1.0,<2.0.0",
-    "requests>=2.0.0,<3.0.0",
-    "litellm>=1.40.0,<=1.82.6", # Unified LLM provider (supports 100+ providers)
-    "tqdm>=4.0.0,<5.0.0",
-    # Remote rollout SDK dependencies
-    "httpx>=0.25.0,<1.0.0",
     "pydantic>=2.0.0,<3.0.0",
-    # Eval cache dependencies
-    "filelock>=3.0.0,<4.0.0",
-    "xxhash>=3.0.0",
-    "strands-agents[litellm]>=1.29.0",
-    "rich>=14.2.0",
-    # Secure credential storage (system keychain)
-    "keyring>=25.0.0",
-    # Interactive CLI prompts
-    "questionary>=2.1.0,<3.0.0",
-    # CLI framework
-    "typer>=0.16.0",
-    "rich>=13.0.0",
-    "harbor==0.3.0",
 ]
 
 [project.optional-dependencies]
-# Platform CLI (dataset upload/validate)
-platform = [
-    "pyarrow>=14.0.0",      # Parquet file validation
-]
+# Types-only — base install already covers this; explicit for documentation
+types = []
 
-# Server dependencies for rollout serving
+# Rollout server: FastAPI app, execution backends, agent integrations
 server = [
-    "osmosis-ai[platform]",
     "fastapi>=0.100.0,<1.0.0",
     "uvicorn>=0.23.0,<1.0.0",
     "pydantic-settings>=2.0.0,<3.0.0",
+    "httpx>=0.25.0,<1.0.0",
+    "harbor==0.3.0",
+    "strands-agents[litellm]>=1.29.0",
+]
+
+# Platform API client: auth, credential storage, API operations
+client = [
+    "httpx>=0.25.0,<1.0.0",
+    "keyring>=25.0.0",
+    "python-dotenv>=0.1.0,<2.0.0",
+]
+
+# CLI: interactive commands, eval, rubric engine
+cli = [
+    "osmosis-ai[client]",
+    "typer>=0.16.0",
+    "rich>=14.2.0",
+    "questionary>=2.1.0,<3.0.0",
+    "PyYAML>=6.0,<7.0",
+    "litellm>=1.40.0,<=1.82.6",
+    "tqdm>=4.0.0,<5.0.0",
+    "filelock>=3.0.0,<4.0.0",
+    "xxhash>=3.0.0",
+]
+
+# Full installation with all optional features
+full = [
+    "osmosis-ai[server]",
+    "osmosis-ai[cli]",
 ]
 
 # Development dependencies (testing, formatting, type checking, etc.)
-# Includes server extra so pyright/mypy can resolve server-related imports.
 dev = [
-    "osmosis-ai[server]",
+    "osmosis-ai[full]",
     "pytest>=8.0.0,<10.0.0",
     "pytest-asyncio>=0.23.0,<2.0.0",
     "pytest-cov>=6.0.0",
@@ -71,11 +76,7 @@ dev = [
     "mypy==1.20.2",
     "types-PyYAML>=6.0",
     "types-requests>=2.0",
-]
-
-# Full installation with all optional features
-full = [
-    "osmosis-ai[server]",
+    "pyarrow>=14.0.0",
 ]
 
 [project.urls]

--- a/tests/unit/auth/test_error_messages.py
+++ b/tests/unit/auth/test_error_messages.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 
 import pytest
 
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 from osmosis_ai.platform.auth.credentials import Credentials, UserInfo
 from osmosis_ai.platform.auth.platform_client import (
     AuthenticationExpiredError,

--- a/tests/unit/auth/test_platform_client.py
+++ b/tests/unit/auth/test_platform_client.py
@@ -12,7 +12,7 @@ from urllib.error import HTTPError, URLError
 
 import pytest
 
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 from osmosis_ai.platform.auth.credentials import (
     Credentials,
     UserInfo,

--- a/tests/unit/cli/test_model_commands.py
+++ b/tests/unit/cli/test_model_commands.py
@@ -136,7 +136,7 @@ class TestDeleteModel:
     def test_affected_resources_api_error(
         self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
     ) -> None:
-        from osmosis_ai.cli.errors import CLIError
+        from osmosis_ai.errors import CLIError
         from osmosis_ai.platform.auth.platform_client import PlatformAPIError
 
         class FakeClient:

--- a/tests/unit/cli/test_train_commands.py
+++ b/tests/unit/cli/test_train_commands.py
@@ -11,7 +11,7 @@ import osmosis_ai.cli.commands.train as train_module
 import osmosis_ai.platform.api.client as api_client_module
 import osmosis_ai.platform.cli.utils as utils_module
 from osmosis_ai.cli.console import Console
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 from osmosis_ai.platform.api.models import (
     DeleteTrainingRunResult,
     PaginatedTrainingRuns,

--- a/tests/unit/cli/test_train_metrics_cmd.py
+++ b/tests/unit/cli/test_train_metrics_cmd.py
@@ -401,7 +401,7 @@ class TestMetricsCommandErrors:
         client.get_training_run.return_value = _make_run_detail(status="pending")
 
         from osmosis_ai.cli.commands.train import metrics
-        from osmosis_ai.cli.errors import CLIError
+        from osmosis_ai.errors import CLIError
 
         with pytest.raises(CLIError, match="not yet available for pending"):
             metrics(
@@ -436,7 +436,7 @@ class TestMetricsCommandErrors:
     def test_no_workspace_no_output_raises(self, tmp_path: Path) -> None:
         """Without .osmosis/workspace.toml and no -o flag, should error."""
         from osmosis_ai.cli.commands.train import _resolve_default_output
-        from osmosis_ai.cli.errors import CLIError
+        from osmosis_ai.errors import CLIError
 
         with pytest.raises(CLIError, match="Not in an Osmosis workspace"):
             _resolve_default_output("my-run", "abc12345", cwd=tmp_path)

--- a/tests/unit/eval/common/test_grader_resolution.py
+++ b/tests/unit/eval/common/test_grader_resolution.py
@@ -3,7 +3,7 @@ import types
 
 import pytest
 
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 from osmosis_ai.eval.common.cli import _resolve_grader
 
 

--- a/tests/unit/eval/common/test_multi_candidate.py
+++ b/tests/unit/eval/common/test_multi_candidate.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 from osmosis_ai.eval.common.cli import _resolve_workflow, auto_discover_grader
 from osmosis_ai.rollout.grader import Grader
 from osmosis_ai.rollout.types import GraderConfig

--- a/tests/unit/eval/test_config.py
+++ b/tests/unit/eval/test_config.py
@@ -96,14 +96,14 @@ model = "openai/gpt-3.5-turbo"
 
 
 def test_load_config_missing_file():
-    from osmosis_ai.cli.errors import CLIError
+    from osmosis_ai.errors import CLIError
 
     with pytest.raises(CLIError, match="Config file not found"):
         load_eval_config(Path("/nonexistent/config.toml"))
 
 
 def test_load_config_invalid_toml(tmp_toml):
-    from osmosis_ai.cli.errors import CLIError
+    from osmosis_ai.errors import CLIError
 
     path = tmp_toml("this is not [valid toml")
     with pytest.raises(CLIError, match="Invalid TOML"):
@@ -111,7 +111,7 @@ def test_load_config_invalid_toml(tmp_toml):
 
 
 def test_load_config_missing_eval_section(tmp_toml):
-    from osmosis_ai.cli.errors import CLIError
+    from osmosis_ai.errors import CLIError
 
     path = tmp_toml("""
 [llm]
@@ -122,7 +122,7 @@ model = "openai/gpt-5.4"
 
 
 def test_load_config_missing_rollout(tmp_toml):
-    from osmosis_ai.cli.errors import CLIError
+    from osmosis_ai.errors import CLIError
 
     path = tmp_toml("""
 [eval]
@@ -137,7 +137,7 @@ model = "openai/gpt-5.4"
 
 
 def test_load_config_missing_entrypoint(tmp_toml):
-    from osmosis_ai.cli.errors import CLIError
+    from osmosis_ai.errors import CLIError
 
     path = tmp_toml("""
 [eval]
@@ -152,7 +152,7 @@ model = "openai/gpt-5.4"
 
 
 def test_load_config_missing_dataset(tmp_toml):
-    from osmosis_ai.cli.errors import CLIError
+    from osmosis_ai.errors import CLIError
 
     path = tmp_toml("""
 [eval]
@@ -167,7 +167,7 @@ model = "openai/gpt-5.4"
 
 
 def test_load_config_missing_llm_model(tmp_toml):
-    from osmosis_ai.cli.errors import CLIError
+    from osmosis_ai.errors import CLIError
 
     path = tmp_toml("""
 [eval]
@@ -200,7 +200,7 @@ config = "my_rollout:grader_config"
 
 def test_load_config_invalid_runs_n_type(tmp_toml):
     """runs.n must be an integer, not a string."""
-    from osmosis_ai.cli.errors import CLIError
+    from osmosis_ai.errors import CLIError
 
     path = tmp_toml("""
 [eval]
@@ -220,7 +220,7 @@ n = "four"
 
 def test_load_config_invalid_batch_size_zero(tmp_toml):
     """runs.batch_size must be >= 1."""
-    from osmosis_ai.cli.errors import CLIError
+    from osmosis_ai.errors import CLIError
 
     path = tmp_toml("""
 [eval]
@@ -240,7 +240,7 @@ batch_size = 0
 
 def test_load_config_invalid_pass_threshold_range(tmp_toml):
     """runs.pass_threshold must be 0.0..1.0."""
-    from osmosis_ai.cli.errors import CLIError
+    from osmosis_ai.errors import CLIError
 
     path = tmp_toml("""
 [eval]

--- a/tests/unit/eval/test_llm_proxy.py
+++ b/tests/unit/eval/test_llm_proxy.py
@@ -52,7 +52,7 @@ def test_proxy_trace_dir_set():
 
 async def test_preflight_check_bad_model_format(monkeypatch):
     """preflight_check raises CLIError on invalid model format."""
-    from osmosis_ai.cli.errors import CLIError
+    from osmosis_ai.errors import CLIError
 
     def fake_get_llm_provider(model, api_base=None):
         raise Exception("Bad model format")
@@ -76,7 +76,7 @@ async def test_preflight_check_bad_model_format(monkeypatch):
 
 async def test_preflight_check_auth_failure(monkeypatch):
     """preflight_check raises CLIError on authentication error."""
-    from osmosis_ai.cli.errors import CLIError
+    from osmosis_ai.errors import CLIError
 
     class FakeAuthError(Exception):
         pass

--- a/tests/unit/platform/cli/test_dataset_workspace_context.py
+++ b/tests/unit/platform/cli/test_dataset_workspace_context.py
@@ -12,7 +12,7 @@ import osmosis_ai.platform.api.download as download_module
 import osmosis_ai.platform.api.upload as upload_module
 import osmosis_ai.platform.cli.dataset as dataset_module
 from osmosis_ai.cli.console import Console
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 from osmosis_ai.platform.api.models import (
     DatasetDownloadInfo,
     DatasetFile,

--- a/tests/unit/platform/cli/test_training_config.py
+++ b/tests/unit/platform/cli/test_training_config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 from osmosis_ai.platform.cli.training_config import TrainingConfig, load_training_config
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/platform/cli/test_utils.py
+++ b/tests/unit/platform/cli/test_utils.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from osmosis_ai.cli.console import Console
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 from osmosis_ai.platform.cli.utils import (
     fetch_all_pages,
     format_dataset_status,

--- a/tests/unit/platform/cli/test_workspace_setup.py
+++ b/tests/unit/platform/cli/test_workspace_setup.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 
 # ── Error case: git not found ────────────────────────────────────
 

--- a/tests/unit/platform/cli/test_workspace_upload.py
+++ b/tests/unit/platform/cli/test_workspace_upload.py
@@ -193,7 +193,7 @@ class TestPerformUpload:
     def test_raises_on_missing_upload_info(self, monkeypatch, tmp_path):
         """_perform_upload raises CLIError if server returns no upload info."""
         import osmosis_ai.platform.api.client as api_client_module
-        from osmosis_ai.cli.errors import CLIError
+        from osmosis_ai.errors import CLIError
 
         file_path = tmp_path / "data.jsonl"
         file_path.write_text("{}")
@@ -224,7 +224,7 @@ class TestPerformUpload:
         """_perform_upload aborts and raises CLIError on KeyboardInterrupt."""
         import osmosis_ai.platform.api.client as api_client_module
         import osmosis_ai.platform.api.upload as upload_module
-        from osmosis_ai.cli.errors import CLIError
+        from osmosis_ai.errors import CLIError
 
         file_path = tmp_path / "data.jsonl"
         file_path.write_text("{}")

--- a/tests/unit/test_rubric_cli_command.py
+++ b/tests/unit/test_rubric_cli_command.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.errors import CLIError
 from osmosis_ai.eval.rubric.cli import RubricCommand
 from osmosis_ai.eval.rubric.dataset import (
     RubricRecord,

--- a/uv.lock
+++ b/uv.lock
@@ -2169,27 +2169,36 @@ wheels = [
 name = "osmosis-ai"
 source = { editable = "." }
 dependencies = [
+    { name = "pydantic" },
+]
+
+[package.optional-dependencies]
+cli = [
+    { name = "filelock" },
+    { name = "httpx" },
+    { name = "keyring" },
+    { name = "litellm" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "questionary" },
+    { name = "rich" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "xxhash" },
+]
+client = [
+    { name = "httpx" },
+    { name = "keyring" },
+    { name = "python-dotenv" },
+]
+dev = [
+    { name = "anyio" },
+    { name = "fastapi" },
     { name = "filelock" },
     { name = "harbor" },
     { name = "httpx" },
     { name = "keyring" },
     { name = "litellm" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "questionary" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "strands-agents", extra = ["litellm"] },
-    { name = "tqdm" },
-    { name = "typer" },
-    { name = "xxhash" },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "anyio" },
-    { name = "fastapi" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pyarrow" },
@@ -2198,24 +2207,43 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "questionary" },
+    { name = "rich" },
     { name = "ruff" },
+    { name = "strands-agents", extra = ["litellm"] },
+    { name = "tqdm" },
+    { name = "typer" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
     { name = "uvicorn" },
+    { name = "xxhash" },
 ]
 full = [
     { name = "fastapi" },
-    { name = "pyarrow" },
+    { name = "filelock" },
+    { name = "harbor" },
+    { name = "httpx" },
+    { name = "keyring" },
+    { name = "litellm" },
     { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "questionary" },
+    { name = "rich" },
+    { name = "strands-agents", extra = ["litellm"] },
+    { name = "tqdm" },
+    { name = "typer" },
     { name = "uvicorn" },
-]
-platform = [
-    { name = "pyarrow" },
+    { name = "xxhash" },
 ]
 server = [
     { name = "fastapi" },
-    { name = "pyarrow" },
+    { name = "harbor" },
+    { name = "httpx" },
     { name = "pydantic-settings" },
+    { name = "strands-agents", extra = ["litellm"] },
     { name = "uvicorn" },
 ]
 
@@ -2223,39 +2251,39 @@ server = [
 requires-dist = [
     { name = "anyio", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.100.0,<1.0.0" },
-    { name = "filelock", specifier = ">=3.0.0,<4.0.0" },
-    { name = "harbor", specifier = "==0.3.0" },
-    { name = "httpx", specifier = ">=0.25.0,<1.0.0" },
-    { name = "keyring", specifier = ">=25.0.0" },
-    { name = "litellm", specifier = ">=1.40.0,<=1.82.6" },
+    { name = "filelock", marker = "extra == 'cli'", specifier = ">=3.0.0,<4.0.0" },
+    { name = "harbor", marker = "extra == 'server'", specifier = "==0.3.0" },
+    { name = "httpx", marker = "extra == 'client'", specifier = ">=0.25.0,<1.0.0" },
+    { name = "httpx", marker = "extra == 'server'", specifier = ">=0.25.0,<1.0.0" },
+    { name = "keyring", marker = "extra == 'client'", specifier = ">=25.0.0" },
+    { name = "litellm", marker = "extra == 'cli'", specifier = ">=1.40.0,<=1.82.6" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.20.2" },
-    { name = "osmosis-ai", extras = ["platform"], marker = "extra == 'server'" },
-    { name = "osmosis-ai", extras = ["server"], marker = "extra == 'dev'" },
+    { name = "osmosis-ai", extras = ["cli"], marker = "extra == 'full'" },
+    { name = "osmosis-ai", extras = ["client"], marker = "extra == 'cli'" },
+    { name = "osmosis-ai", extras = ["full"], marker = "extra == 'dev'" },
     { name = "osmosis-ai", extras = ["server"], marker = "extra == 'full'" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0,<5.0.0" },
-    { name = "pyarrow", marker = "extra == 'platform'", specifier = ">=14.0.0" },
+    { name = "pyarrow", marker = "extra == 'dev'", specifier = ">=14.0.0" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
     { name = "pydantic-settings", marker = "extra == 'server'", specifier = ">=2.0.0,<3.0.0" },
     { name = "pyright", extras = ["nodejs"], marker = "extra == 'dev'", specifier = "==1.1.408" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0,<10.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0,<2.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
-    { name = "python-dotenv", specifier = ">=0.1.0,<2.0.0" },
-    { name = "pyyaml", specifier = ">=6.0,<7.0" },
-    { name = "questionary", specifier = ">=2.1.0,<3.0.0" },
-    { name = "requests", specifier = ">=2.0.0,<3.0.0" },
-    { name = "rich", specifier = ">=13.0.0" },
-    { name = "rich", specifier = ">=14.2.0" },
+    { name = "python-dotenv", marker = "extra == 'client'", specifier = ">=0.1.0,<2.0.0" },
+    { name = "pyyaml", marker = "extra == 'cli'", specifier = ">=6.0,<7.0" },
+    { name = "questionary", marker = "extra == 'cli'", specifier = ">=2.1.0,<3.0.0" },
+    { name = "rich", marker = "extra == 'cli'", specifier = ">=14.2.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.11" },
-    { name = "strands-agents", extras = ["litellm"], specifier = ">=1.29.0" },
-    { name = "tqdm", specifier = ">=4.0.0,<5.0.0" },
-    { name = "typer", specifier = ">=0.16.0" },
+    { name = "strands-agents", extras = ["litellm"], marker = "extra == 'server'", specifier = ">=1.29.0" },
+    { name = "tqdm", marker = "extra == 'cli'", specifier = ">=4.0.0,<5.0.0" },
+    { name = "typer", marker = "extra == 'cli'", specifier = ">=0.16.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.23.0,<1.0.0" },
-    { name = "xxhash", specifier = ">=3.0.0" },
+    { name = "xxhash", marker = "extra == 'cli'", specifier = ">=3.0.0" },
 ]
-provides-extras = ["platform", "server", "dev", "full"]
+provides-extras = ["types", "server", "client", "cli", "full", "dev"]
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
<!--
PR Title Format: [module] type: description
  modules: reward, rollout, server, cli, auth, eval, misc, ci, doc
  types:   feat, fix, refactor, chore, test, doc

Examples:
  [rollout] feat: add streaming support for chat completions
  [BREAKING][reward] refactor: rename decorator parameters
  [ci] chore: update GitHub Actions versions
-->

## What

<!-- Brief description of the changes. What does this PR do? -->

## Why

<!-- Why are these changes needed? Link any related issues. -->
<!-- Closes #<issue_number> -->

## How to Test

<!-- Describe how reviewers can verify these changes. -->

## Checklist

- [ ] PR title follows `[module] type: description` format
- [ ] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pyright osmosis_ai/` passes
- [ ] `pytest` passes (new tests added if applicable)
- [ ] Public API changes are documented
- [ ] No secrets or credentials included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split CLI, client, and server into optional extras with lazy imports to reduce the base install and avoid unnecessary dependencies. Centralized `CLIError`, added clear import-time hints, and kept public rollout/rubric imports stable.

- **Refactors**
  - Moved `CLIError` to `osmosis_ai.errors`; updated all imports.
  - Added lazy exports in `osmosis_ai.rollout` for `create_rollout_server` and agent integrations with helpful error hints.
  - Gated rubric exports behind the `cli` extra; accessing them without it raises an ImportError with an install hint.
  - Deferred side-effectful imports (e.g., console) to runtime to avoid circular imports.

- **Migration**
  - Replace `from osmosis_ai.cli.errors import CLIError` with `from osmosis_ai.errors import CLIError`.
  - Install extras based on usage:
    - CLI and eval/rubric commands: `pip install osmosis-ai[cli]`
    - Rollout server and agent integrations: `pip install osmosis-ai[server]`
    - Platform client/auth tooling: `pip install osmosis-ai[client]`
    - Everything: `pip install osmosis-ai[full]`
  - Existing `from osmosis_ai.rollout import create_rollout_server` continues to work (now lazily loaded) but requires the `server` extra.

<sup>Written for commit 8b6351735fa474063d31ce3f7b61b029a71dc101. Summary will update on new commits. <a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/146?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

