### PR TITLE
[misc] chore: increment version to 0.2.19

### DIFF
--- a/osmosis_ai/consts.py
+++ b/osmosis_ai/consts.py
@@ -1,3 +1,3 @@
 # package metadata
 package_name = "osmosis-ai"
-PACKAGE_VERSION = "0.2.18"
+PACKAGE_VERSION = "0.2.19"


### PR DESCRIPTION
## What

- Bump `PACKAGE_VERSION` in `osmosis_ai/consts.py` from `0.2.18` to `0.2.19`.

## Why

Cuts the next patch release for `osmosis-ai`. Pairs with the release-branch sync PR #150 — once both land we can tag `v0.2.19` from `release` and let `.github/workflows/publish.yml` pick up the new version.

## How to Test

- `git diff origin/main -- osmosis_ai/consts.py` — only the version string changes.
- `python -c "from osmosis_ai.consts import PACKAGE_VERSION; print(PACKAGE_VERSION)"` → `0.2.19`.
- `python -c "exec(open('osmosis_ai/consts.py').read()); print(PACKAGE_VERSION)"` (mirrors the publish workflow at `.github/workflows/publish.yml:40`).

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pyright osmosis_ai/` passes
- [ ] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `osmosis-ai` to 0.2.19 to prepare the next patch release. Updates `PACKAGE_VERSION` in `osmosis_ai/consts.py`.

<sup>Written for commit 38e1428d063fbd3772155c348bdee5fcd88f61d0. Summary will update on new commits. <a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/151?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

