### PR TITLE
[BREAKING][eval] fix: align eval timeout config keys

### DIFF
--- a/docs/eval.md
+++ b/docs/eval.md
@@ -46,8 +46,8 @@ use separate eval configs.
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `agent_sec` | `450` | Max seconds to wait for the rollout completion callback. |
-| `grader_sec` | `150` | Max seconds to wait for the grader completion callback. |
+| `agent_workflow_timeout_s` | `450` | Max seconds to wait for the rollout completion callback. |
+| `grader_timeout_s` | `150` | Max seconds to wait for the grader completion callback. |
 
 **`[output]`**
 
@@ -85,8 +85,8 @@ batch_size = 1
 pass_threshold = 1.0
 
 [timeouts]
-agent_sec = 450
-grader_sec = 150
+agent_workflow_timeout_s = 450
+grader_timeout_s = 150
 
 [output]
 log_samples = false

--- a/osmosis_ai/eval/config.py
+++ b/osmosis_ai/eval/config.py
@@ -52,8 +52,8 @@ class _OutputSection(BaseModel):
 class _TimeoutsSection(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    agent_sec: Annotated[float, Field(gt=0)] = 450.0
-    grader_sec: Annotated[float, Field(gt=0)] = 150.0
+    agent_workflow_timeout_s: Annotated[float, Field(gt=0)] = 450.0
+    grader_timeout_s: Annotated[float, Field(gt=0)] = 150.0
 
 
 class EvalConfig(BaseModel):
@@ -161,8 +161,8 @@ def load_eval_config(path: Path) -> EvalConfig:
         output_path=output.output_path,
         output_quiet=output.quiet,
         output_debug=output.debug,
-        timeout_agent_sec=timeouts.agent_sec,
-        timeout_grader_sec=timeouts.grader_sec,
+        timeout_agent_sec=timeouts.agent_workflow_timeout_s,
+        timeout_grader_sec=timeouts.grader_timeout_s,
     )
 
 

--- a/osmosis_ai/platform/cli/templates/configs/eval/default.toml.tpl
+++ b/osmosis_ai/platform/cli/templates/configs/eval/default.toml.tpl
@@ -26,8 +26,8 @@ model = "openai/gpt-5-mini"                # Model passed to LiteLLM
 # pass_threshold = 1.0                     # Fraction of attempts required to pass
 
 [timeouts]
-# agent_sec = 450                          # Agent rollout timeout per row
-# grader_sec = 150                         # Grader timeout per row
+# agent_workflow_timeout_s = 450           # Agent rollout timeout per row
+# grader_timeout_s = 150                   # Grader timeout per row
 
 [output]
 # log_samples = false                      # Persist full sample records in cache

--- a/osmosis_ai/templates/cookbook/multiply/configs/eval/multiply.toml
+++ b/osmosis_ai/templates/cookbook/multiply/configs/eval/multiply.toml
@@ -13,8 +13,8 @@ batch_size = 1
 pass_threshold = 1.0
 
 [timeouts]
-agent_sec = 450
-grader_sec = 150
+agent_workflow_timeout_s = 450
+grader_timeout_s = 150
 
 [output]
 log_samples = false

--- a/tests/unit/eval/test_config.py
+++ b/tests/unit/eval/test_config.py
@@ -325,7 +325,10 @@ def test_load_eval_config_timeout_defaults(tmp_path: Path) -> None:
 
 def test_load_eval_config_timeout_overrides(tmp_path: Path) -> None:
     config_path = tmp_path / "eval.toml"
-    _write_eval_config(config_path, "\n[timeouts]\nagent_sec = 12.5\ngrader_sec = 7\n")
+    _write_eval_config(
+        config_path,
+        "\n[timeouts]\nagent_workflow_timeout_s = 12.5\ngrader_timeout_s = 7\n",
+    )
 
     config = load_eval_config(config_path)
 
@@ -335,7 +338,10 @@ def test_load_eval_config_timeout_overrides(tmp_path: Path) -> None:
 
 def test_load_eval_config_rejects_invalid_timeout_values(tmp_path: Path) -> None:
     config_path = tmp_path / "eval.toml"
-    _write_eval_config(config_path, "\n[timeouts]\nagent_sec = 0\ngrader_sec = -1\n")
+    _write_eval_config(
+        config_path,
+        "\n[timeouts]\nagent_workflow_timeout_s = 0\ngrader_timeout_s = -1\n",
+    )
 
     with pytest.raises(CLIError, match="Invalid config"):
         load_eval_config(config_path)


### PR DESCRIPTION
## What

- Rename eval `[timeouts]` keys to `agent_workflow_timeout_s` and `grader_timeout_s` to match training config naming.
- Update eval config parsing tests for the aligned timeout keys.
- Update eval docs and starter templates with the new timeout key names.

## Why

Eval configs used `agent_sec` and `grader_sec`, while training configs use `agent_workflow_timeout_s` and `grader_timeout_s`. Aligning the names reduces confusion when moving between local eval and training configs.

This is a breaking config rename for eval users: replace `[timeouts].agent_sec` with `[timeouts].agent_workflow_timeout_s`, and `[timeouts].grader_sec` with `[timeouts].grader_timeout_s`.

## How to Test

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright osmosis_ai/`
- `uv run pytest`

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align eval `[timeouts]` keys with training config naming by renaming to `agent_workflow_timeout_s` and `grader_timeout_s`. This is a breaking change; docs, templates, and tests updated.

- **Migration**
  - In `[timeouts]`, rename `agent_sec` → `agent_workflow_timeout_s`.
  - Rename `grader_sec` → `grader_timeout_s`.

<sup>Written for commit 4c823e01cc2567076e6ace80fda4681c6e0f4ab3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

