### PR TITLE
[cli][eval] feat: enrich train submit confirmation and harden auth-aware reads

### DIFF
--- a/osmosis_ai/cli/commands/train.py
+++ b/osmosis_ai/cli/commands/train.py
@@ -21,7 +21,23 @@ def _detail_fields(rows: list[tuple[str, str]]) -> list[Any]:
     return [DetailField(label=label, value=value) for label, value in rows]
 
 
-def _require_confirmation(message: str, *, yes: bool) -> None:
+def _require_confirmation(
+    message: str,
+    *,
+    yes: bool,
+    summary: list[tuple[str, str]] | None = None,
+    notes: list[str] | None = None,
+    warnings: list[str] | None = None,
+) -> None:
+    """Confirm a destructive action, surfacing context in non-interactive modes.
+
+    In rich+interactive mode, falls back to the questionary prompt. In JSON
+    and plain modes (or any non-interactive shell), raises an
+    ``INTERACTIVE_REQUIRED`` error that carries the prompt question, the
+    summary of what would be acted on, and any notes/warnings — so AI
+    agents and CI scripts can see exactly what they're being asked to
+    confirm without first having to retry with ``--yes``.
+    """
     if yes:
         return
 
@@ -29,9 +45,36 @@ def _require_confirmation(message: str, *, yes: bool) -> None:
 
     output = get_output_context()
     if output.format is not OutputFormat.rich or not output.interactive:
+        details: dict[str, Any] = {"prompt": message}
+        if summary:
+            details["summary"] = {label: value for label, value in summary}
+        if notes:
+            details["notes"] = list(notes)
+        if warnings:
+            details["warnings"] = list(warnings)
+
+        if output.format is OutputFormat.plain:
+            import sys
+
+            lines: list[str] = [f"Confirmation required: {message}"]
+            if summary:
+                for label, value in summary:
+                    lines.append(f"  {label}: {value}")
+            if notes:
+                lines.append("Notes:")
+                for note in notes:
+                    lines.append(f"  - {note}")
+            if warnings:
+                lines.append("Warnings:")
+                for warning in warnings:
+                    lines.append(f"  - {warning}")
+            sys.stderr.write("\n".join(lines) + "\n")
+            sys.stderr.flush()
+
         err = CLIError(
             "Use --yes to confirm in non-interactive mode.",
             code="INTERACTIVE_REQUIRED",
+            details=details,
         )
         if output.format is OutputFormat.json:
             from osmosis_ai.cli.output import emit_structured_error_to_stderr
@@ -43,6 +86,109 @@ def _require_confirmation(message: str, *, yes: bool) -> None:
     from osmosis_ai.cli.prompts import require_confirmation
 
     require_confirmation(message, yes=yes)
+
+
+def _print_remote_fetch_notice(
+    project_root: Path,
+    *,
+    pinned_commit_sha: str | None,
+) -> tuple[list[str], list[str]]:
+    """Remind the user that submit pulls *code* from the connected Git remote
+    while reading *config values* from the local TOML file.
+
+    The platform clones the workspace's connected Git repository (or
+    fetches a pinned commit) before training, so local *code* changes
+    that haven't been pushed will silently be ignored. The config TOML
+    passed to ``osmosis train submit``, by contrast, is read from disk
+    and its values are sent verbatim in the submit payload — local
+    edits to the config take effect immediately, even if they are
+    uncommitted.
+
+    Returns ``(notes, warnings)`` as plain-text lists so callers can
+    surface the same context in non-rich modes (e.g. the JSON error
+    envelope when ``--yes`` is missing). The Rich panel is rendered
+    only when the output format is Rich.
+    """
+    from osmosis_ai.cli.output import OutputFormat, get_output_context
+    from osmosis_ai.platform.cli.workspace_repo import summarize_local_git_state
+
+    state = summarize_local_git_state(project_root)
+
+    warnings: list[str] = []
+    if state is not None:
+        if state.is_dirty:
+            warnings.append(
+                "Uncommitted changes detected — code edits won't be picked up "
+                "(only the config file above is read locally)."
+            )
+        if state.has_upstream and state.ahead > 0:
+            commits_word = "commit" if state.ahead == 1 else "commits"
+            warnings.append(
+                f"{state.ahead} unpushed {commits_word} ahead of upstream — "
+                "push code before submitting."
+            )
+        elif state.branch is not None and not state.has_upstream:
+            warnings.append(
+                f"Branch '{state.branch}' has no upstream — "
+                "push code and set tracking before submitting."
+            )
+
+    notes: list[str] = []
+    if pinned_commit_sha:
+        notes.append(
+            f"Osmosis will fetch commit {pinned_commit_sha} from the "
+            "workspace's connected Git repository for training code."
+        )
+        notes.append("Make sure that commit is already pushed to the remote.")
+    else:
+        notes.append(
+            "Osmosis will fetch the latest training code from the workspace's "
+            "connected Git repository."
+        )
+        if state is not None and state.branch and state.head_sha:
+            notes.append(f"Local branch: {state.branch} @ {state.head_sha[:8]}")
+        notes.append("Make sure your code changes are committed and pushed.")
+    notes.append(
+        "Config values come from your local TOML file and are submitted "
+        "as-is — uncommitted edits to the config still apply."
+    )
+
+    if get_output_context().format is OutputFormat.rich:
+        body_lines: list[str] = []
+        if pinned_commit_sha:
+            body_lines.append(
+                f"Osmosis will fetch commit [bold]{console.escape(pinned_commit_sha)}[/bold] "
+                "from the workspace's connected Git repository for training code."
+            )
+            body_lines.append("Make sure that commit is already pushed to the remote.")
+        else:
+            body_lines.append(
+                "Osmosis will fetch the latest training code from the workspace's "
+                "connected Git repository."
+            )
+            if state is not None and state.branch and state.head_sha:
+                body_lines.append(
+                    f"Local: [bold]{console.escape(state.branch)}[/bold] @ "
+                    f"[dim]{console.escape(state.head_sha[:8])}[/dim]"
+                )
+            body_lines.append("Make sure your code changes are committed and pushed.")
+
+        body_lines.append("")
+        body_lines.append(
+            "[dim]Config values above come from your local TOML file and are "
+            "submitted as-is — uncommitted edits to the config still apply.[/dim]"
+        )
+
+        if warnings:
+            body_lines.append("")
+            for warning in warnings:
+                body_lines.append(f"[yellow]• {console.escape(warning)}[/yellow]")
+
+        style = "yellow" if warnings else "blue"
+        title = "Push before submitting" if warnings else "Before you submit"
+        console.panel(title, "\n".join(body_lines), style=style)
+
+    return notes, warnings
 
 
 @app.command("list")
@@ -230,6 +376,11 @@ def submit(
         _require_auth,
         platform_entity_url,
     )
+    from osmosis_ai.platform.cli.workspace_repo import (
+        validate_active_workspace_repo,
+    )
+
+    command_label = "`osmosis train submit`"
 
     project_root = resolve_project_root(config_path)
     validate_project_contract(project_root)
@@ -237,28 +388,48 @@ def submit(
         config_path,
         project_root,
         config_dir="configs/training",
-        command_label="`osmosis train submit`",
+        command_label=command_label,
     )
     config = load_training_config(config_path)
     validate_rollout_backend(
         project_root=project_root,
         rollout=config.experiment_rollout,
         entrypoint=config.experiment_entrypoint,
-        command_label="`osmosis train submit`",
+        command_label=command_label,
     )
     ws_name, credentials = _require_auth()
+    validate_active_workspace_repo(
+        project_root=project_root,
+        workspace_name=ws_name,
+        credentials=credentials,
+        command_label=command_label,
+    )
 
-    rows: list[tuple[str, str]] = [
-        ("Rollout", console.escape(config.experiment_rollout)),
-        ("Entrypoint", console.escape(config.experiment_entrypoint)),
-        ("Model", console.escape(config.experiment_model_path)),
-        ("Dataset", console.escape(config.experiment_dataset)),
+    summary_rows: list[tuple[str, str]] = [
+        ("Rollout", config.experiment_rollout),
+        ("Entrypoint", config.experiment_entrypoint),
+        ("Model", config.experiment_model_path),
+        ("Dataset", config.experiment_dataset),
     ]
     if config.experiment_commit_sha:
-        rows.append(("Commit", console.escape(config.experiment_commit_sha)))
-    console.table(rows, title="Training Run")
+        summary_rows.append(("Commit", config.experiment_commit_sha))
+    console.table(
+        [(label, console.escape(value)) for label, value in summary_rows],
+        title="Training Run",
+    )
 
-    _require_confirmation("Submit this training run?", yes=yes)
+    notes, warnings = _print_remote_fetch_notice(
+        project_root,
+        pinned_commit_sha=config.experiment_commit_sha,
+    )
+
+    _require_confirmation(
+        "Submit this training run?",
+        yes=yes,
+        summary=summary_rows,
+        notes=notes,
+        warnings=warnings,
+    )
 
     from osmosis_ai.platform.api.client import OsmosisClient
 
@@ -549,7 +720,11 @@ def stop(
 
     client = OsmosisClient()
 
-    _require_confirmation(f'Stop training run "{name}"?', yes=yes)
+    _require_confirmation(
+        f'Stop training run "{name}"?',
+        yes=yes,
+        summary=[("Name", name)],
+    )
 
     output = get_output_context()
     with output.status("Stopping training run..."):
@@ -578,7 +753,9 @@ def delete(
     client = OsmosisClient()
 
     _require_confirmation(
-        f'Delete training run "{name}"? This cannot be undone.', yes=yes
+        f'Delete training run "{name}"? This cannot be undone.',
+        yes=yes,
+        summary=[("Name", name)],
     )
 
     output = get_output_context()

--- a/osmosis_ai/eval/common/cli.py
+++ b/osmosis_ai/eval/common/cli.py
@@ -137,6 +137,21 @@ def _ensure_parent_packages(
         _load_package_module(current_package, current_dir)
 
 
+def _ensure_rollout_dir_on_path(rollout_dir: Path) -> None:
+    """Add the rollout directory to ``sys.path`` so sibling packages resolve.
+
+    The synthetic-package wrapper isolates the entrypoint module itself, but
+    real-world entrypoints commonly do absolute imports of sibling packages
+    that live next to them (e.g. ``from multiply_openai_agents.grader import
+    ...`` next to ``local_rollout_server_openai_agents_example.py``). Those
+    are top-level imports, so the rollout directory must be searchable via
+    ``sys.path`` for them to resolve.
+    """
+    rollout_dir_str = str(rollout_dir)
+    if rollout_dir_str not in sys.path:
+        sys.path.insert(0, rollout_dir_str)
+
+
 def _load_rollout_module(
     rollout: str,
     entrypoint: str,
@@ -149,6 +164,7 @@ def _load_rollout_module(
         entrypoint,
         project_root=project_root,
     )
+    _ensure_rollout_dir_on_path(rollout_dir)
     package_name = _synthetic_rollout_package_name(rollout_dir)
     _clear_rollout_module_cache(package_name)
     _load_package_module(package_name, rollout_dir)

--- a/osmosis_ai/platform/cli/init.py
+++ b/osmosis_ai/platform/cli/init.py
@@ -22,11 +22,7 @@ from typing import Any
 from osmosis_ai.cli.console import console
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.platform.auth.config import PLATFORM_URL
-from osmosis_ai.platform.auth.local_config import (
-    get_active_workspace_id,
-    get_active_workspace_name,
-    set_active_workspace,
-)
+from osmosis_ai.platform.auth.local_config import get_active_workspace_id
 from osmosis_ai.platform.cli.constants import validate_name
 
 # ── Prerequisites ────────────────────────────────────────────────
@@ -252,123 +248,69 @@ def _git_initial_commit(target: Path) -> None:
     )
 
 
-def _selected_workspace_git_context() -> dict[str, str | bool | None]:
-    """Best-effort Git integration context for the active platform workspace.
+def _resolve_workspace_git_context(
+    *,
+    workspace_name: str,
+    workspace_id: str | None,
+    credentials: Any,
+) -> dict[str, str | bool | None]:
+    """Fetch the active workspace's Git Sync metadata from the platform.
 
-    Always verifies the active workspace against the platform when
-    credentials are usable, so a stale local selection (e.g. a
-    workspace the user no longer belongs to) can't silently bypass Git
-    Sync guidance or connected-repo blocking. Also auto-selects the
-    only available workspace when nothing is saved locally, keeping
-    behavior consistent with the rest of the CLI for single-workspace
-    users.
+    The caller is responsible for ensuring an active workspace exists
+    (typically via :func:`_require_auth`); this function only refreshes
+    the connected-repo state and GitHub App installation flag used to
+    drive the post-init CTA and the connected-repo guard.
 
-    Falls back to the locally cached workspace name (without
-    connected-repo metadata) only when the platform is unreachable or
-    credentials are missing/expired.
+    Network/auth errors during the metadata refresh degrade the
+    returned context (no connected repo, no GitHub App), but the
+    workspace identity and Git Sync URL are always preserved so the
+    CTA still points at the right page. The connected-repo guard only
+    blocks when the platform confirms a connected repo, so a transient
+    outage doesn't spuriously block init.
     """
+    from osmosis_ai.platform.api.client import OsmosisClient
     from osmosis_ai.platform.auth import (
         AuthenticationExpiredError,
         PlatformAPIError,
-        load_credentials,
-        platform_request,
     )
     from osmosis_ai.platform.cli.utils import platform_call
 
-    empty_context: dict[str, str | bool | None] = {
-        "workspace_id": None,
-        "workspace_name": None,
-        "git_sync_url": None,
+    context: dict[str, str | bool | None] = {
+        "workspace_id": workspace_id,
+        "workspace_name": workspace_name,
+        "git_sync_url": f"{PLATFORM_URL}/{workspace_name}/integrations/git",
         "has_github_app_installation": False,
         "connected_repo_url": None,
     }
 
-    def _offline_fallback() -> dict[str, str | bool | None]:
-        local_name = get_active_workspace_name()
-        if not local_name:
-            return empty_context
-        return {
-            "workspace_id": get_active_workspace_id(),
-            "workspace_name": local_name,
-            "git_sync_url": f"{PLATFORM_URL}/{local_name}/integrations/git",
-            "has_github_app_installation": False,
-            "connected_repo_url": None,
-        }
-
-    credentials = load_credentials()
-    if credentials is None or credentials.is_expired():
-        return _offline_fallback()
-
+    client = OsmosisClient()
     try:
-        data = platform_call(
+        info = platform_call(
             "Loading workspace Git Sync status...",
-            lambda: platform_request(
-                "/api/cli/workspaces",
+            lambda: client.refresh_workspace_info(
                 credentials=credentials,
-                require_workspace=False,
+                workspace_name=workspace_name,
                 cleanup_on_401=False,
             ),
             output_console=console,
         )
     except (AuthenticationExpiredError, PlatformAPIError):
-        return _offline_fallback()
+        return context
 
-    workspaces = [ws for ws in data.get("workspaces", []) if isinstance(ws, dict)]
-
-    local_id = get_active_workspace_id()
-    matched: dict[str, Any] | None = None
-    if local_id:
-        matched = next((ws for ws in workspaces if ws.get("id") == local_id), None)
-
-    # Auto-select the only workspace when nothing valid is saved locally.
-    # Mirrors ensure_active_workspace() so single-workspace users get the
-    # same Git Sync guidance and connected-repo blocking as everyone else.
-    if matched is None and len(workspaces) == 1:
-        only_ws = workspaces[0]
-        only_id = only_ws.get("id")
-        only_name = only_ws.get("name")
-        if (
-            isinstance(only_id, str)
-            and only_id
-            and isinstance(only_name, str)
-            and only_name
-        ):
-            set_active_workspace(only_id, only_name)
-            matched = only_ws
-
-    if matched is None:
-        return empty_context
-
-    selected_name = matched.get("name")
-    if not isinstance(selected_name, str) or not selected_name:
-        return empty_context
-
-    connected_repo_url: str | None = None
-    connected_repo = matched.get("connected_repo")
+    context["has_github_app_installation"] = bool(
+        info.get("has_github_app_installation")
+    )
+    connected_repo = info.get("connected_repo")
     if isinstance(connected_repo, dict):
         repo_url = connected_repo.get("repo_url")
         if isinstance(repo_url, str) and repo_url:
-            connected_repo_url = repo_url
-
-    return {
-        "workspace_id": matched.get("id")
-        if isinstance(matched.get("id"), str)
-        else None,
-        "workspace_name": selected_name,
-        "git_sync_url": f"{PLATFORM_URL}/{selected_name}/integrations/git",
-        "has_github_app_installation": bool(matched.get("has_github_app_installation")),
-        "connected_repo_url": connected_repo_url,
-    }
+            context["connected_repo_url"] = repo_url
+    return context
 
 
-def _git_sync_cta_text(
-    git_context: dict[str, str | bool | None] | None = None,
-) -> Any:
+def _git_sync_cta_text(git_context: dict[str, str | bool | None]) -> Any:
     """Build the Git Sync CTA shown after project scaffolding."""
     from rich.text import Text
-
-    if git_context is None:
-        git_context = _selected_workspace_git_context()
 
     connected_repo_url = git_context.get("connected_repo_url")
     if isinstance(connected_repo_url, str) and connected_repo_url:
@@ -396,11 +338,9 @@ def _git_sync_cta_text(
 
 
 def _raise_if_selected_workspace_has_connected_repo(
-    git_context: dict[str, str | bool | None] | None = None,
+    git_context: dict[str, str | bool | None],
 ) -> None:
     """Block fresh init when the active platform workspace already has a connected repo."""
-    if git_context is None:
-        git_context = _selected_workspace_git_context()
     workspace_name = git_context.get("workspace_name")
     connected_repo_url = git_context.get("connected_repo_url")
 
@@ -428,7 +368,7 @@ def _print_next_steps(
     project_name: str,
     *,
     here: bool = False,
-    git_context: dict[str, str | bool | None] | None = None,
+    git_context: dict[str, str | bool | None],
 ) -> None:
     """Print post-setup CTA with Rich panels."""
     from rich import box as rich_box
@@ -560,17 +500,19 @@ def _created_paths_for_result(target: Path) -> list[str]:
 def _workspace_for_result(
     git_context: dict[str, str | bool | None],
 ) -> dict[str, str] | None:
+    """Shape workspace metadata for the JSON/plain ``init`` result envelope.
+
+    ``init`` requires an active workspace, so ``workspace_name`` is
+    expected to always be set; ``workspace_id`` may be missing when the
+    locally cached id wasn't returned by ``_require_auth``.
+    """
     workspace_id = git_context.get("workspace_id")
     workspace_name = git_context.get("workspace_name")
-    if (
-        isinstance(workspace_id, str)
-        and workspace_id
-        and isinstance(workspace_name, str)
-    ):
+    if not (isinstance(workspace_name, str) and workspace_name):
+        return None
+    if isinstance(workspace_id, str) and workspace_id:
         return {"id": workspace_id, "name": workspace_name}
-    if isinstance(workspace_name, str) and workspace_name:
-        return {"name": workspace_name}
-    return None
+    return {"name": workspace_name}
 
 
 def _init_next_steps_structured(
@@ -647,8 +589,15 @@ def init(name: str, here: bool = False) -> Any:
     """Initialise a new local Osmosis project directory.
 
     This is the main entry point for ``osmosis init <name>``.
+
+    Requires an authenticated session with an active platform
+    workspace. The connected-repo guard then runs against authoritative
+    platform state instead of best-effort local cache, so we never
+    silently scaffold a fresh project into a workspace that's already
+    wired to a different repo.
     """
     from osmosis_ai.cli.output import OperationResult, OutputFormat, get_output_context
+    from osmosis_ai.platform.cli.utils import _require_auth
 
     output = get_output_context()
     _check_git_installed()
@@ -657,17 +606,17 @@ def init(name: str, here: bool = False) -> Any:
     if name_error:
         raise CLIError(name_error)
 
-    # Determine target directory
-    created_dir = False
-    # Resolve active platform workspace (and Git integration state) once so we
-    # don't hit the platform twice during a single `osmosis init`.
-    git_context: dict[str, str | bool | None] | None = None
+    # Auth + active workspace are required before any directory work so
+    # the connected-repo guard runs on every fresh init path. The same
+    # gating is used by `osmosis train submit` for consistency.
+    workspace_name, credentials = _require_auth()
+    git_context = _resolve_workspace_git_context(
+        workspace_name=workspace_name,
+        workspace_id=get_active_workspace_id(),
+        credentials=credentials,
+    )
 
-    def _ensure_git_context() -> dict[str, str | bool | None]:
-        nonlocal git_context
-        if git_context is None:
-            git_context = _selected_workspace_git_context()
-        return git_context
+    created_dir = False
 
     if here:
         target = Path.cwd()
@@ -677,7 +626,7 @@ def init(name: str, here: bool = False) -> Any:
                 "Use 'osmosis init <name>' (without --here) to create a new directory, "
                 "or empty this directory first."
             )
-        _raise_if_selected_workspace_has_connected_repo(_ensure_git_context())
+        _raise_if_selected_workspace_has_connected_repo(git_context)
     else:
         target = Path.cwd() / name
         if target.exists():
@@ -693,7 +642,7 @@ def init(name: str, here: bool = False) -> Any:
                     "Use --here to initialize in the current directory."
                 )
         else:
-            _raise_if_selected_workspace_has_connected_repo(_ensure_git_context())
+            _raise_if_selected_workspace_has_connected_repo(git_context)
             target.mkdir()
             created_dir = True
 
@@ -711,17 +660,16 @@ def init(name: str, here: bool = False) -> Any:
             shutil.rmtree(target)
         raise
 
-    final_git_context = _ensure_git_context()
     if output.format is OutputFormat.rich:
-        _print_next_steps(name, here=here, git_context=final_git_context)
+        _print_next_steps(name, here=here, git_context=git_context)
         return None
 
     resource = {
         "path": str(target.resolve()),
         "created_paths": _created_paths_for_result(target),
-        "workspace": _workspace_for_result(final_git_context),
-        "git_sync_url": final_git_context.get("git_sync_url"),
-        "connected_repo_url": final_git_context.get("connected_repo_url"),
+        "workspace": _workspace_for_result(git_context),
+        "git_sync_url": git_context.get("git_sync_url"),
+        "connected_repo_url": git_context.get("connected_repo_url"),
         "mode": "update" if is_update else "create",
     }
     return OperationResult(
@@ -737,6 +685,6 @@ def init(name: str, here: bool = False) -> Any:
         next_steps_structured=_init_next_steps_structured(
             name,
             here=here,
-            git_context=final_git_context,
+            git_context=git_context,
         ),
     )

--- a/osmosis_ai/platform/cli/utils.py
+++ b/osmosis_ai/platform/cli/utils.py
@@ -330,6 +330,10 @@ def _require_subscription(*, workspace_name: str) -> None:
     refreshed = False
     api_reached = False
     workspace_found = False
+    # Intentionally do NOT suppress AuthenticationExpiredError here: a real
+    # 401 must surface as "session expired" rather than be silently swallowed
+    # and reported below as the misleading "subscription required" error
+    # when a stale `False` subscription cache is present.
     with contextlib.suppress(PlatformAPIError, OSError):
         credentials = require_credentials()
         from osmosis_ai.platform.api.client import OsmosisClient
@@ -338,7 +342,9 @@ def _require_subscription(*, workspace_name: str) -> None:
         info = platform_call(
             "Checking subscription...",
             lambda: client.refresh_workspace_info(
-                credentials=credentials, workspace_name=workspace_name
+                credentials=credentials,
+                workspace_name=workspace_name,
+                cleanup_on_401=False,
             ),
         )
         api_reached = True

--- a/osmosis_ai/platform/cli/workspace.py
+++ b/osmosis_ai/platform/cli/workspace.py
@@ -99,7 +99,13 @@ def _select_workspace(
     """Prompt the user to select a workspace. Returns (ws_id, ws_name), BACK, or None."""
     try:
         with console.spinner("Loading workspaces..."):
-            result = platform_request("/api/cli/workspaces", require_workspace=False)
+            # Read-only menu fetch: a transient 401 must not wipe local
+            # credentials/workspace state out from under the user mid-menu.
+            result = platform_request(
+                "/api/cli/workspaces",
+                require_workspace=False,
+                cleanup_on_401=False,
+            )
         workspaces = result.get("workspaces", [])
     except PlatformAPIError as e:
         console.print_error(f"Failed to load workspaces: {e}")
@@ -433,15 +439,21 @@ def list_workspaces() -> Any:
 
     output = get_output_context()
     credentials = require_credentials()
+    # Read-only listing: never let a transient 401 wipe local credentials
+    # or active-workspace state. A real auth failure surfaces as
+    # AuthenticationExpiredError on the next mutating command.
     active_ws = platform_call(
         "Loading workspaces...",
-        lambda: ensure_active_workspace(credentials=credentials),
+        lambda: ensure_active_workspace(credentials=credentials, cleanup_on_401=False),
         output_console=console,
     )
     result = platform_call(
         "Loading workspaces...",
         lambda: platform_request(
-            "/api/cli/workspaces", require_workspace=False, credentials=credentials
+            "/api/cli/workspaces",
+            require_workspace=False,
+            credentials=credentials,
+            cleanup_on_401=False,
         ),
         output_console=console,
     )
@@ -655,10 +667,16 @@ def switch_workspace(workspace: str) -> Any:
 
     output = get_output_context()
     credentials = require_credentials()
+    # Read-only fetch to resolve the requested workspace name → id.
+    # A transient 401 must not wipe local credentials/workspace state;
+    # the next mutating command will surface a real auth failure.
     result = platform_call(
         "Loading workspaces...",
         lambda: platform_request(
-            "/api/cli/workspaces", require_workspace=False, credentials=credentials
+            "/api/cli/workspaces",
+            require_workspace=False,
+            credentials=credentials,
+            cleanup_on_401=False,
         ),
         output_console=console,
     )
@@ -704,9 +722,11 @@ def workspace() -> None:
     if credentials is None:
         raise CLIError(MSG_NOT_LOGGED_IN)
 
+    # Interactive entrypoint: never let a transient 401 wipe local
+    # credentials/workspace state just from opening the menu.
     active_ws = platform_call(
         "Loading workspace...",
-        lambda: ensure_active_workspace(credentials=credentials),
+        lambda: ensure_active_workspace(credentials=credentials, cleanup_on_401=False),
         output_console=console,
     )
     ws_name = active_ws["name"] if active_ws else None

--- a/osmosis_ai/platform/cli/workspace_repo.py
+++ b/osmosis_ai/platform/cli/workspace_repo.py
@@ -1,0 +1,294 @@
+"""Validate that the local project's git remote matches the active workspace's
+connected repository.
+
+Used by commands that submit work to the platform (e.g. ``osmosis train submit``)
+to guard against accidentally running from the wrong checkout when a workspace
+is wired up to a specific Git Sync repo.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.platform.auth import (
+    AuthenticationExpiredError,
+    PlatformAPIError,
+)
+from osmosis_ai.platform.auth.config import PLATFORM_URL
+
+from .utils import platform_call
+
+if TYPE_CHECKING:
+    from osmosis_ai.platform.auth.credentials import Credentials
+
+
+# Captures host + path from common Git URL forms:
+#   https://github.com/owner/repo[.git][/]
+#   http(s)://user[:pat]@host/owner/repo[.git]
+#   ssh://git@host/owner/repo[.git]
+#   git@host:owner/repo[.git]
+_GIT_URL_RE = re.compile(
+    r"""^
+    (?:[A-Za-z0-9+.\-]+://)?      # optional scheme (https://, ssh://, git://)
+    (?:[^@/]+@)?                  # optional user@ (e.g. git@, user:pat@)
+    (?P<host>[^:/]+)              # host
+    [:/]                          # separator (':' for SSH-style, '/' for URL)
+    (?P<path>.+?)                 # repo path (lazy)
+    (?:\.git)?                    # optional .git suffix
+    /?                            # optional trailing slash
+    $""",
+    re.VERBOSE,
+)
+
+
+def normalize_git_url(url: str | None) -> str | None:
+    """Reduce a Git URL to ``host/owner/repo`` for fuzzy-equality comparison.
+
+    Returns ``None`` for empty or unparseable input. The host is lowercased so
+    case differences (``GitHub.com`` vs ``github.com``) don't trip the check.
+    """
+    if not url:
+        return None
+
+    match = _GIT_URL_RE.match(url.strip())
+    if match is None:
+        return None
+
+    host = match.group("host").lower()
+    path = match.group("path").strip("/")
+    if not path:
+        return None
+    return f"{host}/{path}"
+
+
+def get_local_git_remote_url(project_root: Path) -> str | None:
+    """Return ``origin``'s URL for the project, or ``None`` if unavailable.
+
+    Returns ``None`` when:
+    * ``git`` is not installed on PATH;
+    * the project is not a git repository;
+    * there is no ``origin`` remote.
+    """
+    if shutil.which("git") is None:
+        return None
+    # Anchor to *this* project. ``git -C`` walks up parent directories
+    # by default, which would otherwise pick up an unrelated parent
+    # repo's ``origin`` (e.g. when the project is nested inside another
+    # checkout). Mirrors the same guard in ``summarize_local_git_state``.
+    if not (project_root / ".git").exists():
+        return None
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_root), "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+
+    if result.returncode != 0:
+        return None
+    url = result.stdout.strip()
+    return url or None
+
+
+@dataclass(frozen=True, slots=True)
+class LocalGitState:
+    """Best-effort summary of a local git working tree.
+
+    Attributes:
+        branch: Current branch name, or ``None`` for a detached HEAD or
+            when the lookup failed.
+        head_sha: Full HEAD commit SHA, or ``None`` if unavailable.
+        is_dirty: ``True`` when ``git status --porcelain`` reports any
+            modified, staged, or untracked entries.
+        has_upstream: ``True`` when the current branch tracks an upstream.
+        ahead: Number of local commits not yet on the upstream. ``0``
+            when there is no upstream or no unpushed commits.
+    """
+
+    branch: str | None
+    head_sha: str | None
+    is_dirty: bool
+    has_upstream: bool
+    ahead: int
+
+
+def summarize_local_git_state(project_root: Path) -> LocalGitState | None:
+    """Return a best-effort snapshot of the local git state for the project.
+
+    Used by command flows (e.g. ``osmosis train submit``) to surface a
+    "push your changes first" reminder, since the platform always
+    pulls source from the workspace's connected Git remote.
+
+    Returns ``None`` when ``git`` is not on PATH or ``project_root`` is
+    not a git working tree (no ``.git`` entry); individual fields are
+    safely defaulted when sub-commands fail rather than raising.
+    """
+    if shutil.which("git") is None:
+        return None
+    # Anchor to *this* project. ``git -C`` walks up parent directories
+    # by default, which would otherwise pick up an unrelated parent
+    # repo (e.g. when a project is nested inside another checkout).
+    if not (project_root / ".git").exists():
+        return None
+
+    def _run(*args: str) -> str | None:
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(project_root), *args],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError:
+            return None
+        if result.returncode != 0:
+            return None
+        return result.stdout.strip()
+
+    head_sha = _run("rev-parse", "HEAD")
+    if head_sha is None:
+        return None
+
+    branch = _run("rev-parse", "--abbrev-ref", "HEAD")
+    if branch == "HEAD":  # detached
+        branch = None
+
+    porcelain = _run("status", "--porcelain")
+    is_dirty = porcelain is not None and bool(porcelain)
+
+    upstream = _run("rev-parse", "--abbrev-ref", "@{u}")
+    has_upstream = upstream is not None and bool(upstream)
+
+    ahead = 0
+    if has_upstream:
+        ahead_str = _run("rev-list", "--count", "@{u}..HEAD")
+        if ahead_str and ahead_str.isdigit():
+            ahead = int(ahead_str)
+
+    return LocalGitState(
+        branch=branch,
+        head_sha=head_sha,
+        is_dirty=is_dirty,
+        has_upstream=has_upstream,
+        ahead=ahead,
+    )
+
+
+def _git_sync_url(workspace_name: str) -> str:
+    return f"{PLATFORM_URL}/{workspace_name}/integrations/git"
+
+
+def _raise_no_connected_repo(workspace_name: str, command_label: str) -> None:
+    raise CLIError(
+        f"{command_label} requires the active workspace to have a Git Sync "
+        "connected repository (the platform pulls training code from there).\n"
+        f"  Workspace '{workspace_name}' has no connected repo configured.\n"
+        "\n"
+        "  Connect a repo via Git Sync at:\n"
+        f"    {_git_sync_url(workspace_name)}\n"
+        "  Or switch to a workspace that already has one:\n"
+        "    osmosis workspace switch"
+    )
+
+
+def validate_active_workspace_repo(
+    *,
+    project_root: Path,
+    workspace_name: str,
+    credentials: Credentials,
+    command_label: str,
+) -> None:
+    """Ensure ``project_root`` is a clone of the active workspace's connected repo.
+
+    The platform pulls training code from the workspace's Git Sync repo, so a
+    workspace without a connected repo cannot run a training submission at all.
+    This function therefore enforces both:
+
+    * The active workspace has a ``connected_repo`` configured, and
+    * The local project's ``origin`` remote points at that same repository.
+
+    Raises :class:`CLIError` on any mismatch. Network/auth errors are swallowed
+    so the actual submit call surfaces them with full context.
+    """
+    from osmosis_ai.platform.api.client import OsmosisClient
+
+    client = OsmosisClient()
+    try:
+        info = platform_call(
+            "Checking workspace Git Sync...",
+            lambda: client.refresh_workspace_info(
+                credentials=credentials,
+                workspace_name=workspace_name,
+                # Pre-flight check: a transient 401 must not wipe local
+                # credentials/workspace state. Defer auth handling to the
+                # actual submit call below.
+                cleanup_on_401=False,
+            ),
+        )
+    except (AuthenticationExpiredError, PlatformAPIError):
+        # Defer to the actual submit call to surface platform/auth errors.
+        return
+
+    connected_repo = info.get("connected_repo")
+    repo_url: str | None = None
+    if isinstance(connected_repo, dict):
+        candidate = connected_repo.get("repo_url")
+        if isinstance(candidate, str) and candidate:
+            repo_url = candidate
+
+    if repo_url is None:
+        _raise_no_connected_repo(workspace_name, command_label)
+        return  # pragma: no cover - _raise_no_connected_repo always raises
+
+    expected = normalize_git_url(repo_url)
+    if expected is None:
+        # Platform returned a URL we can't parse; don't block on a format we
+        # don't understand.
+        return
+
+    local_remote = get_local_git_remote_url(project_root)
+    if local_remote is None:
+        raise CLIError(
+            f"{command_label} must be run from a clone of the workspace's "
+            "connected Git repository.\n"
+            f"  Workspace '{workspace_name}' is connected to:\n"
+            f"    {repo_url}\n"
+            f"  Local project at {project_root} has no `origin` remote.\n"
+            "\n"
+            "  Clone the connected repo:\n"
+            f"    git clone {repo_url}\n"
+            "  Or switch workspaces:\n"
+            "    osmosis workspace switch"
+        )
+
+    if normalize_git_url(local_remote) != expected:
+        raise CLIError(
+            f"{command_label} must be run from a clone of the workspace's "
+            "connected Git repository.\n"
+            f"  Workspace '{workspace_name}' is connected to:\n"
+            f"    {repo_url}\n"
+            f"  Local `origin` remote:\n"
+            f"    {local_remote}\n"
+            "\n"
+            "  Run from the connected repo, or switch workspaces:\n"
+            "    osmosis workspace switch"
+        )
+
+
+__all__ = [
+    "LocalGitState",
+    "get_local_git_remote_url",
+    "normalize_git_url",
+    "summarize_local_git_state",
+    "validate_active_workspace_repo",
+]

--- a/tests/unit/cli/test_init_json.py
+++ b/tests/unit/cli/test_init_json.py
@@ -3,26 +3,56 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 from osmosis_ai.cli import main as cli
 
 
-def test_init_json_returns_created_paths_and_next_steps(
-    monkeypatch, tmp_path, capsys
-) -> None:
+class _FakeCreds:
+    def is_expired(self) -> bool:
+        return False
+
+
+def _stub_init_dependencies(monkeypatch) -> None:
+    """Stub side-effecting helpers so init() runs without touching disk/git."""
     import osmosis_ai.platform.cli.init as init_module
 
-    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
     monkeypatch.setattr(init_module, "_write_scaffold", lambda *args, **kwargs: None)
     monkeypatch.setattr(init_module, "_git_init", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         init_module, "_git_initial_commit", lambda *args, **kwargs: None
     )
+
+
+def _patch_workspace_context(
+    monkeypatch, *, workspace_id: str | None, git_context: dict[str, Any]
+) -> None:
+    """Pin auth + workspace metadata so init's auth gate is satisfied."""
+    import osmosis_ai.platform.cli.init as init_module
+
+    workspace_name = git_context.get("workspace_name")
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.utils._require_auth",
+        lambda: (workspace_name or "default", _FakeCreds()),
+    )
+    monkeypatch.setattr(init_module, "get_active_workspace_id", lambda: workspace_id)
     monkeypatch.setattr(
         init_module,
-        "_selected_workspace_git_context",
-        lambda: {
+        "_resolve_workspace_git_context",
+        lambda **_kwargs: git_context,
+    )
+
+
+def test_init_json_returns_created_paths_and_next_steps(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _stub_init_dependencies(monkeypatch)
+    _patch_workspace_context(
+        monkeypatch,
+        workspace_id="ws_1",
+        git_context={
             "workspace_id": "ws_1",
             "workspace_name": "default",
             "git_sync_url": "https://platform.osmosis.ai/default/integrations/git",
@@ -48,22 +78,15 @@ def test_init_json_returns_created_paths_and_next_steps(
 def test_init_plain_uses_renderer_without_rich_panels(
     monkeypatch, tmp_path, capsys
 ) -> None:
-    import osmosis_ai.platform.cli.init as init_module
-
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
-    monkeypatch.setattr(init_module, "_write_scaffold", lambda *args, **kwargs: None)
-    monkeypatch.setattr(init_module, "_git_init", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        init_module, "_git_initial_commit", lambda *args, **kwargs: None
-    )
-    monkeypatch.setattr(
-        init_module,
-        "_selected_workspace_git_context",
-        lambda: {
-            "workspace_id": None,
-            "workspace_name": None,
-            "git_sync_url": None,
+    _stub_init_dependencies(monkeypatch)
+    _patch_workspace_context(
+        monkeypatch,
+        workspace_id="ws_solo",
+        git_context={
+            "workspace_id": "ws_solo",
+            "workspace_name": "solo-team",
+            "git_sync_url": ("https://platform.osmosis.ai/solo-team/integrations/git"),
             "has_github_app_installation": False,
             "connected_repo_url": None,
         },

--- a/tests/unit/cli/test_train_commands.py
+++ b/tests/unit/cli/test_train_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from io import StringIO
 from pathlib import Path
 
@@ -13,6 +14,7 @@ import osmosis_ai.platform.cli.utils as utils_module
 from osmosis_ai.cli.console import Console
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.cli.output import DetailResult, ListResult, OperationResult
+from osmosis_ai.cli.output.context import OutputFormat, override_output_context
 from osmosis_ai.platform.api.models import (
     DeleteTrainingRunResult,
     PaginatedTrainingRuns,
@@ -24,9 +26,14 @@ from osmosis_ai.platform.api.models import (
 
 @pytest.fixture()
 def console_capture(monkeypatch: pytest.MonkeyPatch) -> StringIO:
-    """Swap console in both train_module and utils_module, return the output buffer."""
+    """Swap console in both train_module and utils_module, return the output buffer.
+
+    Sets a wide fixed width so Rich panels render their content on a
+    single line per logical line, which lets tests assert on the
+    rendered panel body with plain substring checks.
+    """
     output = StringIO()
-    console = Console(file=output, force_terminal=False)
+    console = Console(file=output, force_terminal=False, width=200)
     monkeypatch.setattr(train_module, "console", console)
     monkeypatch.setattr(utils_module, "console", console)
     return output
@@ -37,6 +44,18 @@ def _mock_auth(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "osmosis_ai.platform.cli.utils._require_auth",
         lambda: ("ws-test", object()),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _mock_workspace_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default `train submit` to skip the workspace<->git-repo check.
+
+    Individual tests can re-mock this when exercising the validator.
+    """
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.workspace_repo.validate_active_workspace_repo",
+        lambda **kwargs: None,
     )
 
 
@@ -457,6 +476,329 @@ dataset = "d"
 
         with pytest.raises(CLIError, match="Grader"):
             train_module.submit(config_path=path, yes=True)
+
+    def test_submit_prints_remote_fetch_notice(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        console_capture: StringIO,
+        tmp_path: Path,
+    ) -> None:
+        config_path = self._write_config(tmp_path)
+
+        class FakeClient:
+            def submit_training_run(self, **kwargs):
+                return TestSubmit.SUBMIT_RESULT
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        train_module.submit(config_path=config_path, yes=True)
+
+        out = console_capture.getvalue()
+        # Reminder always renders; "Before you submit" is the calm
+        # variant when no warnings are detected.
+        assert "Before you submit" in out
+        assert "connected Git repository" in out
+        assert "committed and pushed" in out
+
+    def test_submit_warns_about_unpushed_commits(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        console_capture: StringIO,
+        tmp_path: Path,
+    ) -> None:
+        from osmosis_ai.platform.cli import workspace_repo
+
+        config_path = self._write_config(tmp_path)
+
+        monkeypatch.setattr(
+            workspace_repo,
+            "summarize_local_git_state",
+            lambda _root: workspace_repo.LocalGitState(
+                branch="main",
+                head_sha="abcdef1234567890" + "0" * 24,
+                is_dirty=False,
+                has_upstream=True,
+                ahead=2,
+            ),
+        )
+
+        class FakeClient:
+            def submit_training_run(self, **kwargs):
+                return TestSubmit.SUBMIT_RESULT
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        train_module.submit(config_path=config_path, yes=True)
+
+        out = console_capture.getvalue()
+        assert "Push before submitting" in out
+        assert "2 unpushed commits" in out
+
+    def test_submit_warns_about_uncommitted_changes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        console_capture: StringIO,
+        tmp_path: Path,
+    ) -> None:
+        from osmosis_ai.platform.cli import workspace_repo
+
+        config_path = self._write_config(tmp_path)
+
+        monkeypatch.setattr(
+            workspace_repo,
+            "summarize_local_git_state",
+            lambda _root: workspace_repo.LocalGitState(
+                branch="feature",
+                head_sha="0" * 40,
+                is_dirty=True,
+                has_upstream=True,
+                ahead=0,
+            ),
+        )
+
+        class FakeClient:
+            def submit_training_run(self, **kwargs):
+                return TestSubmit.SUBMIT_RESULT
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        train_module.submit(config_path=config_path, yes=True)
+
+        out = console_capture.getvalue()
+        assert "Push before submitting" in out
+        assert "Uncommitted changes" in out
+
+    def test_submit_warns_when_branch_has_no_upstream(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        console_capture: StringIO,
+        tmp_path: Path,
+    ) -> None:
+        from osmosis_ai.platform.cli import workspace_repo
+
+        config_path = self._write_config(tmp_path)
+
+        monkeypatch.setattr(
+            workspace_repo,
+            "summarize_local_git_state",
+            lambda _root: workspace_repo.LocalGitState(
+                branch="local-only",
+                head_sha="0" * 40,
+                is_dirty=False,
+                has_upstream=False,
+                ahead=0,
+            ),
+        )
+
+        class FakeClient:
+            def submit_training_run(self, **kwargs):
+                return TestSubmit.SUBMIT_RESULT
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        train_module.submit(config_path=config_path, yes=True)
+
+        out = console_capture.getvalue()
+        assert "Push before submitting" in out
+        assert "no upstream" in out
+        assert "local-only" in out
+
+    def test_submit_remote_fetch_notice_for_pinned_commit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        console_capture: StringIO,
+        tmp_path: Path,
+    ) -> None:
+        project_root = self._write_project(tmp_path, rollout="r")
+        path = project_root / "configs" / "training" / "train.toml"
+        path.write_text(
+            """
+[experiment]
+rollout = "r"
+entrypoint = "main.py"
+model_path = "m"
+dataset = "d"
+commit_sha = "deadbeef1234"
+""".strip(),
+            encoding="utf-8",
+        )
+
+        class FakeClient:
+            def submit_training_run(self, **kwargs):
+                return TestSubmit.SUBMIT_RESULT
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        train_module.submit(config_path=path, yes=True)
+
+        out = console_capture.getvalue()
+        assert "deadbeef1234" in out
+        assert "already pushed to the remote" in out
+
+    def test_submit_passes_workspace_and_project_to_validator(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        console_capture: StringIO,
+        tmp_path: Path,
+    ) -> None:
+        config_path = self._write_config(tmp_path)
+        captured: dict = {}
+
+        def _capture(**kwargs: object) -> None:
+            captured.update(kwargs)
+
+        monkeypatch.setattr(
+            "osmosis_ai.platform.cli.workspace_repo.validate_active_workspace_repo",
+            _capture,
+        )
+
+        class FakeClient:
+            def submit_training_run(self, **kwargs):
+                return TestSubmit.SUBMIT_RESULT
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        train_module.submit(config_path=config_path, yes=True)
+
+        assert captured["workspace_name"] == "ws-test"
+        assert captured["project_root"] == config_path.parent.parent.parent
+        assert captured["command_label"] == "`osmosis train submit`"
+
+    def test_submit_propagates_workspace_repo_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        config_path = self._write_config(tmp_path)
+
+        def _fail(**kwargs: object) -> None:
+            raise CLIError(
+                "`osmosis train submit` must be run from a clone of the workspace's connected Git repository."
+            )
+
+        monkeypatch.setattr(
+            "osmosis_ai.platform.cli.workspace_repo.validate_active_workspace_repo",
+            _fail,
+        )
+
+        with pytest.raises(CLIError, match="connected Git repository"):
+            train_module.submit(config_path=config_path, yes=True)
+
+
+class TestSubmitNonInteractiveContext:
+    """`train submit` without --yes should surface its prompt context.
+
+    AI agents and CI scripts can't see the Rich confirmation panel, so
+    the JSON/plain error must carry the summary, notes, and warnings.
+    """
+
+    def test_submit_json_without_yes_includes_prompt_context(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        config_path = TestSubmit._write_config(tmp_path)
+
+        class FakeClient:
+            def submit_training_run(self, **kwargs):
+                raise AssertionError("API must not be reached without confirmation")
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+
+        from osmosis_ai.cli import main as cli
+
+        exit_code = cli.main(["--json", "train", "submit", str(config_path)])
+        captured = capsys.readouterr()
+
+        assert exit_code != 0
+        assert captured.out == ""
+        envelope = json.loads(captured.err)
+        assert envelope["error"]["code"] == "INTERACTIVE_REQUIRED"
+        details = envelope["error"]["details"]
+        assert details["prompt"] == "Submit this training run?"
+        assert details["summary"] == {
+            "Rollout": "calculator",
+            "Entrypoint": "main.py",
+            "Model": "Qwen/Qwen3.5-35B-A3B",
+            "Dataset": "abc-123",
+        }
+        assert any("connected Git repository" in note for note in details["notes"])
+
+    def test_submit_json_includes_git_warnings(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        from osmosis_ai.platform.cli import workspace_repo
+
+        config_path = TestSubmit._write_config(tmp_path)
+
+        monkeypatch.setattr(
+            workspace_repo,
+            "summarize_local_git_state",
+            lambda _root: workspace_repo.LocalGitState(
+                branch="feature",
+                head_sha="0" * 40,
+                is_dirty=True,
+                has_upstream=True,
+                ahead=3,
+            ),
+        )
+
+        from osmosis_ai.cli import main as cli
+
+        exit_code = cli.main(["--json", "train", "submit", str(config_path)])
+        captured = capsys.readouterr()
+
+        assert exit_code != 0
+        envelope = json.loads(captured.err)
+        warnings = envelope["error"]["details"]["warnings"]
+        assert any("Uncommitted changes" in w for w in warnings)
+        assert any("3 unpushed commits" in w for w in warnings)
+
+    def test_submit_plain_without_yes_writes_context_to_stderr(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        config_path = TestSubmit._write_config(tmp_path)
+
+        class FakeClient:
+            def submit_training_run(self, **kwargs):
+                raise AssertionError("API must not be reached without confirmation")
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+
+        from osmosis_ai.cli import main as cli
+
+        exit_code = cli.main(["--plain", "train", "submit", str(config_path)])
+        captured = capsys.readouterr()
+
+        assert exit_code != 0
+        # plain stderr carries the prompt + summary + at least one note
+        assert "Confirmation required: Submit this training run?" in captured.err
+        assert "Rollout: calculator" in captured.err
+        assert "Dataset: abc-123" in captured.err
+        assert "Notes:" in captured.err
+        # final error line is still surfaced for humans
+        assert "Use --yes to confirm in non-interactive mode." in captured.err
+
+    def test_require_confirmation_includes_details_in_cli_error(
+        self,
+    ) -> None:
+        with override_output_context(format=OutputFormat.plain, interactive=False):
+            with pytest.raises(CLIError) as exc_info:
+                train_module._require_confirmation(
+                    "Submit this training run?",
+                    yes=False,
+                    summary=[("Model", "Qwen")],
+                    notes=["fetched from git"],
+                    warnings=["unpushed commits"],
+                )
+
+        err = exc_info.value
+        assert err.code == "INTERACTIVE_REQUIRED"
+        assert err.details["prompt"] == "Submit this training run?"
+        assert err.details["summary"] == {"Model": "Qwen"}
+        assert err.details["notes"] == ["fetched from git"]
+        assert err.details["warnings"] == ["unpushed commits"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_workspace_json.py
+++ b/tests/unit/cli/test_workspace_json.py
@@ -25,7 +25,7 @@ def test_workspace_list_json_returns_list_result(monkeypatch, capsys) -> None:
     )
     monkeypatch.setattr(
         "osmosis_ai.platform.cli.workspace.ensure_active_workspace",
-        lambda credentials=None: {"id": "ws_1", "name": "default"},
+        lambda credentials=None, **_kwargs: {"id": "ws_1", "name": "default"},
     )
     monkeypatch.setattr(
         "osmosis_ai.platform.cli.workspace.platform_request",

--- a/tests/unit/eval/common/test_multi_candidate.py
+++ b/tests/unit/eval/common/test_multi_candidate.py
@@ -184,3 +184,60 @@ def test_resolve_workflow_multiple_agent_workflow_config_instances(
             entrypoint="two_cfg.py",
         )
     assert "Multiple AgentWorkflowConfig" in str(exc_info.value)
+
+
+def test_resolve_workflow_entrypoint_can_import_sibling_package(
+    tmp_rollout_layout: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Entrypoints commonly do absolute imports of sibling packages within
+    the rollout directory (e.g. ``from multiply_openai_agents.workflow import
+    MultiplyWorkflow``). The loader must put the rollout dir on ``sys.path``
+    so those imports resolve."""
+    rollout_dir = tmp_path / "rollouts" / tmp_rollout_layout
+
+    # Sibling package next to the entrypoint.
+    sibling_pkg = rollout_dir / "sibling_pkg"
+    sibling_pkg.mkdir()
+    (sibling_pkg / "__init__.py").write_text("", encoding="utf-8")
+    (sibling_pkg / "workflow.py").write_text(
+        textwrap.dedent(
+            """\
+            from osmosis_ai.rollout.agent_workflow import AgentWorkflow
+
+            class SiblingWorkflow(AgentWorkflow):
+                async def run(self, ctx):
+                    pass
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    _write_entrypoint(
+        tmp_path,
+        tmp_rollout_layout,
+        "ep_sibling.py",
+        """\
+        from sibling_pkg.workflow import SiblingWorkflow
+        """,
+    )
+
+    rollout_dir_str = str(rollout_dir.resolve())
+
+    def _cleanup_sys_path():
+        if rollout_dir_str in sys.path:
+            sys.path.remove(rollout_dir_str)
+        sys.modules.pop("sibling_pkg", None)
+        sys.modules.pop("sibling_pkg.workflow", None)
+
+    monkeypatch.setattr(sys, "path", [p for p in sys.path if p != rollout_dir_str])
+    try:
+        wf_cls, _cfg, _mod_name = _resolve_workflow(
+            rollout=tmp_rollout_layout,
+            entrypoint="ep_sibling.py",
+        )
+        assert wf_cls is not None
+        assert wf_cls.__name__ == "SiblingWorkflow"
+    finally:
+        _cleanup_sys_path()

--- a/tests/unit/platform/cli/test_project_setup.py
+++ b/tests/unit/platform/cli/test_project_setup.py
@@ -4,10 +4,82 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from osmosis_ai.cli.errors import CLIError
+
+# ── Shared fixtures ──────────────────────────────────────────────
+
+
+class _FakeCreds:
+    """Minimal credentials stand-in for the auth fixture below."""
+
+    def is_expired(self) -> bool:
+        return False
+
+
+_DEFAULT_WORKSPACE_NAME = "default-workspace"
+_DEFAULT_WORKSPACE_ID = "ws_default"
+
+
+def _default_git_context() -> dict[str, str | bool | None]:
+    """Return a workspace context with no connected repo and no GitHub App."""
+    return {
+        "workspace_id": _DEFAULT_WORKSPACE_ID,
+        "workspace_name": _DEFAULT_WORKSPACE_NAME,
+        "git_sync_url": (
+            f"https://platform.osmosis.ai/{_DEFAULT_WORKSPACE_NAME}/integrations/git"
+        ),
+        "has_github_app_installation": False,
+        "connected_repo_url": None,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _mock_init_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default `osmosis init` to a healthy auth + workspace context.
+
+    `init` now requires an active platform workspace upfront via
+    ``_require_auth``. Most tests in this module exercise local
+    behavior (scaffolding, directory checks, post-init CTA), so this
+    autouse fixture stubs the auth + Git Sync lookup to a workspace
+    with no connected repo. Individual tests override these patches to
+    cover auth/workspace failure modes and the connected-repo guard.
+
+    The autouse stubs leave the real ``_resolve_workspace_git_context``
+    in place so its graceful-degradation behavior is exercised; tests
+    that care about specific Git Sync metadata can either patch
+    ``_resolve_workspace_git_context`` directly or replace
+    ``OsmosisClient.refresh_workspace_info`` to drive the underlying
+    API call.
+    """
+    import osmosis_ai.platform.api.client as client_module
+    import osmosis_ai.platform.cli.init as init_module
+
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.utils._require_auth",
+        lambda: (_DEFAULT_WORKSPACE_NAME, _FakeCreds()),
+    )
+    monkeypatch.setattr(
+        init_module, "get_active_workspace_id", lambda: _DEFAULT_WORKSPACE_ID
+    )
+
+    def _default_refresh(self: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "found": True,
+            "has_subscription": True,
+            "has_github_app_installation": False,
+            "connected_repo": None,
+        }
+
+    monkeypatch.setattr(
+        client_module.OsmosisClient,
+        "refresh_workspace_info",
+        _default_refresh,
+    )
+
 
 # ── Error case: git not found ────────────────────────────────────
 
@@ -20,6 +92,55 @@ def test_init_raises_when_git_not_found(monkeypatch) -> None:
 
     with pytest.raises(CLIError, match=r"[Gg]it"):
         init_module.init(name="test-project")
+
+
+# ── Error case: no active workspace ──────────────────────────────
+
+
+def test_init_raises_when_no_workspace_selected(monkeypatch, tmp_path: Path) -> None:
+    """init refuses to scaffold when ``_require_auth`` has no active workspace."""
+    import osmosis_ai.platform.cli.init as init_module
+
+    monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
+
+    def _no_workspace() -> tuple[str, Any]:
+        raise CLIError(
+            "No workspace selected. Run 'osmosis workspace' to select a workspace."
+        )
+
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.utils._require_auth",
+        _no_workspace,
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(CLIError, match="No workspace selected"):
+        init_module.init(name="test-project")
+
+    assert not (tmp_path / "test-project").exists()
+
+
+def test_init_raises_when_not_logged_in(monkeypatch, tmp_path: Path) -> None:
+    """init refuses to scaffold when credentials are missing/expired."""
+    import osmosis_ai.platform.cli.init as init_module
+
+    monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
+
+    def _not_logged_in() -> tuple[str, Any]:
+        raise CLIError("Not logged in. Run 'osmosis auth login' first.")
+
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.utils._require_auth",
+        _not_logged_in,
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(CLIError, match="Not logged in"):
+        init_module.init(name="test-project")
+
+    assert not (tmp_path / "test-project").exists()
 
 
 # ── Error case: directory exists without project.toml ─────────────────
@@ -146,8 +267,9 @@ def test_init_raises_when_selected_workspace_has_connected_repo(
     monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
     monkeypatch.setattr(
         init_module,
-        "_selected_workspace_git_context",
-        lambda: {
+        "_resolve_workspace_git_context",
+        lambda **_kwargs: {
+            "workspace_id": "ws_alpha",
             "workspace_name": "team-alpha",
             "git_sync_url": "https://platform.osmosis.ai/team-alpha/integrations/git",
             "has_github_app_installation": True,
@@ -173,8 +295,9 @@ def test_init_here_raises_when_selected_workspace_has_connected_repo(
     monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
     monkeypatch.setattr(
         init_module,
-        "_selected_workspace_git_context",
-        lambda: {
+        "_resolve_workspace_git_context",
+        lambda **_kwargs: {
+            "workspace_id": "ws_alpha",
             "workspace_name": "team-alpha",
             "git_sync_url": "https://platform.osmosis.ai/team-alpha/integrations/git",
             "has_github_app_installation": True,
@@ -189,195 +312,35 @@ def test_init_here_raises_when_selected_workspace_has_connected_repo(
         init_module.init(name="test-project", here=True)
 
 
-def test_init_ignores_auth_expiry_in_best_effort_workspace_lookup(
+def test_init_tolerates_auth_expiry_in_workspace_lookup(
     monkeypatch, tmp_path: Path
 ) -> None:
-    """init should continue when best-effort workspace Git metadata lookup hits 401."""
+    """A 401 during the post-auth Git Sync refresh shouldn't block scaffolding.
+
+    ``_require_auth`` already validated the session, so a transient
+    auth/platform error during the connected-repo metadata refresh
+    degrades gracefully to a context with no connected repo (never
+    blocks init on a non-existent connected repo).
+    """
+    import osmosis_ai.platform.api.client as client_module
     import osmosis_ai.platform.auth as auth_module
     import osmosis_ai.platform.cli.init as init_module
 
-    class _Creds:
-        def is_expired(self) -> bool:
-            return False
+    monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
+    _stub_scaffold_fns(monkeypatch, init_module)
 
-    def fake_platform_request(endpoint, **kwargs):
-        assert endpoint == "/api/cli/workspaces"
-        assert kwargs.get("cleanup_on_401") is False
+    def _fake_refresh(self: Any, **_kwargs: Any) -> dict[str, Any]:
         raise auth_module.AuthenticationExpiredError("session expired")
 
-    monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
-    for fn_name in (
-        "_write_scaffold",
-        "_git_init",
-        "_git_initial_commit",
-        "_update_project_metadata",
-    ):
-        monkeypatch.setattr(init_module, fn_name, lambda *a, **kw: None)
-    monkeypatch.setattr(init_module, "get_active_workspace_name", lambda: "team-alpha")
-    monkeypatch.setattr(auth_module, "load_credentials", lambda: _Creds())
-    monkeypatch.setattr(auth_module, "platform_request", fake_platform_request)
+    monkeypatch.setattr(
+        client_module.OsmosisClient, "refresh_workspace_info", _fake_refresh
+    )
 
     monkeypatch.chdir(tmp_path)
 
     init_module.init(name="test-project")
 
     assert (tmp_path / "test-project").is_dir()
-
-
-def test_init_auto_selects_single_workspace_for_git_context(
-    monkeypatch, tmp_path: Path
-) -> None:
-    """init should auto-select the only workspace when none is saved locally.
-
-    This also persists the selection to local config so subsequent CLI
-    commands see the same active workspace.
-    """
-    import osmosis_ai.platform.auth as auth_module
-    import osmosis_ai.platform.cli.init as init_module
-
-    class _Creds:
-        def is_expired(self) -> bool:
-            return False
-
-    calls: list[tuple[str, dict]] = []
-    persisted: dict[str, str] = {}
-
-    def fake_platform_request(endpoint, **kwargs):
-        calls.append((endpoint, kwargs))
-        assert endpoint == "/api/cli/workspaces"
-        assert kwargs.get("cleanup_on_401") is False
-        return {
-            "workspaces": [
-                {
-                    "id": "ws_solo",
-                    "name": "solo-team",
-                    "has_github_app_installation": False,
-                    "connected_repo": None,
-                }
-            ]
-        }
-
-    def fake_set_active_workspace(workspace_id, workspace_name):
-        persisted["id"] = workspace_id
-        persisted["name"] = workspace_name
-
-    monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
-    for fn_name in (
-        "_write_scaffold",
-        "_git_init",
-        "_git_initial_commit",
-        "_update_project_metadata",
-    ):
-        monkeypatch.setattr(init_module, fn_name, lambda *a, **kw: None)
-    monkeypatch.setattr(init_module, "get_active_workspace_name", lambda: None)
-    monkeypatch.setattr(init_module, "get_active_workspace_id", lambda: None)
-    monkeypatch.setattr(init_module, "set_active_workspace", fake_set_active_workspace)
-    monkeypatch.setattr(auth_module, "load_credentials", lambda: _Creds())
-    monkeypatch.setattr(auth_module, "platform_request", fake_platform_request)
-
-    monkeypatch.chdir(tmp_path)
-
-    init_module.init(name="test-project")
-
-    assert (tmp_path / "test-project").is_dir()
-    # Only one API call — fetch + verify + extract metadata are unified.
-    assert len(calls) == 1
-    # Auto-selection should have been persisted.
-    assert persisted == {"id": "ws_solo", "name": "solo-team"}
-
-
-def test_init_blocks_when_auto_selected_workspace_has_connected_repo(
-    monkeypatch, tmp_path: Path
-) -> None:
-    """init should raise when the auto-selected single workspace already has a connected repo."""
-    import osmosis_ai.platform.auth as auth_module
-    import osmosis_ai.platform.cli.init as init_module
-
-    class _Creds:
-        def is_expired(self) -> bool:
-            return False
-
-    def fake_platform_request(endpoint, **kwargs):
-        assert endpoint == "/api/cli/workspaces"
-        return {
-            "workspaces": [
-                {
-                    "id": "ws_solo",
-                    "name": "solo-team",
-                    "has_github_app_installation": True,
-                    "connected_repo": {
-                        "repo_url": "https://github.com/acme/rollouts",
-                    },
-                }
-            ]
-        }
-
-    monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
-    monkeypatch.setattr(init_module, "get_active_workspace_name", lambda: None)
-    monkeypatch.setattr(init_module, "get_active_workspace_id", lambda: None)
-    monkeypatch.setattr(init_module, "set_active_workspace", lambda *a, **kw: None)
-    monkeypatch.setattr(auth_module, "load_credentials", lambda: _Creds())
-    monkeypatch.setattr(auth_module, "platform_request", fake_platform_request)
-
-    monkeypatch.chdir(tmp_path)
-
-    target = tmp_path / "test-project"
-    with pytest.raises(CLIError, match="already connected"):
-        init_module.init(name="test-project")
-
-    assert not target.exists()
-
-
-def test_init_does_not_trust_stale_local_workspace_id(
-    monkeypatch, tmp_path: Path
-) -> None:
-    """init should ignore a locally cached workspace id that the server no longer returns.
-
-    Regression guard: previously, a stale local workspace name would be
-    trusted verbatim, producing broken Git Sync links and bypassing the
-    connected-repo guardrail.
-    """
-    import osmosis_ai.platform.auth as auth_module
-    import osmosis_ai.platform.cli.init as init_module
-
-    class _Creds:
-        def is_expired(self) -> bool:
-            return False
-
-    def fake_platform_request(endpoint, **kwargs):
-        assert endpoint == "/api/cli/workspaces"
-        # Server lists two *other* workspaces — the local id is gone.
-        return {
-            "workspaces": [
-                {"id": "ws_a", "name": "team-a"},
-                {"id": "ws_b", "name": "team-b"},
-            ]
-        }
-
-    monkeypatch.setattr(init_module.shutil, "which", lambda cmd: "git")
-    for fn_name in (
-        "_write_scaffold",
-        "_git_init",
-        "_git_initial_commit",
-        "_update_project_metadata",
-    ):
-        monkeypatch.setattr(init_module, fn_name, lambda *a, **kw: None)
-    # Local state points to a workspace the user no longer belongs to.
-    monkeypatch.setattr(init_module, "get_active_workspace_name", lambda: "old-team")
-    monkeypatch.setattr(init_module, "get_active_workspace_id", lambda: "ws_stale")
-    monkeypatch.setattr(auth_module, "load_credentials", lambda: _Creds())
-    monkeypatch.setattr(auth_module, "platform_request", fake_platform_request)
-
-    monkeypatch.chdir(tmp_path)
-
-    # init should still succeed (empty Git context, no false connected-repo block).
-    init_module.init(name="test-project")
-
-    context = init_module._selected_workspace_git_context()
-    # Stale id wasn't trusted, and there's no unambiguous auto-selection.
-    assert context["workspace_name"] is None
-    assert context["git_sync_url"] is None
-    assert context["connected_repo_url"] is None
 
 
 # ── _render_template ─────────────────────────────────────────────
@@ -803,21 +766,32 @@ class TestGitInitialCommit:
 
 
 class TestPrintNextSteps:
-    def test_print_next_steps_default(self, monkeypatch) -> None:
-        """_print_next_steps includes 'cd' and generic Git Sync CTA when no workspace is selected."""
+    @staticmethod
+    def _build_console(monkeypatch):
+        """Swap the init module's console for a captured StringIO console."""
         import io
 
-        import osmosis_ai.platform.auth as auth_module
         import osmosis_ai.platform.cli.init as mod
         from osmosis_ai.cli.console import Console
-        from osmosis_ai.platform.cli.init import _print_next_steps
 
         buf = io.StringIO()
         test_console = Console(file=buf, force_terminal=False, no_color=True)
         monkeypatch.setattr(mod, "console", test_console)
-        monkeypatch.setattr(mod, "get_active_workspace_name", lambda: None)
-        monkeypatch.setattr(auth_module, "load_credentials", lambda: None)
-        _print_next_steps("my-project", here=False)
+        return buf
+
+    def test_print_next_steps_empty_context(self, monkeypatch) -> None:
+        """_print_next_steps falls back to the generic Git Sync CTA with an empty context."""
+        from osmosis_ai.platform.cli.init import _print_next_steps
+
+        buf = self._build_console(monkeypatch)
+        empty_context: dict[str, str | bool | None] = {
+            "workspace_id": None,
+            "workspace_name": None,
+            "git_sync_url": None,
+            "has_github_app_installation": False,
+            "connected_repo_url": None,
+        }
+        _print_next_steps("my-project", here=False, git_context=empty_context)
         output = buf.getvalue()
         assert "cd my-project" in output
         assert "Git Sync" in output
@@ -825,60 +799,42 @@ class TestPrintNextSteps:
 
     def test_print_next_steps_selected_workspace(self, monkeypatch) -> None:
         """_print_next_steps shows a workspace Git Sync URL when no repo is connected."""
-        import io
-
-        import osmosis_ai.platform.auth as auth_module
         import osmosis_ai.platform.cli.init as mod
-        from osmosis_ai.cli.console import Console
         from osmosis_ai.platform.cli.init import _print_next_steps
 
-        buf = io.StringIO()
-        test_console = Console(file=buf, force_terminal=False, no_color=True)
-        monkeypatch.setattr(mod, "console", test_console)
-        monkeypatch.setattr(mod, "get_active_workspace_name", lambda: "team-alpha")
-        monkeypatch.setattr(auth_module, "load_credentials", lambda: None)
-        _print_next_steps("my-project", here=False)
+        buf = self._build_console(monkeypatch)
+        _print_next_steps(
+            "my-project",
+            here=False,
+            git_context={
+                "workspace_id": "ws_alpha",
+                "workspace_name": "team-alpha",
+                "git_sync_url": (f"{mod.PLATFORM_URL}/team-alpha/integrations/git"),
+                "has_github_app_installation": False,
+                "connected_repo_url": None,
+            },
+        )
         output = buf.getvalue()
         assert "cd my-project" in output
         assert f"{mod.PLATFORM_URL}/team-alpha/integrations/git" in output
 
     def test_print_next_steps_connected_repo(self, monkeypatch) -> None:
         """_print_next_steps shows the connected repository URL when one exists."""
-        import io
-
-        import osmosis_ai.platform.auth as auth_module
         import osmosis_ai.platform.cli.init as mod
-        from osmosis_ai.cli.console import Console
         from osmosis_ai.platform.cli.init import _print_next_steps
 
-        class _Creds:
-            def is_expired(self) -> bool:
-                return False
-
-        def fake_platform_request(endpoint, **kwargs):
-            assert endpoint == "/api/cli/workspaces"
-            assert kwargs.get("cleanup_on_401") is False
-            return {
-                "workspaces": [
-                    {
-                        "id": "ws_alpha",
-                        "name": "team-alpha",
-                        "has_github_app_installation": True,
-                        "connected_repo": {
-                            "repo_url": "https://github.com/acme/rollouts",
-                        },
-                    }
-                ]
-            }
-
-        buf = io.StringIO()
-        test_console = Console(file=buf, force_terminal=False, no_color=True)
-        monkeypatch.setattr(mod, "console", test_console)
-        monkeypatch.setattr(mod, "get_active_workspace_name", lambda: "team-alpha")
-        monkeypatch.setattr(mod, "get_active_workspace_id", lambda: "ws_alpha")
-        monkeypatch.setattr(auth_module, "load_credentials", lambda: _Creds())
-        monkeypatch.setattr(auth_module, "platform_request", fake_platform_request)
-        _print_next_steps("my-project", here=False)
+        buf = self._build_console(monkeypatch)
+        _print_next_steps(
+            "my-project",
+            here=False,
+            git_context={
+                "workspace_id": "ws_alpha",
+                "workspace_name": "team-alpha",
+                "git_sync_url": (f"{mod.PLATFORM_URL}/team-alpha/integrations/git"),
+                "has_github_app_installation": True,
+                "connected_repo_url": "https://github.com/acme/rollouts",
+            },
+        )
         output = buf.getvalue()
         assert "cd my-project" in output
         assert "Connected repo:" in output
@@ -886,61 +842,38 @@ class TestPrintNextSteps:
 
     def test_print_next_steps_choose_repo_when_app_installed(self, monkeypatch) -> None:
         """_print_next_steps asks the user to choose a repo when GitHub is connected but no repo is linked."""
-        import io
-
-        import osmosis_ai.platform.auth as auth_module
         import osmosis_ai.platform.cli.init as mod
-        from osmosis_ai.cli.console import Console
         from osmosis_ai.platform.cli.init import _print_next_steps
 
-        class _Creds:
-            def is_expired(self) -> bool:
-                return False
-
-        def fake_platform_request(endpoint, **kwargs):
-            assert endpoint == "/api/cli/workspaces"
-            return {
-                "workspaces": [
-                    {
-                        "id": "ws_alpha",
-                        "name": "team-alpha",
-                        "has_github_app_installation": True,
-                        "connected_repo": None,
-                    }
-                ]
-            }
-
-        buf = io.StringIO()
-        test_console = Console(file=buf, force_terminal=False, no_color=True)
-        monkeypatch.setattr(mod, "console", test_console)
-        monkeypatch.setattr(mod, "get_active_workspace_name", lambda: "team-alpha")
-        monkeypatch.setattr(mod, "get_active_workspace_id", lambda: "ws_alpha")
-        monkeypatch.setattr(auth_module, "load_credentials", lambda: _Creds())
-        monkeypatch.setattr(auth_module, "platform_request", fake_platform_request)
-        _print_next_steps("my-project", here=False)
+        buf = self._build_console(monkeypatch)
+        _print_next_steps(
+            "my-project",
+            here=False,
+            git_context={
+                "workspace_id": "ws_alpha",
+                "workspace_name": "team-alpha",
+                "git_sync_url": (f"{mod.PLATFORM_URL}/team-alpha/integrations/git"),
+                "has_github_app_installation": True,
+                "connected_repo_url": None,
+            },
+        )
         output = buf.getvalue()
         assert f"{mod.PLATFORM_URL}/team-alpha/integrations/git" in output
         assert "choose a repo" in output
 
     def test_print_next_steps_includes_plugin_install_hints(self, monkeypatch) -> None:
         """_print_next_steps advertises the osmosis plugin for Claude / Cursor / Codex."""
-        import io
-
-        import osmosis_ai.platform.auth as auth_module
-        import osmosis_ai.platform.cli.init as mod
-        from osmosis_ai.cli.console import Console
         from osmosis_ai.platform.cli.init import _print_next_steps
 
         monkeypatch.setenv("OSMOSIS_PLUGIN_REPO", "my-org/my-plugins")
         monkeypatch.setenv("OSMOSIS_PLUGIN_MARKETPLACE", "my-marketplace")
 
-        buf = io.StringIO()
-        test_console = Console(file=buf, force_terminal=False, no_color=True)
-        monkeypatch.setattr(mod, "console", test_console)
-        monkeypatch.setattr(mod, "get_active_workspace_name", lambda: None)
-        monkeypatch.setattr(auth_module, "load_credentials", lambda: None)
-
-        _print_next_steps("my-project", here=False)
+        buf = self._build_console(monkeypatch)
+        _print_next_steps(
+            "my-project",
+            here=False,
+            git_context=_default_git_context(),
+        )
         output = buf.getvalue()
         assert "osmosis agent plugin" in output
         assert "Claude Code" in output
@@ -952,22 +885,17 @@ class TestPrintNextSteps:
 
     def test_print_next_steps_here(self, monkeypatch) -> None:
         """_print_next_steps omits 'cd' when here=True but keeps platform URL."""
-        import io
-
-        import osmosis_ai.platform.auth as auth_module
-        import osmosis_ai.platform.cli.init as mod
-        from osmosis_ai.cli.console import Console
         from osmosis_ai.platform.cli.init import _print_next_steps
 
-        buf = io.StringIO()
-        test_console = Console(file=buf, force_terminal=False, no_color=True)
-        monkeypatch.setattr(mod, "console", test_console)
-        monkeypatch.setattr(mod, "get_active_workspace_name", lambda: None)
-        monkeypatch.setattr(auth_module, "load_credentials", lambda: None)
-        _print_next_steps("my-project", here=True)
+        buf = self._build_console(monkeypatch)
+        _print_next_steps(
+            "my-project",
+            here=True,
+            git_context=_default_git_context(),
+        )
         output = buf.getvalue()
         assert "cd my-project" not in output
-        assert "Git Sync" in output
+        assert "Git Sync" in output or "integrations/git" in output
 
 
 # ── Integration tests — full init flow ────────────────────────────

--- a/tests/unit/platform/cli/test_utils.py
+++ b/tests/unit/platform/cli/test_utils.py
@@ -301,3 +301,70 @@ def test_platform_call_uses_injected_console() -> None:
 
     assert result == "ok"
     assert messages == ["Fetching things..."]
+
+
+# ── _require_subscription ────────────────────────────────────────────
+
+
+class _FakeCreds:
+    def is_expired(self) -> bool:
+        return False
+
+
+def test_require_subscription_propagates_auth_expired_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real 401 must surface as AuthenticationExpiredError instead of being
+    masked by the misleading "subscription required" CLIError when a stale
+    `False` cache is present.
+    """
+    import osmosis_ai.platform.cli.utils as utils_module
+    from osmosis_ai.platform.auth import AuthenticationExpiredError
+
+    monkeypatch.setattr(
+        utils_module, "load_subscription_status", lambda *_a, **_kw: False
+    )
+    monkeypatch.setattr(
+        utils_module, "save_subscription_status", lambda *_a, **_kw: None
+    )
+    monkeypatch.setattr(utils_module, "require_credentials", lambda: _FakeCreds())
+
+    class _FakeClient:
+        def refresh_workspace_info(self, **_kwargs):
+            raise AuthenticationExpiredError("session expired")
+
+    monkeypatch.setattr(
+        "osmosis_ai.platform.api.client.OsmosisClient", lambda: _FakeClient()
+    )
+
+    with pytest.raises(AuthenticationExpiredError):
+        utils_module._require_subscription(workspace_name="team-alpha")
+
+
+def test_require_subscription_swallows_platform_api_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Transient platform errors should not block when cache is unknown — the
+    actual mutating call surfaces them with full context.
+    """
+    import osmosis_ai.platform.cli.utils as utils_module
+    from osmosis_ai.platform.auth import PlatformAPIError
+
+    monkeypatch.setattr(
+        utils_module, "load_subscription_status", lambda *_a, **_kw: None
+    )
+    monkeypatch.setattr(
+        utils_module, "save_subscription_status", lambda *_a, **_kw: None
+    )
+    monkeypatch.setattr(utils_module, "require_credentials", lambda: _FakeCreds())
+
+    class _FakeClient:
+        def refresh_workspace_info(self, **_kwargs):
+            raise PlatformAPIError("platform unreachable")
+
+    monkeypatch.setattr(
+        "osmosis_ai.platform.api.client.OsmosisClient", lambda: _FakeClient()
+    )
+
+    # No exception — degrades gracefully so the next API call surfaces it.
+    utils_module._require_subscription(workspace_name="team-alpha")

--- a/tests/unit/platform/cli/test_workspace_repo.py
+++ b/tests/unit/platform/cli/test_workspace_repo.py
@@ -1,0 +1,467 @@
+"""Tests for osmosis_ai.platform.cli.workspace_repo."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.platform.auth import (
+    AuthenticationExpiredError,
+    PlatformAPIError,
+)
+from osmosis_ai.platform.cli import workspace_repo
+
+# ---------------------------------------------------------------------------
+# normalize_git_url
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeGitUrl:
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("https://github.com/acme/rollouts", "github.com/acme/rollouts"),
+            ("https://github.com/acme/rollouts.git", "github.com/acme/rollouts"),
+            ("https://github.com/acme/rollouts/", "github.com/acme/rollouts"),
+            ("git@github.com:acme/rollouts.git", "github.com/acme/rollouts"),
+            ("git@github.com:acme/rollouts", "github.com/acme/rollouts"),
+            ("ssh://git@github.com/acme/rollouts.git", "github.com/acme/rollouts"),
+            (
+                "https://user:pat@github.com/acme/rollouts.git",
+                "github.com/acme/rollouts",
+            ),
+            # Host comparison is case-insensitive.
+            ("https://GitHub.com/acme/rollouts", "github.com/acme/rollouts"),
+        ],
+    )
+    def test_known_forms_normalize_to_host_path(self, url: str, expected: str) -> None:
+        assert workspace_repo.normalize_git_url(url) == expected
+
+    @pytest.mark.parametrize("url", ["", None, "   ", "not a url", "https://"])
+    def test_unparseable_input_returns_none(self, url: Any) -> None:
+        assert workspace_repo.normalize_git_url(url) is None
+
+
+# ---------------------------------------------------------------------------
+# get_local_git_remote_url
+# ---------------------------------------------------------------------------
+
+
+class TestGetLocalGitRemoteUrl:
+    @staticmethod
+    def _make_dot_git(path: Path) -> None:
+        """Create a placeholder ``.git`` directory so the guard short-circuit allows the call through."""
+        (path / ".git").mkdir()
+
+    def test_returns_none_when_git_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._make_dot_git(tmp_path)
+        monkeypatch.setattr(workspace_repo.shutil, "which", lambda _name: None)
+        assert workspace_repo.get_local_git_remote_url(tmp_path) is None
+
+    def test_returns_none_when_not_a_repo(self, tmp_path: Path) -> None:
+        # Without ``.git`` we must short-circuit so ``git -C`` doesn't
+        # walk up and surface an unrelated parent repo's origin.
+        assert workspace_repo.get_local_git_remote_url(tmp_path) is None
+
+    def test_returns_url_from_git(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._make_dot_git(tmp_path)
+        monkeypatch.setattr(
+            workspace_repo.shutil, "which", lambda _name: "/usr/bin/git"
+        )
+
+        def _fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="https://github.com/acme/rollouts.git\n", stderr=""
+            )
+
+        monkeypatch.setattr(workspace_repo.subprocess, "run", _fake_run)
+        assert (
+            workspace_repo.get_local_git_remote_url(tmp_path)
+            == "https://github.com/acme/rollouts.git"
+        )
+
+    def test_returns_none_on_git_failure(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._make_dot_git(tmp_path)
+        monkeypatch.setattr(
+            workspace_repo.shutil, "which", lambda _name: "/usr/bin/git"
+        )
+
+        def _fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                cmd, 128, stdout="", stderr="fatal: not a git repository"
+            )
+
+        monkeypatch.setattr(workspace_repo.subprocess, "run", _fake_run)
+        assert workspace_repo.get_local_git_remote_url(tmp_path) is None
+
+    def test_returns_none_on_oserror(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._make_dot_git(tmp_path)
+        monkeypatch.setattr(
+            workspace_repo.shutil, "which", lambda _name: "/usr/bin/git"
+        )
+
+        def _raise(*args, **kwargs):
+            raise OSError("boom")
+
+        monkeypatch.setattr(workspace_repo.subprocess, "run", _raise)
+        assert workspace_repo.get_local_git_remote_url(tmp_path) is None
+
+    def test_nested_dir_without_git_does_not_walk_up_to_parent(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Nested project without its own ``.git`` must not surface the
+        # parent repo's origin via ``git -C``'s parent-walk behavior.
+        nested = tmp_path / "nested"
+        nested.mkdir()
+
+        def _fake_run(cmd, **kwargs):
+            raise AssertionError("subprocess must not run when .git is absent")
+
+        monkeypatch.setattr(workspace_repo.subprocess, "run", _fake_run)
+        assert workspace_repo.get_local_git_remote_url(nested) is None
+
+
+# ---------------------------------------------------------------------------
+# summarize_local_git_state
+# ---------------------------------------------------------------------------
+
+
+def _make_repo(path: Path) -> None:
+    """Initialise a git repo with a deterministic identity for tests."""
+    subprocess.run(
+        ["git", "init", "-b", "main", str(path)], check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.email", "test@test.com"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.name", "Test"],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _commit(path: Path, message: str = "init") -> None:
+    subprocess.run(
+        ["git", "-C", str(path), "commit", "--allow-empty", "-m", message],
+        check=True,
+        capture_output=True,
+    )
+
+
+class TestSummarizeLocalGitState:
+    def test_returns_none_when_git_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(workspace_repo.shutil, "which", lambda _name: None)
+        assert workspace_repo.summarize_local_git_state(tmp_path) is None
+
+    def test_returns_none_when_not_a_repo(self, tmp_path: Path) -> None:
+        # tmp_path has no .git/ — must short-circuit even if git would
+        # otherwise walk up to a parent repo.
+        assert workspace_repo.summarize_local_git_state(tmp_path) is None
+
+    def test_clean_repo_with_commit(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path)
+        _commit(tmp_path, "initial")
+
+        state = workspace_repo.summarize_local_git_state(tmp_path)
+        assert state is not None
+        assert state.branch == "main"
+        assert state.head_sha is not None
+        assert len(state.head_sha) == 40
+        assert state.is_dirty is False
+        assert state.has_upstream is False
+        assert state.ahead == 0
+
+    def test_dirty_with_untracked_file(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path)
+        _commit(tmp_path, "initial")
+        (tmp_path / "scratch.txt").write_text("hello")
+
+        state = workspace_repo.summarize_local_git_state(tmp_path)
+        assert state is not None
+        assert state.is_dirty is True
+
+    def test_dirty_with_modified_tracked_file(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path)
+        (tmp_path / "tracked.txt").write_text("v1")
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "add", "tracked.txt"],
+            check=True,
+            capture_output=True,
+        )
+        _commit(tmp_path, "add tracked")
+        (tmp_path / "tracked.txt").write_text("v2")
+
+        state = workspace_repo.summarize_local_git_state(tmp_path)
+        assert state is not None
+        assert state.is_dirty is True
+
+    def test_ahead_of_upstream(self, tmp_path: Path) -> None:
+        # Create an "upstream" repo and clone it locally so our branch
+        # has a real upstream tracking ref to be ahead of.
+        upstream = tmp_path / "upstream.git"
+        subprocess.run(
+            ["git", "init", "--bare", "-b", "main", str(upstream)],
+            check=True,
+            capture_output=True,
+        )
+        local = tmp_path / "local"
+        subprocess.run(
+            ["git", "clone", str(upstream), str(local)],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(local), "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(local), "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+        )
+        # First commit is pushed; second stays local.
+        _commit(local, "first")
+        subprocess.run(
+            ["git", "-C", str(local), "push", "-u", "origin", "main"],
+            check=True,
+            capture_output=True,
+        )
+        _commit(local, "second")
+
+        state = workspace_repo.summarize_local_git_state(local)
+        assert state is not None
+        assert state.has_upstream is True
+        assert state.ahead == 1
+
+    def test_detached_head_returns_none_branch(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path)
+        _commit(tmp_path, "first")
+        _commit(tmp_path, "second")
+        head_sha = subprocess.run(
+            ["git", "-C", str(tmp_path), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "checkout", "--detach", head_sha],
+            check=True,
+            capture_output=True,
+        )
+
+        state = workspace_repo.summarize_local_git_state(tmp_path)
+        assert state is not None
+        assert state.branch is None
+        assert state.head_sha == head_sha
+
+
+# ---------------------------------------------------------------------------
+# validate_active_workspace_repo
+# ---------------------------------------------------------------------------
+
+
+def _patch_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+    return_value: dict[str, Any] | Exception,
+    *,
+    captured_kwargs: dict[str, Any] | None = None,
+) -> None:
+    """Replace OsmosisClient.refresh_workspace_info with a deterministic stub.
+
+    When *captured_kwargs* is provided, the stub records the kwargs of each
+    call into it so tests can assert e.g. ``cleanup_on_401`` was forwarded.
+    """
+
+    class _FakeClient:
+        def refresh_workspace_info(self, **kwargs: Any) -> dict[str, Any]:
+            if captured_kwargs is not None:
+                captured_kwargs.update(kwargs)
+            if isinstance(return_value, Exception):
+                raise return_value
+            return return_value
+
+    monkeypatch.setattr("osmosis_ai.platform.api.client.OsmosisClient", _FakeClient)
+
+
+class TestValidateActiveWorkspaceRepo:
+    def _call(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        workspace_repo.validate_active_workspace_repo(
+            project_root=tmp_path,
+            workspace_name="team-alpha",
+            credentials=object(),  # type: ignore[arg-type]
+            command_label="`osmosis train submit`",
+        )
+
+    def test_no_connected_repo_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _patch_refresh(monkeypatch, {"found": True, "connected_repo": None})
+
+        def _fail(*args: Any, **kwargs: Any) -> str:
+            raise AssertionError("git remote should not be checked")
+
+        monkeypatch.setattr(workspace_repo, "get_local_git_remote_url", _fail)
+        with pytest.raises(CLIError) as exc:
+            self._call(monkeypatch, tmp_path)
+        message = str(exc.value)
+        assert "no connected repo" in message
+        assert "team-alpha" in message
+        assert "/team-alpha/integrations/git" in message
+
+    def test_workspace_not_found_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # When the workspace can't be matched, the API response omits
+        # `connected_repo` entirely. Treat it the same as "no connected repo".
+        _patch_refresh(monkeypatch, {"found": False})
+
+        def _fail(*args: Any, **kwargs: Any) -> str:
+            raise AssertionError("git remote should not be checked")
+
+        monkeypatch.setattr(workspace_repo, "get_local_git_remote_url", _fail)
+        with pytest.raises(CLIError, match="no connected repo"):
+            self._call(monkeypatch, tmp_path)
+
+    def test_platform_unreachable_is_noop(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _patch_refresh(monkeypatch, PlatformAPIError("boom"))
+        monkeypatch.setattr(
+            workspace_repo,
+            "get_local_git_remote_url",
+            lambda _root: "ignored",
+        )
+        self._call(monkeypatch, tmp_path)
+
+    def test_auth_error_is_noop(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _patch_refresh(monkeypatch, AuthenticationExpiredError())
+        monkeypatch.setattr(
+            workspace_repo,
+            "get_local_git_remote_url",
+            lambda _root: "ignored",
+        )
+        self._call(monkeypatch, tmp_path)
+
+    def test_matching_remote_passes(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _patch_refresh(
+            monkeypatch,
+            {
+                "found": True,
+                "connected_repo": {
+                    "repo_url": "https://github.com/acme/rollouts",
+                },
+            },
+        )
+        monkeypatch.setattr(
+            workspace_repo,
+            "get_local_git_remote_url",
+            lambda _root: "git@github.com:acme/rollouts.git",
+        )
+        self._call(monkeypatch, tmp_path)
+
+    def test_missing_local_remote_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _patch_refresh(
+            monkeypatch,
+            {
+                "found": True,
+                "connected_repo": {
+                    "repo_url": "https://github.com/acme/rollouts",
+                },
+            },
+        )
+        monkeypatch.setattr(
+            workspace_repo, "get_local_git_remote_url", lambda _root: None
+        )
+        with pytest.raises(CLIError) as exc:
+            self._call(monkeypatch, tmp_path)
+        message = str(exc.value)
+        assert "team-alpha" in message
+        assert "https://github.com/acme/rollouts" in message
+        assert "no `origin` remote" in message
+
+    def test_mismatched_remote_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _patch_refresh(
+            monkeypatch,
+            {
+                "found": True,
+                "connected_repo": {
+                    "repo_url": "https://github.com/acme/rollouts",
+                },
+            },
+        )
+        monkeypatch.setattr(
+            workspace_repo,
+            "get_local_git_remote_url",
+            lambda _root: "https://github.com/other/repo.git",
+        )
+        with pytest.raises(CLIError) as exc:
+            self._call(monkeypatch, tmp_path)
+        message = str(exc.value)
+        assert "team-alpha" in message
+        assert "https://github.com/acme/rollouts" in message
+        assert "https://github.com/other/repo.git" in message
+
+    def test_unparseable_platform_url_is_noop(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _patch_refresh(
+            monkeypatch,
+            {
+                "found": True,
+                "connected_repo": {"repo_url": "garbage"},
+            },
+        )
+
+        def _fail(*args: Any, **kwargs: Any) -> str:
+            raise AssertionError("git remote should not be checked")
+
+        monkeypatch.setattr(workspace_repo, "get_local_git_remote_url", _fail)
+        self._call(monkeypatch, tmp_path)
+
+    def test_disables_cleanup_on_401(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # A pre-flight check must never wipe local credentials/active
+        # workspace on a transient 401 — the actual submit call below
+        # surfaces real auth failures with full context.
+        captured: dict[str, Any] = {}
+        _patch_refresh(
+            monkeypatch,
+            {"found": True, "connected_repo": None},
+            captured_kwargs=captured,
+        )
+
+        def _fail(*args: Any, **kwargs: Any) -> str:
+            raise AssertionError("git remote should not be checked")
+
+        monkeypatch.setattr(workspace_repo, "get_local_git_remote_url", _fail)
+        with pytest.raises(CLIError):
+            self._call(monkeypatch, tmp_path)
+
+        assert captured.get("cleanup_on_401") is False


### PR DESCRIPTION
## What

- Add a new `osmosis_ai/platform/cli/workspace_repo.py` module that validates the local project's `origin` matches the active workspace's connected Git Sync repo, and summarizes local git state (branch, head, ahead, dirty).
- Wire `osmosis train submit` to call `validate_active_workspace_repo` before submission and render a "Before you submit / Push before submitting" panel that flags uncommitted changes, unpushed commits, and missing upstreams.
- Extend `_require_confirmation` to accept `summary`, `notes`, and `warnings`. In JSON/plain modes the same context is surfaced through the `INTERACTIVE_REQUIRED` error envelope (and to stderr in plain mode), so AI agents and CI scripts see exactly what they would be confirming without first having to retry with `--yes`.
- Refactor `osmosis_ai/platform/cli/init.py` so `_resolve_workspace_git_context` takes an explicit `(workspace_name, workspace_id, credentials)` triple instead of re-discovering the active workspace inside the init flow. Callers are now responsible for ensuring an active workspace, removing the implicit auto-select-only-workspace path inside init.
- Pass `cleanup_on_401=False` for read-only paths in `workspace.py` (`workspace`, `workspace list`, `workspace switch`, the interactive `_select_workspace`) and in `_require_subscription` so a transient 401 from a list/menu fetch can't silently wipe local credentials and active-workspace state.
- Fix `osmosis_ai/eval/common/cli.py` to insert the rollout directory onto `sys.path` so absolute imports of sibling packages (e.g. `from multiply_openai_agents.grader import ...`) resolve when loading the rollout entrypoint.
- Add unit tests covering the new train-submit context, `workspace_repo` validation + git-state helpers, JSON-mode workspace listing, the eval multi-candidate sibling-import path, and the `_require_subscription` 401-passthrough behavior. Update `test_init_json` and `test_project_setup` for the new init signature.

## Why

`osmosis train submit` previously asked "Submit this training run?" without reminding users that the platform fetches *code* from the workspace's connected Git repo while reading *config* from the local TOML. Users with uncommitted edits or unpushed commits could submit a run that silently used stale code. The new remote-fetch panel + confirmation context closes that gap and, in JSON/plain modes, exposes the same warnings inside the structured error so non-interactive agents can react to them.

The auth-cleanup hardening fixes a class of footguns where a flaky read (`workspace list`, the interactive workspace menu, the subscription check, the post-init Git Sync probe) could trip a 401 cleanup path and log the user out / clear their active workspace mid-session. Read-only fetches now leave on-disk credentials alone; only mutating commands clean up on a real 401.

The eval `sys.path` change unblocks rollout entrypoints that import sibling packages by absolute name — a common pattern in real-world examples — without having to switch them to relative imports.

## How to Test

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright osmosis_ai/`
- `uv run pytest`
- `uv run pytest tests/unit/cli/test_train_commands.py tests/unit/platform/cli/test_workspace_repo.py tests/unit/platform/cli/test_utils.py tests/unit/eval/common/test_multi_candidate.py`
- Manual: in a project with uncommitted edits, run `osmosis train submit configs/training/<file>.toml` and confirm the yellow "Push before submitting" panel lists the dirty / ahead warnings; rerun with `--json --yes=false` and confirm the `INTERACTIVE_REQUIRED` error payload includes `summary`, `notes`, and `warnings`.

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves training submission safety by validating the local repo against the active workspace’s Git Sync and surfacing uncommitted/unpushed changes before submit. Also hardens auth-aware reads to prevent unintended logouts and fixes rollout imports for evals.

- **New Features**
  - Added `osmosis_ai/platform/cli/workspace_repo.py` to validate local `origin` against the workspace’s connected repo and summarize git state (branch, head, ahead, dirty).
  - `osmosis train submit` now shows a “Push before submitting” panel and blocks with clear warnings for dirty trees, unpushed commits, or missing upstreams.
  - `_require_confirmation` now accepts `summary`, `notes`, and `warnings`; JSON/plain modes return these via `INTERACTIVE_REQUIRED` so scripts and agents see the exact context without `--yes`.

- **Bug Fixes**
  - Read-only flows (`workspace`, `workspace list`, `workspace switch`, selection menu) and `_require_subscription` set `cleanup_on_401=False` so transient 401s don’t wipe local credentials or active workspace; real 401s surface as `AuthenticationExpiredError`.
  - Refactored `init`: `_resolve_workspace_git_context` now takes `(workspace_name, workspace_id, credentials)` explicitly; removed implicit auto-select logic.
  - Eval CLI adds the rollout dir to `sys.path` so absolute imports of sibling packages resolve.
  - Added unit tests for train-submit context, workspace-repo validation, JSON workspace list, eval sibling-imports, and subscription error handling.

<sup>Written for commit d6017fda68ccbf50fdeffff0dad2ad482373f278. Summary will update on new commits. <a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/148?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

