### PR TITLE
[misc] chore: bump version to 0.2.23

### DIFF
--- a/osmosis_ai/consts.py
+++ b/osmosis_ai/consts.py
@@ -1,3 +1,3 @@
 # package metadata
 package_name = "osmosis-ai"
-PACKAGE_VERSION = "0.2.22"
+PACKAGE_VERSION = "0.2.23"

--- a/osmosis_ai/templates/_scaffolds/rollout/pyproject.toml.tpl
+++ b/osmosis_ai/templates/_scaffolds/rollout/pyproject.toml.tpl
@@ -4,7 +4,7 @@ description = "Placeholder rollout scaffolded by `osmosis rollout init`."
 version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
-    "osmosis-ai[server]>=0.2.22",
+    "osmosis-ai[server]>=0.2.23",
 ]
 
 [build-system]


### PR DESCRIPTION
## What

- Bump `PACKAGE_VERSION` to `0.2.23` in `osmosis_ai/consts.py`.
- Bump the pinned `osmosis-ai[server]` floor to `>=0.2.23` in the rollout scaffold template `osmosis_ai/templates/_scaffolds/rollout/pyproject.toml.tpl`.

## Why

Release housekeeping: cut a new patch version so freshly scaffolded rollout projects pin the matching SDK release.

## How to Test

- `uv run ruff check .`
- `uv run ruff format --check .`
- `python -c "from osmosis_ai.consts import PACKAGE_VERSION; print(PACKAGE_VERSION)"` prints `0.2.23`

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped `osmosis-ai` to 0.2.23 and updated the rollout scaffold to require `osmosis-ai[server]>=0.2.23`. Ensures newly scaffolded projects install the matching SDK release.

<sup>Written for commit df1c8eea3770106cba6a073abd5dcdc678328021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

