### PR TITLE
[cli] fix: update workspace scaffold and training run entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ osmosis doctor
 osmosis template apply multiply              # or add your rollout under rollouts/
 cp configs/training/default.toml configs/training/<run>.toml
 $EDITOR configs/training/<run>.toml          # set rollout, dataset, and model_path
-git add rollouts configs data research
+git add rollouts configs data
 git commit -m "configure training run"
 git push
 osmosis train submit configs/training/<run>.toml

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ osmosis doctor
 osmosis template apply multiply              # or add your rollout under rollouts/
 cp configs/training/default.toml configs/training/<run>.toml
 $EDITOR configs/training/<run>.toml          # set rollout, dataset, and model_path
-git add rollouts configs data research
+git add rollouts configs data
 git commit -m "configure training run"
 git push
 osmosis train submit configs/training/<run>.toml

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -45,7 +45,7 @@ osmosis doctor
 osmosis template apply multiply              # or add your rollout under rollouts/
 cp configs/training/default.toml configs/training/<run>.toml
 $EDITOR configs/training/<run>.toml          # set rollout, dataset, and model_path
-git add rollouts configs data research
+git add rollouts configs data
 git commit -m "configure training run"
 git push
 osmosis train submit configs/training/<run>.toml

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,7 +54,7 @@ osmosis doctor
 osmosis template apply multiply              # or add your rollout under rollouts/
 cp configs/training/default.toml configs/training/<run>.toml
 $EDITOR configs/training/<run>.toml          # set rollout, dataset, and model_path
-git add rollouts configs data research
+git add rollouts configs data
 git commit -m "configure training run"
 git push
 osmosis train submit configs/training/<run>.toml

--- a/osmosis_ai/cli/commands/train.py
+++ b/osmosis_ai/cli/commands/train.py
@@ -263,6 +263,7 @@ def list_runs(
         extra=git_result_context(context),
         columns=[
             ListColumn(key="name", label="Name", ratio=4, overflow="fold"),
+            ListColumn(key="rollout_name", label="Rollout", ratio=2, overflow="fold"),
             ListColumn(key="status", label="Status", no_wrap=True, ratio=1),
             ListColumn(key="reward", label="Reward", no_wrap=True, ratio=1),
             ListColumn(
@@ -276,6 +277,7 @@ def list_runs(
             {
                 **serialize_training_run(run),
                 "name": run.name or "(unnamed)",
+                "rollout_name": run.rollout_name or "—",
                 "status": format_run_status(run),
                 "reward": format_reward(run.reward),
                 "created_at": format_local_date(run.created_at),

--- a/osmosis_ai/cli/output/serializers.py
+++ b/osmosis_ai/cli/output/serializers.py
@@ -42,6 +42,8 @@ def serialize_training_run(run: TrainingRun) -> dict[str, Any]:
         "model_name": run.model_name,
         "dataset_id": run.dataset_id,
         "dataset_name": run.dataset_name,
+        "rollout_id": run.rollout_id,
+        "rollout_name": run.rollout_name,
         "eval_accuracy": run.eval_accuracy,
         "reward": run.reward,
         "reward_increase_delta": run.reward_increase_delta,

--- a/osmosis_ai/platform/api/models.py
+++ b/osmosis_ai/platform/api/models.py
@@ -181,12 +181,15 @@ class TrainingRun:
     platform_url: str | None = None
     dataset_id: str | None = None
     dataset_name: str | None = None
+    rollout_id: str | None = None
+    rollout_name: str | None = None
     reward: float | None = field(default=None, kw_only=True)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TrainingRun:
         model = data.get("model") or {}
         dataset = data.get("dataset") or {}
+        rollout = data.get("rollout") or {}
         return cls(
             id=data["id"],
             name=data.get("name"),
@@ -207,6 +210,8 @@ class TrainingRun:
             platform_url=data.get("platform_url"),
             dataset_id=dataset.get("id"),
             dataset_name=dataset.get("file_name"),
+            rollout_id=rollout.get("id"),
+            rollout_name=rollout.get("name"),
         )
 
     @property
@@ -225,16 +230,17 @@ class TrainingRunDetail(TrainingRun):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TrainingRunDetail:
-        # Detail API returns { training_run: {..., enhanced_status}, model: {...} }
+        # Detail API returns unified entity refs for model, dataset, and rollout.
         run = data["training_run"]
         model = data.get("model") or {}
         dataset = data.get("dataset") or {}
+        rollout = data.get("rollout") or {}
         return cls(
             id=run["id"],
             name=run.get("name"),
-            status=run.get("enhanced_status") or run.get("status", ""),
+            status=run.get("status", ""),
             model_id=model.get("id"),
-            model_name=model.get("model_name"),
+            model_name=model.get("name"),
             created_at=run.get("created_at", ""),
             started_at=run.get("started_at"),
             completed_at=run.get("completed_at"),
@@ -248,7 +254,9 @@ class TrainingRunDetail(TrainingRun):
             creator_email=run.get("creator_email"),
             platform_url=run.get("platform_url"),
             dataset_id=dataset.get("id"),
-            dataset_name=dataset.get("file_name"),
+            dataset_name=dataset.get("name"),
+            rollout_id=rollout.get("id"),
+            rollout_name=rollout.get("name"),
             examples_processed_count=run.get("examples_processed_count"),
             notes=run.get("notes"),
             hf_status=run.get("hf_status"),

--- a/osmosis_ai/platform/cli/scaffold.py
+++ b/osmosis_ai/platform/cli/scaffold.py
@@ -7,7 +7,6 @@ not create workspace directories, initialize git repositories, or make initial c
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 from osmosis_ai.cli.errors import CLIError
@@ -17,35 +16,6 @@ from osmosis_ai.templates.catalog import (
     ScaffoldEntry,
 )
 from osmosis_ai.templates.source import workspace_template_root
-
-_PLUGIN_REPO_DEFAULT = "Osmosis-AI/osmosis-plugins"
-_PLUGIN_MARKETPLACE_DEFAULT = "osmosis"
-
-
-def _plugin_repo() -> str:
-    """GitHub repo (`owner/name`) hosting the Osmosis plugin marketplace."""
-    return os.environ.get("OSMOSIS_PLUGIN_REPO") or _PLUGIN_REPO_DEFAULT
-
-
-def _plugin_marketplace() -> str:
-    """Marketplace name as declared in the plugin repo's `marketplace.json`."""
-    return os.environ.get("OSMOSIS_PLUGIN_MARKETPLACE") or _PLUGIN_MARKETPLACE_DEFAULT
-
-
-def _render_official_scaffold(text: str) -> str:
-    """Apply environment-driven plugin substitutions to official scaffold files."""
-    plugin_repo = _plugin_repo()
-    plugin_marketplace = _plugin_marketplace()
-    return (
-        text.replace(_PLUGIN_REPO_DEFAULT, plugin_repo)
-        .replace(
-            f"osmosis@{_PLUGIN_MARKETPLACE_DEFAULT}", f"osmosis@{plugin_marketplace}"
-        )
-        .replace(f'"{_PLUGIN_MARKETPLACE_DEFAULT}"', f'"{plugin_marketplace}"')
-        .replace(
-            f"install {_PLUGIN_MARKETPLACE_DEFAULT}", f"install {plugin_marketplace}"
-        )
-    )
 
 
 def _read_agent_scaffold_files(*, refresh_template: bool) -> dict[str, str]:
@@ -61,9 +31,7 @@ def _read_agent_scaffold_files(*, refresh_template: bool) -> dict[str, str]:
                 f"{rel_path_text}",
                 code="NOT_FOUND",
             )
-        contents[rel_path_text] = _render_official_scaffold(
-            source_path.read_text(encoding="utf-8")
-        )
+        contents[rel_path_text] = source_path.read_text(encoding="utf-8")
     return contents
 
 

--- a/osmosis_ai/platform/cli/utils.py
+++ b/osmosis_ai/platform/cli/utils.py
@@ -171,6 +171,8 @@ def build_run_detail_rows(r: Any) -> list[tuple[str, str]]:
     if step:
         rows.append(("Step", step))
     rows.append(("Model", console.escape(r.model_name) if r.model_name else "—"))
+    rows.append(("Dataset", console.escape(r.dataset_name) if r.dataset_name else "—"))
+    rows.append(("Rollout", console.escape(r.rollout_name) if r.rollout_name else "—"))
     if r.eval_accuracy is not None:
         rows.append(("Accuracy", f"{r.eval_accuracy:.4f}"))
     if r.reward_increase_delta is not None:

--- a/osmosis_ai/templates/catalog.py
+++ b/osmosis_ai/templates/catalog.py
@@ -98,7 +98,6 @@ OFFICIAL_AGENT_SCAFFOLD_PATHS: tuple[Path, ...] = (
     _path("AGENTS.md"),
     _path("CLAUDE.md"),
     _path("configs/AGENTS.md"),
-    _path(".claude/settings.json"),
 )
 
 REQUIRED_WORKSPACE_DIRS: tuple[Path, ...] = (

--- a/tests/golden/cli_output/training_run_serializer.json
+++ b/tests/golden/cli_output/training_run_serializer.json
@@ -8,6 +8,8 @@
     "model_name",
     "dataset_id",
     "dataset_name",
+    "rollout_id",
+    "rollout_name",
     "eval_accuracy",
     "reward",
     "reward_increase_delta",

--- a/tests/integration/test_cli_subprocess_contract.py
+++ b/tests/integration/test_cli_subprocess_contract.py
@@ -19,7 +19,6 @@ def _make_workspace_directory(root: Path) -> Path:
     )
     for rel_path in (
         ".osmosis",
-        ".osmosis/research",
         "rollouts",
         "configs",
         "configs/eval",
@@ -27,9 +26,6 @@ def _make_workspace_directory(root: Path) -> Path:
         "data",
     ):
         (root / rel_path).mkdir(parents=True, exist_ok=True)
-    (root / ".osmosis" / "research" / "program.md").write_text(
-        "# Test\n", encoding="utf-8"
-    )
     return root
 
 

--- a/tests/unit/cli/output/test_serializers.py
+++ b/tests/unit/cli/output/test_serializers.py
@@ -77,6 +77,7 @@ def test_serialize_training_run_keys() -> None:
                 "model_name": "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8",
             },
             "dataset": {"id": None, "file_name": "train.jsonl"},
+            "rollout": {"id": "rollout_1", "name": "math-rollout"},
             "eval_accuracy": 0.4,
             "reward": 0.875,
             "reward_increase_delta": 0.02,
@@ -96,6 +97,8 @@ def test_serialize_training_run_keys() -> None:
     assert payload["model_name"] == "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8"
     assert payload["dataset_id"] is None
     assert payload["dataset_name"] == "train.jsonl"
+    assert payload["rollout_id"] == "rollout_1"
+    assert payload["rollout_name"] == "math-rollout"
     assert payload["reward"] == 0.875
 
 

--- a/tests/unit/cli/test_command_result_migration_train_model_deployment_rollout.py
+++ b/tests/unit/cli/test_command_result_migration_train_model_deployment_rollout.py
@@ -133,6 +133,8 @@ def test_train_list_json_returns_single_list_envelope(
                         name="reward-run",
                         status="running",
                         model_name="Qwen/Qwen3",
+                        rollout_id="rollout_1",
+                        rollout_name="math-rollout",
                         created_at="2026-04-26T00:00:00Z",
                     )
                 ],
@@ -149,6 +151,7 @@ def test_train_list_json_returns_single_list_envelope(
     payload = json.loads(captured.out)
     assert payload["schema_version"] == 1
     assert payload["items"][0]["name"] == "reward-run"
+    assert payload["items"][0]["rollout_name"] == "math-rollout"
     assert payload["total_count"] == 1
     _assert_git_context(payload)
     assert captured.out.count("\n") == 1
@@ -168,6 +171,8 @@ def test_train_info_json_returns_combined_detail_envelope(
                 name=name,
                 status="pending",
                 model_name="Qwen/Qwen3",
+                rollout_id="rollout_1",
+                rollout_name="math-rollout",
             )
 
     monkeypatch.setattr("osmosis_ai.platform.api.client.OsmosisClient", FakeClient)
@@ -179,6 +184,7 @@ def test_train_info_json_returns_combined_detail_envelope(
     payload = json.loads(captured.out)
     assert payload["data"]["training_run"]["name"] == "reward-run"
     assert payload["data"]["training_run"]["status"] == "pending"
+    assert payload["data"]["training_run"]["rollout_name"] == "math-rollout"
     assert payload["data"]["checkpoints"] == []
     assert payload["data"]["metrics_available"] is False
     assert payload["data"]["output_path"] is None

--- a/tests/unit/cli/test_command_result_migration_train_model_deployment_rollout.py
+++ b/tests/unit/cli/test_command_result_migration_train_model_deployment_rollout.py
@@ -85,16 +85,12 @@ def _make_rollout_project(root: Path) -> Path:
     )
     for rel_path in (
         ".osmosis",
-        ".osmosis/research",
         "rollouts/demo",
         "configs/training",
         "configs/eval",
         "data",
     ):
         (root / rel_path).mkdir(parents=True, exist_ok=True)
-    (root / ".osmosis" / "research" / "program.md").write_text(
-        "# Test Program\n", encoding="utf-8"
-    )
     (root / "rollouts" / "demo" / "main.py").write_text(
         """
 from osmosis_ai.rollout.agent_workflow import AgentWorkflow
@@ -260,7 +256,7 @@ def test_train_info_json_does_not_write_default_file(
         capture_output=True,
     )
     for rel_path in (
-        ".osmosis/research",
+        ".osmosis",
         "rollouts",
         "configs/eval",
         "configs/training",

--- a/tests/unit/cli/test_eval_run_json.py
+++ b/tests/unit/cli/test_eval_run_json.py
@@ -67,7 +67,6 @@ def _make_workspace_directory(root: Path) -> Path:
     )
     for rel_path in (
         ".osmosis",
-        ".osmosis/research",
         "rollouts",
         "rollouts/demo_rollout",
         "configs",
@@ -76,9 +75,6 @@ def _make_workspace_directory(root: Path) -> Path:
         "data",
     ):
         (root / rel_path).mkdir(parents=True, exist_ok=True)
-    (root / ".osmosis" / "research" / "program.md").write_text(
-        "# Test\n", encoding="utf-8"
-    )
     (root / "rollouts" / "demo_rollout" / "pyproject.toml").write_text(
         "[project]\nname='demo-rollout'\n",
         encoding="utf-8",

--- a/tests/unit/cli/test_train_commands.py
+++ b/tests/unit/cli/test_train_commands.py
@@ -68,7 +68,7 @@ def _make_workspace_directory(root: Path, *, rollout: str = "demo") -> Path:
         capture_output=True,
     )
     for rel_path in (
-        ".osmosis/research",
+        ".osmosis",
         f"rollouts/{rollout}",
         "configs/training",
         "configs/eval",
@@ -76,10 +76,6 @@ def _make_workspace_directory(root: Path, *, rollout: str = "demo") -> Path:
     ):
         (root / rel_path).mkdir(parents=True, exist_ok=True)
 
-    (root / ".osmosis" / "research" / "program.md").write_text(
-        "# Test Program\n",
-        encoding="utf-8",
-    )
     (root / "rollouts" / rollout / "main.py").write_text(
         """
 from osmosis_ai.rollout import AgentWorkflow, Grader

--- a/tests/unit/cli/test_train_commands.py
+++ b/tests/unit/cli/test_train_commands.py
@@ -231,6 +231,7 @@ class TestListRuns:
             name="long-human-readable-run-name",
             status="running",
             reward=0.875,
+            rollout_name="math-rollout",
             created_at="2026-01-01T00:00:00Z",
         )
 
@@ -248,15 +249,19 @@ class TestListRuns:
 
         assert [column.label for column in result.columns] == [
             "Name",
+            "Rollout",
             "Status",
             "Reward",
-            result.columns[3].label,
+            result.columns[4].label,
         ]
         assert result.columns[0].key == "name"
         assert result.columns[0].ratio == 4
         assert result.columns[0].overflow == "fold"
-        assert result.columns[3].label.startswith("Created (")
+        assert result.columns[1].key == "rollout_name"
+        assert result.columns[1].overflow == "fold"
+        assert result.columns[4].label.startswith("Created (")
         assert result.display_items is not None
+        assert result.display_items[0]["rollout_name"] == "math-rollout"
         assert result.display_items[0]["reward"] == "0.88"
         assert result.display_hints == ["Use osmosis train info <name> for details."]
 
@@ -331,6 +336,8 @@ class TestInfo:
             name="run-1",
             status="finished",
             model_name="gpt-2",
+            dataset_name="train.jsonl",
+            rollout_name="math-rollout",
             platform_url="https://platform.osmosis.ai/ws/training/abcdef1234567890abcdef1234567890",
         )
         checkpoint = LoraCheckpointInfo(
@@ -385,6 +392,9 @@ class TestInfo:
         assert isinstance(result, DetailResult)
         assert result.title == "Training Run Info"
         assert result.data["training_run"]["name"] == "run-1"
+        field_rows = [(field.label, field.value) for field in result.fields]
+        assert ("Dataset", "train.jsonl") in field_rows
+        assert ("Rollout", "math-rollout") in field_rows
         assert result.data["checkpoints"][0]["checkpoint_name"] == "run-1-step-100"
         assert result.data["metrics_available"] is True
         assert result.data["metrics"]["summary"]["final_reward"] == 0.75

--- a/tests/unit/cli/test_whoami.py
+++ b/tests/unit/cli/test_whoami.py
@@ -64,7 +64,6 @@ def _create_canonical_project(workspace_directory: Path) -> None:
     )
     for relative in (
         ".osmosis",
-        ".osmosis/research",
         "rollouts",
         "configs",
         "configs/eval",
@@ -72,10 +71,6 @@ def _create_canonical_project(workspace_directory: Path) -> None:
         "data",
     ):
         (workspace_directory / relative).mkdir(parents=True, exist_ok=True)
-    (workspace_directory / ".osmosis" / "research" / "program.md").write_text(
-        "# Program\n",
-        encoding="utf-8",
-    )
 
 
 def _assert_deprecated_workspace_directory_context_is_empty(data: dict) -> None:

--- a/tests/unit/cli/test_workspace_doctor.py
+++ b/tests/unit/cli/test_workspace_doctor.py
@@ -61,7 +61,6 @@ def test_project_doctor_dry_run_reports_missing_paths(
         "configs/eval/",
         "data/",
     ]
-    assert not (project / "research" / "program.md").exists()
 
 
 def test_project_doctor_reports_git_context(
@@ -215,7 +214,6 @@ def test_project_doctor_fix_creates_missing_paths(
 
     payload = json.loads(capsys.readouterr().out)
     assert rc == 0
-    assert not (project / ".osmosis" / "research" / "program.md").exists()
     assert (project / "configs" / "training").is_dir()
     assert (project / "AGENTS.md").is_file()
     assert (project / "AGENTS.md").read_text(encoding="utf-8") == "template agents\n"
@@ -238,25 +236,6 @@ def test_project_doctor_fix_outside_project_does_not_create_project(
     message = json.loads(captured.err)["error"]["message"]
     assert "Osmosis workspace directory" in message
     assert "osmosis init" not in message
-
-
-def test_project_doctor_fix_preserves_existing_research_program(
-    tmp_path: Path, monkeypatch, capsys, workspace_template: Path
-) -> None:
-    project = _make_workspace_directory(tmp_path / "project")
-    program = project / "research" / "program.md"
-    program.parent.mkdir(parents=True)
-    program.write_text("# Research Brief\n\nKeep this content.\n", encoding="utf-8")
-    monkeypatch.chdir(project)
-
-    rc = main(["--json", "doctor", "--fix"])
-
-    capsys.readouterr()
-    assert rc == 0
-    assert (
-        program.read_text(encoding="utf-8")
-        == "# Research Brief\n\nKeep this content.\n"
-    )
 
 
 def test_project_doctor_reports_agent_updates_without_overwriting(

--- a/tests/unit/cli/test_workspace_json.py
+++ b/tests/unit/cli/test_workspace_json.py
@@ -82,5 +82,4 @@ def test_project_doctor_json_reports_missing_paths_without_error(
         "AGENTS.md",
         "CLAUDE.md",
         "configs/AGENTS.md",
-        ".claude/settings.json",
     ]

--- a/tests/unit/eval/controller/test_process.py
+++ b/tests/unit/eval/controller/test_process.py
@@ -89,7 +89,7 @@ def test_fixed_port_lock_path_is_shared_across_projects(
             capture_output=True,
         )
         for rel_path in (
-            ".osmosis/research",
+            ".osmosis",
             "rollouts",
             "configs/eval",
             "configs/training",

--- a/tests/unit/eval/evaluation/test_cache.py
+++ b/tests/unit/eval/evaluation/test_cache.py
@@ -44,7 +44,6 @@ def _make_workspace_directory(root: Path) -> Path:
     )
     for rel_path in (
         ".osmosis",
-        ".osmosis/research",
         "rollouts",
         "configs",
         "configs/eval",
@@ -52,9 +51,6 @@ def _make_workspace_directory(root: Path) -> Path:
         "data",
     ):
         (root / rel_path).mkdir(parents=True, exist_ok=True)
-    (root / ".osmosis" / "research" / "program.md").write_text(
-        "# Test\n", encoding="utf-8"
-    )
     return root
 
 

--- a/tests/unit/eval/evaluation/test_cli.py
+++ b/tests/unit/eval/evaluation/test_cli.py
@@ -21,7 +21,6 @@ def _make_workspace_directory(root: Path) -> Path:
     )
     for rel_path in (
         ".osmosis",
-        ".osmosis/research",
         "rollouts",
         "configs",
         "configs/eval",
@@ -30,9 +29,6 @@ def _make_workspace_directory(root: Path) -> Path:
         "rollouts/demo",
     ):
         (root / rel_path).mkdir(parents=True, exist_ok=True)
-    (root / ".osmosis" / "research" / "program.md").write_text(
-        "# Test\n", encoding="utf-8"
-    )
     (root / "rollouts" / "demo" / "pyproject.toml").write_text(
         "[project]\nname='demo'\n",
         encoding="utf-8",

--- a/tests/unit/platform/api/test_models.py
+++ b/tests/unit/platform/api/test_models.py
@@ -16,6 +16,7 @@ from osmosis_ai.platform.api.models import (
     MetricDataPoint,
     MetricHistory,
     SubmitTrainingRunResult,
+    TrainingRunDetail,
     TrainingRunMetrics,
     TrainingRunMetricsOverview,
     UploadInfo,
@@ -240,6 +241,7 @@ class TestTrainingRun:
                 "status": "finished",
                 "model": {"id": None, "model_name": "Qwen/Qwen3"},
                 "dataset": {"id": "dataset_1", "file_name": "train.jsonl"},
+                "rollout": {"id": "rollout_1", "name": "math-rollout"},
             }
         )
 
@@ -247,6 +249,8 @@ class TestTrainingRun:
         assert run.model_name == "Qwen/Qwen3"
         assert run.dataset_id == "dataset_1"
         assert run.dataset_name == "train.jsonl"
+        assert run.rollout_id == "rollout_1"
+        assert run.rollout_name == "math-rollout"
 
     def test_from_dict_uses_nested_training_run_contract_only(self) -> None:
         run = api_models.TrainingRun.from_dict(
@@ -286,6 +290,32 @@ class TestTrainingRun:
 
         assert run.reward_increase_delta == 0.2
         assert run.reward is None
+
+
+class TestTrainingRunDetail:
+    def test_from_dict_parses_platform_entity_refs(self) -> None:
+        run = TrainingRunDetail.from_dict(
+            {
+                "training_run": {
+                    "id": "run_1",
+                    "name": "entity-ref-run",
+                    "status": "finished",
+                    "examples_processed_count": 42,
+                },
+                "model": {"id": "model_1", "name": "Qwen/Qwen3"},
+                "dataset": {"id": "dataset_1", "name": "train.jsonl"},
+                "rollout": {"id": "rollout_1", "name": "math-rollout"},
+            }
+        )
+
+        assert run.id == "run_1"
+        assert run.model_id == "model_1"
+        assert run.model_name == "Qwen/Qwen3"
+        assert run.dataset_id == "dataset_1"
+        assert run.dataset_name == "train.jsonl"
+        assert run.rollout_id == "rollout_1"
+        assert run.rollout_name == "math-rollout"
+        assert run.examples_processed_count == 42
 
 
 class TestMetricDataPoint:

--- a/tests/unit/platform/cli/test_workspace_directory_setup.py
+++ b/tests/unit/platform/cli/test_workspace_directory_setup.py
@@ -47,7 +47,6 @@ def test_write_scaffold_creates_repair_paths(
     write_scaffold(target, "project")
 
     assert not (target / ".osmosis" / "project.toml").exists()
-    assert not (target / ".osmosis" / "research" / "program.md").exists()
     assert not (target / ".osmosis" / "cache").exists()
     assert (target / "rollouts" / ".gitkeep").is_file()
     assert (target / "configs" / "eval" / ".gitkeep").is_file()

--- a/tests/unit/platform/cli/test_workspace_directory_setup.py
+++ b/tests/unit/platform/cli/test_workspace_directory_setup.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import pytest
@@ -17,32 +16,13 @@ from osmosis_ai.platform.cli.scaffold import (
 
 def _write_workspace_template(root: Path) -> Path:
     (root / "configs").mkdir(parents=True)
-    (root / ".claude").mkdir()
     (root / "AGENTS.md").write_text(
-        "template agents\n"
-        "codex plugin marketplace add Osmosis-AI/osmosis-plugins\n"
-        "codex plugin install osmosis\n",
+        "template agents\nproject-local skills live in .agents/skills\n",
         encoding="utf-8",
     )
     (root / "CLAUDE.md").write_text("template claude\n", encoding="utf-8")
     (root / "configs" / "AGENTS.md").write_text(
         "template config agents\n", encoding="utf-8"
-    )
-    (root / ".claude" / "settings.json").write_text(
-        json.dumps(
-            {
-                "extraKnownMarketplaces": {
-                    "osmosis": {
-                        "source": {
-                            "source": "github",
-                            "repo": "Osmosis-AI/osmosis-plugins",
-                        }
-                    }
-                },
-                "enabledPlugins": {"osmosis@osmosis": True},
-            }
-        ),
-        encoding="utf-8",
     )
     return root
 
@@ -77,7 +57,7 @@ def test_write_scaffold_creates_repair_paths(
     assert (target / "AGENTS.md").is_file()
     assert (target / "CLAUDE.md").is_file()
     assert (target / "configs" / "AGENTS.md").is_file()
-    assert (target / ".claude" / "settings.json").is_file()
+    assert not (target / ".claude" / "settings.json").exists()
     assert (
         (target / "AGENTS.md")
         .read_text(encoding="utf-8")
@@ -97,7 +77,6 @@ def test_write_scaffold_does_not_overwrite_existing_files(
         "AGENTS.md": "custom agents",
         "CLAUDE.md": "custom claude",
         "configs/AGENTS.md": "custom config agents",
-        ".claude/settings.json": "{}",
     }
     for rel_path, content in existing_files.items():
         (target / rel_path).write_text(content, encoding="utf-8")
@@ -123,22 +102,6 @@ def test_write_scaffold_rejects_broken_symlinked_official_file(
     assert not outside_file.exists()
 
 
-def test_write_scaffold_rejects_symlinked_official_parent_directory(
-    tmp_path: Path,
-) -> None:
-    target = _make_existing_project(tmp_path / "project")
-    outside_dir = tmp_path / "outside-claude"
-    outside_dir.mkdir()
-    (target / ".claude").symlink_to(outside_dir, target_is_directory=True)
-
-    with pytest.raises(CLIError) as exc_info:
-        write_scaffold(target, "project")
-
-    assert exc_info.value.code == "CONFLICT"
-    assert ".claude" in str(exc_info.value)
-    assert not (outside_dir / "settings.json").exists()
-
-
 def test_write_scaffold_update_does_not_overwrite_agent_files(
     tmp_path: Path,
 ) -> None:
@@ -149,7 +112,6 @@ def test_write_scaffold_update_does_not_overwrite_agent_files(
         "AGENTS.md": "custom agents",
         "CLAUDE.md": "custom claude",
         "configs/AGENTS.md": "custom config agents",
-        ".claude/settings.json": "{}",
     }
     preserved_files = {
         "README.md": "custom readme",
@@ -163,27 +125,6 @@ def test_write_scaffold_update_does_not_overwrite_agent_files(
         assert (target / rel_path).read_text(encoding="utf-8") == content
     for rel_path, content in preserved_files.items():
         assert (target / rel_path).read_text(encoding="utf-8") == content
-
-
-def test_write_scaffold_respects_plugin_env_overrides(
-    monkeypatch, tmp_path: Path
-) -> None:
-    monkeypatch.setenv("OSMOSIS_PLUGIN_REPO", "my-org/my-plugins")
-    monkeypatch.setenv("OSMOSIS_PLUGIN_MARKETPLACE", "my-marketplace")
-    target = _make_existing_project(tmp_path / "project")
-
-    write_scaffold(target, "project")
-
-    agents = (target / "AGENTS.md").read_text(encoding="utf-8")
-    settings = json.loads(
-        (target / ".claude" / "settings.json").read_text(encoding="utf-8")
-    )
-    assert "codex plugin marketplace add my-org/my-plugins" in agents
-    assert "codex plugin install my-marketplace" in agents
-    assert settings["extraKnownMarketplaces"]["my-marketplace"]["source"]["repo"] == (
-        "my-org/my-plugins"
-    )
-    assert settings["enabledPlugins"]["osmosis@my-marketplace"] is True
 
 
 def test_write_scaffold_missing_official_file_uses_user_facing_template_terms(
@@ -332,22 +273,3 @@ def test_refresh_agent_scaffold_rejects_broken_symlinked_official_file(
     assert exc_info.value.code == "CONFLICT"
     assert "AGENTS.md" in str(exc_info.value)
     assert not outside_file.exists()
-
-
-def test_refresh_agent_scaffold_rejects_symlinked_official_parent_directory(
-    tmp_path: Path,
-) -> None:
-    target = _make_existing_project(tmp_path / "project")
-    write_scaffold(target, "project")
-    outside_dir = tmp_path / "outside-claude"
-    outside_dir.mkdir()
-    (target / ".claude" / "settings.json").unlink()
-    (target / ".claude").rmdir()
-    (target / ".claude").symlink_to(outside_dir, target_is_directory=True)
-
-    with pytest.raises(CLIError) as exc_info:
-        refresh_agent_scaffold(target, force=True)
-
-    assert exc_info.value.code == "CONFLICT"
-    assert ".claude" in str(exc_info.value)
-    assert not (outside_dir / "settings.json").exists()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -25,16 +25,13 @@ def _make_git_project(root: Path) -> Path:
         capture_output=True,
     )
     for rel_path in (
-        ".osmosis/research",
+        ".osmosis",
         "rollouts",
         "configs/eval",
         "configs/training",
         "data",
     ):
         (root / rel_path).mkdir(parents=True, exist_ok=True)
-    (root / ".osmosis" / "research" / "program.md").write_text(
-        "# Test\n", encoding="utf-8"
-    )
     return root
 
 


### PR DESCRIPTION
## What

- Add rollout identifiers and names to training run serialization, list output, and detail rows.
- Parse platform-provided model, dataset, and rollout entity refs in training run details.
- Stop scaffolding plugin settings and remove stale `research` directory references from docs and tests.
- Update serializer, API model, workspace scaffold, and CLI contract tests for the revised outputs.

## Why

The CLI should reflect the current platform entity shape and workspace scaffold contract. This keeps training run output aligned with rollout-backed workflows while removing stale project setup guidance and generated files that no longer belong in new workspaces.

## How to Test

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright osmosis_ai/`
- `uv run pytest`

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose rollout info in training runs and remove stale plugin/research scaffold. CLI lists and details now show `rollout_id` and `rollout_name`, and the workspace scaffold no longer includes plugin settings or a `research` directory.

- New Features
  - Add `rollout_id` and `rollout_name` to `TrainingRun` and `TrainingRunDetail` by parsing the `rollout` entity.
  - Include rollout in JSON serialization and CLI output: new Rollout column in list; Dataset and Rollout rows in details.
  - Align detail parsing to platform entity refs (`model.name`, `dataset.name`, `rollout.name`).

- Refactors
  - Remove plugin scaffolding and `.claude/settings.json` handling from the workspace scaffold.
  - Drop `.osmosis/research` from docs, scaffold, and tests.
  - Stop applying plugin marketplace env substitutions when rendering scaffold files.

<sup>Written for commit f3c7738ffc5a2593c6ce40a070683b6d364fdeee. Summary will update on new commits. <a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/185?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

