### PR TITLE
[cli][rollout] fix: replace global batch size with rollout batch size

### DIFF
--- a/osmosis_ai/platform/cli/templates/configs/training/default.toml.tpl
+++ b/osmosis_ai/platform/cli/templates/configs/training/default.toml.tpl
@@ -20,7 +20,7 @@ dataset = "<your-dataset-name>"        # Dataset name from `osmosis --json datas
 # lr = 1e-6                          # Learning rate
 # total_epochs = 1                   # Number of training epochs
 # n_samples_per_prompt = 8           # Rollout samples per prompt
-# global_batch_size = 64             # Training batch size
+# rollout_batch_size = 64            # Rollout batch size
 # max_prompt_length = 8192           # Max prompt tokens
 # max_response_length = 8192         # Max response tokens
 

--- a/osmosis_ai/platform/cli/training_config.py
+++ b/osmosis_ai/platform/cli/training_config.py
@@ -130,13 +130,8 @@ def load_training_config(path: Path) -> TrainingConfig:
             f"n_samples_per_prompt must be a positive integer, "
             f"got {training.n_samples_per_prompt} in {path}"
         )
-    if (
-        training.rollout_batch_size is None
-        or training.n_samples_per_prompt is None
-    ):
-        raise CLIError(
-            f"Both rollout_batch_size and n samples per prompt cannot be null"
-        )
+    if training.rollout_batch_size is None or training.n_samples_per_prompt is None:
+        raise CLIError("rollout_batch_size and n_samples_per_prompt must both be set")
 
     return TrainingConfig(
         experiment_rollout=experiment.rollout,

--- a/osmosis_ai/platform/cli/training_config.py
+++ b/osmosis_ai/platform/cli/training_config.py
@@ -131,11 +131,11 @@ def load_training_config(path: Path) -> TrainingConfig:
             f"got {training.n_samples_per_prompt} in {path}"
         )
     if (
-        training.rollout_batch_size is not None
-        and training.n_samples_per_prompt is not None
+        training.rollout_batch_size is None
+        or training.n_samples_per_prompt is None
     ):
         raise CLIError(
-            f"rollout_batch_size and n samples per prompt cannot be null"
+            f"Both rollout_batch_size and n samples per prompt cannot be null"
         )
 
     return TrainingConfig(

--- a/osmosis_ai/platform/cli/training_config.py
+++ b/osmosis_ai/platform/cli/training_config.py
@@ -27,7 +27,7 @@ class _TrainingSection(BaseModel):
     lr: float | None = None
     total_epochs: int | None = None
     n_samples_per_prompt: int | None = None
-    global_batch_size: int | None = None
+    rollout_batch_size: int | None = None
     max_prompt_length: int | None = None
     max_response_length: int | None = None
 
@@ -60,7 +60,7 @@ class TrainingConfig(BaseModel):
     training_lr: float | None
     training_total_epochs: int | None
     training_n_samples_per_prompt: int | None
-    training_global_batch_size: int | None
+    training_rollout_batch_size: int | None
     training_max_prompt_length: int | None
     training_max_response_length: int | None
 
@@ -131,13 +131,11 @@ def load_training_config(path: Path) -> TrainingConfig:
             f"got {training.n_samples_per_prompt} in {path}"
         )
     if (
-        training.global_batch_size is not None
+        training.rollout_batch_size is not None
         and training.n_samples_per_prompt is not None
-        and training.global_batch_size % training.n_samples_per_prompt != 0
     ):
         raise CLIError(
-            f"global_batch_size ({training.global_batch_size}) must be divisible "
-            f"by n_samples_per_prompt ({training.n_samples_per_prompt}) in {path}"
+            f"rollout_batch_size and n samples per prompt cannot be null"
         )
 
     return TrainingConfig(
@@ -149,7 +147,7 @@ def load_training_config(path: Path) -> TrainingConfig:
         training_lr=training.lr,
         training_total_epochs=training.total_epochs,
         training_n_samples_per_prompt=training.n_samples_per_prompt,
-        training_global_batch_size=training.global_batch_size,
+        training_rollout_batch_size=training.rollout_batch_size,
         training_max_prompt_length=training.max_prompt_length,
         training_max_response_length=training.max_response_length,
         sampling_rollout_temperature=sampling.rollout_temperature,

--- a/osmosis_ai/templates/cookbook/multiply/configs/training/multiply.toml
+++ b/osmosis_ai/templates/cookbook/multiply/configs/training/multiply.toml
@@ -24,7 +24,7 @@ dataset = "<your-multiply-dataset>"   # Replace with the uploaded dataset name.
 # lr = 1e-6
 total_epochs = 1
 n_samples_per_prompt = 8
-global_batch_size = 64
+rollout_batch_size = 64
 max_prompt_length = 2048
 max_response_length = 2048
 

--- a/tests/unit/cli/test_command_result_migration_train_model_deployment_rollout.py
+++ b/tests/unit/cli/test_command_result_migration_train_model_deployment_rollout.py
@@ -319,6 +319,10 @@ rollout = "demo"
 entrypoint = "main.py"
 model_path = "Qwen/Qwen3"
 dataset = "demo-dataset"
+
+[training]
+n_samples_per_prompt = 8
+rollout_batch_size = 64
 """.strip(),
         encoding="utf-8",
     )

--- a/tests/unit/cli/test_rollout_validate_command.py
+++ b/tests/unit/cli/test_rollout_validate_command.py
@@ -76,6 +76,10 @@ rollout = "demo"
 entrypoint = "main.py"
 model_path = "Qwen/Qwen3.6-35B-A3B"
 dataset = "demo-dataset"
+
+[training]
+n_samples_per_prompt = 8
+rollout_batch_size = 64
 """.strip(),
         encoding="utf-8",
     )
@@ -122,6 +126,10 @@ rollout = "demo"
 entrypoint = "main.py"
 model_path = "Qwen/Qwen3.6-35B-A3B"
 dataset = "demo-dataset"
+
+[training]
+n_samples_per_prompt = 8
+rollout_batch_size = 64
 """.strip(),
         encoding="utf-8",
     )
@@ -144,6 +152,10 @@ rollout = "demo"
 entrypoint = "main.py"
 model_path = "Qwen/Qwen3.6-35B-A3B"
 dataset = "demo-dataset"
+
+[training]
+n_samples_per_prompt = 8
+rollout_batch_size = 64
 """.strip(),
         encoding="utf-8",
     )

--- a/tests/unit/cli/test_train_commands.py
+++ b/tests/unit/cli/test_train_commands.py
@@ -283,6 +283,8 @@ dataset = "abc-123"
 [training]
 lr = 1e-6
 total_epochs = 1
+n_samples_per_prompt = 8
+rollout_batch_size = 64
 """.strip(),
             encoding="utf-8",
         )
@@ -385,6 +387,10 @@ entrypoint = "main.py"
 model_path = "m"
 dataset = "d"
 commit_sha = "deadbeef"
+
+[training]
+n_samples_per_prompt = 8
+rollout_batch_size = 64
 """.strip(),
             encoding="utf-8",
         )
@@ -424,7 +430,12 @@ commit_sha = "deadbeef"
         assert captured_kwargs["dataset"] == "abc-123"
         assert captured_kwargs["rollout_name"] == "calculator"
         assert captured_kwargs["entrypoint"] == "main.py"
-        assert captured_kwargs["config"] == {"lr": 1e-6, "total_epochs": 1}
+        assert captured_kwargs["config"] == {
+            "lr": 1e-6,
+            "total_epochs": 1,
+            "n_samples_per_prompt": 8,
+            "rollout_batch_size": 64,
+        }
 
     def test_submit_rejects_non_canonical_training_config_path(
         self,
@@ -470,6 +481,10 @@ rollout = "graderless"
 entrypoint = "main.py"
 model_path = "m"
 dataset = "d"
+
+[training]
+n_samples_per_prompt = 8
+rollout_batch_size = 64
 """.strip(),
             encoding="utf-8",
         )
@@ -615,6 +630,10 @@ entrypoint = "main.py"
 model_path = "m"
 dataset = "d"
 commit_sha = "deadbeef1234"
+
+[training]
+n_samples_per_prompt = 8
+rollout_batch_size = 64
 """.strip(),
             encoding="utf-8",
         )

--- a/tests/unit/platform/cli/test_training_config.py
+++ b/tests/unit/platform/cli/test_training_config.py
@@ -29,7 +29,7 @@ commit_sha = "deadbeef"
 lr = 1e-6
 total_epochs = 2
 n_samples_per_prompt = 8
-global_batch_size = 64
+rollout_batch_size = 64
 max_prompt_length = 4096
 max_response_length = 8192
 
@@ -54,7 +54,7 @@ checkpoint_save_freq = 20
     assert cfg.training_lr == 1e-6
     assert cfg.training_total_epochs == 2
     assert cfg.training_n_samples_per_prompt == 8
-    assert cfg.training_global_batch_size == 64
+    assert cfg.training_rollout_batch_size == 64
     assert cfg.training_max_prompt_length == 4096
     assert cfg.training_max_response_length == 8192
     assert cfg.sampling_rollout_temperature == 0.8
@@ -207,28 +207,6 @@ def test_directory_path_raises(tmp_path: Path) -> None:
     assert "Cannot read config file" in str(exc_info.value)
 
 
-def test_batch_size_not_divisible(tmp_path: Path) -> None:
-    path = tmp_path / "bad_batch.toml"
-    path.write_text(
-        """
-[experiment]
-rollout = "r"
-entrypoint = "e.py"
-model_path = "m"
-dataset = "d"
-
-[training]
-n_samples_per_prompt = 8
-global_batch_size = 65
-""".strip(),
-        encoding="utf-8",
-    )
-
-    with pytest.raises(CLIError) as exc_info:
-        load_training_config(path)
-    assert "divisible" in str(exc_info.value)
-
-
 def test_batch_size_divisible_ok(tmp_path: Path) -> None:
     """Batch size exactly divisible by n_samples_per_prompt should succeed."""
     path = tmp_path / "ok_batch.toml"
@@ -242,13 +220,13 @@ dataset = "d"
 
 [training]
 n_samples_per_prompt = 8
-global_batch_size = 64
+rollout_batch_size = 64
 """.strip(),
         encoding="utf-8",
     )
 
     cfg = load_training_config(path)
-    assert cfg.training_global_batch_size == 64
+    assert cfg.training_rollout_batch_size == 64
     assert cfg.training_n_samples_per_prompt == 8
 
 

--- a/tests/unit/platform/cli/test_training_config.py
+++ b/tests/unit/platform/cli/test_training_config.py
@@ -72,6 +72,10 @@ rollout = "r"
 entrypoint = "e.py"
 model_path = "Qwen/Qwen3.6-35B-A3B"
 dataset = "id-1"
+
+[training]
+n_samples_per_prompt = 1
+rollout_batch_size = 1
 """.strip(),
         encoding="utf-8",
     )
@@ -81,6 +85,8 @@ dataset = "id-1"
     assert cfg.experiment_commit_sha is None
     assert cfg.training_lr is None
     assert cfg.training_total_epochs is None
+    assert cfg.training_n_samples_per_prompt == 1
+    assert cfg.training_rollout_batch_size == 1
     assert cfg.sampling_rollout_temperature is None
     assert cfg.checkpoints_eval_interval is None
 
@@ -103,6 +109,8 @@ dataset = "d"
 [training]
 lr = 1e-6
 total_epochs = 1
+n_samples_per_prompt = 8
+rollout_batch_size = 64
 
 [sampling]
 rollout_temperature = 0.9
@@ -118,6 +126,8 @@ checkpoint_save_freq = 10
     assert api == {
         "lr": 1e-6,
         "total_epochs": 1,
+        "n_samples_per_prompt": 8,
+        "rollout_batch_size": 64,
         "rollout_temperature": 0.9,
         "checkpoint_save_freq": 10,
     }
@@ -132,12 +142,19 @@ rollout = "r"
 entrypoint = "e.py"
 model_path = "m"
 dataset = "d"
+
+[training]
+n_samples_per_prompt = 1
+rollout_batch_size = 1
 """.strip(),
         encoding="utf-8",
     )
 
     cfg = load_training_config(path)
-    assert cfg.to_api_config() == {}
+    assert cfg.to_api_config() == {
+        "n_samples_per_prompt": 1,
+        "rollout_batch_size": 1,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -207,8 +224,40 @@ def test_directory_path_raises(tmp_path: Path) -> None:
     assert "Cannot read config file" in str(exc_info.value)
 
 
-def test_batch_size_divisible_ok(tmp_path: Path) -> None:
-    """Batch size exactly divisible by n_samples_per_prompt should succeed."""
+@pytest.mark.parametrize(
+    "training_body",
+    [
+        "rollout_batch_size = 64",
+        "n_samples_per_prompt = 8",
+        "",
+    ],
+)
+def test_required_batch_fields_cannot_be_missing(
+    tmp_path: Path, training_body: str
+) -> None:
+    path = tmp_path / "missing_batch_fields.toml"
+    path.write_text(
+        f"""
+[experiment]
+rollout = "r"
+entrypoint = "e.py"
+model_path = "m"
+dataset = "d"
+
+[training]
+{training_body}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CLIError) as exc_info:
+        load_training_config(path)
+    assert "rollout_batch_size and n_samples_per_prompt must both be set" in str(
+        exc_info.value
+    )
+
+
+def test_rollout_batch_size_not_required_to_be_divisible(tmp_path: Path) -> None:
     path = tmp_path / "ok_batch.toml"
     path.write_text(
         """
@@ -220,13 +269,13 @@ dataset = "d"
 
 [training]
 n_samples_per_prompt = 8
-rollout_batch_size = 64
+rollout_batch_size = 65
 """.strip(),
         encoding="utf-8",
     )
 
     cfg = load_training_config(path)
-    assert cfg.training_rollout_batch_size == 64
+    assert cfg.training_rollout_batch_size == 65
     assert cfg.training_n_samples_per_prompt == 8
 
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced `global_batch_size` with `rollout_batch_size` in training configs and API, and made `rollout_batch_size` and `n_samples_per_prompt` required (no divisibility check). `to_api_config` now includes both fields; templates, cookbook examples, and tests updated.

- **Migration**
  - In training TOML files, rename `[training].global_batch_size` to `rollout_batch_size`.
  - Update code references from `training_global_batch_size` to `training_rollout_batch_size`.

<sup>Written for commit 072b06f832e246da14a3e8fbcdc7f0132d04792d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

