### PR TITLE
[cli] feat: add agent_timeout to training config schema

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -231,8 +231,8 @@ All fields are optional. Omitted fields use platform defaults.
 | `max_prompt_length` | int | Token limit for prompt inputs |
 | `max_response_length` | int | Token limit for model responses |
 | `lr` | float | Learning rate |
-| `agent_workflow_timeout_s` | float | Seconds slime waits for the rollout server to complete one rollout before marking it failed (default: 450 s). Increase for long-horizon agent tasks where each rollout can take several minutes. |
-| `grader_timeout_s` | float | Seconds slime waits for the grader callback after rollout completes (default: 150 s). Increase if your grader runs expensive verification. |
+| `agent_workflow_timeout_s` | float | Seconds osmosis waits for the rollout server to complete one rollout before marking it failed (default: 450 s). Increase for long-horizon agent tasks where each rollout can take several minutes. |
+| `grader_timeout_s` | float | Seconds osmosis waits for the grader callback after rollout completes (default: 150 s). Increase if your grader runs expensive verification. |
 
 > **Sizing `rollout_batch_size`**: the rollout server processes `rollout_batch_size × n_samples_per_prompt` concurrent LLM calls per step. Too high a value overwhelms the inference engine and causes all rollouts to timeout. A good rule of thumb: `rollout_batch_size ≤ 32` when using a remote MCP-based rollout server with a 35B+ model.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -219,6 +219,37 @@ clones the workspace's connected Git repository for the actual rollout code.
 | `model_path` | Supported base model path |
 | `dataset` | Platform dataset name (`osmosis dataset list`) |
 
+#### Optional `[training]` fields
+
+All fields are optional. Omitted fields use platform defaults.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `total_epochs` | int | Number of passes over the dataset |
+| `n_samples_per_prompt` | int | Rollout samples generated per prompt (GRPO group size) |
+| `rollout_batch_size` | int | Prompts rolled out per training step. **Controls how many rollouts run concurrently on the rollout server** — set this to avoid overwhelming the LLM inference engine. Default: 64. For a 32-row dataset with a remote rollout server, `8` or `32` is a safe starting point. |
+| `max_prompt_length` | int | Token limit for prompt inputs |
+| `max_response_length` | int | Token limit for model responses |
+| `lr` | float | Learning rate |
+| `agent_workflow_timeout_s` | float | Seconds slime waits for the rollout server to complete one rollout before marking it failed (default: 450 s). Increase for long-horizon agent tasks where each rollout can take several minutes. |
+| `grader_timeout_s` | float | Seconds slime waits for the grader callback after rollout completes (default: 150 s). Increase if your grader runs expensive verification. |
+
+> **Sizing `rollout_batch_size`**: the rollout server processes `rollout_batch_size × n_samples_per_prompt` concurrent LLM calls per step. Too high a value overwhelms the inference engine and causes all rollouts to timeout. A good rule of thumb: `rollout_batch_size ≤ 32` when using a remote MCP-based rollout server with a 35B+ model.
+
+#### Optional `[sampling]` fields
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `rollout_temperature` | float | Sampling temperature (default: 1.0) |
+| `rollout_top_p` | float | Top-p nucleus sampling (default: 1.0) |
+
+#### Optional `[checkpoints]` fields
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `checkpoint_save_freq` | int | Save a checkpoint every N rollout steps |
+| `eval_interval` | int | Run evaluation every N rollout steps |
+
 #### Environment variables — `[rollout.env]`
 
 Literal key/value pairs injected verbatim into the rollout container. Values

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -127,7 +127,7 @@ agent_workflow_timeout_s = 900   # 15 minutes instead of the default 7.5
 A small number of samples failing intermittently (2–5 rows out of 500+) indicates a resource contention issue on the rollout server rather than a total overload.
 
 Common causes:
-- **Event loop blocking**: synchronous calls inside an `async` rollout workflow (e.g. `mcp.list_tools_sync()`) freeze the uvicorn event loop. New HTTP requests from slime cannot get a 200 OK within the 30 s httpx connect timeout. Fix: wrap blocking calls in `asyncio.get_running_loop().run_in_executor(None, ...)`.
+- **Event loop blocking**: synchronous calls inside an `async` rollout workflow (e.g. `mcp.list_tools_sync()`) freeze the uvicorn event loop. New HTTP requests from our trainer cannot get a 200 OK within the 30 s httpx connect timeout. Fix: wrap blocking calls in `asyncio.get_running_loop().run_in_executor(None, ...)`.
 - **Subprocess exhaustion**: too many concurrent MCP subprocesses saturating OS limits. Set `ConcurrencyConfig(max_concurrent=64)` in your `AgentWorkflowConfig`.
 
 ## Rollout validation

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -99,6 +99,37 @@ Use `--fresh` after mutating the dataset file.
 
 Upgrade the package or delete the specific cache file after `osmosis eval cache ls`.
 
+## Training run rollout failures
+
+### All rollouts timeout / zero reward across the board
+
+If a training run completes with `rollout/raw_reward = 0` and `rollout/response_len/mean = 0`, every rollout timed out before producing output. This usually means the LLM inference engine was overwhelmed with too many concurrent requests.
+
+**Cause:** `rollout_batch_size` defaults to 64. With `n_samples_per_prompt = 8` that's 512 concurrent LLM calls hitting the rollout server simultaneously, which saturates the SGLang engine and causes every rollout to exceed `agent_workflow_timeout_s`.
+
+**Fix:** Reduce `rollout_batch_size` in your training config:
+
+```toml
+[training]
+n_samples_per_prompt = 8
+rollout_batch_size = 8    # 8 × 8 = 64 concurrent calls instead of 512
+```
+
+If rollouts are still timing out with a smaller batch size (e.g. because your agent takes many turns), increase the timeout:
+
+```toml
+[training]
+agent_workflow_timeout_s = 900   # 15 minutes instead of the default 7.5
+```
+
+### Some rollouts timeout (a few rows show zero reward / no output)
+
+A small number of samples failing intermittently (2–5 rows out of 500+) indicates a resource contention issue on the rollout server rather than a total overload.
+
+Common causes:
+- **Event loop blocking**: synchronous calls inside an `async` rollout workflow (e.g. `mcp.list_tools_sync()`) freeze the uvicorn event loop. New HTTP requests from slime cannot get a 200 OK within the 30 s httpx connect timeout. Fix: wrap blocking calls in `asyncio.get_running_loop().run_in_executor(None, ...)`.
+- **Subprocess exhaustion**: too many concurrent MCP subprocesses saturating OS limits. Set `ConcurrencyConfig(max_concurrent=64)` in your `AgentWorkflowConfig`.
+
 ## Rollout validation
 
 ### Validation failures

--- a/osmosis_ai/platform/cli/training_config.py
+++ b/osmosis_ai/platform/cli/training_config.py
@@ -46,7 +46,8 @@ class _TrainingSection(BaseModel):
     rollout_batch_size: int | None = None
     max_prompt_length: int | None = None
     max_response_length: int | None = None
-    agent_timeout: float | None = None
+    agent_workflow_timeout_s: float | None = None
+    grader_timeout_s: float | None = None
 
 
 class _SamplingSection(BaseModel):
@@ -87,7 +88,8 @@ class TrainingConfig(BaseModel):
     training_rollout_batch_size: int | None
     training_max_prompt_length: int | None
     training_max_response_length: int | None
-    training_agent_timeout: float | None
+    training_agent_workflow_timeout_s: float | None
+    training_grader_timeout_s: float | None
 
     # sampling
     sampling_rollout_temperature: float | None
@@ -208,7 +210,8 @@ def load_training_config(path: Path) -> TrainingConfig:
         training_rollout_batch_size=training.rollout_batch_size,
         training_max_prompt_length=training.max_prompt_length,
         training_max_response_length=training.max_response_length,
-        training_agent_timeout=training.agent_timeout,
+        training_agent_workflow_timeout_s=training.agent_workflow_timeout_s,
+        training_grader_timeout_s=training.grader_timeout_s,
         sampling_rollout_temperature=sampling.rollout_temperature,
         sampling_rollout_top_p=sampling.rollout_top_p,
         checkpoints_eval_interval=checkpoints.eval_interval,

--- a/osmosis_ai/platform/cli/training_config.py
+++ b/osmosis_ai/platform/cli/training_config.py
@@ -46,6 +46,7 @@ class _TrainingSection(BaseModel):
     rollout_batch_size: int | None = None
     max_prompt_length: int | None = None
     max_response_length: int | None = None
+    agent_timeout: float | None = None
 
 
 class _SamplingSection(BaseModel):
@@ -86,6 +87,7 @@ class TrainingConfig(BaseModel):
     training_rollout_batch_size: int | None
     training_max_prompt_length: int | None
     training_max_response_length: int | None
+    training_agent_timeout: float | None
 
     # sampling
     sampling_rollout_temperature: float | None
@@ -206,6 +208,7 @@ def load_training_config(path: Path) -> TrainingConfig:
         training_rollout_batch_size=training.rollout_batch_size,
         training_max_prompt_length=training.max_prompt_length,
         training_max_response_length=training.max_response_length,
+        training_agent_timeout=training.agent_timeout,
         sampling_rollout_temperature=sampling.rollout_temperature,
         sampling_rollout_top_p=sampling.rollout_top_p,
         checkpoints_eval_interval=checkpoints.eval_interval,

--- a/osmosis_ai/platform/cli/training_config.py
+++ b/osmosis_ai/platform/cli/training_config.py
@@ -88,8 +88,8 @@ class TrainingConfig(BaseModel):
     training_rollout_batch_size: int | None
     training_max_prompt_length: int | None
     training_max_response_length: int | None
-    training_agent_workflow_timeout_s: float | None
-    training_grader_timeout_s: float | None
+    training_agent_workflow_timeout_s: float | None = None
+    training_grader_timeout_s: float | None = None
 
     # sampling
     sampling_rollout_temperature: float | None

--- a/osmosis_ai/templates/cookbook/multiply/configs/training/multiply.toml
+++ b/osmosis_ai/templates/cookbook/multiply/configs/training/multiply.toml
@@ -24,9 +24,15 @@ dataset = "<your-multiply-dataset>"   # Replace with the uploaded dataset name.
 # lr = 1e-6
 total_epochs = 1
 n_samples_per_prompt = 8
-rollout_batch_size = 64
+# rollout_batch_size controls how many prompts are rolled out per training step.
+# Total concurrent LLM calls = rollout_batch_size × n_samples_per_prompt.
+# Keep this low for remote rollout servers to avoid overwhelming the inference
+# engine (512+ concurrent calls will cause all rollouts to timeout).
+rollout_batch_size = 8
 max_prompt_length = 2048
 max_response_length = 2048
+# agent_workflow_timeout_s = 900  # increase for long-horizon agent tasks (default: 450)
+# grader_timeout_s = 300          # increase if your grader runs slow verification (default: 150)
 
 [sampling]
 rollout_temperature = 1.0


### PR DESCRIPTION
<!--
PR Title Format: [module] type: description
  modules: reward, rollout, server, cli, auth, eval, misc, ci, doc
  types:   feat, fix, refactor, chore, test, doc

Examples:
  [rollout] feat: add streaming support for chat completions
  [BREAKING][reward] refactor: rename decorator parameters
  [ci] chore: update GitHub Actions versions
-->

## What

<!-- Brief description of the changes. What does this PR do? -->

## Why

<!-- Why are these changes needed? Link any related issues. -->
<!-- Closes #<issue_number> -->

## How to Test

<!-- Describe how reviewers can verify these changes. -->

## Checklist

- [ ] PR title follows `[module] type: description` format
- [ ] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pyright osmosis_ai/` passes
- [ ] `pytest` passes (new tests added if applicable)
- [ ] Public API changes are documented
- [ ] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `agent_workflow_timeout_s` and `grader_timeout_s` to the `[training]` config to cap agent and grader runtimes; both are optional floats (seconds) that load as `training_agent_workflow_timeout_s` and `training_grader_timeout_s` (default: `None`).
Docs add `[training]`, `[sampling]`, and `[checkpoints]` field tables, rollout sizing guidance and timeout defaults/troubleshooting; the `multiply.toml` template now sets `rollout_batch_size = 8` with commented timeout examples.

<sup>Written for commit 1949693e52033533f6e3567e20d2dddafbddb5a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

