### PR TITLE
[misc] chore: increment version to `0.2.21`

### DIFF
--- a/osmosis_ai/consts.py
+++ b/osmosis_ai/consts.py
@@ -1,3 +1,3 @@
 # package metadata
 package_name = "osmosis-ai"
-PACKAGE_VERSION = "0.2.20"
+PACKAGE_VERSION = "0.2.21"

--- a/osmosis_ai/templates/_scaffolds/rollout/pyproject.toml.tpl
+++ b/osmosis_ai/templates/_scaffolds/rollout/pyproject.toml.tpl
@@ -4,7 +4,7 @@ description = "Placeholder rollout scaffolded by `osmosis rollout init`."
 version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
-    "osmosis-ai[server]>=0.2.20",
+    "osmosis-ai[server]>=0.2.21",
 ]
 
 [build-system]


### PR DESCRIPTION
<!--
PR Title Format: [module] type: description
  modules: reward, rollout, server, cli, auth, eval, misc, ci, doc
  types:   feat, fix, refactor, chore, test, doc

Examples:
  [rollout] feat: add streaming support for chat completions
  [BREAKING][reward] refactor: rename decorator parameters
  [ci] chore: update GitHub Actions versions
-->

## What

<!-- Brief description of the changes. What does this PR do? -->

## Why

<!-- Why are these changes needed? Link any related issues. -->
<!-- Closes #<issue_number> -->

## How to Test

<!-- Describe how reviewers can verify these changes. -->

## Checklist

- [ ] PR title follows `[module] type: description` format
- [ ] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pyright osmosis_ai/` passes
- [ ] `pytest` passes (new tests added if applicable)
- [ ] Public API changes are documented
- [ ] No secrets or credentials included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `osmosis-ai` to 0.2.21 and update the rollout scaffold to require `osmosis-ai[server]` >= 0.2.21. This keeps template dependencies aligned with the new release.

<sup>Written for commit 63369ce860d333fa99d5113a1fc19ca7805d7902. Summary will update on new commits. <a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/177?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

