### PR TITLE
[cli] feat: add dataset upload overwrite support

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -149,6 +149,29 @@ osmosis eval rubric -d data.jsonl \
 | `--timeout` | Seconds |
 | `--score-min` / `--score-max` | Score range |
 
+## Dataset
+
+### osmosis dataset upload
+
+Upload a local dataset file to the current workspace directory's platform
+project. The dataset name is derived from the file name without its extension.
+
+```bash
+osmosis dataset upload data.jsonl
+osmosis dataset upload data.jsonl --yes
+osmosis dataset upload data.jsonl --overwrite
+```
+
+| Flag | Description |
+|------|-------------|
+| `--yes` / `-y` | Skip the interactive confirmation prompt |
+| `--overwrite` | Replace an existing dataset with the same derived name |
+
+When `--overwrite` is used, the CLI first confirms the duplicate-name conflict
+with the platform, then creates a replacement dataset record and soft-deletes
+the old one. The platform may reject overwrites while the existing dataset is
+still uploading, still processing, or used by an active training run.
+
 ## Training
 
 ### osmosis train submit

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -53,6 +53,29 @@ You are a helpful calculator.,What is 10 * 5?,50
 
 Any other columns are kept on the normalized row dict. Downstream code (workflows, graders, or platform metadata) can read them from that structure.
 
+## Uploading datasets
+
+Upload a local dataset file with:
+
+```bash
+osmosis dataset upload data.jsonl
+```
+
+Add `--yes` (or `-y`) to skip the interactive confirmation prompt, which is
+useful in JSON/plain output modes and CI jobs.
+
+Dataset names are derived from the file name without its extension. If a dataset
+with the same name already exists, the upload fails instead of auto-renaming the
+new dataset. To replace the existing dataset, pass `--overwrite`:
+
+```bash
+osmosis dataset upload data.jsonl --overwrite
+```
+
+Overwrite creates a new dataset record and soft-deletes the old one. The platform
+may reject overwrites while the existing dataset is still uploading, still
+processing, or used by an active training run.
+
 ## See also
 
 - [Eval](./eval.md)

--- a/osmosis_ai/cli/commands/dataset.py
+++ b/osmosis_ai/cli/commands/dataset.py
@@ -17,11 +17,17 @@ app: typer.Typer = typer.Typer(
 @app.command("upload")
 def upload(
     file: str = typer.Argument(..., help="Path to the file to upload."),
+    overwrite: bool = typer.Option(
+        False,
+        "--overwrite",
+        help="Replace an existing dataset with the same name.",
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
 ) -> Any:
     """Upload a dataset file."""
     from osmosis_ai.platform.cli.dataset import upload as _upload
 
-    return _upload(file=file)
+    return _upload(file=file, overwrite=overwrite, yes=yes)
 
 
 @app.command("download")

--- a/osmosis_ai/cli/commands/train.py
+++ b/osmosis_ai/cli/commands/train.py
@@ -634,10 +634,8 @@ def submit(
             "id": result.id,
             "name": result.name,
             "status": result.status,
-            "model_id": result.model_id,
-            "model_name": result.model_name,
-            "dataset_id": result.dataset_id,
-            "dataset_name": result.dataset_name,
+            "model_name": config.experiment_model_path,
+            "dataset_name": config.experiment_dataset,
             "created_at": result.created_at,
             **({"url": result.platform_url} if result.platform_url else {}),
             **git_result_context(context),
@@ -652,8 +650,8 @@ def submit(
         message=f"Training run submitted: {result.name}",
         display_next_steps=[
             f"Status: {result.status}",
-            f"Model: {result.model_name}",
-            f"Dataset: {result.dataset_name}",
+            f"Model: {config.experiment_model_path}",
+            f"Dataset: {config.experiment_dataset}",
             (
                 f"View: {result.platform_url}"
                 if result.platform_url

--- a/osmosis_ai/platform/api/client.py
+++ b/osmosis_ai/platform/api/client.py
@@ -48,17 +48,22 @@ class OsmosisClient:
         file_size: int,
         extension: str,
         *,
+        overwrite_dataset_id: str | None = None,
         credentials: Credentials | None = None,
         git_identity: str,
     ) -> DatasetFile:
+        payload: dict[str, Any] = {
+            "file_name": file_name,
+            "file_size": file_size,
+            "extension": extension,
+        }
+        if overwrite_dataset_id is not None:
+            payload["overwrite_dataset_id"] = overwrite_dataset_id
+
         data = platform_request(
             "/api/cli/datasets",
             method="POST",
-            data={
-                "file_name": file_name,
-                "file_size": file_size,
-                "extension": extension,
-            },
+            data=payload,
             credentials=credentials,
             git_identity=git_identity,
         )

--- a/osmosis_ai/platform/api/models.py
+++ b/osmosis_ai/platform/api/models.py
@@ -283,25 +283,15 @@ class SubmitTrainingRunResult:
     id: str
     name: str
     status: str
-    model_id: str | None
-    model_name: str
-    dataset_id: str | None
-    dataset_name: str
     created_at: str
     platform_url: str | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> SubmitTrainingRunResult:
-        model = data["model"]
-        dataset = data["dataset"]
         return cls(
             id=data["id"],
             name=data["name"],
             status=data["status"],
-            model_id=model["id"],
-            model_name=model["model_name"],
-            dataset_id=dataset["id"],
-            dataset_name=dataset["file_name"],
             created_at=data["created_at"],
             platform_url=data.get("platform_url"),
         )

--- a/osmosis_ai/platform/cli/dataset.py
+++ b/osmosis_ai/platform/cli/dataset.py
@@ -183,6 +183,65 @@ def _dataset_name_from_path(file_path: Path) -> str:
     return file_path.stem
 
 
+def _existing_dataset_id_from_conflict(exc: PlatformAPIError) -> str | None:
+    """Extract the recoverable duplicate-name conflict marker from a platform error."""
+    if exc.status_code != 409 or not isinstance(exc.details, dict):
+        return None
+    existing_dataset_id = exc.details.get("existing_dataset_id")
+    return existing_dataset_id if isinstance(existing_dataset_id, str) else None
+
+
+def _create_dataset_for_upload(
+    *,
+    client: Any,
+    dataset_name: str,
+    file_size: int,
+    ext: str,
+    overwrite: bool,
+    git_identity: str,
+    credentials: Any | None = None,
+) -> Any:
+    """Create the dataset record, retrying with overwrite when explicitly requested."""
+    try:
+        return platform_call(
+            "Creating dataset...",
+            lambda: client.create_dataset(
+                dataset_name,
+                file_size,
+                ext,
+                credentials=credentials,
+                git_identity=git_identity,
+            ),
+            output_console=console,
+        )
+    except PlatformAPIError as exc:
+        existing_dataset_id = _existing_dataset_id_from_conflict(exc)
+        if existing_dataset_id is None:
+            raise
+        if not overwrite:
+            details = dict(exc.details or {})
+            details.setdefault("status_code", exc.status_code)
+            raise CLIError(
+                f"A dataset named '{dataset_name}' already exists. "
+                "Use --overwrite to replace it.",
+                code="CONFLICT",
+                details=details,
+            ) from exc
+
+        return platform_call(
+            "Replacing existing dataset...",
+            lambda: client.create_dataset(
+                dataset_name,
+                file_size,
+                ext,
+                overwrite_dataset_id=existing_dataset_id,
+                credentials=credentials,
+                git_identity=git_identity,
+            ),
+            output_console=console,
+        )
+
+
 def _detail_fields(rows: list[tuple[str, str]]) -> list[DetailField]:
     """Convert existing label/value rows into renderer detail fields."""
     return [DetailField(label=label, value=value) for label, value in rows]
@@ -195,6 +254,7 @@ def _perform_upload(
     file_size: int,
     git_identity: str,
     credentials: Any | None = None,
+    overwrite: bool = False,
 ) -> Any:
     """Core upload: create dataset record → S3 upload → complete.
 
@@ -211,16 +271,14 @@ def _perform_upload(
     client = OsmosisClient()
     dataset_name = _dataset_name_from_path(file_path)
 
-    dataset = platform_call(
-        "Creating dataset...",
-        lambda: client.create_dataset(
-            dataset_name,
-            file_size,
-            ext,
-            credentials=credentials,
-            git_identity=git_identity,
-        ),
-        output_console=console,
+    dataset = _create_dataset_for_upload(
+        client=client,
+        dataset_name=dataset_name,
+        file_size=file_size,
+        ext=ext,
+        overwrite=overwrite,
+        credentials=credentials,
+        git_identity=git_identity,
     )
 
     upload_info = dataset.upload
@@ -307,6 +365,8 @@ def _perform_upload(
 
 def upload(
     file: str,
+    overwrite: bool = False,
+    yes: bool = False,
 ) -> CommandResult:
     """Upload a dataset file."""
     context = require_git_workspace_directory_context()
@@ -323,7 +383,7 @@ def upload(
             "File validation failed:\n" + "\n".join(f"  - {e}" for e in errors)
         )
 
-    if output.interactive:
+    if output.interactive and not yes:
         proceed = confirm("Proceed with upload?", default=True)
         if proceed is None or not proceed:
             return OperationResult(
@@ -336,6 +396,7 @@ def upload(
         file_path=file_path,
         ext=ext,
         file_size=file_size,
+        overwrite=overwrite,
         credentials=credentials,
         git_identity=git_identity,
     )

--- a/tests/unit/cli/test_command_result_migration_train_model_deployment_rollout.py
+++ b/tests/unit/cli/test_command_result_migration_train_model_deployment_rollout.py
@@ -225,10 +225,6 @@ rollout_batch_size = 64
                 id="run_1",
                 name="reward-run",
                 status="pending",
-                model_id="model_1",
-                model_name="Qwen/Qwen3",
-                dataset_id="dataset_1",
-                dataset_name="train.jsonl",
                 created_at="2026-04-26T00:00:00Z",
             )
 
@@ -242,7 +238,7 @@ rollout_batch_size = 64
     assert payload["operation"] == "train.submit"
     assert payload["resource"]["name"] == "reward-run"
     assert payload["resource"]["model_name"] == "Qwen/Qwen3"
-    assert payload["resource"]["dataset_name"] == "train.jsonl"
+    assert payload["resource"]["dataset_name"] == "demo-dataset"
     _assert_git_context(payload["resource"], project)
 
 

--- a/tests/unit/cli/test_dataset_commands_json.py
+++ b/tests/unit/cli/test_dataset_commands_json.py
@@ -15,6 +15,7 @@ import osmosis_ai.platform.api.client as api_client_module
 import osmosis_ai.platform.api.download as download_module
 import osmosis_ai.platform.api.upload as upload_module
 import osmosis_ai.platform.cli.dataset as dataset_module
+from osmosis_ai.cli.output import OperationResult
 from osmosis_ai.platform.api.models import (
     DatasetDownloadInfo,
     DatasetFile,
@@ -328,6 +329,158 @@ def test_dataset_upload_json_stdout_is_one_envelope(
     payload = json.loads(captured.out)
     assert payload["operation"] == "dataset.upload"
     assert payload["resource"]["id"] == "ds_1"
+    assert_git_context(payload["resource"])
+    assert "Uploading" not in captured.out
+
+
+@pytest.mark.parametrize("yes_flag", ["--yes", "-y"])
+def test_dataset_upload_yes_option_is_forwarded(
+    yes_flag: str, monkeypatch, tmp_path: Path
+) -> None:
+    file_path = tmp_path / "train.jsonl"
+    file_path.write_text(
+        json.dumps({"system_prompt": "s", "user_prompt": "u", "ground_truth": "g"})
+        + "\n",
+        encoding="utf-8",
+    )
+    seen: dict[str, object] = {}
+
+    def fake_upload(*, file: str, overwrite: bool, yes: bool) -> OperationResult:
+        seen.update({"file": file, "overwrite": overwrite, "yes": yes})
+        return OperationResult(
+            operation="dataset.upload",
+            status="success",
+            message="Dataset uploaded.",
+        )
+
+    monkeypatch.setattr(dataset_module, "upload", fake_upload)
+
+    exit_code = cli.main(["dataset", "upload", str(file_path), yes_flag])
+
+    assert exit_code == 0
+    assert seen == {"file": str(file_path), "overwrite": False, "yes": True}
+
+
+def test_dataset_upload_json_conflict_preserves_existing_dataset_id(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    _stub_git_context(monkeypatch)
+    file_path = tmp_path / "train.jsonl"
+    file_path.write_text(
+        json.dumps({"system_prompt": "s", "user_prompt": "u", "ground_truth": "g"})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    from osmosis_ai.platform.auth import PlatformAPIError
+
+    class FakeClient:
+        def create_dataset(
+            self, file_name, file_size, extension, *, git_identity, credentials=None
+        ):
+            assert git_identity == GIT_IDENTITY
+            raise PlatformAPIError(
+                "A dataset with this name already exists",
+                status_code=409,
+                details={
+                    "error": "A dataset with this name already exists",
+                    "existing_dataset_id": "ds_existing",
+                },
+            )
+
+    monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+
+    exit_code = cli.main(["--json", "dataset", "upload", str(file_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    payload = json.loads(captured.err)
+    assert payload["error"]["code"] == "CONFLICT"
+    assert payload["error"]["details"]["existing_dataset_id"] == "ds_existing"
+    assert "--overwrite" in payload["error"]["message"]
+    assert "osmosis dataset upload" not in payload["error"]["message"]
+    assert str(file_path) not in payload["error"]["message"]
+
+
+def test_dataset_upload_json_overwrite_stdout_is_one_envelope(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    fake_credentials = _stub_git_context(monkeypatch)
+    file_path = tmp_path / "train.jsonl"
+    file_path.write_text(
+        json.dumps({"system_prompt": "s", "user_prompt": "u", "ground_truth": "g"})
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        upload_module,
+        "make_progress_bar",
+        lambda _size, **_kwargs: (nullcontext(), lambda _done, _total: None),
+    )
+    monkeypatch.setattr(
+        upload_module,
+        "upload_file_simple",
+        lambda _file_path, _upload_info, progress_callback=None: None,
+    )
+
+    from osmosis_ai.platform.auth import PlatformAPIError
+
+    class FakeClient:
+        def create_dataset(
+            self,
+            file_name,
+            file_size,
+            extension,
+            *,
+            git_identity,
+            credentials=None,
+            overwrite_dataset_id=None,
+        ):
+            assert credentials is fake_credentials
+            assert git_identity == GIT_IDENTITY
+            if overwrite_dataset_id is None:
+                raise PlatformAPIError(
+                    "A dataset with this name already exists",
+                    status_code=409,
+                    details={
+                        "error": "A dataset with this name already exists",
+                        "existing_dataset_id": "ds_existing",
+                    },
+                )
+            assert overwrite_dataset_id == "ds_existing"
+            return DatasetFile(
+                id="ds_new",
+                file_name=file_name,
+                file_size=file_size,
+                status="created",
+                upload=UploadInfo(
+                    method="simple",
+                    s3_key="uploads/train",
+                    presigned_url="https://example.com/upload",
+                ),
+            )
+
+        def complete_upload(
+            self, file_id, parts=None, *, git_identity, credentials=None
+        ):
+            assert file_id == "ds_new"
+            assert credentials is fake_credentials
+            assert git_identity == GIT_IDENTITY
+            return _dataset(id=file_id)
+
+    monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+
+    exit_code = cli.main(["--json", "dataset", "upload", str(file_path), "--overwrite"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["operation"] == "dataset.upload"
+    assert payload["resource"]["id"] == "ds_new"
     assert_git_context(payload["resource"])
     assert "Uploading" not in captured.out
 

--- a/tests/unit/cli/test_train_commands.py
+++ b/tests/unit/cli/test_train_commands.py
@@ -652,10 +652,6 @@ class TestSubmit:
         id="550e8400-e29b-41d4-a716-446655440000",
         name="my-training-run",
         status="pending",
-        model_id="model_1",
-        model_name="Qwen/Qwen3",
-        dataset_id="dataset_1",
-        dataset_name="train.jsonl",
         created_at="2026-04-10T12:00:00Z",
         platform_url="https://platform.osmosis.ai/ws/training/550e8400-e29b-41d4-a716-446655440000",
     )
@@ -712,10 +708,8 @@ rollout_batch_size = 64
         assert command_result.resource["name"] == "my-training-run"
         assert command_result.resource["id"] == "550e8400-e29b-41d4-a716-446655440000"
         assert command_result.resource["status"] == "pending"
-        assert command_result.resource["model_id"] == "model_1"
-        assert command_result.resource["model_name"] == "Qwen/Qwen3"
-        assert command_result.resource["dataset_id"] == "dataset_1"
-        assert command_result.resource["dataset_name"] == "train.jsonl"
+        assert command_result.resource["model_name"] == "Qwen/Qwen3.6-35B-A3B"
+        assert command_result.resource["dataset_name"] == "abc-123"
         assert "/training/" in command_result.resource["url"]
         assert command_result.resource["git"] == {
             "identity": GIT_IDENTITY,
@@ -748,8 +742,8 @@ rollout_batch_size = 64
         assert isinstance(command_result, OperationResult)
         assert command_result.resource is not None
         assert command_result.resource["url"] == expected_url
-        assert "Model: Qwen/Qwen3" in command_result.display_next_steps
-        assert "Dataset: train.jsonl" in command_result.display_next_steps
+        assert "Model: Qwen/Qwen3.6-35B-A3B" in command_result.display_next_steps
+        assert "Dataset: abc-123" in command_result.display_next_steps
         assert f"View: {expected_url}" in command_result.display_next_steps
 
     def test_submit_shows_summary_table(

--- a/tests/unit/platform/api/test_client.py
+++ b/tests/unit/platform/api/test_client.py
@@ -33,6 +33,52 @@ class TestRemovedClientMethods:
         assert not hasattr(OsmosisClient, method_name)
 
 
+class TestCreateDataset:
+    """Tests for OsmosisClient.create_dataset request payloads."""
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_create_dataset_omits_overwrite_dataset_id_by_default(
+        self, mock_request: MagicMock
+    ) -> None:
+        mock_request.return_value = {
+            "id": "file-1",
+            "file_name": "data",
+            "file_size": 100,
+            "status": "uploading",
+        }
+
+        OsmosisClient().create_dataset("data", 100, "jsonl", git_identity="git_test")
+
+        payload = mock_request.call_args.kwargs["data"]
+        assert payload == {
+            "file_name": "data",
+            "file_size": 100,
+            "extension": "jsonl",
+        }
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_create_dataset_sends_overwrite_dataset_id_when_provided(
+        self, mock_request: MagicMock
+    ) -> None:
+        mock_request.return_value = {
+            "id": "file-2",
+            "file_name": "data",
+            "file_size": 100,
+            "status": "uploading",
+        }
+
+        OsmosisClient().create_dataset(
+            "data",
+            100,
+            "jsonl",
+            overwrite_dataset_id="file-1",
+            git_identity="git_test",
+        )
+
+        payload = mock_request.call_args.kwargs["data"]
+        assert payload["overwrite_dataset_id"] == "file-1"
+
+
 class TestCompleteUploadValidation:
     """Tests for parameter validation in OsmosisClient.complete_upload."""
 
@@ -157,8 +203,6 @@ class TestGitIdentityPassthrough:
                     "id": "run-1",
                     "name": "Run 1",
                     "status": "pending",
-                    "model": {"id": "model-1", "model_name": "Qwen/Qwen3"},
-                    "dataset": {"id": "dataset-1", "file_name": "train.jsonl"},
                     "created_at": "2026-05-03T00:00:00Z",
                 },
             ),
@@ -311,8 +355,6 @@ class TestSubmitTrainingRun:
             "id": "run-1",
             "name": "run-1",
             "status": "pending",
-            "model": {"id": "model-1", "model_name": "Qwen/Qwen3"},
-            "dataset": {"id": "dataset-1", "file_name": "train.jsonl"},
             "created_at": "2026-05-04T00:00:00Z",
         }
 
@@ -321,7 +363,7 @@ class TestSubmitTrainingRun:
         client = OsmosisClient()
         with pytest.raises(TypeError):
             client.submit_training_run(
-                model_path="m1",
+                model="m1",
                 dataset="ds1",
                 rollout_name="rollout1",
                 entrypoint="rollouts/main.py",

--- a/tests/unit/platform/api/test_models.py
+++ b/tests/unit/platform/api/test_models.py
@@ -208,19 +208,15 @@ class TestSubmitTrainingRunResult:
             "id": "550e8400-e29b-41d4-a716-446655440000",
             "name": "my-training-run",
             "status": "pending",
-            "model": {"id": "model_1", "model_name": "Qwen/Qwen3"},
-            "dataset": {"id": "dataset_1", "file_name": "train.jsonl"},
             "created_at": "2026-04-10T12:00:00Z",
+            "platform_url": "https://platform.osmosis.ai/ws/training/run",
         }
         result = SubmitTrainingRunResult.from_dict(data)
         assert result.id == "550e8400-e29b-41d4-a716-446655440000"
         assert result.name == "my-training-run"
         assert result.status == "pending"
-        assert result.model_id == "model_1"
-        assert result.model_name == "Qwen/Qwen3"
-        assert result.dataset_id == "dataset_1"
-        assert result.dataset_name == "train.jsonl"
         assert result.created_at == "2026-04-10T12:00:00Z"
+        assert result.platform_url == "https://platform.osmosis.ai/ws/training/run"
 
 
 class TestTrainingRun:

--- a/tests/unit/platform/cli/test_dataset_upload.py
+++ b/tests/unit/platform/cli/test_dataset_upload.py
@@ -6,6 +6,7 @@ from contextlib import nullcontext
 
 import pytest
 
+from osmosis_ai.cli.output.context import OutputFormat, override_output_context
 from osmosis_ai.platform.api.models import DatasetFile, UploadInfo
 
 GIT_IDENTITY = "acme/rollouts"
@@ -242,3 +243,212 @@ class TestPerformUpload:
             )
 
         assert aborted.get("called")
+
+    def test_duplicate_name_without_overwrite_raises_guided_conflict(
+        self, monkeypatch, tmp_path
+    ):
+        """_perform_upload points users to --overwrite on duplicate names."""
+        import osmosis_ai.platform.api.client as api_client_module
+        from osmosis_ai.cli.errors import CLIError
+        from osmosis_ai.platform.auth import PlatformAPIError
+
+        file_path = tmp_path / "data.jsonl"
+        file_path.write_text("{}")
+        conflict = PlatformAPIError(
+            "A dataset with this name already exists",
+            status_code=409,
+            details={
+                "error": "A dataset with this name already exists",
+                "existing_dataset_id": "dataset-old",
+            },
+        )
+
+        class FakeClient:
+            def create_dataset(self, *args, git_identity, **kwargs):
+                assert git_identity == GIT_IDENTITY
+                raise conflict
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+
+        from osmosis_ai.platform.cli.dataset import _perform_upload
+
+        with pytest.raises(CLIError) as exc_info:
+            _perform_upload(
+                file_path=file_path,
+                ext="jsonl",
+                file_size=2,
+                git_identity=GIT_IDENTITY,
+                credentials=None,
+            )
+
+        assert exc_info.value.code == "CONFLICT"
+        assert exc_info.value.details["existing_dataset_id"] == "dataset-old"
+        assert "--overwrite" in exc_info.value.message
+        assert "osmosis dataset upload" not in exc_info.value.message
+        assert str(file_path) not in exc_info.value.message
+
+    def test_overwrite_retries_create_with_existing_dataset_id(
+        self, monkeypatch, tmp_path
+    ):
+        """_perform_upload retries create with overwrite_dataset_id before S3 upload."""
+        import osmosis_ai.platform.api.client as api_client_module
+        import osmosis_ai.platform.api.upload as upload_module
+        from osmosis_ai.platform.auth import PlatformAPIError
+
+        file_path = tmp_path / "data.jsonl"
+        file_path.write_text("{}")
+        file_size = file_path.stat().st_size
+        calls: list[dict] = []
+
+        class FakeClient:
+            def create_dataset(
+                self,
+                file_name,
+                file_size,
+                ext,
+                *,
+                git_identity,
+                credentials=None,
+                overwrite_dataset_id=None,
+            ):
+                calls.append(
+                    {
+                        "file_name": file_name,
+                        "overwrite_dataset_id": overwrite_dataset_id,
+                    }
+                )
+                assert git_identity == GIT_IDENTITY
+                if overwrite_dataset_id is None:
+                    raise PlatformAPIError(
+                        "A dataset with this name already exists",
+                        status_code=409,
+                        details={
+                            "error": "A dataset with this name already exists",
+                            "existing_dataset_id": "dataset-old",
+                        },
+                    )
+                assert overwrite_dataset_id == "dataset-old"
+                return _make_fake_dataset(file_name=file_name, file_size=file_size)
+
+            def complete_upload(
+                self, file_id, parts=None, *, git_identity, credentials=None
+            ):
+                assert file_id == "dataset-1"
+                return DatasetFile(
+                    id=file_id,
+                    file_name="data",
+                    file_size=file_size,
+                    status="uploaded",
+                )
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(
+            upload_module,
+            "make_progress_bar",
+            lambda _size: (nullcontext(), lambda _done, _total: None),
+        )
+        monkeypatch.setattr(
+            upload_module,
+            "upload_file_simple",
+            lambda _fp, _info, progress_callback=None: None,
+        )
+
+        from osmosis_ai.platform.cli.dataset import _perform_upload
+
+        result = _perform_upload(
+            file_path=file_path,
+            ext="jsonl",
+            file_size=file_size,
+            git_identity=GIT_IDENTITY,
+            credentials=None,
+            overwrite=True,
+        )
+
+        assert result.status == "uploaded"
+        assert calls == [
+            {"file_name": "data", "overwrite_dataset_id": None},
+            {"file_name": "data", "overwrite_dataset_id": "dataset-old"},
+        ]
+
+    def test_conflict_without_existing_dataset_id_is_not_treated_as_overwriteable(
+        self, monkeypatch, tmp_path
+    ):
+        """Guard conflicts from the platform should surface unchanged."""
+        import osmosis_ai.platform.api.client as api_client_module
+        from osmosis_ai.platform.auth import PlatformAPIError
+
+        file_path = tmp_path / "data.jsonl"
+        file_path.write_text("{}")
+        conflict = PlatformAPIError(
+            "This dataset is still processing.",
+            status_code=409,
+            details={"error": "This dataset is still processing."},
+        )
+
+        class FakeClient:
+            def create_dataset(self, *args, git_identity, **kwargs):
+                assert git_identity == GIT_IDENTITY
+                raise conflict
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+
+        from osmosis_ai.platform.cli.dataset import _perform_upload
+
+        with pytest.raises(PlatformAPIError) as exc_info:
+            _perform_upload(
+                file_path=file_path,
+                ext="jsonl",
+                file_size=2,
+                git_identity=GIT_IDENTITY,
+                credentials=None,
+                overwrite=True,
+            )
+
+        assert exc_info.value is conflict
+
+
+class TestUploadCommand:
+    def test_yes_skips_interactive_confirmation(self, monkeypatch, tmp_path):
+        import osmosis_ai.platform.cli.dataset as dataset_module
+
+        file_path = tmp_path / "data.jsonl"
+        file_path.write_text(
+            '{"system_prompt": "s", "user_prompt": "u", "ground_truth": "g"}\n'
+        )
+        fake_context = type(
+            "Context",
+            (),
+            {
+                "credentials": object(),
+                "git_identity": GIT_IDENTITY,
+                "workspace_directory": tmp_path,
+                "repo_url": "https://github.com/acme/rollouts.git",
+            },
+        )()
+        uploaded = _make_fake_dataset(
+            file_name="data", file_size=file_path.stat().st_size
+        )
+
+        monkeypatch.setattr(
+            dataset_module,
+            "require_git_workspace_directory_context",
+            lambda: fake_context,
+        )
+        monkeypatch.setattr(
+            dataset_module,
+            "_perform_upload",
+            lambda **_kwargs: uploaded,
+        )
+        monkeypatch.setattr(
+            dataset_module,
+            "confirm",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("confirmation prompt should be skipped")
+            ),
+        )
+
+        with override_output_context(format=OutputFormat.rich, interactive=True):
+            result = dataset_module.upload(str(file_path), yes=True)
+
+        assert result.operation == "dataset.upload"
+        assert result.status == "success"

--- a/tests/unit/platform/cli/test_training_config.py
+++ b/tests/unit/platform/cli/test_training_config.py
@@ -59,6 +59,13 @@ custom_flag = true
     assert cfg.experiment_model_path == "Qwen/Qwen3.6-35B-A3B"
     assert cfg.experiment_dataset == "abc-123"
     assert cfg.experiment_commit_sha == "deadbeef"
+    assert cfg.experiment_config == {
+        "rollout": "calculator",
+        "entrypoint": "main.py",
+        "model_path": "Qwen/Qwen3.6-35B-A3B",
+        "dataset": "abc-123",
+        "commit_sha": "deadbeef",
+    }
     assert cfg.training_lr == 1e-6
     assert cfg.training_total_epochs == 2
     assert cfg.training_n_samples_per_prompt == 8


### PR DESCRIPTION
## What

- Add `--yes` / `-y` and `--overwrite` flags to `osmosis dataset upload`.
- Retry duplicate-name dataset creation with `overwrite_dataset_id` when overwrite is explicitly requested.
- Surface guided conflict errors for duplicate dataset names when overwrite is not requested.
- Update dataset upload docs and add CLI/API/unit coverage for overwrite and non-interactive upload flows.

## Why

Dataset uploads currently fail on duplicate derived names without a clear replacement path, and interactive confirmation makes automation noisier. This adds an explicit overwrite flow while keeping duplicate replacement opt-in.

## How to Test

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright osmosis_ai/`
- `uv run pytest tests/unit/cli/test_dataset_commands_json.py tests/unit/platform/cli/test_dataset_upload.py tests/unit/platform/api/test_client.py tests/unit/platform/api/test_models.py tests/unit/cli/test_train_commands.py tests/unit/platform/cli/test_training_config.py`
- `uv run pytest` currently fails because local port `127.0.0.1:8000` is occupied, causing 5 failures in `tests/integration/eval/test_controller_backed_eval.py`; the rest of the suite reported 1615 passed.

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds overwrite support and non-interactive uploads to `osmosis dataset upload` to make CI-friendly runs and duplicate-name replacements explicit and safer. Improves conflict errors and updates docs and tests.

- New Features
  - `--overwrite` replaces an existing dataset with the same derived name; the CLI retries creation with `overwrite_dataset_id`.
  - `--yes` / `-y` skips the confirmation prompt (useful for CI and JSON/plain modes).
  - Clear conflict errors when not overwriting; JSON errors include `existing_dataset_id` to guide recovery.
  - Updated docs: dataset upload usage and flags.

- Migration
  - `train submit` JSON no longer includes `model_id` and `dataset_id`; `model_name` and `dataset_name` now reflect config values. Update any consumers that read the removed fields.

<sup>Written for commit 28b6b3ee9b331119c340889a59722592d8cbf824. Summary will update on new commits. <a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/182?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

