### PR TITLE
[cli] feat: scoped secrets — set/list/delete with workspace and user scope

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,5 +28,5 @@ workspace ID for commands scoped by the workspace directory.
 - [Dataset format](./datasets.md) — Parquet / JSONL / CSV columns
 - [Eval](./eval.md) — `osmosis eval submit` and evaluation run configs
 - [CLI reference](./cli.md) — all `osmosis` commands and options, including
-  `train submit` with `[env]` / `[secrets]`
+  `train submit` with `[env]` / `[secrets].required`
 - [Troubleshooting](./troubleshooting.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,5 +28,5 @@ workspace ID for commands scoped by the workspace directory.
 - [Dataset format](./datasets.md) — Parquet / JSONL / CSV columns
 - [Eval](./eval.md) — `osmosis eval submit` and evaluation run configs
 - [CLI reference](./cli.md) — all `osmosis` commands and options, including
-  `train submit` with `[env]` / `[secrets].required`
+  `train submit` with `[env]` / `[secrets]`
 - [Troubleshooting](./troubleshooting.md)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -116,8 +116,10 @@ dataset = "my-platform-dataset"
 # [env]
 # LOG_LEVEL = "INFO"
 
-# [secrets]
-# required = ["OPENAI_API_KEY"]
+[secrets]
+# Default OpenAI eval models need this platform secret.
+# Use [] only when this evaluation needs no secret refs.
+required = ["OPENAI_API_KEY"]
 ```
 
 ```bash
@@ -239,7 +241,7 @@ LOG_LEVEL = "INFO"
 DEFAULT_REGION = "us-west-2"
 ```
 
-#### Secrets — `[secrets]`
+#### Secrets — `[secrets].required`
 
 A list of Platform `environment_secret` **record names** to inject into the
 rollout container. The platform resolves each name to an encrypted value
@@ -253,16 +255,24 @@ Each name must match `^[A-Z][A-Z0-9_]*$`.
 required = ["OPENAI_API_KEY", "DATABASE_URL"]
 ```
 
+Evaluation configs must include `[secrets].required`; use `required = []` when
+the evaluation needs no secret refs. The default OpenAI eval examples use
+`required = ["OPENAI_API_KEY"]`. Training configs may omit the `[secrets]` table
+when the training run does not need secret refs. If a config includes
+`[secrets]`, that table must include `required`.
+
 Secrets are scoped. A **workspace** secret is shared across the workspace; a
 **personal** secret is private to you. When a workspace and a personal secret
 share a name, your personal value wins at run time. Register secrets with
 `osmosis secret set` (below) or at `/:orgName/secrets` in the platform UI
-before submitting a run that references them.
+before submitting a run that references them. `osmosis secret set NAME` creates
+a personal secret by default; pass `--scope workspace` for workspace-shared
+secrets.
 
 #### Rules
 
-- `[env]` keys must match `^[A-Z_][A-Z0-9_]*$`; `secrets` names must match `^[A-Z][A-Z0-9_]*$`.
-- A name cannot appear in both `[env]` and `secrets`.
+- `[env]` keys must match `^[A-Z_][A-Z0-9_]*$`; `[secrets].required` names must match `^[A-Z][A-Z0-9_]*$`.
+- A name cannot appear in both `[env]` and `[secrets].required`.
 - `[env]` names starting with `_OSMOSIS_` are reserved by the platform.
 - Both are optional.
 
@@ -345,18 +355,19 @@ commands show or accept names + metadata only.
 | Command | Description |
 | --- | --- |
 | `osmosis secret list [--scope all\|workspace\|personal] [--limit N] [--all]` | List secret names + scope (no values). |
-| `osmosis secret set NAME [--scope workspace\|personal] [--env VARNAME]` | Create or update (upsert) a secret. Value read from `--env VARNAME` or a hidden prompt — never a plaintext argument. |
-| `osmosis secret delete NAME [--scope workspace\|personal] [--yes]` | Delete a secret within the given scope. |
+| `osmosis secret set NAME [--scope workspace\|personal] [--env VARNAME]` | Create or update (upsert) a secret. Defaults to personal scope. Value read from `--env VARNAME` or a hidden prompt — never a plaintext argument. |
+| `osmosis secret delete NAME [--scope workspace\|personal] [--yes]` | Delete a secret within the given scope. Defaults to personal scope. |
 
-`--scope` defaults to `workspace` for `set`/`delete` and `all` for `list`.
+`--scope` defaults to `personal` for `set`/`delete` and `all` for `list`.
 Workspace secrets require an admin/owner role; personal secrets are private to you.
 
 ```bash
-# Read the value from an env var (recommended for scripts):
+# Read the value from an env var (recommended for scripts).
+# This creates or updates your personal secret by default:
 OPENAI_API_KEY=sk-... osmosis secret set OPENAI_API_KEY --env OPENAI_API_KEY
 
-# Personal override (only affects your own runs):
-osmosis secret set OPENAI_API_KEY --scope personal --env OPENAI_API_KEY
+# Workspace-shared secret:
+OPENAI_API_KEY=sk-... osmosis secret set OPENAI_API_KEY --scope workspace --env OPENAI_API_KEY
 
 osmosis secret list --scope personal
 osmosis secret delete OPENAI_API_KEY --scope personal --yes

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -241,12 +241,12 @@ LOG_LEVEL = "INFO"
 DEFAULT_REGION = "us-west-2"
 ```
 
-#### Secrets — `[secrets].required`
+#### Secrets — `[secrets]`
 
-A list of Platform `environment_secret` **record names** to inject into the
-rollout container. The platform resolves each name to an encrypted value
-server-side and sets it as an env var of the same name. Secret values never
-appear in the config file, in the API payload, or in CLI output.
+The `[secrets]` section must contain a `required` list of secret names to inject
+into the rollout container. The platform resolves each name to its encrypted
+value server-side and sets it as an env var of the same name. Secret values
+never appear in the config file, in the API payload, or in CLI output.
 
 Each name must match `^[A-Z][A-Z0-9_]*$`.
 
@@ -255,7 +255,7 @@ Each name must match `^[A-Z][A-Z0-9_]*$`.
 required = ["OPENAI_API_KEY", "DATABASE_URL"]
 ```
 
-Evaluation configs must include `[secrets].required`; use `required = []` when
+Evaluation configs must include `[secrets]`; use `required = []` when
 the evaluation needs no secret refs. The default OpenAI eval examples use
 `required = ["OPENAI_API_KEY"]`. Training configs may omit the `[secrets]` table
 when the training run does not need secret refs. If a config includes
@@ -271,8 +271,8 @@ secrets.
 
 #### Rules
 
-- `[env]` keys must match `^[A-Z_][A-Z0-9_]*$`; `[secrets].required` names must match `^[A-Z][A-Z0-9_]*$`.
-- A name cannot appear in both `[env]` and `[secrets].required`.
+- `[env]` keys must match `^[A-Z_][A-Z0-9_]*$`; `[secrets]` names must match `^[A-Z][A-Z0-9_]*$`.
+- A name cannot appear in both `[env]` and `[secrets]`.
 - `[env]` names starting with `_OSMOSIS_` are reserved by the platform.
 - Both are optional.
 
@@ -349,7 +349,7 @@ osmosis undeploy <checkpoint>
 
 ### `osmosis secret`
 
-Manage environment secrets. The platform never returns secret values; these
+Manage secrets. The platform never returns secret values; these
 commands show or accept names + metadata only.
 
 | Command | Description |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -262,9 +262,9 @@ before submitting a run that references them.
 
 #### Rules
 
-- `[env]` keys and `secrets` names must match `^[A-Z][A-Z0-9_]*$`.
+- `[env]` keys must match `^[A-Z_][A-Z0-9_]*$`; `secrets` names must match `^[A-Z][A-Z0-9_]*$`.
 - A name cannot appear in both `[env]` and `secrets`.
-- Any name starting with `_OSMOSIS_` is reserved by the platform.
+- `[env]` names starting with `_OSMOSIS_` are reserved by the platform.
 - Both are optional.
 
 ### osmosis train info

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -97,10 +97,6 @@ selection: `[experiment].dataset` is a platform dataset name from
 `osmosis dataset list`, not a local `data/*.jsonl` path.
 
 ```toml
-# `secrets` must be at the TOP of the file, before any [table] header —
-# otherwise TOML folds it into the preceding table and it is silently ignored.
-# secrets = ["OPENAI_API_KEY"]
-
 [experiment]
 rollout = "my-rollout"
 entrypoint = "main.py"
@@ -119,6 +115,9 @@ dataset = "my-platform-dataset"
 
 # [env]
 # LOG_LEVEL = "INFO"
+
+# [secrets]
+# required = ["OPENAI_API_KEY"]
 ```
 
 ```bash
@@ -240,7 +239,7 @@ LOG_LEVEL = "INFO"
 DEFAULT_REGION = "us-west-2"
 ```
 
-#### Secrets — `secrets`
+#### Secrets — `[secrets]`
 
 A list of Platform `environment_secret` **record names** to inject into the
 rollout container. The platform resolves each name to an encrypted value
@@ -250,12 +249,12 @@ appear in the config file, in the API payload, or in CLI output.
 Each name must match `^[A-Z][A-Z0-9_]*$`.
 
 ```toml
-# Must be at the top of the file, before any [table] header.
-secrets = ["OPENAI_API_KEY", "DATABASE_URL"]
+[secrets]
+required = ["OPENAI_API_KEY", "DATABASE_URL"]
 ```
 
 Secrets are scoped. A **workspace** secret is shared across the workspace; a
-**user** secret is private to you. When a workspace and a personal secret
+**personal** secret is private to you. When a workspace and a personal secret
 share a name, your personal value wins at run time. Register secrets with
 `osmosis secret set` (below) or at `/:orgName/secrets` in the platform UI
 before submitting a run that references them.
@@ -345,22 +344,22 @@ commands show or accept names + metadata only.
 
 | Command | Description |
 | --- | --- |
-| `osmosis secret list [--scope all\|workspace\|user] [--limit N] [--all]` | List secret names + scope (no values). |
-| `osmosis secret set NAME [--scope workspace\|user] [--env VARNAME]` | Create or update (upsert) a secret. Value read from `--env VARNAME` or a hidden prompt — never a plaintext argument. |
-| `osmosis secret delete NAME [--scope workspace\|user] [--yes]` | Delete a secret within the given scope. |
+| `osmosis secret list [--scope all\|workspace\|personal] [--limit N] [--all]` | List secret names + scope (no values). |
+| `osmosis secret set NAME [--scope workspace\|personal] [--env VARNAME]` | Create or update (upsert) a secret. Value read from `--env VARNAME` or a hidden prompt — never a plaintext argument. |
+| `osmosis secret delete NAME [--scope workspace\|personal] [--yes]` | Delete a secret within the given scope. |
 
 `--scope` defaults to `workspace` for `set`/`delete` and `all` for `list`.
-Workspace secrets require an admin/owner role; user secrets are private to you.
+Workspace secrets require an admin/owner role; personal secrets are private to you.
 
 ```bash
 # Read the value from an env var (recommended for scripts):
 OPENAI_API_KEY=sk-... osmosis secret set OPENAI_API_KEY --env OPENAI_API_KEY
 
 # Personal override (only affects your own runs):
-osmosis secret set OPENAI_API_KEY --scope user --env OPENAI_API_KEY
+osmosis secret set OPENAI_API_KEY --scope personal --env OPENAI_API_KEY
 
-osmosis secret list --scope user
-osmosis secret delete OPENAI_API_KEY --scope user --yes
+osmosis secret list --scope personal
+osmosis secret delete OPENAI_API_KEY --scope personal --yes
 ```
 
 ## See also

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -97,6 +97,10 @@ selection: `[experiment].dataset` is a platform dataset name from
 `osmosis dataset list`, not a local `data/*.jsonl` path.
 
 ```toml
+# `secrets` must be at the TOP of the file, before any [table] header —
+# otherwise TOML folds it into the preceding table and it is silently ignored.
+# secrets = ["OPENAI_API_KEY"]
+
 [experiment]
 rollout = "my-rollout"
 entrypoint = "main.py"
@@ -115,9 +119,6 @@ dataset = "my-platform-dataset"
 
 # [env]
 # LOG_LEVEL = "INFO"
-
-# [secrets]
-# OPENAI_API_KEY = "openai-api-key"
 ```
 
 ```bash
@@ -239,26 +240,32 @@ LOG_LEVEL = "INFO"
 DEFAULT_REGION = "us-west-2"
 ```
 
-#### Secrets — `[secrets]`
+#### Secrets — `secrets`
 
-Maps env-var names to Platform `environment_secret` **record names**. The
-platform resolves the actual secret value server-side from encrypted secret
-storage and injects it into the container. Secret values never
+A list of Platform `environment_secret` **record names** to inject into the
+rollout container. The platform resolves each name to an encrypted value
+server-side and sets it as an env var of the same name. Secret values never
 appear in the config file, in the API payload, or in CLI output.
 
-Pre-register secrets before submitting a run that references them — either with [`osmosis secret add`](#osmosis-secret-add) or at `/:orgName/secrets` in the platform UI.
+Each name must match `^[A-Z][A-Z0-9_]*$`.
 
 ```toml
-[secrets]
-OPENAI_API_KEY = "openai-api-key"   # "openai-api-key" is the record name
+# Must be at the top of the file, before any [table] header.
+secrets = ["OPENAI_API_KEY", "DATABASE_URL"]
 ```
 
-#### Rules for both sections
+Secrets are scoped. A **workspace** secret is shared across the workspace; a
+**user** secret is private to you. When a workspace and a personal secret
+share a name, your personal value wins at run time. Register secrets with
+`osmosis secret set` (below) or at `/:orgName/secrets` in the platform UI
+before submitting a run that references them.
 
-- Keys must match `^[A-Z_][A-Z0-9_]*$`.
-- A key cannot appear in both `[env]` and `[secrets]`.
-- Any env var name starting with `_OSMOSIS_` is reserved by the platform and cannot be used.
-- Both sections are optional.
+#### Rules
+
+- `[env]` keys and `secrets` names must match `^[A-Z][A-Z0-9_]*$`.
+- A name cannot appear in both `[env]` and `secrets`.
+- Any name starting with `_OSMOSIS_` is reserved by the platform.
+- Both are optional.
 
 ### osmosis train info
 
@@ -331,31 +338,29 @@ osmosis undeploy <checkpoint>
 
 ## Secrets
 
-Manage workspace `environment_secret` records — the values referenced by the `[secrets]` table in train/eval configs. The platform never returns a secret value: `list` shows names and metadata only, and `add` echoes back only metadata. Secret values are accepted from a hidden interactive prompt or a named environment variable — never as a plaintext command-line argument (which would leak into shell history and the process list).
+### `osmosis secret`
 
-### osmosis secret list
+Manage environment secrets. The platform never returns secret values; these
+commands show or accept names + metadata only.
 
-List secrets for the current workspace directory (names and metadata only).
+| Command | Description |
+| --- | --- |
+| `osmosis secret list [--scope all\|workspace\|user] [--limit N] [--all]` | List secret names + scope (no values). |
+| `osmosis secret set NAME [--scope workspace\|user] [--env VARNAME]` | Create or update (upsert) a secret. Value read from `--env VARNAME` or a hidden prompt — never a plaintext argument. |
+| `osmosis secret delete NAME [--scope workspace\|user] [--yes]` | Delete a secret within the given scope. |
 
-```bash
-osmosis secret list
-osmosis secret list --limit 50
-osmosis secret list --all
-```
-
-### osmosis secret add
-
-Add a workspace secret. The value is read from a named environment variable (`--env VARNAME`) or, with no flag, typed at a hidden interactive prompt. The secret name may contain letters, digits, `_`, and `-` (1–255 chars). Adding a secret whose name already exists fails with a `CONFLICT` error rather than overwriting it.
+`--scope` defaults to `workspace` for `set`/`delete` and `all` for `list`.
+Workspace secrets require an admin/owner role; user secrets are private to you.
 
 ```bash
-# Type the value at a hidden prompt (input is not echoed):
-osmosis secret add OPENAI_API_KEY
+# Read the value from an env var (recommended for scripts):
+OPENAI_API_KEY=sk-... osmosis secret set OPENAI_API_KEY --env OPENAI_API_KEY
 
-# Read the value from an environment variable (recommended for CI):
-osmosis secret add OPENAI_API_KEY --env OPENAI_API_KEY
+# Personal override (only affects your own runs):
+osmosis secret set OPENAI_API_KEY --scope user --env OPENAI_API_KEY
 
-# In --json / --plain (non-interactive) modes, --env is required:
-osmosis --json secret add OPENAI_API_KEY --env SOURCE_VAR
+osmosis secret list --scope user
+osmosis secret delete OPENAI_API_KEY --scope user --yes
 ```
 
 ## See also

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -19,7 +19,7 @@ Evaluation configs must live under `configs/eval/` inside a structured Osmosis w
 
 ### Optional fields and sections
 
-Evaluation submit configs also support optional `[experiment].commit_sha`, `[evaluation]`, `[env]`, and `[secrets]`. The SDK validates only shallow TOML shape, required fields, recognized keys, and env-var names; backend validation owns provider, dataset, model, and evaluation parameter errors.
+Evaluation submit configs also support optional `[experiment].commit_sha`, `[evaluation]`, `[env]`, and a top-level `secrets` list. The SDK validates only shallow TOML shape, required fields, recognized keys, and env-var names; backend validation owns provider, dataset, model, and evaluation parameter errors.
 
 | Key | Description |
 |-----|-------------|
@@ -36,13 +36,17 @@ Evaluation submit configs also support optional `[experiment].commit_sha`, `[eva
 | `agent_workflow_timeout_s` | Agent workflow timeout per row. |
 | `grader_timeout_s` | Grader timeout per row. |
 
-**`[env]` / `[secrets]`**
+**`[env]` / `secrets`**
 
-`[env]` contains literal env-var values. `[secrets]` maps env-var names to workspace secret record names resolved server-side. Keys must match `^[A-Z_][A-Z0-9_]*$`, must not start with `_OSMOSIS_`, and cannot appear in both sections.
+`[env]` contains literal env-var values. `secrets` is a list of workspace `environment_secret` record names; the platform resolves each to its encrypted value server-side and injects it as an env var of the same name. `[env]` keys and `secrets` names must match `^[A-Z][A-Z0-9_]*$`, must not start with `_OSMOSIS_`, and a name cannot appear in both. Register secrets with `osmosis secret set`; use `--scope user` for a personal override that only affects your own runs.
 
 ### Example `configs/eval/my-rollout.toml`
 
 ```toml
+# `secrets` must be at the TOP of the file, before any [table] header —
+# otherwise TOML folds it into the preceding table and it is silently ignored.
+# secrets = ["OPENAI_API_KEY"]
+
 [experiment]
 rollout = "my-rollout"
 entrypoint = "main.py"
@@ -61,9 +65,6 @@ dataset = "my-platform-dataset"
 
 # [env]
 # LOG_LEVEL = "INFO"
-
-# [secrets]
-# OPENAI_API_KEY = "openai-api-key"
 ```
 
 ## Quick start

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -19,7 +19,7 @@ Evaluation configs must live under `configs/eval/` inside a structured Osmosis w
 
 ### Optional fields and sections
 
-Evaluation submit configs also support optional `[experiment].commit_sha`, `[evaluation]`, `[env]`, and a top-level `secrets` list. The SDK validates only shallow TOML shape, required fields, recognized keys, and env-var names; backend validation owns provider, dataset, model, and evaluation parameter errors.
+Evaluation submit configs also support optional `[experiment].commit_sha`, `[evaluation]`, and `[env]`. They must include `[secrets].required`; default OpenAI eval configs should include `OPENAI_API_KEY`, and `required = []` is only for evaluations that need no secret refs. The SDK validates only shallow TOML shape, required fields, recognized keys, and env-var names; backend validation owns provider, dataset, model, and evaluation parameter errors.
 
 | Key | Description |
 |-----|-------------|
@@ -36,9 +36,9 @@ Evaluation submit configs also support optional `[experiment].commit_sha`, `[eva
 | `agent_workflow_timeout_s` | Agent workflow timeout per row. |
 | `grader_timeout_s` | Grader timeout per row. |
 
-**`[env]` / `secrets`**
+**`[env]` / `[secrets]`**
 
-`[env]` contains literal env-var values. `[secrets].required` is a list of platform `environment_secret` record names; the platform resolves each to its encrypted value server-side and injects it as an env var of the same name. `[env]` keys must match `^[A-Z_][A-Z0-9_]*$`; secret names must match `^[A-Z][A-Z0-9_]*$`; `[env]` names must not start with `_OSMOSIS_`; and a name cannot appear in both sections. Register secrets with `osmosis secret set`; use `--scope personal` for a personal override that only affects your own runs.
+`[env]` contains literal env-var values. `[secrets].required` lists platform `environment_secret` record names; the platform resolves each to its encrypted value server-side and injects it as an env var of the same name. `[env]` keys must match `^[A-Z_][A-Z0-9_]*$`; secret names must match `^[A-Z][A-Z0-9_]*$`; `[env]` names must not start with `_OSMOSIS_`; and a name cannot appear in both `[env]` and `[secrets].required`. Register secrets with `osmosis secret set`; personal scope is the default, and `--scope workspace` creates workspace-shared secrets.
 
 ### Example `configs/eval/my-rollout.toml`
 
@@ -62,8 +62,10 @@ dataset = "my-platform-dataset"
 # [env]
 # LOG_LEVEL = "INFO"
 
-# [secrets]
-# required = ["OPENAI_API_KEY"]
+[secrets]
+# Default OpenAI eval models need this platform secret.
+# Use [] only when this evaluation needs no secret refs.
+required = ["OPENAI_API_KEY"]
 ```
 
 ## Quick start

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -38,15 +38,11 @@ Evaluation submit configs also support optional `[experiment].commit_sha`, `[eva
 
 **`[env]` / `secrets`**
 
-`[env]` contains literal env-var values. `secrets` is a list of workspace `environment_secret` record names; the platform resolves each to its encrypted value server-side and injects it as an env var of the same name. `[env]` keys and `secrets` names must match `^[A-Z][A-Z0-9_]*$`, must not start with `_OSMOSIS_`, and a name cannot appear in both. Register secrets with `osmosis secret set`; use `--scope user` for a personal override that only affects your own runs.
+`[env]` contains literal env-var values. `[secrets].required` is a list of platform `environment_secret` record names; the platform resolves each to its encrypted value server-side and injects it as an env var of the same name. `[env]` keys must match `^[A-Z_][A-Z0-9_]*$`; secret names must match `^[A-Z][A-Z0-9_]*$`; `[env]` names must not start with `_OSMOSIS_`; and a name cannot appear in both sections. Register secrets with `osmosis secret set`; use `--scope personal` for a personal override that only affects your own runs.
 
 ### Example `configs/eval/my-rollout.toml`
 
 ```toml
-# `secrets` must be at the TOP of the file, before any [table] header —
-# otherwise TOML folds it into the preceding table and it is silently ignored.
-# secrets = ["OPENAI_API_KEY"]
-
 [experiment]
 rollout = "my-rollout"
 entrypoint = "main.py"
@@ -65,6 +61,9 @@ dataset = "my-platform-dataset"
 
 # [env]
 # LOG_LEVEL = "INFO"
+
+# [secrets]
+# required = ["OPENAI_API_KEY"]
 ```
 
 ## Quick start

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -19,7 +19,7 @@ Evaluation configs must live under `configs/eval/` inside a structured Osmosis w
 
 ### Optional fields and sections
 
-Evaluation submit configs also support optional `[experiment].commit_sha`, `[evaluation]`, and `[env]`. They must include `[secrets].required`; default OpenAI eval configs should include `OPENAI_API_KEY`, and `required = []` is only for evaluations that need no secret refs. The SDK validates only shallow TOML shape, required fields, recognized keys, and env-var names; backend validation owns provider, dataset, model, and evaluation parameter errors.
+Evaluation submit configs also support optional `[experiment].commit_sha`, `[evaluation]`, and `[env]`. They must include `[secrets]`; default OpenAI eval configs should include `OPENAI_API_KEY`, and `required = []` is only for evaluations that need no secret refs. The SDK validates only shallow TOML shape, required fields, recognized keys, and env-var names; backend validation owns provider, dataset, model, and evaluation parameter errors.
 
 | Key | Description |
 |-----|-------------|
@@ -38,7 +38,7 @@ Evaluation submit configs also support optional `[experiment].commit_sha`, `[eva
 
 **`[env]` / `[secrets]`**
 
-`[env]` contains literal env-var values. `[secrets].required` lists platform `environment_secret` record names; the platform resolves each to its encrypted value server-side and injects it as an env var of the same name. `[env]` keys must match `^[A-Z_][A-Z0-9_]*$`; secret names must match `^[A-Z][A-Z0-9_]*$`; `[env]` names must not start with `_OSMOSIS_`; and a name cannot appear in both `[env]` and `[secrets].required`. Register secrets with `osmosis secret set`; personal scope is the default, and `--scope workspace` creates workspace-shared secrets.
+`[env]` contains literal env-var values. `[secrets]` must contain a `required` list of secret names (e.g. `required = ["OPENAI_API_KEY"]`); the platform resolves each to its encrypted value server-side and injects it as an env var of the same name. `[env]` keys must match `^[A-Z_][A-Z0-9_]*$`; secret names must match `^[A-Z][A-Z0-9_]*$`; `[env]` names must not start with `_OSMOSIS_`; and a name cannot appear in both `[env]` and `[secrets]`. Register secrets with `osmosis secret set`; personal scope is the default, and `--scope workspace` creates workspace-shared secrets.
 
 ### Example `configs/eval/my-rollout.toml`
 

--- a/osmosis_ai/cli/commands/auth.py
+++ b/osmosis_ai/cli/commands/auth.py
@@ -556,7 +556,7 @@ def whoami() -> Any:
         fields.append(
             DetailField(label="Name", value=console.format_text(credentials.user.name))
         )
-    fields.append(DetailField(label="Auth source", value=source))
+    fields.append(DetailField(label="Auth Source", value=source))
     fields.append(
         DetailField(label="Expires", value=credentials.expires_at.strftime("%Y-%m-%d"))
     )

--- a/osmosis_ai/cli/commands/secret.py
+++ b/osmosis_ai/cli/commands/secret.py
@@ -1,10 +1,14 @@
 """Secret management commands.
 
 ``osmosis secret`` manages secrets — the same records referenced by the
-``[secrets]`` table in train/eval configs. Secrets are scoped: a ``workspace``
-secret is shared across the workspace (admin/owner only), and a ``personal``
-secret is private to the calling user. When both exist with the same name, the
-personal secret takes precedence at run time.
+``[secrets].required`` list in submit configs. Evaluation configs must include
+that list; default OpenAI eval configs should include ``OPENAI_API_KEY`` and
+use ``required = []`` only when no secret refs are needed. Training configs may
+omit ``[secrets]`` entirely, but any ``[secrets]`` section must include
+``required``. Secrets are scoped: a ``workspace`` secret is shared across the
+workspace (admin/owner only), and a ``personal`` secret is private to the
+calling user. When both exist with the same name, the personal secret takes
+precedence at run time.
 
 The platform never returns secret values: ``list`` shows names + metadata
 only, and ``set`` echoes back only metadata.
@@ -30,7 +34,8 @@ app: typer.Typer = typer.Typer(
 _SCOPE_HELP = (
     "Secret scope: 'workspace' (shared across the workspace, applies to "
     "everyone's runs by default) or 'personal' (overrides "
-    "workspace secrets and applies only to runs you submit)."
+    "workspace secrets and applies only to runs you submit). Defaults to "
+    "'personal' for set/delete."
 )
 
 
@@ -57,7 +62,7 @@ def list_secrets(
 @app.command("set")
 def set_secret(
     name: str = typer.Argument(..., help="Secret name.", metavar="NAME"),
-    scope: str = typer.Option(..., "--scope", help=_SCOPE_HELP),
+    scope: str = typer.Option("personal", "--scope", help=_SCOPE_HELP),
     env: str | None = typer.Option(
         None,
         "--env",
@@ -82,7 +87,7 @@ def set_secret(
 @app.command("delete")
 def delete_secret(
     name: str = typer.Argument(..., help="Secret name.", metavar="NAME"),
-    scope: str = typer.Option(..., "--scope", help=_SCOPE_HELP),
+    scope: str = typer.Option("personal", "--scope", help=_SCOPE_HELP),
     yes: bool = typer.Option(
         False, "--yes", "-y", help="Skip the confirmation prompt."
     ),

--- a/osmosis_ai/cli/commands/secret.py
+++ b/osmosis_ai/cli/commands/secret.py
@@ -1,10 +1,10 @@
-"""Environment secret management commands.
+"""Secret management commands.
 
-``osmosis secret`` manages environment secrets — the same records referenced
-by the ``secrets`` list in train/eval configs. Secrets are scoped: a
-``workspace`` secret is shared across the workspace (admin/owner only), and a
-``user`` secret is private to the calling user. When both exist with the same
-name, the user's personal secret takes precedence at run time.
+``osmosis secret`` manages secrets — the same records referenced by the
+``[secrets]`` table in train/eval configs. Secrets are scoped: a ``workspace``
+secret is shared across the workspace (admin/owner only), and a ``personal``
+secret is private to the calling user. When both exist with the same name, the
+personal secret takes precedence at run time.
 
 The platform never returns secret values: ``list`` shows names + metadata
 only, and ``set`` echoes back only metadata.
@@ -23,13 +23,14 @@ import typer
 from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE
 
 app: typer.Typer = typer.Typer(
-    help="Manage environment secrets (set, list, delete).",
+    help="Manage secrets (set, list, delete).",
     no_args_is_help=True,
 )
 
 _SCOPE_HELP = (
-    "Secret scope: 'workspace' (shared, admin/owner only) or 'user' "
-    "(your personal secret)."
+    "Secret scope: 'workspace' (shared across the workspace, applies to "
+    "everyone's runs by default) or 'personal' (overrides "
+    "workspace secrets and applies only to runs you submit)."
 )
 
 
@@ -44,10 +45,10 @@ def list_secrets(
     scope: str = typer.Option(
         "all",
         "--scope",
-        help="Filter by scope: 'all', 'workspace', or 'user'.",
+        help="Filter by scope: 'all', 'workspace', or 'personal'.",
     ),
 ) -> Any:
-    """List environment secrets (names and metadata only; values are never shown)."""
+    """List secrets (names and metadata only; values are never shown)."""
     from osmosis_ai.platform.cli.secret import list_secrets as _list_secrets
 
     return _list_secrets(limit=limit, all_=all_, scope=scope)
@@ -56,7 +57,7 @@ def list_secrets(
 @app.command("set")
 def set_secret(
     name: str = typer.Argument(..., help="Secret name.", metavar="NAME"),
-    scope: str = typer.Option("workspace", "--scope", help=_SCOPE_HELP),
+    scope: str = typer.Option(..., "--scope", help=_SCOPE_HELP),
     env: str | None = typer.Option(
         None,
         "--env",
@@ -68,7 +69,7 @@ def set_secret(
         ),
     ),
 ) -> Any:
-    """Create or update an environment secret (upsert).
+    """Create or update a secret (upsert).
 
     The value is read from --env VARNAME, or typed at a hidden interactive
     prompt. It is never accepted as a plaintext command-line argument.
@@ -81,12 +82,12 @@ def set_secret(
 @app.command("delete")
 def delete_secret(
     name: str = typer.Argument(..., help="Secret name.", metavar="NAME"),
-    scope: str = typer.Option("workspace", "--scope", help=_SCOPE_HELP),
+    scope: str = typer.Option(..., "--scope", help=_SCOPE_HELP),
     yes: bool = typer.Option(
         False, "--yes", "-y", help="Skip the confirmation prompt."
     ),
 ) -> Any:
-    """Delete an environment secret within the given scope."""
+    """Delete a secret within the given scope."""
     from osmosis_ai.platform.cli.secret import delete_secret as _delete_secret
 
     return _delete_secret(name=name, scope=scope, yes=yes)

--- a/osmosis_ai/cli/commands/secret.py
+++ b/osmosis_ai/cli/commands/secret.py
@@ -1,8 +1,8 @@
 """Secret management commands.
 
 ``osmosis secret`` manages secrets — the same records referenced by the
-``[secrets].required`` list in submit configs. Evaluation configs must include
-that list; default OpenAI eval configs should include ``OPENAI_API_KEY`` and
+``[secrets]`` section in submit configs. Evaluation configs must include
+this section; default OpenAI eval configs should include ``OPENAI_API_KEY`` and
 use ``required = []`` only when no secret refs are needed. Training configs may
 omit ``[secrets]`` entirely, but any ``[secrets]`` section must include
 ``required``. Secrets are scoped: a ``workspace`` secret is shared across the
@@ -32,10 +32,9 @@ app: typer.Typer = typer.Typer(
 )
 
 _SCOPE_HELP = (
-    "Secret scope: 'workspace' (shared across the workspace, applies to "
-    "everyone's runs by default) or 'personal' (overrides "
-    "workspace secrets and applies only to runs you submit). Defaults to "
-    "'personal' for set/delete."
+    "'personal' (default) or 'workspace'. Personal secrets apply only to "
+    "your runs and override workspace secrets with the same name. "
+    "Workspace secrets are shared across the workspace."
 )
 
 

--- a/osmosis_ai/cli/commands/secret.py
+++ b/osmosis_ai/cli/commands/secret.py
@@ -1,9 +1,13 @@
-"""Workspace secret management commands.
+"""Environment secret management commands.
 
-``osmosis secret`` manages workspace environment secrets — the same records
-referenced by the ``[secrets]`` table in train/eval configs. The platform
-never returns secret values: ``list`` shows names + metadata only, and
-``add`` echoes back only metadata.
+``osmosis secret`` manages environment secrets — the same records referenced
+by the ``secrets`` list in train/eval configs. Secrets are scoped: a
+``workspace`` secret is shared across the workspace (admin/owner only), and a
+``user`` secret is private to the calling user. When both exist with the same
+name, the user's personal secret takes precedence at run time.
+
+The platform never returns secret values: ``list`` shows names + metadata
+only, and ``set`` echoes back only metadata.
 
 Secret values are accepted from a hidden interactive prompt or from a named
 environment variable (``--env VARNAME``) — never as a plaintext command-line
@@ -19,8 +23,13 @@ import typer
 from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE
 
 app: typer.Typer = typer.Typer(
-    help="Manage workspace secrets (list, add).",
+    help="Manage environment secrets (set, list, delete).",
     no_args_is_help=True,
+)
+
+_SCOPE_HELP = (
+    "Secret scope: 'workspace' (shared, admin/owner only) or 'user' "
+    "(your personal secret)."
 )
 
 
@@ -32,16 +41,22 @@ def list_secrets(
         help="Maximum number of secrets to show.",
     ),
     all_: bool = typer.Option(False, "--all", help="Show all secrets."),
+    scope: str = typer.Option(
+        "all",
+        "--scope",
+        help="Filter by scope: 'all', 'workspace', or 'user'.",
+    ),
 ) -> Any:
-    """List workspace secrets (names and metadata only; values are never shown)."""
+    """List environment secrets (names and metadata only; values are never shown)."""
     from osmosis_ai.platform.cli.secret import list_secrets as _list_secrets
 
-    return _list_secrets(limit=limit, all_=all_)
+    return _list_secrets(limit=limit, all_=all_, scope=scope)
 
 
-@app.command("add")
-def add_secret(
+@app.command("set")
+def set_secret(
     name: str = typer.Argument(..., help="Secret name.", metavar="NAME"),
+    scope: str = typer.Option("workspace", "--scope", help=_SCOPE_HELP),
     env: str | None = typer.Option(
         None,
         "--env",
@@ -53,11 +68,25 @@ def add_secret(
         ),
     ),
 ) -> Any:
-    """Add a workspace secret.
+    """Create or update an environment secret (upsert).
 
     The value is read from --env VARNAME, or typed at a hidden interactive
     prompt. It is never accepted as a plaintext command-line argument.
     """
-    from osmosis_ai.platform.cli.secret import add_secret as _add_secret
+    from osmosis_ai.platform.cli.secret import set_secret as _set_secret
 
-    return _add_secret(name=name, env=env)
+    return _set_secret(name=name, scope=scope, env=env)
+
+
+@app.command("delete")
+def delete_secret(
+    name: str = typer.Argument(..., help="Secret name.", metavar="NAME"),
+    scope: str = typer.Option("workspace", "--scope", help=_SCOPE_HELP),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Skip the confirmation prompt."
+    ),
+) -> Any:
+    """Delete an environment secret within the given scope."""
+    from osmosis_ai.platform.cli.secret import delete_secret as _delete_secret
+
+    return _delete_secret(name=name, scope=scope, yes=yes)

--- a/osmosis_ai/cli/main.py
+++ b/osmosis_ai/cli/main.py
@@ -10,8 +10,22 @@ from typing import Any
 import click
 import typer
 import typer.core
-from typer._click import exceptions as _typer_exc
 from dotenv import find_dotenv, load_dotenv
+
+try:
+    from typer._click import exceptions as _typer_exc
+
+    _EXIT_EXCEPTIONS: tuple[type[BaseException], ...] = (
+        click.exceptions.Exit,
+        _typer_exc.Exit,
+    )
+    _USAGE_EXCEPTIONS: tuple[type[BaseException], ...] = (
+        click.UsageError,
+        _typer_exc.UsageError,
+    )
+except ImportError:
+    _EXIT_EXCEPTIONS = (click.exceptions.Exit,)
+    _USAGE_EXCEPTIONS = (click.UsageError,)
 
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.cli.output.context import (
@@ -230,11 +244,11 @@ def main(argv: list[str] | None = None) -> int:
         if isinstance(result, int) and result != 0:
             return result
         return 0
-    except (click.exceptions.Exit, _typer_exc.Exit) as e:
+    except _EXIT_EXCEPTIONS as e:
         return e.exit_code
     except SystemExit as e:
         return int(e.code) if e.code is not None else 0
-    except (click.UsageError, _typer_exc.UsageError) as exc:
+    except _USAGE_EXCEPTIONS as exc:
         if not str(exc):
             return 0
         return _handle_cli_error(exc, argv=argv, exit_code=exc.exit_code)

--- a/osmosis_ai/cli/main.py
+++ b/osmosis_ai/cli/main.py
@@ -1,31 +1,13 @@
 """Osmosis AI CLI — built with Typer."""
 
-from __future__ import annotations
-
 import difflib
 import sys
 import warnings
-from typing import Any
 
 import click
 import typer
 import typer.core
 from dotenv import find_dotenv, load_dotenv
-
-try:
-    from typer._click import exceptions as _typer_exc
-
-    _EXIT_EXCEPTIONS: tuple[type[BaseException], ...] = (
-        click.exceptions.Exit,
-        _typer_exc.Exit,
-    )
-    _USAGE_EXCEPTIONS: tuple[type[BaseException], ...] = (
-        click.UsageError,
-        _typer_exc.UsageError,
-    )
-except ImportError:
-    _EXIT_EXCEPTIONS = (click.exceptions.Exit,)
-    _USAGE_EXCEPTIONS = (click.UsageError,)
 
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.cli.output.context import (
@@ -53,9 +35,9 @@ from osmosis_ai.platform.auth.platform_client import (
 class OsmosisGroup(typer.core.TyperGroup):
     """Typer group with fuzzy command suggestion."""
 
-    def resolve_command(  # type: ignore[override]
-        self, ctx: Any, args: list[str]
-    ) -> tuple[str | None, Any, list[str]]:
+    def resolve_command(
+        self, ctx: click.Context, args: list[str]
+    ) -> tuple[str | None, click.Command | None, list[str]]:
         try:
             return super().resolve_command(ctx, args)
         except click.UsageError:
@@ -125,7 +107,7 @@ def _callback(
         format=selected_format,
         interactive=selected_format is OutputFormat.rich and sys.stdin.isatty(),
     )
-    install_output_context(ctx, output)  # type: ignore[arg-type]
+    install_output_context(ctx, output)
     ctx.call_on_close(verify_output_emitted)
     load_dotenv(find_dotenv(usecwd=True))
 
@@ -244,11 +226,13 @@ def main(argv: list[str] | None = None) -> int:
         if isinstance(result, int) and result != 0:
             return result
         return 0
-    except _EXIT_EXCEPTIONS as e:
+    except click.exceptions.Exit as e:
         return e.exit_code
     except SystemExit as e:
         return int(e.code) if e.code is not None else 0
-    except _USAGE_EXCEPTIONS as exc:
+    except click.UsageError as exc:
+        # NoArgsIsHelpError (from no_args_is_help=True) has an empty message
+        # after help is already printed — just exit cleanly.
         if not str(exc):
             return 0
         return _handle_cli_error(exc, argv=argv, exit_code=exc.exit_code)

--- a/osmosis_ai/cli/main.py
+++ b/osmosis_ai/cli/main.py
@@ -1,8 +1,11 @@
 """Osmosis AI CLI — built with Typer."""
 
+from __future__ import annotations
+
 import difflib
 import sys
 import warnings
+from typing import Any
 
 import click
 import typer
@@ -35,9 +38,9 @@ from osmosis_ai.platform.auth.platform_client import (
 class OsmosisGroup(typer.core.TyperGroup):
     """Typer group with fuzzy command suggestion."""
 
-    def resolve_command(
-        self, ctx: click.Context, args: list[str]
-    ) -> tuple[str | None, click.Command | None, list[str]]:
+    def resolve_command(  # type: ignore[override]
+        self, ctx: Any, args: list[str]
+    ) -> tuple[str | None, Any, list[str]]:
         try:
             return super().resolve_command(ctx, args)
         except click.UsageError:
@@ -107,7 +110,7 @@ def _callback(
         format=selected_format,
         interactive=selected_format is OutputFormat.rich and sys.stdin.isatty(),
     )
-    install_output_context(ctx, output)
+    install_output_context(ctx, output)  # type: ignore[arg-type]
     ctx.call_on_close(verify_output_emitted)
     load_dotenv(find_dotenv(usecwd=True))
 

--- a/osmosis_ai/cli/main.py
+++ b/osmosis_ai/cli/main.py
@@ -10,6 +10,7 @@ from typing import Any
 import click
 import typer
 import typer.core
+from typer._click import exceptions as _typer_exc
 from dotenv import find_dotenv, load_dotenv
 
 from osmosis_ai.cli.errors import CLIError
@@ -229,13 +230,11 @@ def main(argv: list[str] | None = None) -> int:
         if isinstance(result, int) and result != 0:
             return result
         return 0
-    except click.exceptions.Exit as e:
+    except (click.exceptions.Exit, _typer_exc.Exit) as e:
         return e.exit_code
     except SystemExit as e:
         return int(e.code) if e.code is not None else 0
-    except click.UsageError as exc:
-        # NoArgsIsHelpError (from no_args_is_help=True) has an empty message
-        # after help is already printed — just exit cleanly.
+    except (click.UsageError, _typer_exc.UsageError) as exc:
         if not str(exc):
             return 0
         return _handle_cli_error(exc, argv=argv, exit_code=exc.exit_code)

--- a/osmosis_ai/cli/output/display.py
+++ b/osmosis_ai/cli/output/display.py
@@ -43,13 +43,22 @@ def created_column_label(
     return "Created"
 
 
+def _twelve_hour_time(dt: datetime, *, with_seconds: bool = False) -> str:
+    """12-hour clock time with AM/PM and no leading-zero hour (e.g. ``6:16 PM``)."""
+    hour = dt.hour % 12 or 12
+    meridiem = "AM" if dt.hour < 12 else "PM"
+    seconds = f":{dt.second:02d}" if with_seconds else ""
+    return f"{hour}:{dt.minute:02d}{seconds} {meridiem}"
+
+
 def format_local_date(
     value: str | None, *, now: datetime | None = None, tz: tzinfo | None = None
 ) -> str:
     parsed = _parse_iso_datetime(value)
     if parsed is None:
         return "" if value is None else str(value)[:10]
-    return _localize(parsed, tz=tz).strftime("%Y-%m-%d %H:%M %Z")
+    local = _localize(parsed, tz=tz)
+    return f"{local.strftime('%Y-%m-%d')} {_twelve_hour_time(local)} {local.strftime('%Z')}"
 
 
 def format_local_datetime(
@@ -58,4 +67,8 @@ def format_local_datetime(
     parsed = _parse_iso_datetime(value)
     if parsed is None:
         return "" if value is None else str(value)
-    return _localize(parsed, tz=tz).strftime("%Y-%m-%d %H:%M:%S %Z")
+    local = _localize(parsed, tz=tz)
+    return (
+        f"{local.strftime('%Y-%m-%d')} "
+        f"{_twelve_hour_time(local, with_seconds=True)} {local.strftime('%Z')}"
+    )

--- a/osmosis_ai/cli/output/error.py
+++ b/osmosis_ai/cli/output/error.py
@@ -7,7 +7,16 @@ import sys
 from typing import Any
 
 import click
-from typer._click import exceptions as _typer_exc
+
+try:
+    from typer._click import exceptions as _typer_exc
+
+    _USAGE_EXCEPTIONS: tuple[type[BaseException], ...] = (
+        click.UsageError,
+        _typer_exc.UsageError,
+    )
+except ImportError:
+    _USAGE_EXCEPTIONS = (click.UsageError,)
 
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.consts import PACKAGE_VERSION
@@ -97,7 +106,7 @@ def classify_error(exc: BaseException) -> CLIError:
             details=details,
         )
 
-    if isinstance(exc, (click.UsageError, _typer_exc.UsageError)):
+    if isinstance(exc, _USAGE_EXCEPTIONS):
         return CLIError(str(exc) or "Invalid usage.", code="VALIDATION")
 
     return CLIError(

--- a/osmosis_ai/cli/output/error.py
+++ b/osmosis_ai/cli/output/error.py
@@ -7,6 +7,7 @@ import sys
 from typing import Any
 
 import click
+from typer._click import exceptions as _typer_exc
 
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.consts import PACKAGE_VERSION
@@ -96,7 +97,7 @@ def classify_error(exc: BaseException) -> CLIError:
             details=details,
         )
 
-    if isinstance(exc, click.UsageError):
+    if isinstance(exc, (click.UsageError, _typer_exc.UsageError)):
         return CLIError(str(exc) or "Invalid usage.", code="VALIDATION")
 
     return CLIError(

--- a/osmosis_ai/cli/output/error.py
+++ b/osmosis_ai/cli/output/error.py
@@ -8,16 +8,6 @@ from typing import Any
 
 import click
 
-try:
-    from typer._click import exceptions as _typer_exc
-
-    _USAGE_EXCEPTIONS: tuple[type[BaseException], ...] = (
-        click.UsageError,
-        _typer_exc.UsageError,
-    )
-except ImportError:
-    _USAGE_EXCEPTIONS = (click.UsageError,)
-
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.consts import PACKAGE_VERSION
 
@@ -106,7 +96,7 @@ def classify_error(exc: BaseException) -> CLIError:
             details=details,
         )
 
-    if isinstance(exc, _USAGE_EXCEPTIONS):
+    if isinstance(exc, click.UsageError):
         return CLIError(str(exc) or "Invalid usage.", code="VALIDATION")
 
     return CLIError(

--- a/osmosis_ai/cli/output/serializers.py
+++ b/osmosis_ai/cli/output/serializers.py
@@ -118,6 +118,7 @@ def serialize_environment_secret(secret: EnvironmentSecretInfo) -> dict[str, Any
     return {
         "id": secret.id,
         "name": secret.name,
+        "scope": secret.scope,
         "created_at": secret.created_at,
         "updated_at": secret.updated_at,
         "creator_name": secret.creator_name,

--- a/osmosis_ai/cli/output/serializers.py
+++ b/osmosis_ai/cli/output/serializers.py
@@ -118,10 +118,12 @@ def serialize_environment_secret(secret: EnvironmentSecretInfo) -> dict[str, Any
     return {
         "id": secret.id,
         "name": secret.name,
-        "scope": secret.scope,
+        # User-facing scope vocabulary: the platform's wire "user" is "personal".
+        "scope": "personal" if secret.scope == "user" else secret.scope,
         "created_at": secret.created_at,
         "updated_at": secret.updated_at,
         "creator_name": secret.creator_name,
+        "updater_name": secret.updater_name,
     }
 
 

--- a/osmosis_ai/cli/prompts.py
+++ b/osmosis_ai/cli/prompts.py
@@ -402,6 +402,7 @@ def require_confirmation(
     message: str,
     *,
     yes: bool = False,
+    default: bool = True,
     summary: list[tuple[str, str]] | None = None,
     notes: list[str] | None = None,
     warnings: list[str] | None = None,
@@ -466,7 +467,7 @@ def require_confirmation(
             raise typer.Exit(1)
         raise err
 
-    if not confirm(message):
+    if not confirm(message, default=default):
         import typer
 
         from osmosis_ai.cli.console import console

--- a/osmosis_ai/platform/api/client.py
+++ b/osmosis_ai/platform/api/client.py
@@ -193,10 +193,9 @@ class OsmosisClient:
     ) -> SubmitRunResult:
         """Submit a new training run.
 
-        ``env_config`` is a literal env-var-name → value map applied to the
-        rollout container. ``secrets`` is a list of workspace
-        ``environment_secret`` names; their values are resolved server-side and
-        never travel through the CLI.
+        ``env_config`` is a literal env-var-name to value map applied to the
+        rollout container. ``secrets`` is a list of ``environment_secret`` names;
+        their values are resolved server-side and never travel through the CLI.
         """
         data: dict[str, Any] = {
             "experiment_config": experiment_config,

--- a/osmosis_ai/platform/api/client.py
+++ b/osmosis_ai/platform/api/client.py
@@ -212,7 +212,7 @@ class OsmosisClient:
         if env_config:
             data["env_config"] = env_config
         if secrets:
-            data["secrets"] = secrets
+            data["secrets"] = {"required": secrets}
         result = platform_request(
             "/api/cli/training-runs",
             method="POST",
@@ -506,7 +506,7 @@ class OsmosisClient:
         if env_config:
             data["env_config"] = env_config
         if secrets:
-            data["secrets"] = secrets
+            data["secrets"] = {"required": secrets}
         result = platform_request(
             "/api/cli/eval-runs",
             method="POST",

--- a/osmosis_ai/platform/api/client.py
+++ b/osmosis_ai/platform/api/client.py
@@ -320,19 +320,25 @@ class OsmosisClient:
         return PaginatedBaseModels.from_dict(data)
 
     # ── Environment Secrets ───────────────────────────────────────
-    # Workspace-scoped secrets. The platform never echoes secret values:
-    # list returns names + metadata only; create returns metadata only.
+    # Scoped secrets. The platform never echoes secret values:
+    # list returns names + metadata only; set returns metadata only.
 
     def list_environment_secrets(
         self,
         limit: int = DEFAULT_PAGE_SIZE,
         offset: int = 0,
         *,
+        scope: str = "all",
         credentials: Credentials | None = None,
         git_identity: str,
     ) -> PaginatedEnvironmentSecrets:
-        """List workspace environment secrets (names + metadata only)."""
-        qs = urlencode({"limit": limit, "offset": offset})
+        """List environment secrets (names + metadata only).
+
+        ``scope`` is one of ``"all"`` (workspace + the caller's personal
+        secrets), ``"workspace"``, or ``"user"`` (the caller's personal
+        secrets only). The platform never returns secret values.
+        """
+        qs = urlencode({"limit": limit, "offset": offset, "scope": scope})
         data = platform_request(
             f"/api/cli/environment-secrets?{qs}",
             credentials=credentials,
@@ -340,28 +346,50 @@ class OsmosisClient:
         )
         return PaginatedEnvironmentSecrets.from_dict(data)
 
-    def create_environment_secret(
+    def set_environment_secret(
         self,
         name: str,
         value: str,
         *,
+        scope: str,
         credentials: Credentials | None = None,
         git_identity: str,
     ) -> EnvironmentSecretInfo:
-        """Create a workspace environment secret.
+        """Create or update (upsert) an environment secret.
 
-        The secret ``value`` is sent once in the request body and is never
-        returned by the platform — the response carries only metadata
-        (id, name, timestamps). Callers must not log or echo ``value``.
+        ``scope`` is ``"workspace"`` or ``"user"``. The secret ``value`` is
+        sent once in the request body and is never returned by the platform —
+        the response carries only metadata. Callers must not log or echo
+        ``value``.
         """
         data = platform_request(
             "/api/cli/environment-secrets",
             method="POST",
-            data={"name": name, "value": value},
+            data={"name": name, "value": value, "scope": scope},
             credentials=credentials,
             git_identity=git_identity,
         )
         return EnvironmentSecretInfo.from_dict(data)
+
+    def delete_environment_secret(
+        self,
+        name: str,
+        *,
+        scope: str,
+        credentials: Credentials | None = None,
+        git_identity: str,
+    ) -> None:
+        """Delete an environment secret by name within ``scope``.
+
+        ``scope`` is ``"workspace"`` or ``"user"``.
+        """
+        platform_request(
+            "/api/cli/environment-secrets",
+            method="DELETE",
+            data={"name": name, "scope": scope},
+            credentials=credentials,
+            git_identity=git_identity,
+        )
 
     # ── Deployments ───────────────────────────────────────────────
     # All mutating endpoints key off `checkpoint` (UUID or checkpoint_name).

--- a/osmosis_ai/platform/api/client.py
+++ b/osmosis_ai/platform/api/client.py
@@ -187,16 +187,16 @@ class OsmosisClient:
         checkpoints_config: dict[str, Any] | None = None,
         advanced_config: dict[str, Any] | None = None,
         env_config: dict[str, str] | None = None,
-        secret_refs_config: dict[str, str] | None = None,
+        secrets: list[str] | None = None,
         credentials: Credentials | None = None,
         git_identity: str,
     ) -> SubmitRunResult:
         """Submit a new training run.
 
         ``env_config`` is a literal env-var-name → value map applied to the
-        rollout container. ``secret_refs_config`` maps env-var names to the
-        names of workspace ``environment_secret`` records; values are resolved
-        server-side and never travel through the CLI.
+        rollout container. ``secrets`` is a list of workspace
+        ``environment_secret`` names; their values are resolved server-side and
+        never travel through the CLI.
         """
         data: dict[str, Any] = {
             "experiment_config": experiment_config,
@@ -211,8 +211,8 @@ class OsmosisClient:
             data["advanced_config"] = advanced_config
         if env_config:
             data["env_config"] = env_config
-        if secret_refs_config:
-            data["secret_refs_config"] = secret_refs_config
+        if secrets:
+            data["secrets"] = secrets
         result = platform_request(
             "/api/cli/training-runs",
             method="POST",
@@ -463,7 +463,7 @@ class OsmosisClient:
         evaluation_config: dict[str, Any] | None = None,
         advanced_config: dict[str, Any] | None = None,
         env_config: dict[str, str] | None = None,
-        secret_refs_config: dict[str, str] | None = None,
+        secrets: list[str] | None = None,
         credentials: Credentials | None = None,
         git_identity: str,
     ) -> SubmitRunResult:
@@ -477,8 +477,8 @@ class OsmosisClient:
             data["advanced_config"] = advanced_config
         if env_config:
             data["env_config"] = env_config
-        if secret_refs_config:
-            data["secret_refs_config"] = secret_refs_config
+        if secrets:
+            data["secrets"] = secrets
         result = platform_request(
             "/api/cli/eval-runs",
             method="POST",

--- a/osmosis_ai/platform/api/models.py
+++ b/osmosis_ai/platform/api/models.py
@@ -470,6 +470,9 @@ class EnvironmentSecretInfo:
     created_at: str = ""
     updated_at: str = ""
     creator_name: str | None = None
+    # "workspace" or "user". None when the platform did not report it
+    # (older responses / endpoints that don't distinguish scope).
+    scope: str | None = None
     # Page/operation-level link to the secrets console page. Populated by the
     # platform on create (and exposed at the list level via
     # ``PaginatedEnvironmentSecrets.platform_url``); ``None`` for list items.
@@ -483,6 +486,7 @@ class EnvironmentSecretInfo:
             created_at=data.get("created_at", ""),
             updated_at=data.get("updated_at", ""),
             creator_name=data.get("creator_name"),
+            scope=data.get("scope"),
             platform_url=data.get("platform_url"),
         )
 

--- a/osmosis_ai/platform/api/models.py
+++ b/osmosis_ai/platform/api/models.py
@@ -470,6 +470,7 @@ class EnvironmentSecretInfo:
     created_at: str = ""
     updated_at: str = ""
     creator_name: str | None = None
+    updater_name: str | None = None
     # "workspace" or "user". None when the platform did not report it
     # (older responses / endpoints that don't distinguish scope).
     scope: str | None = None
@@ -486,6 +487,7 @@ class EnvironmentSecretInfo:
             created_at=data.get("created_at", ""),
             updated_at=data.get("updated_at", ""),
             creator_name=data.get("creator_name"),
+            updater_name=data.get("updater_name"),
             scope=data.get("scope"),
             platform_url=data.get("platform_url"),
         )

--- a/osmosis_ai/platform/cli/eval.py
+++ b/osmosis_ai/platform/cli/eval.py
@@ -16,7 +16,6 @@ from osmosis_ai.cli.output import (
     serialize_eval_run,
 )
 from osmosis_ai.cli.output.display import (
-    created_column_label,
     format_local_date,
     format_local_datetime,
 )
@@ -157,13 +156,8 @@ def list_eval_runs(*, limit: int, all_: bool) -> ListResult:
             ListColumn(key="rollout", label="Rollout", ratio=2, overflow="fold"),
             ListColumn(key="status", label="Status", no_wrap=True, ratio=1),
             ListColumn(key="model", label="Model", no_wrap=True, ratio=2),
+            ListColumn(key="created_at", label="Submitted", no_wrap=True, ratio=1),
             ListColumn(key="creator_name", label="Submitted By", no_wrap=True, ratio=1),
-            ListColumn(
-                key="created_at",
-                label=created_column_label(),
-                no_wrap=True,
-                ratio=1,
-            ),
         ],
         display_items=[
             {

--- a/osmosis_ai/platform/cli/eval.py
+++ b/osmosis_ai/platform/cli/eval.py
@@ -74,12 +74,14 @@ def _eval_next_steps(
 ) -> tuple[list[str], list[dict[str, Any]]]:
     display = [
         f"Status: {result.status}",
+        f"Rollout: {_config.experiment_rollout}",
+        f"Model: {_config.experiment_model_path}",
+        f"Dataset: {_config.experiment_dataset}",
         (
             f"View: {result.platform_url}"
             if result.platform_url
             else f"Check status with: osmosis eval info {result.name}"
         ),
-        "List all evaluation runs with: osmosis eval list",
     ]
     structured: list[dict[str, Any]] = [
         {"action": "eval_info", "name": result.name},

--- a/osmosis_ai/platform/cli/eval.py
+++ b/osmosis_ai/platform/cli/eval.py
@@ -265,6 +265,7 @@ def stop(name_or_id: str, *, yes: bool) -> OperationResult:
     require_confirmation(
         f'Stop evaluation run "{name_or_id}"?',
         yes=yes,
+        default=False,
         summary=[("Name", name_or_id)],
     )
 

--- a/osmosis_ai/platform/cli/eval.py
+++ b/osmosis_ai/platform/cli/eval.py
@@ -64,7 +64,7 @@ def _submit_eval(
         evaluation_config=config.evaluation_config or None,
         advanced_config=config.advanced_config or None,
         env_config=config.env or None,
-        secret_refs_config=config.secrets or None,
+        secrets=config.secrets or None,
         credentials=credentials,
         git_identity=git_identity,
     )

--- a/osmosis_ai/platform/cli/eval_config.py
+++ b/osmosis_ai/platform/cli/eval_config.py
@@ -45,6 +45,7 @@ def load_eval_submit_config(path: Path) -> EvalSubmitConfig:
         config_class=EvalSubmitConfig,
         extra_sections=[("evaluation", _EvaluationSection)],
         config_label=_EVAL_CONFIG_LABEL,
+        secrets_section_required=True,
     )
 
 

--- a/osmosis_ai/platform/cli/secret.py
+++ b/osmosis_ai/platform/cli/secret.py
@@ -244,7 +244,9 @@ def list_secrets(*, limit: int, all_: bool, scope: str = "all") -> ListResult:
     )
 
 
-def set_secret(*, name: str, scope: str, env: str | None) -> OperationResult:
+def set_secret(
+    *, name: str, scope: str = "personal", env: str | None = None
+) -> OperationResult:
     """Create or update (upsert) a secret.
 
     The value is read from ``--env VARNAME`` or a hidden interactive prompt,
@@ -306,7 +308,7 @@ def set_secret(*, name: str, scope: str, env: str | None) -> OperationResult:
         operation="secret.set",
         status="success",
         resource=resource,
-        message=f'Secret "{name}" saved.',
+        message=f'Secret "{name}" saved in {scope} scope.',
         display_next_steps=display_next_steps,
         next_steps_structured=next_steps_structured,
         extra=extra,
@@ -339,7 +341,9 @@ def _existing_secret_names(
         return None
 
 
-def delete_secret(*, name: str, scope: str, yes: bool) -> OperationResult:
+def delete_secret(
+    *, name: str, scope: str = "personal", yes: bool = False
+) -> OperationResult:
     """Delete a secret by name within ``scope``.
 
     ``scope`` is ``"workspace"`` or ``"personal"``. Requires confirmation
@@ -403,5 +407,5 @@ def delete_secret(*, name: str, scope: str, yes: bool) -> OperationResult:
         operation="secret.delete",
         status="success",
         resource=resource,
-        message=f'Secret "{name}" deleted.',
+        message=f'Secret "{name}" deleted from {scope} scope.',
     )

--- a/osmosis_ai/platform/cli/secret.py
+++ b/osmosis_ai/platform/cli/secret.py
@@ -1,4 +1,4 @@
-"""Business logic for ``osmosis secret`` (list + add).
+"""Business logic for ``osmosis secret`` (set, list, delete).
 
 Security invariants for this module:
   * The secret *value* travels through this process only to be POSTed once.
@@ -156,8 +156,17 @@ def _redact_secret_platform_error(exc: Any, secret_value: str) -> Any:
     )
 
 
-def list_secrets(*, limit: int, all_: bool) -> ListResult:
-    """List workspace secrets (names + metadata only; values are never returned)."""
+def list_secrets(*, limit: int, all_: bool, scope: str = "all") -> ListResult:
+    """List environment secrets (names + metadata only; values never shown).
+
+    ``scope`` is ``"all"`` (workspace + the caller's personal secrets),
+    ``"workspace"``, or ``"user"`` (personal only).
+    """
+    if scope not in _VALID_LIST_SCOPES:
+        raise CLIError(
+            "Scope must be 'all', 'workspace', or 'user'.",
+            code="VALIDATION",
+        )
     effective_limit, fetch_all = validate_list_options(limit=limit, all_=all_)
 
     context = require_git_workspace_directory_context()
@@ -174,6 +183,7 @@ def list_secrets(*, limit: int, all_: bool) -> ListResult:
         page = client.list_environment_secrets(
             limit=lim,
             offset=off,
+            scope=scope,
             credentials=credentials,
             git_identity=context.git_identity,
         )
@@ -211,12 +221,14 @@ def list_secrets(*, limit: int, all_: bool) -> ListResult:
         extra=extra,
         columns=[
             ListColumn(key="name", label="Name", ratio=3, overflow="fold"),
+            ListColumn(key="scope", label="Scope", no_wrap=True, ratio=1),
             ListColumn(key="created_at", label="Added", no_wrap=True, ratio=1),
             ListColumn(key="creator_name", label="Added by", no_wrap=True, ratio=1),
         ],
         display_items=[
             {
                 **serialize_environment_secret(s),
+                "scope": s.scope or "—",
                 "created_at": format_local_date(s.created_at),
                 "creator_name": s.creator_name or "—",
             }
@@ -226,13 +238,14 @@ def list_secrets(*, limit: int, all_: bool) -> ListResult:
     )
 
 
-def add_secret(*, name: str, env: str | None) -> OperationResult:
-    """Add a workspace secret.
+def set_secret(*, name: str, scope: str, env: str | None) -> OperationResult:
+    """Create or update (upsert) an environment secret.
 
     The value is read from ``--env VARNAME`` or a hidden interactive prompt,
     POSTed once, and immediately discarded. It never appears in the result.
     """
     _validate_secret_name(name)
+    _validate_scope(scope)
 
     output = get_output_context()
     if env is None and (
@@ -245,7 +258,7 @@ def add_secret(*, name: str, env: str | None) -> OperationResult:
     value = _resolve_secret_value(env=env, output=output)
     if value is None:
         return OperationResult(
-            operation="secret.add",
+            operation="secret.set",
             status="cancelled",
             resource=git_result_context(context),
             message="Cancelled.",
@@ -255,10 +268,11 @@ def add_secret(*, name: str, env: str | None) -> OperationResult:
     from osmosis_ai.platform.auth.platform_client import PlatformAPIError
 
     try:
-        with output.status(f'Adding secret "{name}"...'):
-            secret = client.create_environment_secret(
+        with output.status(f'Saving secret "{name}"...'):
+            secret = client.set_environment_secret(
                 name,
                 value,
+                scope=scope,
                 credentials=context.credentials,
                 git_identity=context.git_identity,
             )
@@ -283,11 +297,48 @@ def add_secret(*, name: str, env: str | None) -> OperationResult:
         )
 
     return OperationResult(
-        operation="secret.add",
+        operation="secret.set",
         status="success",
         resource=resource,
-        message=f'Secret "{name}" added.',
+        message=f'Secret "{name}" saved.',
         display_next_steps=display_next_steps,
         next_steps_structured=next_steps_structured,
         extra=extra,
+    )
+
+
+def delete_secret(*, name: str, scope: str, yes: bool) -> OperationResult:
+    """Delete an environment secret by name within ``scope``.
+
+    ``scope`` is ``"workspace"`` or ``"user"``. Requires confirmation
+    (``--yes`` to skip). Workspace deletion is additionally role-gated
+    server-side (admin/owner).
+    """
+    _validate_secret_name(name)
+    _validate_scope(scope)
+
+    context = require_git_workspace_directory_context()
+
+    require_confirmation(
+        f'Delete {scope} secret "{name}"? This cannot be undone.',
+        yes=yes,
+        summary=[("Name", name), ("Scope", scope)],
+    )
+
+    client = OsmosisClient()
+    with get_output_context().status(f'Deleting secret "{name}"...'):
+        client.delete_environment_secret(
+            name,
+            scope=scope,
+            credentials=context.credentials,
+            git_identity=context.git_identity,
+        )
+
+    resource: dict[str, Any] = {"name": name, "scope": scope}
+    resource.update(git_result_context(context))
+    return OperationResult(
+        operation="secret.delete",
+        status="success",
+        resource=resource,
+        message=f'Secret "{name}" deleted.',
     )

--- a/osmosis_ai/platform/cli/secret.py
+++ b/osmosis_ai/platform/cli/secret.py
@@ -60,6 +60,20 @@ def _validate_secret_name(name: str) -> None:
         )
 
 
+def _validate_secret_name_for_lookup(name: str) -> None:
+    """Lenient name check for delete — mirrors the platform's ``environmentSecretNameLookupSchema``.
+
+    Only enforces non-empty and max 255 chars; no character-set restriction.
+    This allows legacy-named secrets (lowercase/dashes, created before the
+    SCREAMING_SNAKE rule) to still be deleted via the CLI.
+    """
+    if not name or len(name) > _SECRET_NAME_MAX:
+        raise CLIError(
+            "Secret name must be between 1 and 255 characters.",
+            code="VALIDATION",
+        )
+
+
 def _validate_scope(scope: str) -> None:
     if scope not in _VALID_SCOPES:
         raise CLIError(
@@ -313,8 +327,12 @@ def delete_secret(*, name: str, scope: str, yes: bool) -> OperationResult:
     ``scope`` is ``"workspace"`` or ``"user"``. Requires confirmation
     (``--yes`` to skip). Workspace deletion is additionally role-gated
     server-side (admin/owner).
+
+    Name validation uses the lenient lookup schema (non-empty, max 255 chars)
+    rather than the strict SCREAMING_SNAKE rule so that legacy-named secrets
+    (created before the naming convention was enforced) can still be deleted.
     """
-    _validate_secret_name(name)
+    _validate_secret_name_for_lookup(name)
     _validate_scope(scope)
 
     context = require_git_workspace_directory_context()

--- a/osmosis_ai/platform/cli/secret.py
+++ b/osmosis_ai/platform/cli/secret.py
@@ -13,7 +13,6 @@ Security invariants for this module:
 from __future__ import annotations
 
 import os
-import re
 from typing import Any
 
 from osmosis_ai.cli.errors import CLIError
@@ -26,7 +25,9 @@ from osmosis_ai.cli.output import (
     serialize_environment_secret,
 )
 from osmosis_ai.cli.output.display import format_local_date
+from osmosis_ai.cli.prompts import require_confirmation
 from osmosis_ai.platform.api.client import OsmosisClient
+from osmosis_ai.platform.cli.shared_config import SECRET_NAME_RE
 from osmosis_ai.platform.cli.utils import (
     fetch_all_pages,
     require_git_workspace_directory_context,
@@ -34,12 +35,15 @@ from osmosis_ai.platform.cli.utils import (
 )
 from osmosis_ai.platform.cli.workspace_directory_context import git_result_context
 
-# Mirror the platform's ``environmentSecretNameSchema`` so we fail fast with a
-# clear local message instead of round-tripping an obviously invalid name —
-# and so the name (never the value) is the only thing a validation error
-# can reference.
-_SECRET_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+# Mirror the platform's ``environmentSecretNameSchema`` (^[A-Z][A-Z0-9_]*$):
+# uppercase env-var style so a referencing config's [env]-style name and the
+# secret record name are the same shape. Validating fails fast locally and,
+# because only the name (never the value) is referenced, can never leak a value.
+_SECRET_NAME_RE = SECRET_NAME_RE
 _SECRET_NAME_MAX = 255
+
+_VALID_SCOPES = ("workspace", "user")
+_VALID_LIST_SCOPES = ("all", "workspace", "user")
 
 
 def _validate_secret_name(name: str) -> None:
@@ -50,7 +54,16 @@ def _validate_secret_name(name: str) -> None:
         )
     if not _SECRET_NAME_RE.fullmatch(name):
         raise CLIError(
-            "Secret name may only contain letters, digits, '_' and '-'.",
+            "Secret name must match ^[A-Z][A-Z0-9_]*$ "
+            "(uppercase letters, digits and '_', starting with a letter).",
+            code="VALIDATION",
+        )
+
+
+def _validate_scope(scope: str) -> None:
+    if scope not in _VALID_SCOPES:
+        raise CLIError(
+            "Scope must be 'workspace' or 'user'.",
             code="VALIDATION",
         )
 

--- a/osmosis_ai/platform/cli/secret.py
+++ b/osmosis_ai/platform/cli/secret.py
@@ -42,8 +42,14 @@ from osmosis_ai.platform.cli.workspace_directory_context import git_result_conte
 _SECRET_NAME_RE = SECRET_NAME_RE
 _SECRET_NAME_MAX = 255
 
-_VALID_SCOPES = ("workspace", "user")
-_VALID_LIST_SCOPES = ("all", "workspace", "user")
+# User-facing scope vocabulary is "personal"/"workspace"; the platform wire
+# value for a personal secret is "user", so translate at the API boundary.
+_VALID_SCOPES = ("workspace", "personal")
+_VALID_LIST_SCOPES = ("all", "workspace", "personal")
+_SCOPE_TO_WIRE = {"all": "all", "workspace": "workspace", "personal": "user"}
+
+# Human-facing labels for the scope column (the raw wire values stay in JSON output).
+_SCOPE_DISPLAY = {"workspace": "Workspace", "user": "Personal"}
 
 
 def _validate_secret_name(name: str) -> None:
@@ -60,24 +66,10 @@ def _validate_secret_name(name: str) -> None:
         )
 
 
-def _validate_secret_name_for_lookup(name: str) -> None:
-    """Lenient name check for delete — mirrors the platform's ``environmentSecretNameLookupSchema``.
-
-    Only enforces non-empty and max 255 chars; no character-set restriction.
-    This allows legacy-named secrets (lowercase/dashes, created before the
-    SCREAMING_SNAKE rule) to still be deleted via the CLI.
-    """
-    if not name or len(name) > _SECRET_NAME_MAX:
-        raise CLIError(
-            "Secret name must be between 1 and 255 characters.",
-            code="VALIDATION",
-        )
-
-
 def _validate_scope(scope: str) -> None:
     if scope not in _VALID_SCOPES:
         raise CLIError(
-            "Scope must be 'workspace' or 'user'.",
+            "Scope must be 'workspace' or 'personal'.",
             code="VALIDATION",
         )
 
@@ -171,14 +163,14 @@ def _redact_secret_platform_error(exc: Any, secret_value: str) -> Any:
 
 
 def list_secrets(*, limit: int, all_: bool, scope: str = "all") -> ListResult:
-    """List environment secrets (names + metadata only; values never shown).
+    """List secrets (names + metadata only; values never shown).
 
     ``scope`` is ``"all"`` (workspace + the caller's personal secrets),
-    ``"workspace"``, or ``"user"`` (personal only).
+    ``"workspace"``, or ``"personal"`` (personal only).
     """
     if scope not in _VALID_LIST_SCOPES:
         raise CLIError(
-            "Scope must be 'all', 'workspace', or 'user'.",
+            "Scope must be 'all', 'workspace', or 'personal'.",
             code="VALIDATION",
         )
     effective_limit, fetch_all = validate_list_options(limit=limit, all_=all_)
@@ -197,7 +189,7 @@ def list_secrets(*, limit: int, all_: bool, scope: str = "all") -> ListResult:
         page = client.list_environment_secrets(
             limit=lim,
             offset=off,
-            scope=scope,
+            scope=_SCOPE_TO_WIRE[scope],
             credentials=credentials,
             git_identity=context.git_identity,
         )
@@ -236,15 +228,17 @@ def list_secrets(*, limit: int, all_: bool, scope: str = "all") -> ListResult:
         columns=[
             ListColumn(key="name", label="Name", ratio=3, overflow="fold"),
             ListColumn(key="scope", label="Scope", no_wrap=True, ratio=1),
-            ListColumn(key="created_at", label="Added", no_wrap=True, ratio=1),
-            ListColumn(key="creator_name", label="Added by", no_wrap=True, ratio=1),
+            ListColumn(key="updated_at", label="Updated", no_wrap=True, ratio=1),
+            ListColumn(
+                key="updater_name", label="Updated By", no_wrap=True, ratio=1
+            ),
         ],
         display_items=[
             {
                 **serialize_environment_secret(s),
-                "scope": s.scope or "—",
-                "created_at": format_local_date(s.created_at),
-                "creator_name": s.creator_name or "—",
+                "scope": _SCOPE_DISPLAY.get(s.scope, "—"),
+                "updated_at": format_local_date(s.updated_at),
+                "updater_name": s.updater_name or "—",
             }
             for s in secrets
         ],
@@ -253,7 +247,7 @@ def list_secrets(*, limit: int, all_: bool, scope: str = "all") -> ListResult:
 
 
 def set_secret(*, name: str, scope: str, env: str | None) -> OperationResult:
-    """Create or update (upsert) an environment secret.
+    """Create or update (upsert) a secret.
 
     The value is read from ``--env VARNAME`` or a hidden interactive prompt,
     POSTed once, and immediately discarded. It never appears in the result.
@@ -286,7 +280,7 @@ def set_secret(*, name: str, scope: str, env: str | None) -> OperationResult:
             secret = client.set_environment_secret(
                 name,
                 value,
-                scope=scope,
+                scope=_SCOPE_TO_WIRE[scope],
                 credentials=context.credentials,
                 git_identity=context.git_identity,
             )
@@ -321,33 +315,86 @@ def set_secret(*, name: str, scope: str, env: str | None) -> OperationResult:
     )
 
 
-def delete_secret(*, name: str, scope: str, yes: bool) -> OperationResult:
-    """Delete an environment secret by name within ``scope``.
+def _existing_secret_names(
+    client: OsmosisClient,
+    *,
+    scope: str,
+    credentials: Any,
+    git_identity: str,
+) -> set[str] | None:
+    """Names that exist in ``scope`` (a wire value). ``None`` if the lookup fails,
+    so a transient error falls back to letting the platform validate."""
+    try:
 
-    ``scope`` is ``"workspace"`` or ``"user"``. Requires confirmation
+        def _fetch(limit: int, offset: int) -> Any:
+            return client.list_environment_secrets(
+                limit=limit,
+                offset=offset,
+                scope=scope,
+                credentials=credentials,
+                git_identity=git_identity,
+            )
+
+        secrets, _ = fetch_all_pages(_fetch, items_attr="environment_secrets")
+        return {s.name for s in secrets}
+    except Exception:
+        return None
+
+
+def delete_secret(*, name: str, scope: str, yes: bool) -> OperationResult:
+    """Delete a secret by name within ``scope``.
+
+    ``scope`` is ``"workspace"`` or ``"personal"``. Requires confirmation
     (``--yes`` to skip). Workspace deletion is additionally role-gated
     server-side (admin/owner).
-
-    Name validation uses the lenient lookup schema (non-empty, max 255 chars)
-    rather than the strict SCREAMING_SNAKE rule so that legacy-named secrets
-    (created before the naming convention was enforced) can still be deleted.
     """
-    _validate_secret_name_for_lookup(name)
+    _validate_secret_name(name)
     _validate_scope(scope)
 
     context = require_git_workspace_directory_context()
+    client = OsmosisClient()
+    wire_scope = _SCOPE_TO_WIRE[scope]
+
+    # Fail before prompting if the secret doesn't exist in the requested scope,
+    # so a typo or wrong --scope is reported immediately instead of after a Y/n.
+    existing = _existing_secret_names(
+        client,
+        scope=wire_scope,
+        credentials=context.credentials,
+        git_identity=context.git_identity,
+    )
+    if existing is not None and name not in existing:
+        other_scope = "personal" if scope == "workspace" else "workspace"
+        other_wire = _SCOPE_TO_WIRE[other_scope]
+        other_names = _existing_secret_names(
+            client,
+            scope=other_wire,
+            credentials=context.credentials,
+            git_identity=context.git_identity,
+        )
+        if other_names is not None and name in other_names:
+            raise CLIError(
+                f'Secret "{name}" not found in {scope} scope.'
+                f"\nDid you mean: osmosis secret delete {name}"
+                f" --scope {other_scope}",
+                code="NOT_FOUND",
+            )
+        raise CLIError(
+            f'Secret "{name}" not found.',
+            code="NOT_FOUND",
+        )
 
     require_confirmation(
         f'Delete {scope} secret "{name}"? This cannot be undone.',
         yes=yes,
+        default=False,
         summary=[("Name", name), ("Scope", scope)],
     )
 
-    client = OsmosisClient()
     with get_output_context().status(f'Deleting secret "{name}"...'):
         client.delete_environment_secret(
             name,
-            scope=scope,
+            scope=wire_scope,
             credentials=context.credentials,
             git_identity=context.git_identity,
         )

--- a/osmosis_ai/platform/cli/secret.py
+++ b/osmosis_ai/platform/cli/secret.py
@@ -229,9 +229,7 @@ def list_secrets(*, limit: int, all_: bool, scope: str = "all") -> ListResult:
             ListColumn(key="name", label="Name", ratio=3, overflow="fold"),
             ListColumn(key="scope", label="Scope", no_wrap=True, ratio=1),
             ListColumn(key="updated_at", label="Updated", no_wrap=True, ratio=1),
-            ListColumn(
-                key="updater_name", label="Updated By", no_wrap=True, ratio=1
-            ),
+            ListColumn(key="updater_name", label="Updated By", no_wrap=True, ratio=1),
         ],
         display_items=[
             {

--- a/osmosis_ai/platform/cli/shared_config.py
+++ b/osmosis_ai/platform/cli/shared_config.py
@@ -124,29 +124,44 @@ def read_toml_table(
     return section
 
 
-def read_toml_secrets_list(raw: dict[str, Any], path: Path) -> list[str]:
-    """Read the top-level ``secrets`` array.
+def read_toml_secrets_required(raw: dict[str, Any], path: Path) -> list[str]:
+    """Read the ``required`` array from the ``[secrets]`` table.
 
-    The ``[secrets]`` *table* (map) form is no longer supported and raises a
+    Legacy ``[secrets]`` key=value pairs (``NAME = "secret-id"``) raise a
     :class:`CLIError` with a conversion hint.
     """
     if "secrets" not in raw:
         return []
 
     value = raw["secrets"]
-    if isinstance(value, dict):
+    if not isinstance(value, dict):
         raise CLIError(
-            f"The [secrets] map form is no longer supported in {path}. "
-            'Use a list: secrets = ["NAME", ...]. '
-            'For example, [secrets] with OPENAI_API_KEY = "OPENAI_API_KEY" '
-            'becomes secrets = ["OPENAI_API_KEY"].'
+            f"[secrets] in {path} must be a table with a 'required' array, "
+            'e.g.\n[secrets]\nrequired = ["OPENAI_API_KEY"].'
         )
-    if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
+
+    if "required" not in value:
+        if value:
+            old_keys = ", ".join(value)
+            quoted = ", ".join(f'"{k}"' for k in value)
+            raise CLIError(
+                f"[secrets] in {path} uses key=value pairs (i.e. {old_keys}), "
+                "which is no longer supported. "
+                "Replace with a required array, e.g.:\n\n"
+                "[secrets]\n"
+                f"required = [{quoted}]"
+            )
+        return []
+
+    required = value["required"]
+    if not isinstance(required, list) or not all(
+        isinstance(item, str) for item in required
+    ):
         raise CLIError(
-            f"'secrets' in {path} must be a list of strings, "
-            'e.g. secrets = ["OPENAI_API_KEY", "DATABASE_URL"].'
+            f"'required' in [secrets] of {path} must be a list of strings, "
+            'e.g. required = ["OPENAI_API_KEY", "GITHUB_TOKEN"].'
         )
-    return value
+    return required
 
 
 def format_input(value: Any) -> str:
@@ -292,18 +307,24 @@ def validate_secret_names(
     env: dict[str, str],
     path: Path,
 ) -> None:
-    """Validate each secret name and reject overlap with [env] keys."""
+    """Validate each secret name, reject duplicates and overlap with [env] keys."""
+    duplicates = sorted({name for name in secrets if secrets.count(name) > 1})
+    if duplicates:
+        raise CLIError(
+            f"Duplicate secret name(s) in [secrets].required of {path}: "
+            f"{', '.join(duplicates)}. Each name must appear once."
+        )
+
     for name in secrets:
         if not SECRET_NAME_RE.match(name):
             raise CLIError(
-                f"Invalid secret name '{name}' in {path}: "
-                "use SCREAMING_SNAKE_CASE (uppercase letters, digits, "
-                "underscores; must start with a letter). "
-                "Must match ^[A-Z][A-Z0-9_]*$."
+                f"Invalid secret name '{name}' in {path}: use uppercase "
+                "letters, digits, and underscores, starting with a letter "
+                "(e.g. MY_SECRET). Must match ^[A-Z][A-Z0-9_]*$."
             )
         if name.startswith(RESERVED_ENV_PREFIX):
             raise CLIError(
-                f"'{name}' in secrets of {path}: names starting with "
+                f"'{name}' in [secrets] of {path}: names starting with "
                 f"{RESERVED_ENV_PREFIX} are reserved by the platform; "
                 "choose a different name."
             )
@@ -312,7 +333,7 @@ def validate_secret_names(
     if overlap:
         names = ", ".join(overlap)
         raise CLIError(
-            f"Name(s) appear in both [env] and secrets of {path}: "
+            f"Name(s) appear in both [env] and [secrets] of {path}: "
             f"{names}. Each env var name must come from exactly one place."
         )
 
@@ -415,7 +436,7 @@ def load_submit_config[SubmitConfigT: BaseSubmitConfig](
     }
     advanced_section = read_toml_table(raw, "advanced", path)
     env_section = read_toml_table(raw, "env", path)
-    secrets_list = read_toml_secrets_list(raw, path)
+    secrets_list = read_toml_secrets_required(raw, path)
 
     allowed_sections = frozenset(
         {
@@ -484,12 +505,36 @@ def build_submit_summary_rows(
     ]
     if commit_sha:
         rows.append(("Commit", commit_sha))
-    if env:
-        env_keys = ", ".join(sorted(env))
-        rows.append((f"Rollout env ({len(env)})", env_keys))
-    if secrets:
-        secret_names = ", ".join(sorted(secrets))
-        rows.append((f"Rollout secrets ({len(secrets)})", secret_names))
+    return rows
+
+
+def build_env_table_rows(env: dict[str, str]) -> list[tuple[str, str]]:
+    """Build (name, value) rows for the env vars table, sorted by name."""
+    return [(name, value) for name, value in sorted(env.items())]
+
+
+def build_secret_table_rows(
+    secrets: list[str],
+    *,
+    user_secret_names: set[str],
+    workspace_secret_names: set[str],
+) -> list[tuple[str, str]]:
+    """Build (name, scope) rows for the secrets table, sorted by name.
+
+    A personal secret is labeled an override only when a workspace secret of
+    the same name also exists; otherwise it is a personal-only secret.
+    """
+    rows: list[tuple[str, str]] = []
+    for name in sorted(secrets):
+        if name in user_secret_names:
+            label = (
+                "Personal (overrides workspace)"
+                if name in workspace_secret_names
+                else "Personal"
+            )
+        else:
+            label = "Workspace"
+        rows.append((name, label))
     return rows
 
 
@@ -518,6 +563,8 @@ __all__ = [
     "BackendValidatedParamSection",
     "BaseSubmitConfig",
     "ExperimentSection",
+    "build_env_table_rows",
+    "build_secret_table_rows",
     "build_submit_summary_rows",
     "collect_section_validation_issues",
     "collect_top_level_validation_issues",

--- a/osmosis_ai/platform/cli/shared_config.py
+++ b/osmosis_ai/platform/cli/shared_config.py
@@ -123,6 +123,31 @@ def read_toml_table(
     return section
 
 
+def read_toml_secrets_list(raw: dict[str, Any], path: Path) -> list[str]:
+    """Read the top-level ``secrets`` array.
+
+    The ``[secrets]`` *table* (map) form is no longer supported and raises a
+    :class:`CLIError` with a conversion hint.
+    """
+    if "secrets" not in raw:
+        return []
+
+    value = raw["secrets"]
+    if isinstance(value, dict):
+        raise CLIError(
+            f"The [secrets] map form is no longer supported in {path}. "
+            'Use a list: secrets = ["NAME", ...]. '
+            'For example, [secrets] with OPENAI_API_KEY = "OPENAI_API_KEY" '
+            'becomes secrets = ["OPENAI_API_KEY"].'
+        )
+    if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
+        raise CLIError(
+            f"'secrets' in {path} must be a list of strings, "
+            'e.g. secrets = ["OPENAI_API_KEY", "DATABASE_URL"].'
+        )
+    return value
+
+
 def format_input(value: Any) -> str:
     return repr(value)
 
@@ -270,6 +295,16 @@ def validate_env_var_keys(
         )
 
 
+def validate_secret_names(
+    *,
+    secrets: list[str],
+    env: dict[str, str],
+    path: Path,
+) -> None:
+    """Validate each secret name and reject overlap with [env] keys."""
+    return None
+
+
 class ExperimentSection(BaseModel):
     """``[experiment]`` table — shared between train and eval submit configs."""
 
@@ -306,7 +341,7 @@ class BaseSubmitConfig(BaseModel):
         default_factory=AdvancedPassthroughSection
     )
     env: dict[str, str] = Field(default_factory=dict)
-    secrets: dict[str, str] = Field(default_factory=dict)
+    secrets: list[str] = Field(default_factory=list)
 
     @property
     def experiment_rollout(self) -> str:
@@ -368,7 +403,7 @@ def load_submit_config[SubmitConfigT: BaseSubmitConfig](
     }
     advanced_section = read_toml_table(raw, "advanced", path)
     env_section = read_toml_table(raw, "env", path)
-    secrets_section = read_toml_table(raw, "secrets", path)
+    secrets_list = read_toml_secrets_list(raw, path)
 
     allowed_sections = frozenset(
         {
@@ -397,7 +432,7 @@ def load_submit_config[SubmitConfigT: BaseSubmitConfig](
                 data=data,
             )
         ),
-        *validate_env_values(env=env_section, secrets=secrets_section),
+        *validate_env_values(env=env_section, secrets={}),
     ]
     if issues:
         raise config_issues_error(issues=issues, config_label=config_label)
@@ -412,12 +447,10 @@ def load_submit_config[SubmitConfigT: BaseSubmitConfig](
         )
 
     env = {key: value for key, value in env_section.items() if isinstance(value, str)}
-    secrets = {
-        key: value for key, value in secrets_section.items() if isinstance(value, str)
-    }
-    validate_env_var_keys(env=env, secrets=secrets, path=path)
+    validate_env_var_keys(env=env, secrets={}, path=path)
+    validate_secret_names(secrets=secrets_list, env=env, path=path)
 
-    return config_class(**parsed, env=env, secrets=secrets)
+    return config_class(**parsed, env=env, secrets=secrets_list)
 
 
 def build_submit_summary_rows(

--- a/osmosis_ai/platform/cli/shared_config.py
+++ b/osmosis_ai/platform/cli/shared_config.py
@@ -124,34 +124,36 @@ def read_toml_table(
     return section
 
 
-def read_toml_secrets_required(raw: dict[str, Any], path: Path) -> list[str]:
-    """Read the ``required`` array from the ``[secrets]`` table.
+def read_toml_secrets(
+    raw: dict[str, Any],
+    path: Path,
+    *,
+    section_required: bool = False,
+) -> list[str]:
+    """Read secret refs from ``[secrets].required`` when present.
 
-    Legacy ``[secrets]`` key=value pairs (``NAME = "secret-id"``) raise a
-    :class:`CLIError` with a conversion hint.
+    Training configs may omit the whole ``[secrets]`` section. Evaluation
+    configs must include it. When the section exists, it must always include
+    the ``required`` field.
     """
     if "secrets" not in raw:
+        if section_required:
+            raise CLIError(f"Missing [secrets] section in {path}")
         return []
 
     value = raw["secrets"]
     if not isinstance(value, dict):
+        raise CLIError(f"[secrets] must be a table in {path}")
+
+    extra_keys = sorted(set(value) - {"required"})
+    if extra_keys:
         raise CLIError(
-            f"[secrets] in {path} must be a table with a 'required' array, "
-            'e.g.\n[secrets]\nrequired = ["OPENAI_API_KEY"].'
+            f"[secrets] in {path} only supports the 'required' field; "
+            f"unknown key(s): {', '.join(extra_keys)}."
         )
 
     if "required" not in value:
-        if value:
-            old_keys = ", ".join(value)
-            quoted = ", ".join(f'"{k}"' for k in value)
-            raise CLIError(
-                f"[secrets] in {path} uses key=value pairs (i.e. {old_keys}), "
-                "which is no longer supported. "
-                "Replace with a required array, e.g.:\n\n"
-                "[secrets]\n"
-                f"required = [{quoted}]"
-            )
-        return []
+        raise CLIError(f"Missing 'required' in [secrets] section of {path}")
 
     required = value["required"]
     if not isinstance(required, list) or not all(
@@ -159,7 +161,7 @@ def read_toml_secrets_required(raw: dict[str, Any], path: Path) -> list[str]:
     ):
         raise CLIError(
             f"'required' in [secrets] of {path} must be a list of strings, "
-            'e.g. required = ["OPENAI_API_KEY", "GITHUB_TOKEN"].'
+            'e.g. required = ["OPENAI_API_KEY"].'
         )
     return required
 
@@ -405,6 +407,7 @@ def load_submit_config[SubmitConfigT: BaseSubmitConfig](
     config_class: type[SubmitConfigT],
     extra_sections: list[tuple[str, type[BaseModel]]],
     config_label: str,
+    secrets_section_required: bool = False,
 ) -> SubmitConfigT:
     """Load and validate a submit TOML file into ``config_class``.
 
@@ -430,7 +433,9 @@ def load_submit_config[SubmitConfigT: BaseSubmitConfig](
     }
     advanced_section = read_toml_table(raw, "advanced", path)
     env_section = read_toml_table(raw, "env", path)
-    secrets_list = read_toml_secrets_required(raw, path)
+    secrets_list = read_toml_secrets(
+        raw, path, section_required=secrets_section_required
+    )
 
     allowed_sections = frozenset(
         {
@@ -569,6 +574,7 @@ __all__ = [
     "load_submit_config",
     "parse_section",
     "read_toml_file",
+    "read_toml_secrets",
     "read_toml_table",
     "validate_env_values",
     "validate_env_var_keys",

--- a/osmosis_ai/platform/cli/shared_config.py
+++ b/osmosis_ai/platform/cli/shared_config.py
@@ -322,12 +322,6 @@ def validate_secret_names(
                 "letters, digits, and underscores, starting with a letter "
                 "(e.g. MY_SECRET). Must match ^[A-Z][A-Z0-9_]*$."
             )
-        if name.startswith(RESERVED_ENV_PREFIX):
-            raise CLIError(
-                f"'{name}' in [secrets] of {path}: names starting with "
-                f"{RESERVED_ENV_PREFIX} are reserved by the platform; "
-                "choose a different name."
-            )
 
     overlap = sorted(set(env) & set(secrets))
     if overlap:

--- a/osmosis_ai/platform/cli/shared_config.py
+++ b/osmosis_ai/platform/cli/shared_config.py
@@ -13,6 +13,7 @@ from pydantic_core import ErrorDetails
 from osmosis_ai.cli.errors import CLIError
 
 ENV_VAR_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+SECRET_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
 RESERVED_ENV_PREFIX = "_OSMOSIS_"
 
 _EXPECTED_TYPE_BY_ERROR: dict[str, str] = {
@@ -268,31 +269,21 @@ def parse_section(
 def validate_env_var_keys(
     *,
     env: dict[str, str],
-    secrets: dict[str, str],
     path: Path,
 ) -> None:
-    """Reject invalid env-var names, reserved names, and overlap between sections."""
-    for section_name, section in (("env", env), ("secrets", secrets)):
-        for key in section:
-            if not ENV_VAR_NAME_RE.match(key):
-                raise CLIError(
-                    f"Invalid env var name '{key}' in [{section_name}] of {path}: "
-                    "must match ^[A-Z_][A-Z0-9_]*$"
-                )
-            if key.startswith(RESERVED_ENV_PREFIX):
-                raise CLIError(
-                    f"'{key}' in [{section_name}] of {path}: env var names starting "
-                    f"with {RESERVED_ENV_PREFIX} are reserved by the platform; "
-                    "choose a different name."
-                )
-
-    overlap = sorted(set(env) & set(secrets))
-    if overlap:
-        names = ", ".join(overlap)
-        raise CLIError(
-            f"Key(s) appear in both [env] and [secrets] of {path}: "
-            f"{names}. Each env var name must come from exactly one section."
-        )
+    """Reject invalid or reserved [env] var names."""
+    for key in env:
+        if not ENV_VAR_NAME_RE.match(key):
+            raise CLIError(
+                f"Invalid env var name '{key}' in [env] of {path}: "
+                "must match ^[A-Z_][A-Z0-9_]*$"
+            )
+        if key.startswith(RESERVED_ENV_PREFIX):
+            raise CLIError(
+                f"'{key}' in [env] of {path}: env var names starting "
+                f"with {RESERVED_ENV_PREFIX} are reserved by the platform; "
+                "choose a different name."
+            )
 
 
 def validate_secret_names(
@@ -302,7 +293,28 @@ def validate_secret_names(
     path: Path,
 ) -> None:
     """Validate each secret name and reject overlap with [env] keys."""
-    return None
+    for name in secrets:
+        if not SECRET_NAME_RE.match(name):
+            raise CLIError(
+                f"Invalid secret name '{name}' in {path}: "
+                "use SCREAMING_SNAKE_CASE (uppercase letters, digits, "
+                "underscores; must start with a letter). "
+                "Must match ^[A-Z][A-Z0-9_]*$."
+            )
+        if name.startswith(RESERVED_ENV_PREFIX):
+            raise CLIError(
+                f"'{name}' in secrets of {path}: names starting with "
+                f"{RESERVED_ENV_PREFIX} are reserved by the platform; "
+                "choose a different name."
+            )
+
+    overlap = sorted(set(env) & set(secrets))
+    if overlap:
+        names = ", ".join(overlap)
+        raise CLIError(
+            f"Name(s) appear in both [env] and secrets of {path}: "
+            f"{names}. Each env var name must come from exactly one place."
+        )
 
 
 class ExperimentSection(BaseModel):
@@ -432,7 +444,7 @@ def load_submit_config[SubmitConfigT: BaseSubmitConfig](
                 data=data,
             )
         ),
-        *validate_env_values(env=env_section, secrets={}),
+        *validate_env_values(env=env_section),
     ]
     if issues:
         raise config_issues_error(issues=issues, config_label=config_label)
@@ -447,7 +459,7 @@ def load_submit_config[SubmitConfigT: BaseSubmitConfig](
         )
 
     env = {key: value for key, value in env_section.items() if isinstance(value, str)}
-    validate_env_var_keys(env=env, secrets={}, path=path)
+    validate_env_var_keys(env=env, path=path)
     validate_secret_names(secrets=secrets_list, env=env, path=path)
 
     return config_class(**parsed, env=env, secrets=secrets_list)
@@ -487,25 +499,24 @@ def build_submit_summary_rows(
 def validate_env_values(
     *,
     env: dict[str, Any],
-    secrets: dict[str, Any],
 ) -> list[dict[str, str]]:
-    """Return issues for any env/secret value that is not a string."""
+    """Return issues for any [env] value that is not a string."""
     issues: list[dict[str, str]] = []
-    for section_name, section in (("env", env), ("secrets", secrets)):
-        for key, value in section.items():
-            if not isinstance(value, str):
-                issues.append(
-                    {
-                        "key": f"{section_name}.{key}",
-                        "message": f"must be a string, got {format_input(value)}",
-                    }
-                )
+    for key, value in env.items():
+        if not isinstance(value, str):
+            issues.append(
+                {
+                    "key": f"env.{key}",
+                    "message": f"must be a string, got {format_input(value)}",
+                }
+            )
     return issues
 
 
 __all__ = [
     "ENV_VAR_NAME_RE",
     "RESERVED_ENV_PREFIX",
+    "SECRET_NAME_RE",
     "AdvancedPassthroughSection",
     "BackendValidatedParamSection",
     "BaseSubmitConfig",
@@ -523,6 +534,7 @@ __all__ = [
     "read_toml_table",
     "validate_env_values",
     "validate_env_var_keys",
+    "validate_secret_names",
     "validate_workspace_rollout_paths",
     "validation_issue_to_config_issue",
 ]

--- a/osmosis_ai/platform/cli/shared_config.py
+++ b/osmosis_ai/platform/cli/shared_config.py
@@ -473,7 +473,7 @@ def build_submit_summary_rows(
     dataset: str,
     commit_sha: str | None,
     env: dict[str, str],
-    secrets: dict[str, str],
+    secrets: list[str],
 ) -> list[tuple[str, str]]:
     """Build the confirmation-table rows shared by ``train`` and ``eval`` submit."""
     rows: list[tuple[str, str]] = [
@@ -488,11 +488,8 @@ def build_submit_summary_rows(
         env_keys = ", ".join(sorted(env))
         rows.append((f"Rollout env ({len(env)})", env_keys))
     if secrets:
-        secret_summary = ", ".join(
-            f"{env_name}={secret_name}"
-            for env_name, secret_name in sorted(secrets.items())
-        )
-        rows.append((f"Rollout secrets ({len(secrets)})", secret_summary))
+        secret_names = ", ".join(sorted(secrets))
+        rows.append((f"Rollout secrets ({len(secrets)})", secret_names))
     return rows
 
 

--- a/osmosis_ai/platform/cli/shared_submit.py
+++ b/osmosis_ai/platform/cli/shared_submit.py
@@ -129,9 +129,15 @@ def _missing_secret_message(names: list[str]) -> str:
     lines = [
         f"Secret(s) not found: {', '.join(names)}.",
         "",
-        "Add them, then resubmit:",
+        "Add them as personal secrets, then resubmit (personal is the default):",
     ]
-    lines.extend(f"  osmosis secret set {name}" for name in names)
+    lines.extend(f"  osmosis secret set {name} --scope personal" for name in names)
+    lines.extend(
+        [
+            "",
+            "Use --scope workspace instead for secrets shared across the workspace.",
+        ]
+    )
     return "\n".join(lines)
 
 
@@ -151,9 +157,17 @@ def _enrich_missing_secret_error(
     names = [n.strip() for n in match.group(1).split(",")]
     platform_url = (exc.details or {}).get("platform_url")
 
-    lines = [str(exc), "", "To add the missing secret(s):"]
+    lines = [
+        str(exc),
+        "",
+        "To add the missing secret(s) as personal secrets (personal is the default):",
+    ]
     for name in names:
-        lines.append(f"  osmosis secret set {name}")
+        lines.append(f"  osmosis secret set {name} --scope personal")
+    lines.append("")
+    lines.append(
+        "Use --scope workspace instead for secrets shared across the workspace."
+    )
     if platform_url:
         lines.append(f"\nOr add them in the UI: {platform_url}")
 

--- a/osmosis_ai/platform/cli/shared_submit.py
+++ b/osmosis_ai/platform/cli/shared_submit.py
@@ -30,6 +30,7 @@ from osmosis_ai.platform.cli.shared_config import (
     build_submit_summary_rows,
 )
 from osmosis_ai.platform.cli.utils import (
+    fetch_all_pages,
     print_remote_fetch_notice,
     require_git_workspace_directory_context,
 )
@@ -85,6 +86,58 @@ class CloudSubmitSpec[ConfigT: BaseSubmitConfig]:
     ]
 
 
+def _fetch_user_secret_names(
+    client: OsmosisClient, *, credentials: Any, git_identity: str
+) -> set[str]:
+    """Return the names of the caller's personal (user-scope) secrets.
+
+    Best-effort: any failure (network, auth) returns an empty set so the
+    confirmation reminder never blocks a submit.
+    """
+    try:
+
+        def _fetch(limit: int, offset: int) -> Any:
+            return client.list_environment_secrets(
+                limit=limit,
+                offset=offset,
+                scope="user",
+                credentials=credentials,
+                git_identity=git_identity,
+            )
+
+        secrets, _ = fetch_all_pages(_fetch, items_attr="environment_secrets")
+        return {s.name for s in secrets}
+    except Exception:
+        return set()
+
+
+def _annotate_secret_override_row(
+    rows: list[tuple[str, str]],
+    *,
+    referenced: list[str],
+    user_secret_names: set[str],
+) -> list[tuple[str, str]]:
+    """Rewrite the ``Rollout secrets (N)`` row to spell out, per referenced
+    name, whether it resolves to the caller's personal value or the shared
+    workspace value (e.g. ``OPENAI_API_KEY (personal), DATABASE_URL
+    (workspace)``). Returns a new list; non-secret rows are untouched.
+    """
+    if not referenced:
+        return rows
+
+    annotated_value = ", ".join(
+        f"{name} (personal)" if name in user_secret_names else f"{name} (workspace)"
+        for name in referenced
+    )
+    result: list[tuple[str, str]] = []
+    for label, value in rows:
+        if label.startswith("Rollout secrets"):
+            result.append((label, annotated_value))
+        else:
+            result.append((label, value))
+    return result
+
+
 def run_cloud_submit[ConfigT: BaseSubmitConfig](
     config_path: Path,
     *,
@@ -125,6 +178,19 @@ def run_cloud_submit[ConfigT: BaseSubmitConfig](
         env=config.env,
         secrets=config.secrets,
     )
+
+    if config.secrets:
+        user_secret_names = _fetch_user_secret_names(
+            OsmosisClient(),
+            credentials=context.credentials,
+            git_identity=context.git_identity,
+        )
+        summary_rows = _annotate_secret_override_row(
+            summary_rows,
+            referenced=list(config.secrets),
+            user_secret_names=user_secret_names,
+        )
+
     console.table(
         [(label, console.escape(value)) for label, value in summary_rows],
         title=spec.table_title,

--- a/osmosis_ai/platform/cli/shared_submit.py
+++ b/osmosis_ai/platform/cli/shared_submit.py
@@ -15,18 +15,23 @@ those, and ``run_cloud_submit`` is the single implementation.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from osmosis_ai.cli.console import console
+from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.cli.output import OperationResult, get_output_context
 from osmosis_ai.cli.prompts import require_confirmation
 from osmosis_ai.platform.api.client import OsmosisClient
 from osmosis_ai.platform.api.models import SubmitRunResult
+from osmosis_ai.platform.auth.platform_client import PlatformAPIError
 from osmosis_ai.platform.cli.shared_config import (
     BaseSubmitConfig,
+    build_env_table_rows,
+    build_secret_table_rows,
     build_submit_summary_rows,
 )
 from osmosis_ai.platform.cli.utils import (
@@ -39,6 +44,10 @@ from osmosis_ai.platform.cli.workspace_directory_contract import (
     ensure_workspace_directory_config_path,
     validate_rollout_backend,
     validate_workspace_directory_contract,
+)
+
+_MISSING_SECRET_RE = re.compile(
+    r"Secret\(s\) not found: (.+)"
 )
 
 
@@ -86,13 +95,17 @@ class CloudSubmitSpec[ConfigT: BaseSubmitConfig]:
     ]
 
 
-def _fetch_user_secret_names(
+def _fetch_secret_scopes(
     client: OsmosisClient, *, credentials: Any, git_identity: str
-) -> set[str]:
-    """Return the names of the caller's personal (user-scope) secrets.
+) -> tuple[set[str], set[str]] | None:
+    """Return ``(workspace_names, personal_names)`` for the caller's workspace.
 
-    Best-effort: any failure (network, auth) returns an empty set so the
-    confirmation reminder never blocks a submit.
+    Fetches both scopes so the submit summary can mirror the platform's
+    resolution (personal preferred, override only when a workspace secret of
+    the same name also exists) and detect missing secrets up front.
+
+    Returns ``None`` on failure (network, auth) so the caller can fall back to
+    a best-effort display instead of blocking the submit.
     """
     try:
 
@@ -100,42 +113,59 @@ def _fetch_user_secret_names(
             return client.list_environment_secrets(
                 limit=limit,
                 offset=offset,
-                scope="user",
+                scope="all",
                 credentials=credentials,
                 git_identity=git_identity,
             )
 
         secrets, _ = fetch_all_pages(_fetch, items_attr="environment_secrets")
-        return {s.name for s in secrets}
+        workspace = {s.name for s in secrets if s.scope == "workspace"}
+        personal = {s.name for s in secrets if s.scope == "user"}
+        return workspace, personal
     except Exception:
-        return set()
+        return None
 
 
-def _annotate_secret_override_row(
-    rows: list[tuple[str, str]],
-    *,
-    referenced: list[str],
-    user_secret_names: set[str],
-) -> list[tuple[str, str]]:
-    """Rewrite the ``Rollout secrets (N)`` row to spell out, per referenced
-    name, whether it resolves to the caller's personal value or the shared
-    workspace value (e.g. ``OPENAI_API_KEY (personal), DATABASE_URL
-    (workspace)``). Returns a new list; non-secret rows are untouched.
+def _missing_secret_message(names: list[str]) -> str:
+    """Build a fail-fast message for run-submit secrets that don't exist."""
+    lines = [
+        f"Secret(s) not found: {', '.join(names)}.",
+        "",
+        "Add them, then resubmit:",
+    ]
+    lines.extend(f"  osmosis secret set {name}" for name in names)
+    return "\n".join(lines)
+
+
+def _enrich_missing_secret_error(
+    exc: PlatformAPIError,
+) -> PlatformAPIError | None:
+    """If ``exc`` is a missing-secret 404, return a new error with actionable hints.
+
+    Returns ``None`` when ``exc`` is unrelated so the caller can re-raise as-is.
     """
-    if not referenced:
-        return rows
+    if exc.status_code != 404:
+        return None
+    match = _MISSING_SECRET_RE.search(str(exc))
+    if not match:
+        return None
 
-    annotated_value = ", ".join(
-        f"{name} (personal)" if name in user_secret_names else f"{name} (workspace)"
-        for name in referenced
+    names = [n.strip() for n in match.group(1).split(",")]
+    platform_url = (exc.details or {}).get("platform_url")
+
+    lines = [str(exc), "", "To add the missing secret(s):"]
+    for name in names:
+        lines.append(f"  osmosis secret set {name}")
+    if platform_url:
+        lines.append(f"\nOr add them in the UI: {platform_url}")
+
+    return PlatformAPIError(
+        "\n".join(lines),
+        exc.status_code,
+        error_code=exc.error_code,
+        field=exc.field,
+        details=exc.details,
     )
-    result: list[tuple[str, str]] = []
-    for label, value in rows:
-        if label.startswith("Rollout secrets"):
-            result.append((label, annotated_value))
-        else:
-            result.append((label, value))
-    return result
 
 
 def run_cloud_submit[ConfigT: BaseSubmitConfig](
@@ -179,22 +209,58 @@ def run_cloud_submit[ConfigT: BaseSubmitConfig](
         secrets=config.secrets,
     )
 
-    if config.secrets:
-        user_secret_names = _fetch_user_secret_names(
-            OsmosisClient(),
-            credentials=context.credentials,
-            git_identity=context.git_identity,
-        )
-        summary_rows = _annotate_secret_override_row(
-            summary_rows,
-            referenced=list(config.secrets),
-            user_secret_names=user_secret_names,
-        )
-
     console.table(
         [(label, console.escape(value)) for label, value in summary_rows],
         title=spec.table_title,
     )
+
+    full_summary: list[tuple[str, str]] = list(summary_rows)
+
+    if config.env:
+        env_rows = build_env_table_rows(config.env)
+        console.table(
+            [(name, console.escape(value)) for name, value in env_rows],
+            title=f"Env Vars ({len(env_rows)})",
+            headers=("Name", "Value"),
+        )
+        full_summary.extend(
+            (f"env.{name}", value) for name, value in env_rows
+        )
+
+    if config.secrets:
+        scopes = _fetch_secret_scopes(
+            OsmosisClient(),
+            credentials=context.credentials,
+            git_identity=context.git_identity,
+        )
+        if scopes is None:
+            # Lookup failed — show names without a confident scope rather than
+            # blocking the submit or mislabeling; the server still validates.
+            secret_rows = [(name, "—") for name in sorted(config.secrets)]
+        else:
+            workspace_names, personal_names = scopes
+            missing = sorted(
+                {
+                    name
+                    for name in config.secrets
+                    if name not in workspace_names and name not in personal_names
+                }
+            )
+            if missing:
+                raise CLIError(_missing_secret_message(missing))
+            secret_rows = build_secret_table_rows(
+                config.secrets,
+                user_secret_names=personal_names,
+                workspace_secret_names=workspace_names,
+            )
+        console.table(
+            secret_rows,
+            title=f"Secrets ({len(secret_rows)})",
+            headers=("Name", "Scope"),
+        )
+        full_summary.extend(
+            (f"secret.{name}", scope) for name, scope in secret_rows
+        )
 
     notes, warnings = print_remote_fetch_notice(
         workspace_directory,
@@ -204,7 +270,7 @@ def run_cloud_submit[ConfigT: BaseSubmitConfig](
     require_confirmation(
         spec.confirm_prompt,
         yes=yes,
-        summary=summary_rows,
+        summary=full_summary,
         notes=notes,
         warnings=warnings,
     )
@@ -212,7 +278,11 @@ def run_cloud_submit[ConfigT: BaseSubmitConfig](
     client = OsmosisClient()
     output = get_output_context()
     with output.status(spec.status_message):
-        result = spec.submit(client, config, context.credentials, context.git_identity)
+        try:
+            result = spec.submit(client, config, context.credentials, context.git_identity)
+        except PlatformAPIError as exc:
+            enriched = _enrich_missing_secret_error(exc)
+            raise enriched if enriched is not None else exc
 
     display_next_steps, next_steps_structured = spec.build_next_steps(result, config)
 

--- a/osmosis_ai/platform/cli/shared_submit.py
+++ b/osmosis_ai/platform/cli/shared_submit.py
@@ -127,15 +127,15 @@ def _fetch_secret_scopes(
 def _missing_secret_message(names: list[str]) -> str:
     """Build a fail-fast message for run-submit secrets that don't exist."""
     lines = [
-        f"Secret(s) not found: {', '.join(names)}.",
+        f"Could not find secret(s): {', '.join(names)}.",
         "",
-        "Add them as personal secrets, then resubmit (personal is the default):",
+        "Run the following to add them:",
     ]
-    lines.extend(f"  osmosis secret set {name} --scope personal" for name in names)
+    lines.extend(f"  osmosis secret set {name}" for name in names)
     lines.extend(
         [
             "",
-            "Use --scope workspace instead for secrets shared across the workspace.",
+            "Secrets default to personal scope. Use --scope workspace for secrets shared across the workspace.",
         ]
     )
     return "\n".join(lines)
@@ -160,13 +160,13 @@ def _enrich_missing_secret_error(
     lines = [
         str(exc),
         "",
-        "To add the missing secret(s) as personal secrets (personal is the default):",
+        "Run the following to add them:",
     ]
     for name in names:
-        lines.append(f"  osmosis secret set {name} --scope personal")
+        lines.append(f"  osmosis secret set {name}")
     lines.append("")
     lines.append(
-        "Use --scope workspace instead for secrets shared across the workspace."
+        "Secrets default to personal scope. Use --scope workspace for secrets shared across the workspace."
     )
     if platform_url:
         lines.append(f"\nOr add them in the UI: {platform_url}")

--- a/osmosis_ai/platform/cli/shared_submit.py
+++ b/osmosis_ai/platform/cli/shared_submit.py
@@ -46,9 +46,7 @@ from osmosis_ai.platform.cli.workspace_directory_contract import (
     validate_workspace_directory_contract,
 )
 
-_MISSING_SECRET_RE = re.compile(
-    r"Secret\(s\) not found: (.+)"
-)
+_MISSING_SECRET_RE = re.compile(r"Secret\(s\) not found: (.+)")
 
 
 @dataclass(frozen=True)
@@ -223,9 +221,7 @@ def run_cloud_submit[ConfigT: BaseSubmitConfig](
             title=f"Env Vars ({len(env_rows)})",
             headers=("Name", "Value"),
         )
-        full_summary.extend(
-            (f"env.{name}", value) for name, value in env_rows
-        )
+        full_summary.extend((f"env.{name}", value) for name, value in env_rows)
 
     if config.secrets:
         scopes = _fetch_secret_scopes(
@@ -258,9 +254,7 @@ def run_cloud_submit[ConfigT: BaseSubmitConfig](
             title=f"Secrets ({len(secret_rows)})",
             headers=("Name", "Scope"),
         )
-        full_summary.extend(
-            (f"secret.{name}", scope) for name, scope in secret_rows
-        )
+        full_summary.extend((f"secret.{name}", scope) for name, scope in secret_rows)
 
     notes, warnings = print_remote_fetch_notice(
         workspace_directory,
@@ -279,10 +273,14 @@ def run_cloud_submit[ConfigT: BaseSubmitConfig](
     output = get_output_context()
     with output.status(spec.status_message):
         try:
-            result = spec.submit(client, config, context.credentials, context.git_identity)
+            result = spec.submit(
+                client, config, context.credentials, context.git_identity
+            )
         except PlatformAPIError as exc:
             enriched = _enrich_missing_secret_error(exc)
-            raise enriched if enriched is not None else exc
+            if enriched is not None:
+                raise enriched from exc
+            raise
 
     display_next_steps, next_steps_structured = spec.build_next_steps(result, config)
 

--- a/osmosis_ai/platform/cli/train.py
+++ b/osmosis_ai/platform/cli/train.py
@@ -115,7 +115,7 @@ def _submit_training(
         checkpoints_config=config.checkpoints_config or None,
         advanced_config=config.advanced_config or None,
         env_config=config.env or None,
-        secret_refs_config=config.secrets or None,
+        secrets=config.secrets or None,
         credentials=credentials,
         git_identity=git_identity,
     )

--- a/osmosis_ai/platform/cli/train.py
+++ b/osmosis_ai/platform/cli/train.py
@@ -126,6 +126,7 @@ def _train_next_steps(
 ) -> tuple[list[str], list[dict[str, Any]]]:
     display = [
         f"Status: {result.status}",
+        f"Rollout: {config.experiment_rollout}",
         f"Model: {config.experiment_model_path}",
         f"Dataset: {config.experiment_dataset}",
         (

--- a/osmosis_ai/platform/cli/train.py
+++ b/osmosis_ai/platform/cli/train.py
@@ -416,6 +416,7 @@ def stop(name: str, *, yes: bool) -> OperationResult:
     require_confirmation(
         f'Stop training run "{name}"?',
         yes=yes,
+        default=False,
         summary=[("Name", name)],
     )
 

--- a/osmosis_ai/templates/_scaffolds/rollout/eval.toml.tpl
+++ b/osmosis_ai/templates/_scaffolds/rollout/eval.toml.tpl
@@ -29,8 +29,8 @@ dataset = "<your-dataset-name>"       # Platform dataset name
 # LOG_LEVEL = "INFO"
 #
 # [secrets]
-# Maps env-var names to workspace environment_secret record names.
-# Values are resolved server-side from the workspace's encrypted secret store.
-# Pre-register secrets with `osmosis secret add` or at /:orgName/secrets in
+# Lists platform environment_secret record names.
+# Values are resolved server-side from the encrypted secret store.
+# Pre-register secrets with `osmosis secret set` or at /:orgName/secrets in
 # the platform UI before submitting.
-# OPENAI_API_KEY = "openai-api-key"
+# required = ["OPENAI_API_KEY"]

--- a/osmosis_ai/templates/_scaffolds/rollout/eval.toml.tpl
+++ b/osmosis_ai/templates/_scaffolds/rollout/eval.toml.tpl
@@ -1,6 +1,6 @@
 # Osmosis evaluation config reference.
 # Command: osmosis eval submit configs/eval/<your-rollout>.toml
-
+#
 [experiment]
 rollout = "<your-rollout>"            # Rollout name
 entrypoint = "main.py"                # Entrypoint file name
@@ -18,19 +18,15 @@ dataset = "<your-dataset-name>"       # Platform dataset name
 # agent_workflow_timeout_s = 450      # Agent workflow timeout per row
 # grader_timeout_s = 150              # Grader timeout per row
 
-# Environment variables & secrets
-# Both sections are optional. Omit them entirely if your rollout needs no
-# additional environment configuration.
-#
 # [env]
 # Literal key = "value" pairs injected verbatim into the rollout container.
 # Values are visible in this file and in CLI output - do NOT put secrets here.
 # Keys must match ^[A-Z_][A-Z0-9_]*$ and must not start with _OSMOSIS_.
 # LOG_LEVEL = "INFO"
-#
-# [secrets]
-# Lists platform environment_secret record names.
-# Values are resolved server-side from the encrypted secret store.
-# Pre-register secrets with `osmosis secret set` or at /:orgName/secrets in
-# the platform UI before submitting.
-# required = ["OPENAI_API_KEY"]
+
+[secrets]
+# Default OpenAI eval models need this platform secret.
+# Use [] only when this evaluation needs no secret refs.
+# Register secret records first with `osmosis secret set NAME` (personal is the default),
+# or pass `--scope workspace` for workspace-shared secrets.
+required = ["OPENAI_API_KEY"]

--- a/osmosis_ai/templates/_scaffolds/rollout/training.toml.tpl
+++ b/osmosis_ai/templates/_scaffolds/rollout/training.toml.tpl
@@ -51,11 +51,11 @@ dataset = "<your-dataset-name>"  # Platform dataset name from `osmosis dataset l
 #   DEFAULT_REGION = "us-west-2"
 #
 # [secrets]
-# Maps env-var names to workspace environment_secret record *names*.
-# Values are resolved server-side from the workspace's encrypted secret store
+# Lists platform environment_secret record names.
+# Values are resolved server-side from the encrypted secret store
 # and injected into the container - they never appear in this file or in transit.
-# Pre-register secrets with `osmosis secret add` or at /:orgName/secrets in
+# Pre-register secrets with `osmosis secret set` or at /:orgName/secrets in
 # the platform UI before submitting.
 #
 # Example:
-#   OPENAI_API_KEY = "openai-api-key"   # value is the *name* of the secret record
+#   required = ["OPENAI_API_KEY"]

--- a/osmosis_ai/templates/_scaffolds/rollout/training.toml.tpl
+++ b/osmosis_ai/templates/_scaffolds/rollout/training.toml.tpl
@@ -37,9 +37,9 @@ dataset = "<your-dataset-name>"  # Platform dataset name from `osmosis dataset l
 # eval_interval = 10                  # Evaluate every N rollouts
 # checkpoint_save_freq = 20           # Save checkpoint every N rollouts
 
-# Environment variables & secrets
-# Both sections are optional. Omit them entirely if your rollout needs no
-# additional environment configuration.
+# Environment variables
+# Optional. Omit entirely if your rollout needs no additional environment
+# configuration.
 #
 # [env]
 # Literal key = "value" pairs injected verbatim into the rollout container.
@@ -51,11 +51,10 @@ dataset = "<your-dataset-name>"  # Platform dataset name from `osmosis dataset l
 #   DEFAULT_REGION = "us-west-2"
 #
 # [secrets]
-# Lists platform environment_secret record names.
-# Values are resolved server-side from the encrypted secret store
-# and injected into the container - they never appear in this file or in transit.
-# Pre-register secrets with `osmosis secret set` or at /:orgName/secrets in
-# the platform UI before submitting.
+# Include this block only when this rollout needs platform secret refs.
+# When this block is present, it must include `required`.
+# Register them first with `osmosis secret set NAME` (personal is the default),
+# or pass `--scope workspace` for workspace-shared secrets.
 #
 # Example:
 #   required = ["OPENAI_API_KEY"]

--- a/tests/unit/cli/output/test_display.py
+++ b/tests/unit/cli/output/test_display.py
@@ -20,7 +20,7 @@ def test_local_timezone_label_returns_non_empty_text() -> None:
 def test_format_local_date_uses_explicit_timezone() -> None:
     formatted = format_local_date("2026-05-13T12:34:56Z", tz=ZoneInfo("UTC"))
 
-    assert formatted == "2026-05-13 12:34 UTC"
+    assert formatted == "2026-05-13 12:34 PM UTC"
 
 
 def test_created_column_label_uses_created_at_label() -> None:
@@ -34,10 +34,12 @@ def test_format_local_date_includes_per_timestamp_timezone_rules() -> None:
         pytest.skip("America/Los_Angeles timezone data is unavailable")
 
     assert (
-        format_local_date("2026-01-01T12:00:00Z", tz=pacific) == "2026-01-01 04:00 PST"
+        format_local_date("2026-01-01T12:00:00Z", tz=pacific)
+        == "2026-01-01 4:00 AM PST"
     )
     assert (
-        format_local_date("2026-07-01T12:00:00Z", tz=pacific) == "2026-07-01 05:00 PDT"
+        format_local_date("2026-07-01T12:00:00Z", tz=pacific)
+        == "2026-07-01 5:00 AM PDT"
     )
 
 
@@ -53,11 +55,11 @@ def test_format_local_datetime_uses_per_timestamp_timezone_rules() -> None:
 
     assert (
         format_local_datetime("2026-01-01T12:00:00Z", tz=pacific)
-        == "2026-01-01 04:00:00 PST"
+        == "2026-01-01 4:00:00 AM PST"
     )
     assert (
         format_local_datetime("2026-07-01T12:00:00Z", tz=pacific)
-        == "2026-07-01 05:00:00 PDT"
+        == "2026-07-01 5:00:00 AM PDT"
     )
 
 
@@ -82,11 +84,11 @@ def test_format_local_datetime_does_not_use_now_offset_for_conversion() -> None:
             now=july_fixed_offset_now,
             tz=pacific,
         )
-        == "2026-01-01 04:00:00 PST"
+        == "2026-01-01 4:00:00 AM PST"
     )
     assert (
         format_local_datetime("2026-01-01T12:00:00Z", now=july_fixed_offset_now)
-        != "2026-01-01 05:00:00 PDT"
+        != "2026-01-01 5:00:00 AM PDT"
     )
 
 

--- a/tests/unit/cli/output/test_serialize_environment_secret.py
+++ b/tests/unit/cli/output/test_serialize_environment_secret.py
@@ -17,7 +17,8 @@ def test_serialize_includes_scope_and_no_value() -> None:
             scope="user",
         )
     )
-    assert out["scope"] == "user"
+    # Wire "user" is presented to users as "personal".
+    assert out["scope"] == "personal"
     assert out["name"] == "OPENAI_API_KEY"
     assert "value" not in out
     assert "secret_value" not in out

--- a/tests/unit/cli/output/test_serialize_environment_secret.py
+++ b/tests/unit/cli/output/test_serialize_environment_secret.py
@@ -1,0 +1,23 @@
+"""serialize_environment_secret must expose scope but never a value."""
+
+from __future__ import annotations
+
+from osmosis_ai.cli.output import serialize_environment_secret
+from osmosis_ai.platform.api.models import EnvironmentSecretInfo
+
+
+def test_serialize_includes_scope_and_no_value() -> None:
+    out = serialize_environment_secret(
+        EnvironmentSecretInfo(
+            id="sec_1",
+            name="OPENAI_API_KEY",
+            created_at="2026-05-01T00:00:00Z",
+            updated_at="2026-05-01T00:00:01Z",
+            creator_name="Ada",
+            scope="user",
+        )
+    )
+    assert out["scope"] == "user"
+    assert out["name"] == "OPENAI_API_KEY"
+    assert "value" not in out
+    assert "secret_value" not in out

--- a/tests/unit/cli/test_rollout_init.py
+++ b/tests/unit/cli/test_rollout_init.py
@@ -149,12 +149,13 @@ def test_rollout_init_substitutes_rollout_name_in_configs(
     assert 'model_path = "openai/gpt-5-mini"' in eval_toml
     assert "[llm]" not in eval_toml
     assert "base_url" not in eval_toml
-    # Evaluation tuning and env/secrets are optional; templates should not
-    # submit SDK-side defaults.
+    # Evaluation tuning and env are optional; the default OpenAI eval model
+    # still needs an explicit secret ref.
     assert "# limit = 200" in eval_toml
     assert "# n = 1" in eval_toml
     assert "# [env]" in eval_toml
-    assert "# [secrets]" in eval_toml
+    assert "[secrets]" in eval_toml
+    assert 'required = ["OPENAI_API_KEY"]' in eval_toml
     assert "\nlimit = 200" not in eval_toml
     assert "\nLOG_LEVEL =" not in eval_toml
 
@@ -172,6 +173,7 @@ def test_rollout_init_substitutes_rollout_name_in_configs(
     assert "Qwen/Qwen3.5-122B-A10B" in training_toml
     assert "# [env]" in training_toml
     assert "# [secrets]" in training_toml
+    assert '#   required = ["OPENAI_API_KEY"]' in training_toml
 
 
 def test_rollout_init_training_config_omits_platform_defaults(

--- a/tests/unit/cli/test_secret_commands.py
+++ b/tests/unit/cli/test_secret_commands.py
@@ -323,15 +323,34 @@ def test_secret_set_from_env_forwards_name_value_scope(monkeypatch, capsys) -> N
     assert "value" not in payload["resource"]
 
 
-def test_secret_set_requires_scope(monkeypatch, capsys) -> None:
-    """--scope is required for set; omitting it is an error."""
-    _stub_git_context(monkeypatch)
+def test_secret_set_defaults_scope_to_personal(monkeypatch, capsys) -> None:
+    """Omitting --scope saves a personal secret by default."""
+    fake_credentials = _stub_git_context(monkeypatch)
     monkeypatch.setenv("SOURCE_VAR", SENTINEL_VALUE)
+    seen: dict[str, object] = {}
+
+    class FakeClient:
+        def set_environment_secret(
+            self, name, value, *, scope, git_identity, credentials=None
+        ):
+            assert credentials is fake_credentials
+            assert git_identity == GIT_IDENTITY
+            seen.update(name=name, value=value, scope=scope)
+            return _secret(name=name, scope=scope, platform_url=SECRETS_URL)
+
+    monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
 
     exit_code = cli.main(
         ["--json", "secret", "set", "OPENAI_API_KEY", "--env", "SOURCE_VAR"]
     )
-    assert exit_code != 0
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert seen == {"name": "OPENAI_API_KEY", "value": SENTINEL_VALUE, "scope": "user"}
+    payload = json.loads(captured.out)
+    assert payload["resource"]["scope"] == "personal"
+    assert SENTINEL_VALUE not in captured.out
+    assert SENTINEL_VALUE not in captured.err
 
 
 def test_secret_set_invalid_scope_is_validation_error(monkeypatch, capsys) -> None:
@@ -806,11 +825,26 @@ def test_secret_add_subcommand_is_removed(monkeypatch, capsys) -> None:
     assert exit_code != 0
 
 
-def test_secret_delete_requires_scope(monkeypatch, capsys) -> None:
-    """--scope is required for delete; omitting it is an error."""
+def test_secret_delete_defaults_scope_to_personal(monkeypatch, capsys) -> None:
+    """Omitting --scope deletes from personal scope by default."""
     _stub_git_context(monkeypatch)
+    seen: dict[str, object] = {}
+
+    class FakeClient:
+        def delete_environment_secret(
+            self, name, *, scope, git_identity, credentials=None
+        ):
+            seen.update(name=name, scope=scope)
+
+    monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
+
     exit_code = cli.main(["--json", "secret", "delete", "X", "--yes"])
-    assert exit_code != 0
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert seen == {"name": "X", "scope": "user"}
+    payload = json.loads(captured.out)
+    assert payload["resource"]["scope"] == "personal"
 
 
 def test_secret_delete_subcommand_wires_through(monkeypatch, capsys) -> None:

--- a/tests/unit/cli/test_secret_commands.py
+++ b/tests/unit/cli/test_secret_commands.py
@@ -248,8 +248,16 @@ def test_secret_set_from_env_success_omits_value(monkeypatch, capsys) -> None:
     monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
 
     exit_code = cli.main(
-        ["--json", "secret", "set", "OPENAI_API_KEY", "--scope", "workspace",
-         "--env", "SOURCE_VAR"]
+        [
+            "--json",
+            "secret",
+            "set",
+            "OPENAI_API_KEY",
+            "--scope",
+            "workspace",
+            "--env",
+            "SOURCE_VAR",
+        ]
     )
     captured = capsys.readouterr()
 
@@ -289,8 +297,16 @@ def test_secret_set_from_env_forwards_name_value_scope(monkeypatch, capsys) -> N
     monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
 
     exit_code = cli.main(
-        ["--json", "secret", "set", "OPENAI_API_KEY",
-         "--scope", "personal", "--env", "SOURCE_VAR"]
+        [
+            "--json",
+            "secret",
+            "set",
+            "OPENAI_API_KEY",
+            "--scope",
+            "personal",
+            "--env",
+            "SOURCE_VAR",
+        ]
     )
     captured = capsys.readouterr()
 
@@ -323,8 +339,16 @@ def test_secret_set_invalid_scope_is_validation_error(monkeypatch, capsys) -> No
     monkeypatch.setenv("SOURCE_VAR", SENTINEL_VALUE)
 
     exit_code = cli.main(
-        ["--json", "secret", "set", "OPENAI_API_KEY",
-         "--scope", "team", "--env", "SOURCE_VAR"]
+        [
+            "--json",
+            "secret",
+            "set",
+            "OPENAI_API_KEY",
+            "--scope",
+            "team",
+            "--env",
+            "SOURCE_VAR",
+        ]
     )
     captured = capsys.readouterr()
     assert exit_code == 1
@@ -338,8 +362,16 @@ def test_secret_set_env_unset_is_validation_error(monkeypatch, capsys) -> None:
     monkeypatch.delenv("MISSING_VAR", raising=False)
 
     exit_code = cli.main(
-        ["--json", "secret", "set", "MY_SECRET", "--scope", "workspace",
-         "--env", "MISSING_VAR"]
+        [
+            "--json",
+            "secret",
+            "set",
+            "MY_SECRET",
+            "--scope",
+            "workspace",
+            "--env",
+            "MISSING_VAR",
+        ]
     )
     captured = capsys.readouterr()
 
@@ -354,7 +386,9 @@ def test_secret_set_without_value_source_requires_interactive(
 ) -> None:
     _stub_git_context(monkeypatch)
 
-    exit_code = cli.main(["--json", "secret", "set", "MY_SECRET", "--scope", "workspace"])
+    exit_code = cli.main(
+        ["--json", "secret", "set", "MY_SECRET", "--scope", "workspace"]
+    )
     captured = capsys.readouterr()
 
     assert exit_code == 1
@@ -375,7 +409,9 @@ def test_secret_set_without_value_source_checks_before_workspace(
         fail_if_workspace_resolved,
     )
 
-    exit_code = cli.main(["--json", "secret", "set", "MY_SECRET", "--scope", "workspace"])
+    exit_code = cli.main(
+        ["--json", "secret", "set", "MY_SECRET", "--scope", "workspace"]
+    )
     captured = capsys.readouterr()
 
     assert exit_code == 1
@@ -389,8 +425,16 @@ def test_secret_set_invalid_name_is_validation_error(monkeypatch, capsys) -> Non
     monkeypatch.setenv("SOURCE_VAR", SENTINEL_VALUE)
 
     exit_code = cli.main(
-        ["--json", "secret", "set", "bad name!", "--scope", "workspace",
-         "--env", "SOURCE_VAR"]
+        [
+            "--json",
+            "secret",
+            "set",
+            "bad name!",
+            "--scope",
+            "workspace",
+            "--env",
+            "SOURCE_VAR",
+        ]
     )
     captured = capsys.readouterr()
 
@@ -443,8 +487,16 @@ def test_secret_set_conflict_maps_to_conflict_code(monkeypatch, capsys) -> None:
     monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
 
     exit_code = cli.main(
-        ["--json", "secret", "set", "OPENAI_API_KEY", "--scope", "workspace",
-         "--env", "SOURCE_VAR"]
+        [
+            "--json",
+            "secret",
+            "set",
+            "OPENAI_API_KEY",
+            "--scope",
+            "workspace",
+            "--env",
+            "SOURCE_VAR",
+        ]
     )
     captured = capsys.readouterr()
 
@@ -480,8 +532,16 @@ def test_secret_set_redacts_value_from_platform_error(monkeypatch, capsys) -> No
     monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
 
     exit_code = cli.main(
-        ["--json", "secret", "set", "OPENAI_API_KEY", "--scope", "personal",
-         "--env", "SOURCE_VAR"]
+        [
+            "--json",
+            "secret",
+            "set",
+            "OPENAI_API_KEY",
+            "--scope",
+            "personal",
+            "--env",
+            "SOURCE_VAR",
+        ]
     )
     captured = capsys.readouterr()
 
@@ -597,8 +657,7 @@ def test_secret_delete_forwards_name_scope(monkeypatch, capsys) -> None:
 
     monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
     exit_code = cli.main(
-        ["--json", "secret", "delete", "OPENAI_API_KEY",
-         "--scope", "personal", "--yes"]
+        ["--json", "secret", "delete", "OPENAI_API_KEY", "--scope", "personal", "--yes"]
     )
     captured = capsys.readouterr()
     assert exit_code == 0
@@ -711,7 +770,9 @@ def test_secret_delete_missing_hints_other_scope_when_exists(
         ):
             if scope == "user":
                 return PaginatedEnvironmentSecrets(
-                    environment_secrets=[], total_count=0, has_more=False,
+                    environment_secrets=[],
+                    total_count=0,
+                    has_more=False,
                 )
             return PaginatedEnvironmentSecrets(
                 environment_secrets=[_secret(name="MY_KEY", scope="workspace")],
@@ -727,7 +788,9 @@ def test_secret_delete_missing_hints_other_scope_when_exists(
     assert exit_code == 1
     payload = json.loads(captured.err)
     assert payload["error"]["code"] == "NOT_FOUND"
-    assert "osmosis secret delete MY_KEY --scope workspace" in payload["error"]["message"]
+    assert (
+        "osmosis secret delete MY_KEY --scope workspace" in payload["error"]["message"]
+    )
 
 
 # ── typer wiring ──────────────────────────────────────────────────
@@ -801,8 +864,16 @@ def test_secret_set_rejects_legacy_names(monkeypatch, capsys) -> None:
     monkeypatch.setenv("SOURCE_VAR", SENTINEL_VALUE)
 
     exit_code = cli.main(
-        ["--json", "secret", "set", "my-old-key",
-         "--scope", "workspace", "--env", "SOURCE_VAR"]
+        [
+            "--json",
+            "secret",
+            "set",
+            "my-old-key",
+            "--scope",
+            "workspace",
+            "--env",
+            "SOURCE_VAR",
+        ]
     )
     captured = capsys.readouterr()
     assert exit_code == 1

--- a/tests/unit/cli/test_secret_commands.py
+++ b/tests/unit/cli/test_secret_commands.py
@@ -261,6 +261,24 @@ def test_secret_name_with_trailing_newline_is_invalid() -> None:
     assert exc.value.code == "VALIDATION"
 
 
+@pytest.mark.parametrize(
+    "name",
+    ["OPENAI_API_KEY", "A", "DATABASE_URL", "X1", "A_B_C"],
+)
+def test_validate_secret_name_accepts_screaming_snake_case(name: str) -> None:
+    secret_module._validate_secret_name(name)  # no raise
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["lowercase", "1LEADING_DIGIT", "_LEADING_UNDERSCORE", "HAS-DASH", "HAS SPACE", ""],
+)
+def test_validate_secret_name_rejects_non_env_style(name: str) -> None:
+    with pytest.raises(CLIError) as exc:
+        secret_module._validate_secret_name(name)
+    assert exc.value.code == "VALIDATION"
+
+
 def test_secret_add_conflict_maps_to_conflict_code(monkeypatch, capsys) -> None:
     _stub_git_context(monkeypatch)
     monkeypatch.setenv("SOURCE_VAR", SENTINEL_VALUE)

--- a/tests/unit/cli/test_secret_commands.py
+++ b/tests/unit/cli/test_secret_commands.py
@@ -58,6 +58,7 @@ def _secret(
     id: str = "sec_1",
     name: str = "OPENAI_API_KEY",
     creator_name: str | None = "Ada",
+    scope: str | None = "workspace",
     platform_url: str | None = None,
 ) -> EnvironmentSecretInfo:
     return EnvironmentSecretInfo(
@@ -66,6 +67,7 @@ def _secret(
         created_at="2026-05-01T00:00:00Z",
         updated_at="2026-05-01T00:00:01Z",
         creator_name=creator_name,
+        scope=scope,
         platform_url=platform_url,
     )
 
@@ -78,7 +80,7 @@ def test_secret_list_json_envelope_has_no_value(monkeypatch, capsys) -> None:
 
     class FakeClient:
         def list_environment_secrets(
-            self, *, limit, offset, git_identity, credentials=None
+            self, *, limit, offset, scope, git_identity, credentials=None
         ):
             assert credentials is fake_credentials
             assert git_identity == GIT_IDENTITY
@@ -118,7 +120,7 @@ def test_secret_list_plain_emits_names(monkeypatch, capsys) -> None:
 
     class FakeClient:
         def list_environment_secrets(
-            self, *, limit, offset, git_identity, credentials=None
+            self, *, limit, offset, scope, git_identity, credentials=None
         ):
             return PaginatedEnvironmentSecrets(
                 environment_secrets=[
@@ -149,36 +151,116 @@ def test_secret_list_requires_linked_workspace(tmp_path, monkeypatch, capsys) ->
     assert "workspace directory" in capsys.readouterr().err.lower()
 
 
-# ── add (--env) ───────────────────────────────────────────────────
+def test_secret_list_forwards_scope_to_client(monkeypatch, capsys) -> None:
+    _stub_git_context(monkeypatch)
+    seen: dict[str, object] = {}
+
+    class FakeClient:
+        def list_environment_secrets(
+            self, *, limit, offset, scope, git_identity, credentials=None
+        ):
+            seen["scope"] = scope
+            return PaginatedEnvironmentSecrets(
+                environment_secrets=[_secret(scope="user")],
+                total_count=1,
+                has_more=False,
+                platform_url=SECRETS_URL,
+            )
+
+    monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
+    exit_code = cli.main(["--json", "secret", "list", "--scope", "user"])
+    assert exit_code == 0
+    assert seen["scope"] == "user"
 
 
-def test_secret_add_from_env_success_omits_value(monkeypatch, capsys) -> None:
+def test_secret_list_default_scope_is_all(monkeypatch, capsys) -> None:
+    _stub_git_context(monkeypatch)
+    seen: dict[str, object] = {}
+
+    class FakeClient:
+        def list_environment_secrets(
+            self, *, limit, offset, scope, git_identity, credentials=None
+        ):
+            seen["scope"] = scope
+            return PaginatedEnvironmentSecrets(
+                environment_secrets=[],
+                total_count=0,
+                has_more=False,
+            )
+
+    monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
+    assert cli.main(["--json", "secret", "list"]) == 0
+    assert seen["scope"] == "all"
+
+
+def test_secret_list_invalid_scope_is_validation_error(monkeypatch, capsys) -> None:
+    _stub_git_context(monkeypatch)
+    exit_code = cli.main(["--json", "secret", "list", "--scope", "team"])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    payload = json.loads(captured.err)
+    assert payload["error"]["code"] == "VALIDATION"
+
+
+def test_secret_list_plain_shows_scope(monkeypatch, capsys) -> None:
+    _stub_git_context(monkeypatch)
+
+    class FakeClient:
+        def list_environment_secrets(
+            self, *, limit, offset, scope, git_identity, credentials=None
+        ):
+            return PaginatedEnvironmentSecrets(
+                environment_secrets=[
+                    _secret(id="a", name="ALPHA", scope="workspace"),
+                    _secret(id="b", name="BETA", scope="user"),
+                ],
+                total_count=2,
+                has_more=False,
+            )
+
+    monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
+    assert cli.main(["--plain", "secret", "list"]) == 0
+    out = capsys.readouterr().out
+    assert "workspace" in out
+    assert "user" in out
+
+
+# ── set (upsert) ──────────────────────────────────────────────────
+
+
+def test_secret_set_from_env_success_omits_value(monkeypatch, capsys) -> None:
     fake_credentials = _stub_git_context(monkeypatch)
     monkeypatch.setenv("SOURCE_VAR", SENTINEL_VALUE)
     seen: dict[str, object] = {}
 
     class FakeClient:
-        def create_environment_secret(
-            self, name, value, *, git_identity, credentials=None
+        def set_environment_secret(
+            self, name, value, *, scope, git_identity, credentials=None
         ):
             assert credentials is fake_credentials
             assert git_identity == GIT_IDENTITY
             seen["name"] = name
             seen["value"] = value
-            return _secret(name=name, platform_url=SECRETS_URL)
+            seen["scope"] = scope
+            return _secret(name=name, scope=scope, platform_url=SECRETS_URL)
 
     monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
 
     exit_code = cli.main(
-        ["--json", "secret", "add", "OPENAI_API_KEY", "--env", "SOURCE_VAR"]
+        ["--json", "secret", "set", "OPENAI_API_KEY", "--scope", "workspace",
+         "--env", "SOURCE_VAR"]
     )
     captured = capsys.readouterr()
 
     assert exit_code == 0
     # The value was read from the env var and forwarded to the client...
-    assert seen == {"name": "OPENAI_API_KEY", "value": SENTINEL_VALUE}
+    assert seen == {
+        "name": "OPENAI_API_KEY",
+        "value": SENTINEL_VALUE,
+        "scope": "workspace",
+    }
     payload = json.loads(captured.out)
-    assert payload["operation"] == "secret.add"
+    assert payload["operation"] == "secret.set"
     assert payload["status"] == "success"
     assert payload["resource"]["name"] == "OPENAI_API_KEY"
     assert payload["platform_url"] == SECRETS_URL
@@ -189,12 +271,83 @@ def test_secret_add_from_env_success_omits_value(monkeypatch, capsys) -> None:
     assert "value" not in payload["resource"]
 
 
-def test_secret_add_env_unset_is_validation_error(monkeypatch, capsys) -> None:
+def test_secret_set_from_env_forwards_name_value_scope(monkeypatch, capsys) -> None:
+    fake_credentials = _stub_git_context(monkeypatch)
+    monkeypatch.setenv("SOURCE_VAR", SENTINEL_VALUE)
+    seen: dict[str, object] = {}
+
+    class FakeClient:
+        def set_environment_secret(
+            self, name, value, *, scope, git_identity, credentials=None
+        ):
+            assert credentials is fake_credentials
+            assert git_identity == GIT_IDENTITY
+            seen.update(name=name, value=value, scope=scope)
+            return _secret(name=name, scope=scope, platform_url=SECRETS_URL)
+
+    monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
+
+    exit_code = cli.main(
+        ["--json", "secret", "set", "OPENAI_API_KEY",
+         "--scope", "user", "--env", "SOURCE_VAR"]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert seen == {"name": "OPENAI_API_KEY", "value": SENTINEL_VALUE, "scope": "user"}
+    payload = json.loads(captured.out)
+    assert payload["operation"] == "secret.set"
+    assert payload["status"] == "success"
+    assert payload["resource"]["name"] == "OPENAI_API_KEY"
+    assert payload["resource"]["scope"] == "user"
+    assert SENTINEL_VALUE not in captured.out
+    assert SENTINEL_VALUE not in captured.err
+    assert "value" not in payload["resource"]
+
+
+def test_secret_set_defaults_scope_to_workspace(monkeypatch, capsys) -> None:
+    _stub_git_context(monkeypatch)
+    monkeypatch.setenv("SOURCE_VAR", SENTINEL_VALUE)
+    seen: dict[str, object] = {}
+
+    class FakeClient:
+        def set_environment_secret(
+            self, name, value, *, scope, git_identity, credentials=None
+        ):
+            seen["scope"] = scope
+            return _secret(name=name, scope=scope)
+
+    monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
+
+    exit_code = cli.main(
+        ["--json", "secret", "set", "OPENAI_API_KEY", "--env", "SOURCE_VAR"]
+    )
+    assert exit_code == 0
+    assert seen["scope"] == "workspace"
+
+
+def test_secret_set_invalid_scope_is_validation_error(monkeypatch, capsys) -> None:
+    _stub_git_context(monkeypatch)
+    monkeypatch.setenv("SOURCE_VAR", SENTINEL_VALUE)
+
+    exit_code = cli.main(
+        ["--json", "secret", "set", "OPENAI_API_KEY",
+         "--scope", "team", "--env", "SOURCE_VAR"]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    payload = json.loads(captured.err)
+    assert payload["error"]["code"] == "VALIDATION"
+    assert SENTINEL_VALUE not in captured.err
+
+
+def test_secret_set_env_unset_is_validation_error(monkeypatch, capsys) -> None:
     _stub_git_context(monkeypatch)
     monkeypatch.delenv("MISSING_VAR", raising=False)
 
     exit_code = cli.main(
-        ["--json", "secret", "add", "MY_SECRET", "--env", "MISSING_VAR"]
+        ["--json", "secret", "set", "MY_SECRET", "--scope", "workspace",
+         "--env", "MISSING_VAR"]
     )
     captured = capsys.readouterr()
 
@@ -204,12 +357,12 @@ def test_secret_add_env_unset_is_validation_error(monkeypatch, capsys) -> None:
     assert "MISSING_VAR" in payload["error"]["message"]
 
 
-def test_secret_add_without_value_source_requires_interactive(
+def test_secret_set_without_value_source_requires_interactive(
     monkeypatch, capsys
 ) -> None:
     _stub_git_context(monkeypatch)
 
-    exit_code = cli.main(["--json", "secret", "add", "MY_SECRET"])
+    exit_code = cli.main(["--json", "secret", "set", "MY_SECRET", "--scope", "workspace"])
     captured = capsys.readouterr()
 
     assert exit_code == 1
@@ -218,7 +371,7 @@ def test_secret_add_without_value_source_requires_interactive(
     assert "--env" in payload["error"]["message"]
 
 
-def test_secret_add_without_value_source_checks_before_workspace(
+def test_secret_set_without_value_source_checks_before_workspace(
     monkeypatch, capsys
 ) -> None:
     def fail_if_workspace_resolved():
@@ -230,7 +383,7 @@ def test_secret_add_without_value_source_checks_before_workspace(
         fail_if_workspace_resolved,
     )
 
-    exit_code = cli.main(["--json", "secret", "add", "MY_SECRET"])
+    exit_code = cli.main(["--json", "secret", "set", "MY_SECRET", "--scope", "workspace"])
     captured = capsys.readouterr()
 
     assert exit_code == 1
@@ -239,12 +392,13 @@ def test_secret_add_without_value_source_checks_before_workspace(
     assert "--env" in payload["error"]["message"]
 
 
-def test_secret_add_invalid_name_is_validation_error(monkeypatch, capsys) -> None:
+def test_secret_set_invalid_name_is_validation_error(monkeypatch, capsys) -> None:
     _stub_git_context(monkeypatch)
     monkeypatch.setenv("SOURCE_VAR", SENTINEL_VALUE)
 
     exit_code = cli.main(
-        ["--json", "secret", "add", "bad name!", "--env", "SOURCE_VAR"]
+        ["--json", "secret", "set", "bad name!", "--scope", "workspace",
+         "--env", "SOURCE_VAR"]
     )
     captured = capsys.readouterr()
 
@@ -279,15 +433,15 @@ def test_validate_secret_name_rejects_non_env_style(name: str) -> None:
     assert exc.value.code == "VALIDATION"
 
 
-def test_secret_add_conflict_maps_to_conflict_code(monkeypatch, capsys) -> None:
+def test_secret_set_conflict_maps_to_conflict_code(monkeypatch, capsys) -> None:
     _stub_git_context(monkeypatch)
     monkeypatch.setenv("SOURCE_VAR", SENTINEL_VALUE)
 
     from osmosis_ai.platform.auth import PlatformAPIError
 
     class FakeClient:
-        def create_environment_secret(
-            self, name, value, *, git_identity, credentials=None
+        def set_environment_secret(
+            self, name, value, *, scope, git_identity, credentials=None
         ):
             raise PlatformAPIError(
                 "A secret with this name already exists",
@@ -297,7 +451,8 @@ def test_secret_add_conflict_maps_to_conflict_code(monkeypatch, capsys) -> None:
     monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
 
     exit_code = cli.main(
-        ["--json", "secret", "add", "OPENAI_API_KEY", "--env", "SOURCE_VAR"]
+        ["--json", "secret", "set", "OPENAI_API_KEY", "--scope", "workspace",
+         "--env", "SOURCE_VAR"]
     )
     captured = capsys.readouterr()
 
@@ -307,15 +462,15 @@ def test_secret_add_conflict_maps_to_conflict_code(monkeypatch, capsys) -> None:
     assert SENTINEL_VALUE not in captured.err
 
 
-def test_secret_add_redacts_value_from_platform_error(monkeypatch, capsys) -> None:
+def test_secret_set_redacts_value_from_platform_error(monkeypatch, capsys) -> None:
     _stub_git_context(monkeypatch)
     monkeypatch.setenv("SOURCE_VAR", SENTINEL_VALUE)
 
     from osmosis_ai.platform.auth import PlatformAPIError
 
     class FakeClient:
-        def create_environment_secret(
-            self, name, value, *, git_identity, credentials=None
+        def set_environment_secret(
+            self, name, value, *, scope, git_identity, credentials=None
         ):
             assert value == SENTINEL_VALUE
             raise PlatformAPIError(
@@ -333,7 +488,8 @@ def test_secret_add_redacts_value_from_platform_error(monkeypatch, capsys) -> No
     monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
 
     exit_code = cli.main(
-        ["--json", "secret", "add", "OPENAI_API_KEY", "--env", "SOURCE_VAR"]
+        ["--json", "secret", "set", "OPENAI_API_KEY", "--scope", "user",
+         "--env", "SOURCE_VAR"]
     )
     captured = capsys.readouterr()
 
@@ -350,7 +506,7 @@ def test_secret_add_redacts_value_from_platform_error(monkeypatch, capsys) -> No
     assert payload["error"]["details"]["items"] == ["[REDACTED]"]
 
 
-def test_secret_add_redacted_platform_error_suppresses_original_cause(
+def test_secret_set_redacted_platform_error_suppresses_original_cause(
     monkeypatch,
 ) -> None:
     _stub_git_context(monkeypatch)
@@ -359,8 +515,8 @@ def test_secret_add_redacted_platform_error_suppresses_original_cause(
     from osmosis_ai.platform.auth import PlatformAPIError
 
     class FakeClient:
-        def create_environment_secret(
-            self, name, value, *, git_identity, credentials=None
+        def set_environment_secret(
+            self, name, value, *, scope, git_identity, credentials=None
         ):
             raise PlatformAPIError(
                 f"Rejected value {SENTINEL_VALUE}",
@@ -371,7 +527,9 @@ def test_secret_add_redacted_platform_error_suppresses_original_cause(
 
     with override_output_context(format=OutputFormat.json, interactive=False):
         with pytest.raises(PlatformAPIError) as exc:
-            secret_module.add_secret(name="OPENAI_API_KEY", env="SOURCE_VAR")
+            secret_module.set_secret(
+                name="OPENAI_API_KEY", scope="workspace", env="SOURCE_VAR"
+            )
 
     assert exc.value.__cause__ is None
     assert SENTINEL_VALUE not in str(exc.value)
@@ -428,3 +586,133 @@ def test_resolve_value_from_env_preserves_value_verbatim(monkeypatch) -> None:
     )
 
     assert value == spaced
+
+
+# ── delete ────────────────────────────────────────────────────────
+
+
+def test_secret_delete_forwards_name_scope(monkeypatch, capsys) -> None:
+    fake_credentials = _stub_git_context(monkeypatch)
+    seen: dict[str, object] = {}
+
+    class FakeClient:
+        def delete_environment_secret(
+            self, name, *, scope, git_identity, credentials=None
+        ):
+            assert credentials is fake_credentials
+            assert git_identity == GIT_IDENTITY
+            seen.update(name=name, scope=scope)
+
+    monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
+    exit_code = cli.main(
+        ["--json", "secret", "delete", "OPENAI_API_KEY",
+         "--scope", "user", "--yes"]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert seen == {"name": "OPENAI_API_KEY", "scope": "user"}
+    payload = json.loads(captured.out)
+    assert payload["operation"] == "secret.delete"
+    assert payload["status"] == "success"
+    assert payload["resource"]["name"] == "OPENAI_API_KEY"
+    assert payload["resource"]["scope"] == "user"
+
+
+def test_secret_delete_requires_scope_confirmation_without_yes(
+    monkeypatch, capsys
+) -> None:
+    _stub_git_context(monkeypatch)
+    called = {"deleted": False}
+
+    class FakeClient:
+        def delete_environment_secret(
+            self, name, *, scope, git_identity, credentials=None
+        ):
+            called["deleted"] = True
+
+    monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
+    # --json + non-interactive => require_confirmation emits INTERACTIVE_REQUIRED
+    exit_code = cli.main(
+        ["--json", "secret", "delete", "OPENAI_API_KEY", "--scope", "workspace"]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    payload = json.loads(captured.err)
+    assert payload["error"]["code"] == "INTERACTIVE_REQUIRED"
+    assert called["deleted"] is False
+
+
+def test_secret_delete_invalid_scope_is_validation_error(monkeypatch, capsys) -> None:
+    _stub_git_context(monkeypatch)
+    exit_code = cli.main(
+        ["--json", "secret", "delete", "OPENAI_API_KEY", "--scope", "all", "--yes"]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    payload = json.loads(captured.err)
+    assert payload["error"]["code"] == "VALIDATION"
+
+
+def test_secret_delete_not_found_maps_to_not_found(monkeypatch, capsys) -> None:
+    _stub_git_context(monkeypatch)
+    from osmosis_ai.platform.auth import PlatformAPIError
+
+    class FakeClient:
+        def delete_environment_secret(
+            self, name, *, scope, git_identity, credentials=None
+        ):
+            raise PlatformAPIError("Secret not found", status_code=404)
+
+    monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
+    exit_code = cli.main(
+        ["--json", "secret", "delete", "MISSING", "--scope", "user", "--yes"]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    payload = json.loads(captured.err)
+    assert payload["error"]["code"] == "NOT_FOUND"
+
+
+# ── typer wiring ──────────────────────────────────────────────────
+
+
+def test_secret_add_subcommand_is_removed(monkeypatch, capsys) -> None:
+    _stub_git_context(monkeypatch)
+    monkeypatch.setenv("SOURCE_VAR", SENTINEL_VALUE)
+    # The old `add` verb must no longer be a recognized subcommand.
+    exit_code = cli.main(
+        ["--json", "secret", "add", "OPENAI_API_KEY", "--env", "SOURCE_VAR"]
+    )
+    assert exit_code != 0
+
+
+def test_secret_set_wires_scope_default_workspace(monkeypatch, capsys) -> None:
+    _stub_git_context(monkeypatch)
+    monkeypatch.setenv("SOURCE_VAR", SENTINEL_VALUE)
+    seen: dict[str, object] = {}
+
+    class FakeClient:
+        def set_environment_secret(
+            self, name, value, *, scope, git_identity, credentials=None
+        ):
+            seen["scope"] = scope
+            return _secret(name=name, scope=scope)
+
+    monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
+    assert cli.main(["--json", "secret", "set", "X", "--env", "SOURCE_VAR"]) == 0
+    assert seen["scope"] == "workspace"
+
+
+def test_secret_delete_subcommand_wires_through(monkeypatch, capsys) -> None:
+    _stub_git_context(monkeypatch)
+    seen: dict[str, object] = {}
+
+    class FakeClient:
+        def delete_environment_secret(
+            self, name, *, scope, git_identity, credentials=None
+        ):
+            seen.update(name=name, scope=scope)
+
+    monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
+    assert cli.main(["--json", "secret", "delete", "X", "--scope", "user", "--yes"]) == 0
+    assert seen == {"name": "X", "scope": "user"}

--- a/tests/unit/cli/test_secret_commands.py
+++ b/tests/unit/cli/test_secret_commands.py
@@ -168,8 +168,9 @@ def test_secret_list_forwards_scope_to_client(monkeypatch, capsys) -> None:
             )
 
     monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
-    exit_code = cli.main(["--json", "secret", "list", "--scope", "user"])
+    exit_code = cli.main(["--json", "secret", "list", "--scope", "personal"])
     assert exit_code == 0
+    # User-facing "personal" is translated to the wire value "user".
     assert seen["scope"] == "user"
 
 
@@ -221,8 +222,8 @@ def test_secret_list_plain_shows_scope(monkeypatch, capsys) -> None:
     monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
     assert cli.main(["--plain", "secret", "list"]) == 0
     out = capsys.readouterr().out
-    assert "workspace" in out
-    assert "user" in out
+    assert "Workspace" in out
+    assert "Personal" in out
 
 
 # ── set (upsert) ──────────────────────────────────────────────────
@@ -289,41 +290,32 @@ def test_secret_set_from_env_forwards_name_value_scope(monkeypatch, capsys) -> N
 
     exit_code = cli.main(
         ["--json", "secret", "set", "OPENAI_API_KEY",
-         "--scope", "user", "--env", "SOURCE_VAR"]
+         "--scope", "personal", "--env", "SOURCE_VAR"]
     )
     captured = capsys.readouterr()
 
     assert exit_code == 0
+    # "personal" is sent to the platform as the wire value "user".
     assert seen == {"name": "OPENAI_API_KEY", "value": SENTINEL_VALUE, "scope": "user"}
     payload = json.loads(captured.out)
     assert payload["operation"] == "secret.set"
     assert payload["status"] == "success"
     assert payload["resource"]["name"] == "OPENAI_API_KEY"
-    assert payload["resource"]["scope"] == "user"
+    assert payload["resource"]["scope"] == "personal"
     assert SENTINEL_VALUE not in captured.out
     assert SENTINEL_VALUE not in captured.err
     assert "value" not in payload["resource"]
 
 
-def test_secret_set_defaults_scope_to_workspace(monkeypatch, capsys) -> None:
+def test_secret_set_requires_scope(monkeypatch, capsys) -> None:
+    """--scope is required for set; omitting it is an error."""
     _stub_git_context(monkeypatch)
     monkeypatch.setenv("SOURCE_VAR", SENTINEL_VALUE)
-    seen: dict[str, object] = {}
-
-    class FakeClient:
-        def set_environment_secret(
-            self, name, value, *, scope, git_identity, credentials=None
-        ):
-            seen["scope"] = scope
-            return _secret(name=name, scope=scope)
-
-    monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
 
     exit_code = cli.main(
         ["--json", "secret", "set", "OPENAI_API_KEY", "--env", "SOURCE_VAR"]
     )
-    assert exit_code == 0
-    assert seen["scope"] == "workspace"
+    assert exit_code != 0
 
 
 def test_secret_set_invalid_scope_is_validation_error(monkeypatch, capsys) -> None:
@@ -417,7 +409,7 @@ def test_secret_name_with_trailing_newline_is_invalid() -> None:
 
 @pytest.mark.parametrize(
     "name",
-    ["OPENAI_API_KEY", "A", "DATABASE_URL", "X1", "A_B_C"],
+    ["OPENAI_API_KEY", "A", "GITHUB_TOKEN", "X1", "A_B_C"],
 )
 def test_validate_secret_name_accepts_screaming_snake_case(name: str) -> None:
     secret_module._validate_secret_name(name)  # no raise
@@ -488,7 +480,7 @@ def test_secret_set_redacts_value_from_platform_error(monkeypatch, capsys) -> No
     monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
 
     exit_code = cli.main(
-        ["--json", "secret", "set", "OPENAI_API_KEY", "--scope", "user",
+        ["--json", "secret", "set", "OPENAI_API_KEY", "--scope", "personal",
          "--env", "SOURCE_VAR"]
     )
     captured = capsys.readouterr()
@@ -606,16 +598,17 @@ def test_secret_delete_forwards_name_scope(monkeypatch, capsys) -> None:
     monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
     exit_code = cli.main(
         ["--json", "secret", "delete", "OPENAI_API_KEY",
-         "--scope", "user", "--yes"]
+         "--scope", "personal", "--yes"]
     )
     captured = capsys.readouterr()
     assert exit_code == 0
+    # "personal" is sent to the platform as the wire value "user".
     assert seen == {"name": "OPENAI_API_KEY", "scope": "user"}
     payload = json.loads(captured.out)
     assert payload["operation"] == "secret.delete"
     assert payload["status"] == "success"
     assert payload["resource"]["name"] == "OPENAI_API_KEY"
-    assert payload["resource"]["scope"] == "user"
+    assert payload["resource"]["scope"] == "personal"
 
 
 def test_secret_delete_requires_scope_confirmation_without_yes(
@@ -665,12 +658,76 @@ def test_secret_delete_not_found_maps_to_not_found(monkeypatch, capsys) -> None:
 
     monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
     exit_code = cli.main(
-        ["--json", "secret", "delete", "MISSING", "--scope", "user", "--yes"]
+        ["--json", "secret", "delete", "MISSING", "--scope", "personal", "--yes"]
     )
     captured = capsys.readouterr()
     assert exit_code == 1
     payload = json.loads(captured.err)
     assert payload["error"]["code"] == "NOT_FOUND"
+
+
+def test_secret_delete_missing_in_scope_fails_before_confirmation(
+    monkeypatch, capsys
+) -> None:
+    """A name absent from the requested scope errors without prompting or deleting."""
+    _stub_git_context(monkeypatch)
+    called: dict[str, bool] = {"deleted": False}
+
+    class FakeClient:
+        def list_environment_secrets(
+            self, *, limit, offset, scope, git_identity, credentials=None
+        ):
+            return PaginatedEnvironmentSecrets(
+                environment_secrets=[_secret(name="OTHER", scope="user")],
+                total_count=1,
+                has_more=False,
+            )
+
+        def delete_environment_secret(self, *args, **kwargs):
+            called["deleted"] = True
+
+    monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
+    # No --yes: if the pre-check didn't fire this would block on confirmation.
+    exit_code = cli.main(
+        ["--json", "secret", "delete", "WANDB_API_KEY", "--scope", "personal"]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    payload = json.loads(captured.err)
+    assert payload["error"]["code"] == "NOT_FOUND"
+    assert payload["error"]["message"] == 'Secret "WANDB_API_KEY" not found.'
+    assert called["deleted"] is False
+
+
+def test_secret_delete_missing_hints_other_scope_when_exists(
+    monkeypatch, capsys
+) -> None:
+    """When the secret exists in the OTHER scope, the error hints at it."""
+    _stub_git_context(monkeypatch)
+
+    class FakeClient:
+        def list_environment_secrets(
+            self, *, limit, offset, scope, git_identity, credentials=None
+        ):
+            if scope == "user":
+                return PaginatedEnvironmentSecrets(
+                    environment_secrets=[], total_count=0, has_more=False,
+                )
+            return PaginatedEnvironmentSecrets(
+                environment_secrets=[_secret(name="MY_KEY", scope="workspace")],
+                total_count=1,
+                has_more=False,
+            )
+
+    monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
+    exit_code = cli.main(
+        ["--json", "secret", "delete", "MY_KEY", "--scope", "personal", "--yes"]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    payload = json.loads(captured.err)
+    assert payload["error"]["code"] == "NOT_FOUND"
+    assert "osmosis secret delete MY_KEY --scope workspace" in payload["error"]["message"]
 
 
 # ── typer wiring ──────────────────────────────────────────────────
@@ -686,21 +743,11 @@ def test_secret_add_subcommand_is_removed(monkeypatch, capsys) -> None:
     assert exit_code != 0
 
 
-def test_secret_set_wires_scope_default_workspace(monkeypatch, capsys) -> None:
+def test_secret_delete_requires_scope(monkeypatch, capsys) -> None:
+    """--scope is required for delete; omitting it is an error."""
     _stub_git_context(monkeypatch)
-    monkeypatch.setenv("SOURCE_VAR", SENTINEL_VALUE)
-    seen: dict[str, object] = {}
-
-    class FakeClient:
-        def set_environment_secret(
-            self, name, value, *, scope, git_identity, credentials=None
-        ):
-            seen["scope"] = scope
-            return _secret(name=name, scope=scope)
-
-    monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
-    assert cli.main(["--json", "secret", "set", "X", "--env", "SOURCE_VAR"]) == 0
-    assert seen["scope"] == "workspace"
+    exit_code = cli.main(["--json", "secret", "delete", "X", "--yes"])
+    assert exit_code != 0
 
 
 def test_secret_delete_subcommand_wires_through(monkeypatch, capsys) -> None:
@@ -714,47 +761,42 @@ def test_secret_delete_subcommand_wires_through(monkeypatch, capsys) -> None:
             seen.update(name=name, scope=scope)
 
     monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
-    assert cli.main(["--json", "secret", "delete", "X", "--scope", "user", "--yes"]) == 0
+    assert (
+        cli.main(["--json", "secret", "delete", "X", "--scope", "personal", "--yes"])
+        == 0
+    )
+    # "personal" is sent to the platform as the wire value "user".
     assert seen == {"name": "X", "scope": "user"}
 
 
-# ── lenient name validation on delete (legacy-named secrets) ──────
+# ── strict name validation on set and delete ──────────────────────
 
 
 @pytest.mark.parametrize(
     "legacy_name",
-    ["my-old-key", "lowercase_name", "dash-and-lower", "oldkey"],
+    ["my-old-key", "lowercase_name", "dash-and-lower"],
 )
-def test_secret_delete_accepts_legacy_names(
+def test_secret_delete_rejects_legacy_names(
     monkeypatch, capsys, legacy_name: str
 ) -> None:
-    """delete should NOT block legacy-named secrets at the client side.
+    """delete enforces the strict name rule, like set.
 
-    The platform DELETE endpoint uses a lenient lookup schema (non-empty,
-    max 255 chars, no character-set restriction) so pre-existing secrets
-    with lowercase/dash names can still be deleted via the CLI.
+    Existing secrets are normalized to the strict rule by migration, so the
+    CLI validates names up front rather than relying on a lenient lookup.
     """
-    fake_credentials = _stub_git_context(monkeypatch)
-    seen: dict[str, object] = {}
+    _stub_git_context(monkeypatch)
 
-    class FakeClient:
-        def delete_environment_secret(
-            self, name, *, scope, git_identity, credentials=None
-        ):
-            assert credentials is fake_credentials
-            seen.update(name=name, scope=scope)
-
-    monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
     exit_code = cli.main(
         ["--json", "secret", "delete", legacy_name, "--scope", "workspace", "--yes"]
     )
     captured = capsys.readouterr()
-    assert exit_code == 0, captured.err
-    assert seen == {"name": legacy_name, "scope": "workspace"}
+    assert exit_code == 1
+    payload = json.loads(captured.err)
+    assert payload["error"]["code"] == "VALIDATION"
 
 
-def test_secret_set_still_rejects_legacy_names(monkeypatch, capsys) -> None:
-    """set must STILL enforce SCREAMING_SNAKE_CASE — only delete is lenient."""
+def test_secret_set_rejects_legacy_names(monkeypatch, capsys) -> None:
+    """set enforces the strict name rule."""
     _stub_git_context(monkeypatch)
     monkeypatch.setenv("SOURCE_VAR", SENTINEL_VALUE)
 
@@ -766,24 +808,3 @@ def test_secret_set_still_rejects_legacy_names(monkeypatch, capsys) -> None:
     assert exit_code == 1
     payload = json.loads(captured.err)
     assert payload["error"]["code"] == "VALIDATION"
-
-
-@pytest.mark.parametrize(
-    "name",
-    ["my-old-key", "lowercase_name", "dash-and-lower"],
-)
-def test_validate_secret_name_for_lookup_accepts_legacy(name: str) -> None:
-    """The lenient lookup validator passes names that strict validation rejects."""
-    secret_module._validate_secret_name_for_lookup(name)  # no raise
-
-
-def test_validate_secret_name_for_lookup_rejects_empty() -> None:
-    with pytest.raises(CLIError) as exc:
-        secret_module._validate_secret_name_for_lookup("")
-    assert exc.value.code == "VALIDATION"
-
-
-def test_validate_secret_name_for_lookup_rejects_too_long() -> None:
-    with pytest.raises(CLIError) as exc:
-        secret_module._validate_secret_name_for_lookup("A" * 256)
-    assert exc.value.code == "VALIDATION"

--- a/tests/unit/cli/test_secret_commands.py
+++ b/tests/unit/cli/test_secret_commands.py
@@ -716,3 +716,74 @@ def test_secret_delete_subcommand_wires_through(monkeypatch, capsys) -> None:
     monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
     assert cli.main(["--json", "secret", "delete", "X", "--scope", "user", "--yes"]) == 0
     assert seen == {"name": "X", "scope": "user"}
+
+
+# ── lenient name validation on delete (legacy-named secrets) ──────
+
+
+@pytest.mark.parametrize(
+    "legacy_name",
+    ["my-old-key", "lowercase_name", "dash-and-lower", "oldkey"],
+)
+def test_secret_delete_accepts_legacy_names(
+    monkeypatch, capsys, legacy_name: str
+) -> None:
+    """delete should NOT block legacy-named secrets at the client side.
+
+    The platform DELETE endpoint uses a lenient lookup schema (non-empty,
+    max 255 chars, no character-set restriction) so pre-existing secrets
+    with lowercase/dash names can still be deleted via the CLI.
+    """
+    fake_credentials = _stub_git_context(monkeypatch)
+    seen: dict[str, object] = {}
+
+    class FakeClient:
+        def delete_environment_secret(
+            self, name, *, scope, git_identity, credentials=None
+        ):
+            assert credentials is fake_credentials
+            seen.update(name=name, scope=scope)
+
+    monkeypatch.setattr(secret_module, "OsmosisClient", FakeClient)
+    exit_code = cli.main(
+        ["--json", "secret", "delete", legacy_name, "--scope", "workspace", "--yes"]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.err
+    assert seen == {"name": legacy_name, "scope": "workspace"}
+
+
+def test_secret_set_still_rejects_legacy_names(monkeypatch, capsys) -> None:
+    """set must STILL enforce SCREAMING_SNAKE_CASE — only delete is lenient."""
+    _stub_git_context(monkeypatch)
+    monkeypatch.setenv("SOURCE_VAR", SENTINEL_VALUE)
+
+    exit_code = cli.main(
+        ["--json", "secret", "set", "my-old-key",
+         "--scope", "workspace", "--env", "SOURCE_VAR"]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    payload = json.loads(captured.err)
+    assert payload["error"]["code"] == "VALIDATION"
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["my-old-key", "lowercase_name", "dash-and-lower"],
+)
+def test_validate_secret_name_for_lookup_accepts_legacy(name: str) -> None:
+    """The lenient lookup validator passes names that strict validation rejects."""
+    secret_module._validate_secret_name_for_lookup(name)  # no raise
+
+
+def test_validate_secret_name_for_lookup_rejects_empty() -> None:
+    with pytest.raises(CLIError) as exc:
+        secret_module._validate_secret_name_for_lookup("")
+    assert exc.value.code == "VALIDATION"
+
+
+def test_validate_secret_name_for_lookup_rejects_too_long() -> None:
+    with pytest.raises(CLIError) as exc:
+        secret_module._validate_secret_name_for_lookup("A" * 256)
+    assert exc.value.code == "VALIDATION"

--- a/tests/unit/cli/test_train_commands.py
+++ b/tests/unit/cli/test_train_commands.py
@@ -937,6 +937,8 @@ rollout_batch_size = 64
         path = workspace_directory / "configs" / "training" / "train.toml"
         path.write_text(
             """
+secrets = ["OPENAI_API_KEY"]
+
 [experiment]
 rollout = "r"
 entrypoint = "main.py"
@@ -945,9 +947,6 @@ dataset = "d"
 
 [env]
 LOG_LEVEL = "INFO"
-
-[secrets]
-OPENAI_API_KEY = "openai-api-key"
 """.strip(),
             encoding="utf-8",
         )
@@ -964,9 +963,7 @@ OPENAI_API_KEY = "openai-api-key"
         train_module.submit(config_path=path, yes=True)
 
         assert captured_kwargs["env_config"] == {"LOG_LEVEL": "INFO"}
-        assert captured_kwargs["secret_refs_config"] == {
-            "OPENAI_API_KEY": "openai-api-key"
-        }
+        assert captured_kwargs["secrets"] == ["OPENAI_API_KEY"]
 
     def test_submit_rejects_non_canonical_training_config_path(
         self,

--- a/tests/unit/cli/test_train_commands.py
+++ b/tests/unit/cli/test_train_commands.py
@@ -937,8 +937,6 @@ rollout_batch_size = 64
         path = workspace_directory / "configs" / "training" / "train.toml"
         path.write_text(
             """
-secrets = ["OPENAI_API_KEY"]
-
 [experiment]
 rollout = "r"
 entrypoint = "main.py"
@@ -947,6 +945,9 @@ dataset = "d"
 
 [env]
 LOG_LEVEL = "INFO"
+
+[secrets]
+required = ["OPENAI_API_KEY"]
 """.strip(),
             encoding="utf-8",
         )

--- a/tests/unit/platform/api/test_client.py
+++ b/tests/unit/platform/api/test_client.py
@@ -549,11 +549,11 @@ class TestSubmitTrainingRun:
                 "rollout": "rollout1",
                 "entrypoint": "rollouts/main.py",
             },
-            secrets=["OPENAI_API_KEY", "DATABASE_URL"],
+            secrets=["OPENAI_API_KEY", "GITHUB_TOKEN"],
             git_identity="git_test",
         )
         payload = mock_request.call_args.kwargs["data"]
-        assert payload["secrets"] == ["OPENAI_API_KEY", "DATABASE_URL"]
+        assert payload["secrets"] == {"required": ["OPENAI_API_KEY", "GITHUB_TOKEN"]}
         assert "env_config" not in payload
         assert "secret_refs_config" not in payload
 
@@ -616,7 +616,7 @@ class TestSubmitTrainingRun:
         assert payload["checkpoints_config"] == {"checkpoint_save_freq": 10}
         assert payload["advanced_config"] == {"optimizer": "adam"}
         assert payload["env_config"] == {"FOO": "bar"}
-        assert payload["secrets"] == ["OPENAI_API_KEY"]
+        assert payload["secrets"] == {"required": ["OPENAI_API_KEY"]}
 
 
 class TestEvaluationRuns:
@@ -680,7 +680,7 @@ class TestEvaluationRuns:
             "evaluation_config": {"rubric": "grade correctness"},
             "advanced_config": {"max_concurrent_rollouts": 8},
             "env_config": {"FOO": "bar"},
-            "secrets": ["OPENAI_API_KEY"],
+            "secrets": {"required": ["OPENAI_API_KEY"]},
         }
 
     @patch("osmosis_ai.platform.api.client.platform_request")

--- a/tests/unit/platform/api/test_client.py
+++ b/tests/unit/platform/api/test_client.py
@@ -332,7 +332,7 @@ class TestEnvironmentSecrets:
         )
 
         assert mock_request.call_args[0][0] == (
-            "/api/cli/environment-secrets?limit=25&offset=50"
+            "/api/cli/environment-secrets?limit=25&offset=50&scope=all"
         )
         assert mock_request.call_args.kwargs["credentials"] is credentials
         assert mock_request.call_args.kwargs["git_identity"] == "git_123"
@@ -342,7 +342,7 @@ class TestEnvironmentSecrets:
         assert result.platform_url == "https://platform.osmosis.ai/acme/secrets"
 
     @patch("osmosis_ai.platform.api.client.platform_request")
-    def test_create_environment_secret_posts_value_once_and_returns_metadata(
+    def test_set_environment_secret_posts_value_once_and_returns_metadata(
         self, mock_request: MagicMock
     ) -> None:
         credentials = object()
@@ -353,12 +353,14 @@ class TestEnvironmentSecrets:
             "created_at": "2026-05-01T00:00:00Z",
             "updated_at": "2026-05-01T00:00:01Z",
             "creator_name": "Ada",
+            "scope": "workspace",
             "platform_url": "https://platform.osmosis.ai/acme/secrets",
         }
 
-        result = OsmosisClient().create_environment_secret(
+        result = OsmosisClient().set_environment_secret(
             "OPENAI_API_KEY",
             secret_value,
+            scope="workspace",
             credentials=credentials,
             git_identity="git_123",
         )
@@ -368,6 +370,7 @@ class TestEnvironmentSecrets:
         assert mock_request.call_args.kwargs["data"] == {
             "name": "OPENAI_API_KEY",
             "value": secret_value,
+            "scope": "workspace",
         }
         assert mock_request.call_args.kwargs["credentials"] is credentials
         assert mock_request.call_args.kwargs["git_identity"] == "git_123"

--- a/tests/unit/platform/api/test_client.py
+++ b/tests/unit/platform/api/test_client.py
@@ -512,7 +512,7 @@ class TestSubmitTrainingRun:
             },
         }
         assert "env_config" not in payload
-        assert "secret_refs_config" not in payload
+        assert "secrets" not in payload
 
     @patch("osmosis_ai.platform.api.client.platform_request")
     def test_env_config_included_when_non_empty(self, mock_request: MagicMock) -> None:
@@ -532,16 +532,13 @@ class TestSubmitTrainingRun:
         )
         payload = mock_request.call_args.kwargs["data"]
         assert payload["env_config"] == env_config
-        assert "secret_refs_config" not in payload
+        assert "secrets" not in payload
 
     @patch("osmosis_ai.platform.api.client.platform_request")
-    def test_secret_refs_config_included_when_non_empty(
-        self, mock_request: MagicMock
-    ) -> None:
-        """Non-empty secret_refs_config map is forwarded to the platform."""
+    def test_secrets_included_when_non_empty(self, mock_request: MagicMock) -> None:
+        """Non-empty secrets list is forwarded to the platform."""
         mock_request.return_value = self._response()
         client = OsmosisClient()
-        secret_refs_config = {"OPENAI_API_KEY": "openai-prod"}
         client.submit_training_run(
             experiment_config={
                 "model_path": "m1",
@@ -549,18 +546,19 @@ class TestSubmitTrainingRun:
                 "rollout": "rollout1",
                 "entrypoint": "rollouts/main.py",
             },
-            secret_refs_config=secret_refs_config,
+            secrets=["OPENAI_API_KEY", "DATABASE_URL"],
             git_identity="git_test",
         )
         payload = mock_request.call_args.kwargs["data"]
-        assert payload["secret_refs_config"] == secret_refs_config
+        assert payload["secrets"] == ["OPENAI_API_KEY", "DATABASE_URL"]
         assert "env_config" not in payload
+        assert "secret_refs_config" not in payload
 
     @patch("osmosis_ai.platform.api.client.platform_request")
-    def test_empty_env_and_secret_refs_configs_are_omitted(
+    def test_empty_env_and_secrets_are_omitted(
         self, mock_request: MagicMock
     ) -> None:
-        """Empty dicts are treated as 'not provided' and stripped from payload."""
+        """Empty containers are treated as 'not provided' and stripped."""
         mock_request.return_value = self._response()
         client = OsmosisClient()
         client.submit_training_run(
@@ -571,11 +569,12 @@ class TestSubmitTrainingRun:
                 "entrypoint": "rollouts/main.py",
             },
             env_config={},
-            secret_refs_config={},
+            secrets=[],
             git_identity="git_test",
         )
         payload = mock_request.call_args.kwargs["data"]
         assert "env_config" not in payload
+        assert "secrets" not in payload
         assert "secret_refs_config" not in payload
 
     @patch("osmosis_ai.platform.api.client.platform_request")
@@ -598,7 +597,7 @@ class TestSubmitTrainingRun:
             checkpoints_config={"checkpoint_save_freq": 10},
             advanced_config={"optimizer": "adam"},
             env_config={"FOO": "bar"},
-            secret_refs_config={"OPENAI_API_KEY": "openai-prod"},
+            secrets=["OPENAI_API_KEY"],
             git_identity="git_test",
         )
         payload = mock_request.call_args.kwargs["data"]
@@ -614,7 +613,7 @@ class TestSubmitTrainingRun:
         assert payload["checkpoints_config"] == {"checkpoint_save_freq": 10}
         assert payload["advanced_config"] == {"optimizer": "adam"}
         assert payload["env_config"] == {"FOO": "bar"}
-        assert payload["secret_refs_config"] == {"OPENAI_API_KEY": "openai-prod"}
+        assert payload["secrets"] == ["OPENAI_API_KEY"]
 
 
 class TestEvaluationRuns:
@@ -668,7 +667,7 @@ class TestEvaluationRuns:
             evaluation_config={"rubric": "grade correctness"},
             advanced_config={"max_concurrent_rollouts": 8},
             env_config={"FOO": "bar"},
-            secret_refs_config={"OPENAI_API_KEY": "openai-prod"},
+            secrets=["OPENAI_API_KEY"],
             git_identity="git_test",
         )
 
@@ -678,7 +677,7 @@ class TestEvaluationRuns:
             "evaluation_config": {"rubric": "grade correctness"},
             "advanced_config": {"max_concurrent_rollouts": 8},
             "env_config": {"FOO": "bar"},
-            "secret_refs_config": {"OPENAI_API_KEY": "openai-prod"},
+            "secrets": ["OPENAI_API_KEY"],
         }
 
     @patch("osmosis_ai.platform.api.client.platform_request")

--- a/tests/unit/platform/api/test_client.py
+++ b/tests/unit/platform/api/test_client.py
@@ -558,9 +558,7 @@ class TestSubmitTrainingRun:
         assert "secret_refs_config" not in payload
 
     @patch("osmosis_ai.platform.api.client.platform_request")
-    def test_empty_env_and_secrets_are_omitted(
-        self, mock_request: MagicMock
-    ) -> None:
+    def test_empty_env_and_secrets_are_omitted(self, mock_request: MagicMock) -> None:
         """Empty containers are treated as 'not provided' and stripped."""
         mock_request.return_value = self._response()
         client = OsmosisClient()

--- a/tests/unit/platform/api/test_client_environment_secrets.py
+++ b/tests/unit/platform/api/test_client_environment_secrets.py
@@ -1,0 +1,116 @@
+"""Tests for OsmosisClient environment-secret endpoints (set/list/delete)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import osmosis_ai.platform.api.client as client_module
+from osmosis_ai.platform.api.client import OsmosisClient
+from osmosis_ai.platform.api.models import (
+    EnvironmentSecretInfo,
+    PaginatedEnvironmentSecrets,
+)
+
+GIT_IDENTITY = "acme/rollouts"
+CREDS = object()
+
+
+@pytest.fixture()
+def captured(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    calls: dict[str, Any] = {}
+
+    def fake_request(
+        endpoint,
+        method="GET",
+        data=None,
+        *,
+        credentials=None,
+        git_identity=None,
+        **kwargs,
+    ):
+        calls["endpoint"] = endpoint
+        calls["method"] = method
+        calls["data"] = data
+        calls["credentials"] = credentials
+        calls["git_identity"] = git_identity
+        return {
+            "id": "sec_1",
+            "name": "OPENAI_API_KEY",
+            "created_at": "2026-05-01T00:00:00Z",
+            "updated_at": "2026-05-01T00:00:01Z",
+            "scope": "user",
+            "environment_secrets": [
+                {"id": "sec_1", "name": "OPENAI_API_KEY", "scope": "user"}
+            ],
+            "total_count": 1,
+            "has_more": False,
+        }
+
+    monkeypatch.setattr(client_module, "platform_request", fake_request)
+    return calls
+
+
+def test_set_environment_secret_posts_name_value_scope(captured) -> None:
+    result = OsmosisClient().set_environment_secret(
+        "OPENAI_API_KEY",
+        "sk-x",
+        scope="user",
+        credentials=CREDS,
+        git_identity=GIT_IDENTITY,
+    )
+    assert captured["endpoint"] == "/api/cli/environment-secrets"
+    assert captured["method"] == "POST"
+    assert captured["data"] == {
+        "name": "OPENAI_API_KEY",
+        "value": "sk-x",
+        "scope": "user",
+    }
+    assert captured["credentials"] is CREDS
+    assert captured["git_identity"] == GIT_IDENTITY
+    assert isinstance(result, EnvironmentSecretInfo)
+    assert result.scope == "user"
+
+
+def test_delete_environment_secret_sends_delete_with_name_scope(captured) -> None:
+    OsmosisClient().delete_environment_secret(
+        "OPENAI_API_KEY",
+        scope="workspace",
+        credentials=CREDS,
+        git_identity=GIT_IDENTITY,
+    )
+    assert captured["endpoint"] == "/api/cli/environment-secrets"
+    assert captured["method"] == "DELETE"
+    assert captured["data"] == {"name": "OPENAI_API_KEY", "scope": "workspace"}
+
+
+def test_list_environment_secrets_puts_scope_in_query(captured) -> None:
+    OsmosisClient().list_environment_secrets(
+        limit=10,
+        offset=0,
+        scope="workspace",
+        credentials=CREDS,
+        git_identity=GIT_IDENTITY,
+    )
+    assert captured["endpoint"].startswith("/api/cli/environment-secrets?")
+    assert "scope=workspace" in captured["endpoint"]
+    assert "limit=10" in captured["endpoint"]
+    assert "offset=0" in captured["endpoint"]
+
+
+def test_list_environment_secrets_default_scope_is_all(captured) -> None:
+    OsmosisClient().list_environment_secrets(
+        credentials=CREDS,
+        git_identity=GIT_IDENTITY,
+    )
+    assert "scope=all" in captured["endpoint"]
+
+
+def test_list_environment_secrets_returns_paginated(captured) -> None:
+    page = OsmosisClient().list_environment_secrets(
+        credentials=CREDS,
+        git_identity=GIT_IDENTITY,
+    )
+    assert isinstance(page, PaginatedEnvironmentSecrets)
+    assert page.environment_secrets[0].scope == "user"

--- a/tests/unit/platform/api/test_models_environment_secret.py
+++ b/tests/unit/platform/api/test_models_environment_secret.py
@@ -1,0 +1,41 @@
+"""Tests for EnvironmentSecretInfo.scope round-trip from API payloads."""
+
+from __future__ import annotations
+
+from osmosis_ai.platform.api.models import (
+    EnvironmentSecretInfo,
+    PaginatedEnvironmentSecrets,
+)
+
+
+def test_environment_secret_info_parses_scope() -> None:
+    info = EnvironmentSecretInfo.from_dict(
+        {
+            "id": "sec_1",
+            "name": "OPENAI_API_KEY",
+            "created_at": "2026-05-01T00:00:00Z",
+            "updated_at": "2026-05-01T00:00:01Z",
+            "creator_name": "Ada",
+            "scope": "user",
+        }
+    )
+    assert info.scope == "user"
+
+
+def test_environment_secret_info_scope_defaults_to_none_when_absent() -> None:
+    info = EnvironmentSecretInfo.from_dict({"id": "sec_1", "name": "X"})
+    assert info.scope is None
+
+
+def test_paginated_environment_secrets_parses_scope_per_item() -> None:
+    page = PaginatedEnvironmentSecrets.from_dict(
+        {
+            "environment_secrets": [
+                {"id": "a", "name": "A", "scope": "workspace"},
+                {"id": "b", "name": "B", "scope": "user"},
+            ],
+            "total_count": 2,
+            "has_more": False,
+        }
+    )
+    assert [s.scope for s in page.environment_secrets] == ["workspace", "user"]

--- a/tests/unit/platform/cli/test_eval_config.py
+++ b/tests/unit/platform/cli/test_eval_config.py
@@ -92,6 +92,28 @@ dataset = "multiply"
     assert config.secrets == []
 
 
+def test_secrets_map_form_is_rejected_with_conversion_hint(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path / "eval.toml",
+        """
+[experiment]
+rollout = "calculator"
+entrypoint = "main.py"
+model_path = "openai/gpt-5-mini"
+dataset = "multiply"
+
+[secrets]
+OPENAI_API_KEY = "OPENAI_API_KEY"
+""",
+    )
+
+    with pytest.raises(CLIError) as exc_info:
+        load_eval_submit_config(path)
+    message = str(exc_info.value)
+    assert "[secrets] map form is no longer supported" in message
+    assert 'secrets = ["NAME", ...]' in message
+
+
 def test_load_eval_submit_config_advanced_section_preserves_backend_params(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/platform/cli/test_eval_config.py
+++ b/tests/unit/platform/cli/test_eval_config.py
@@ -20,6 +20,8 @@ def test_load_eval_submit_config_accepts_new_cloud_schema(tmp_path: Path) -> Non
     path = _write_config(
         tmp_path / "eval.toml",
         """
+secrets = ["OPENAI_API_KEY", "DATABASE_URL"]
+
 [experiment]
 rollout = "calculator"
 entrypoint = "main.py"
@@ -37,9 +39,6 @@ grader_timeout_s = 150
 
 [env]
 LOG_LEVEL = "INFO"
-
-[secrets]
-OPENAI_API_KEY = "openai-api-key"
 """,
     )
 
@@ -59,7 +58,7 @@ OPENAI_API_KEY = "openai-api-key"
         "grader_timeout_s": 150.0,
     }
     assert config.env == {"LOG_LEVEL": "INFO"}
-    assert config.secrets == {"OPENAI_API_KEY": "openai-api-key"}
+    assert config.secrets == ["OPENAI_API_KEY", "DATABASE_URL"]
     assert config.experiment_config == {
         "rollout": "calculator",
         "entrypoint": "main.py",
@@ -90,7 +89,7 @@ dataset = "multiply"
     assert config.evaluation_config == {}
     assert config.advanced_config == {}
     assert config.env == {}
-    assert config.secrets == {}
+    assert config.secrets == []
 
 
 def test_load_eval_submit_config_advanced_section_preserves_backend_params(

--- a/tests/unit/platform/cli/test_eval_config.py
+++ b/tests/unit/platform/cli/test_eval_config.py
@@ -80,6 +80,9 @@ rollout = "calculator"
 entrypoint = "main.py"
 model_path = "openai/gpt-5-mini"
 dataset = "multiply"
+
+[secrets]
+required = []
 """,
     )
 
@@ -93,7 +96,7 @@ dataset = "multiply"
     assert config.secrets == []
 
 
-def test_secrets_map_form_is_rejected_with_conversion_hint(tmp_path: Path) -> None:
+def test_secrets_required_field_is_required_for_eval(tmp_path: Path) -> None:
     path = _write_config(
         tmp_path / "eval.toml",
         """
@@ -104,15 +107,51 @@ model_path = "openai/gpt-5-mini"
 dataset = "multiply"
 
 [secrets]
+""",
+    )
+
+    with pytest.raises(CLIError) as exc_info:
+        load_eval_submit_config(path)
+    assert "Missing 'required' in [secrets]" in str(exc_info.value)
+
+
+def test_secrets_section_is_required_for_eval(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path / "eval.toml",
+        """
+[experiment]
+rollout = "calculator"
+entrypoint = "main.py"
+model_path = "openai/gpt-5-mini"
+dataset = "multiply"
+""",
+    )
+
+    with pytest.raises(CLIError) as exc_info:
+        load_eval_submit_config(path)
+    assert "Missing [secrets] section" in str(exc_info.value)
+
+
+def test_secrets_rejects_unknown_keys(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path / "eval.toml",
+        """
+[secrets]
 OPENAI_API_KEY = "OPENAI_API_KEY"
+
+[experiment]
+rollout = "calculator"
+entrypoint = "main.py"
+model_path = "openai/gpt-5-mini"
+dataset = "multiply"
 """,
     )
 
     with pytest.raises(CLIError) as exc_info:
         load_eval_submit_config(path)
     message = str(exc_info.value)
-    assert "uses key=value pairs" in message
-    assert "required = [" in message
+    assert "only supports the 'required' field" in message
+    assert "OPENAI_API_KEY" in message
 
 
 def test_load_eval_submit_config_advanced_section_preserves_backend_params(
@@ -130,6 +169,9 @@ dataset = "multiply"
 [advanced]
 custom_eval_flag = true
 future_knob = "experimental"
+
+[secrets]
+required = []
 """,
     )
 
@@ -155,6 +197,9 @@ dataset = "multiply"
 
 [evaluation]
 unknown_eval_knob = 42
+
+[secrets]
+required = []
 """,
     )
 
@@ -198,6 +243,9 @@ dataset = "multiply"
 
 [llm]
 model_path = "openai/gpt-5-mini"
+
+[secrets]
+required = []
 """,
     )
 
@@ -217,6 +265,9 @@ dataset = "multiply"
 
 [env]
 _OSMOSIS_INTERNAL = "bad"
+
+[secrets]
+required = []
 """,
     )
 
@@ -239,6 +290,9 @@ dataset = "multiply"
 [evaluation]
 limit = "many"
 pass_threshold = "strict"
+
+[secrets]
+required = []
 """,
     )
 
@@ -261,6 +315,9 @@ rollout = "calculator"
 entrypoint = "../main.py"
 model_path = "openai/gpt-5-mini"
 dataset = "multiply"
+
+[secrets]
+required = []
 """,
     )
     config = load_eval_submit_config(config_path)
@@ -278,6 +335,9 @@ rollout = "{rollout}"
 entrypoint = "main.py"
 model_path = "openai/gpt-5-mini"
 dataset = "multiply"
+
+[secrets]
+required = []
 """,
     )
 

--- a/tests/unit/platform/cli/test_eval_config.py
+++ b/tests/unit/platform/cli/test_eval_config.py
@@ -20,8 +20,6 @@ def test_load_eval_submit_config_accepts_new_cloud_schema(tmp_path: Path) -> Non
     path = _write_config(
         tmp_path / "eval.toml",
         """
-secrets = ["OPENAI_API_KEY", "DATABASE_URL"]
-
 [experiment]
 rollout = "calculator"
 entrypoint = "main.py"
@@ -39,6 +37,9 @@ grader_timeout_s = 150
 
 [env]
 LOG_LEVEL = "INFO"
+
+[secrets]
+required = ["OPENAI_API_KEY", "GITHUB_TOKEN"]
 """,
     )
 
@@ -58,7 +59,7 @@ LOG_LEVEL = "INFO"
         "grader_timeout_s": 150.0,
     }
     assert config.env == {"LOG_LEVEL": "INFO"}
-    assert config.secrets == ["OPENAI_API_KEY", "DATABASE_URL"]
+    assert config.secrets == ["OPENAI_API_KEY", "GITHUB_TOKEN"]
     assert config.experiment_config == {
         "rollout": "calculator",
         "entrypoint": "main.py",
@@ -110,8 +111,8 @@ OPENAI_API_KEY = "OPENAI_API_KEY"
     with pytest.raises(CLIError) as exc_info:
         load_eval_submit_config(path)
     message = str(exc_info.value)
-    assert "[secrets] map form is no longer supported" in message
-    assert 'secrets = ["NAME", ...]' in message
+    assert "uses key=value pairs" in message
+    assert "required = [" in message
 
 
 def test_load_eval_submit_config_advanced_section_preserves_backend_params(

--- a/tests/unit/platform/cli/test_eval_submit.py
+++ b/tests/unit/platform/cli/test_eval_submit.py
@@ -69,7 +69,6 @@ def _write_eval_config(path: Path, *, commit_sha: str | None = None) -> Path:
     commit_line = f'commit_sha = "{commit_sha}"\n' if commit_sha is not None else ""
     path.write_text(
         (
-            'secrets = ["OPENAI_API_KEY"]\n\n'
             "[experiment]\n"
             'rollout = "calculator"\n'
             'entrypoint = "main.py"\n'
@@ -84,7 +83,9 @@ def _write_eval_config(path: Path, *, commit_sha: str | None = None) -> Path:
             "agent_workflow_timeout_s = 450\n"
             "grader_timeout_s = 150\n\n"
             "[env]\n"
-            'LOG_LEVEL = "INFO"\n'
+            'LOG_LEVEL = "INFO"\n\n'
+            "[secrets]\n"
+            'required = ["OPENAI_API_KEY"]\n'
         ),
         encoding="utf-8",
     )

--- a/tests/unit/platform/cli/test_eval_submit.py
+++ b/tests/unit/platform/cli/test_eval_submit.py
@@ -69,6 +69,7 @@ def _write_eval_config(path: Path, *, commit_sha: str | None = None) -> Path:
     commit_line = f'commit_sha = "{commit_sha}"\n' if commit_sha is not None else ""
     path.write_text(
         (
+            'secrets = ["OPENAI_API_KEY"]\n\n'
             "[experiment]\n"
             'rollout = "calculator"\n'
             'entrypoint = "main.py"\n'
@@ -83,9 +84,7 @@ def _write_eval_config(path: Path, *, commit_sha: str | None = None) -> Path:
             "agent_workflow_timeout_s = 450\n"
             "grader_timeout_s = 150\n\n"
             "[env]\n"
-            'LOG_LEVEL = "INFO"\n\n'
-            "[secrets]\n"
-            'OPENAI_API_KEY = "openai-api-key"\n'
+            'LOG_LEVEL = "INFO"\n'
         ),
         encoding="utf-8",
     )
@@ -176,7 +175,7 @@ def test_eval_submit_passes_new_schema_to_evaluation_run_api(
     assert captured_kwargs["git_identity"] == GIT_IDENTITY
     assert captured_kwargs["credentials"] is FAKE_CREDENTIALS
     assert captured_kwargs["env_config"] == {"LOG_LEVEL": "INFO"}
-    assert captured_kwargs["secret_refs_config"] == {"OPENAI_API_KEY": "openai-api-key"}
+    assert captured_kwargs["secrets"] == ["OPENAI_API_KEY"]
     assert captured_kwargs["experiment_config"] == {
         "rollout": "calculator",
         "entrypoint": "main.py",

--- a/tests/unit/platform/cli/test_submit_secret_override_reminder.py
+++ b/tests/unit/platform/cli/test_submit_secret_override_reminder.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+import osmosis_ai.platform.cli.shared_submit as shared_submit
 from osmosis_ai.platform.api.models import (
     EnvironmentSecretInfo,
     PaginatedEnvironmentSecrets,
 )
 from osmosis_ai.platform.cli.shared_config import build_secret_table_rows
-import osmosis_ai.platform.cli.shared_submit as shared_submit
 
 
 def test_build_secret_table_rows_annotates_scope() -> None:

--- a/tests/unit/platform/cli/test_submit_secret_override_reminder.py
+++ b/tests/unit/platform/cli/test_submit_secret_override_reminder.py
@@ -67,10 +67,10 @@ def test_fetch_secret_scopes_returns_none_on_error(monkeypatch) -> None:
 
 def test_missing_secret_message_lists_set_commands() -> None:
     msg = shared_submit._missing_secret_message(["OPENAI_API_KEY", "WANDB_API_KEY"])
-    assert "not found: OPENAI_API_KEY, WANDB_API_KEY" in msg
-    assert "personal is the default" in msg
-    assert "osmosis secret set OPENAI_API_KEY --scope personal" in msg
-    assert "osmosis secret set WANDB_API_KEY --scope personal" in msg
+    assert "Could not find secret(s): OPENAI_API_KEY, WANDB_API_KEY" in msg
+    assert "osmosis secret set OPENAI_API_KEY" in msg
+    assert "osmosis secret set WANDB_API_KEY" in msg
+    assert "Secrets default to personal scope" in msg
     assert "--scope workspace" in msg
 
 
@@ -88,9 +88,9 @@ def test_enrich_missing_secret_error_adds_hint() -> None:
     enriched = shared_submit._enrich_missing_secret_error(exc)
     assert enriched is not None
     msg = str(enriched)
-    assert "personal is the default" in msg
-    assert "osmosis secret set OPENAI_API_KEY --scope personal" in msg
-    assert "osmosis secret set WANDB_API_KEY --scope personal" in msg
+    assert "osmosis secret set OPENAI_API_KEY" in msg
+    assert "osmosis secret set WANDB_API_KEY" in msg
+    assert "Secrets default to personal scope" in msg
     assert "--scope workspace" in msg
     assert "https://platform.osmosis.ai/my-workspace/secrets" in msg
 

--- a/tests/unit/platform/cli/test_submit_secret_override_reminder.py
+++ b/tests/unit/platform/cli/test_submit_secret_override_reminder.py
@@ -68,8 +68,10 @@ def test_fetch_secret_scopes_returns_none_on_error(monkeypatch) -> None:
 def test_missing_secret_message_lists_set_commands() -> None:
     msg = shared_submit._missing_secret_message(["OPENAI_API_KEY", "WANDB_API_KEY"])
     assert "not found: OPENAI_API_KEY, WANDB_API_KEY" in msg
-    assert "osmosis secret set OPENAI_API_KEY" in msg
-    assert "osmosis secret set WANDB_API_KEY" in msg
+    assert "personal is the default" in msg
+    assert "osmosis secret set OPENAI_API_KEY --scope personal" in msg
+    assert "osmosis secret set WANDB_API_KEY --scope personal" in msg
+    assert "--scope workspace" in msg
 
 
 def test_enrich_missing_secret_error_adds_hint() -> None:
@@ -86,8 +88,10 @@ def test_enrich_missing_secret_error_adds_hint() -> None:
     enriched = shared_submit._enrich_missing_secret_error(exc)
     assert enriched is not None
     msg = str(enriched)
-    assert "osmosis secret set OPENAI_API_KEY" in msg
-    assert "osmosis secret set WANDB_API_KEY" in msg
+    assert "personal is the default" in msg
+    assert "osmosis secret set OPENAI_API_KEY --scope personal" in msg
+    assert "osmosis secret set WANDB_API_KEY --scope personal" in msg
+    assert "--scope workspace" in msg
     assert "https://platform.osmosis.ai/my-workspace/secrets" in msg
 
 

--- a/tests/unit/platform/cli/test_submit_secret_override_reminder.py
+++ b/tests/unit/platform/cli/test_submit_secret_override_reminder.py
@@ -1,50 +1,28 @@
-"""The submit confirmation reminds the user which referenced secrets resolve
-to their personal (user-scope) value vs the shared workspace value."""
+"""Tests for separate secrets table rendering and missing-secret error enrichment."""
 
 from __future__ import annotations
 
-import osmosis_ai.platform.cli.shared_submit as shared_submit
 from osmosis_ai.platform.api.models import (
     EnvironmentSecretInfo,
     PaginatedEnvironmentSecrets,
 )
+from osmosis_ai.platform.cli.shared_config import build_secret_table_rows
+import osmosis_ai.platform.cli.shared_submit as shared_submit
 
 
-def _user_secrets_page(names: list[str]) -> PaginatedEnvironmentSecrets:
-    return PaginatedEnvironmentSecrets(
-        environment_secrets=[
-            EnvironmentSecretInfo(id=n, name=n, scope="user") for n in names
-        ],
-        total_count=len(names),
-        has_more=False,
+def test_build_secret_table_rows_annotates_scope() -> None:
+    rows = build_secret_table_rows(
+        ["OPENAI_API_KEY", "GITHUB_TOKEN", "MY_PERSONAL"],
+        user_secret_names={"OPENAI_API_KEY", "MY_PERSONAL"},
+        workspace_secret_names={"OPENAI_API_KEY", "GITHUB_TOKEN"},
     )
+    assert ("GITHUB_TOKEN", "Workspace") in rows
+    assert ("OPENAI_API_KEY", "Personal (overrides workspace)") in rows
+    # personal-only: no workspace secret of that name → not an override
+    assert ("MY_PERSONAL", "Personal") in rows
 
 
-def test_annotates_rows_with_personal_vs_workspace() -> None:
-    rows = [
-        ("Rollout secrets (2)", "OPENAI_API_KEY, DATABASE_URL"),
-    ]
-    annotated = shared_submit._annotate_secret_override_row(
-        rows,
-        referenced=["OPENAI_API_KEY", "DATABASE_URL"],
-        user_secret_names={"OPENAI_API_KEY"},
-    )
-    # the secrets row value now spells out per-secret resolution
-    label, value = annotated[0]
-    assert label == "Rollout secrets (2)"
-    assert "OPENAI_API_KEY (personal)" in value
-    assert "DATABASE_URL (workspace)" in value
-
-
-def test_no_secrets_row_is_unchanged() -> None:
-    rows = [("Rollout", "calculator")]
-    annotated = shared_submit._annotate_secret_override_row(
-        rows, referenced=[], user_secret_names=set()
-    )
-    assert annotated == rows
-
-
-def test_fetch_user_secret_names_collects_all_pages(monkeypatch) -> None:
+def test_fetch_secret_scopes_collects_all_pages_and_partitions(monkeypatch) -> None:
     calls: list[dict] = []
 
     class FakeClient:
@@ -55,7 +33,7 @@ def test_fetch_user_secret_names_collects_all_pages(monkeypatch) -> None:
             if offset == 0:
                 return PaginatedEnvironmentSecrets(
                     environment_secrets=[
-                        EnvironmentSecretInfo(id="A", name="A", scope="user")
+                        EnvironmentSecretInfo(id="A", name="A", scope="workspace")
                     ],
                     total_count=2,
                     has_more=True,
@@ -69,20 +47,52 @@ def test_fetch_user_secret_names_collects_all_pages(monkeypatch) -> None:
                 has_more=False,
             )
 
-    names = shared_submit._fetch_user_secret_names(
+    result = shared_submit._fetch_secret_scopes(
         FakeClient(), credentials=object(), git_identity="acme/x"
     )
-    assert names == {"A", "B"}
-    assert all(c["scope"] == "user" for c in calls)
+    assert result == ({"A"}, {"B"})
+    assert all(c["scope"] == "all" for c in calls)
 
 
-def test_fetch_user_secret_names_swallows_errors(monkeypatch) -> None:
+def test_fetch_secret_scopes_returns_none_on_error(monkeypatch) -> None:
     class FakeClient:
         def list_environment_secrets(self, **kwargs):
             raise RuntimeError("network down")
 
-    # A failure to fetch the reminder must not block submit.
-    names = shared_submit._fetch_user_secret_names(
+    result = shared_submit._fetch_secret_scopes(
         FakeClient(), credentials=object(), git_identity="acme/x"
     )
-    assert names == set()
+    assert result is None
+
+
+def test_missing_secret_message_lists_set_commands() -> None:
+    msg = shared_submit._missing_secret_message(["OPENAI_API_KEY", "WANDB_API_KEY"])
+    assert "not found: OPENAI_API_KEY, WANDB_API_KEY" in msg
+    assert "osmosis secret set OPENAI_API_KEY" in msg
+    assert "osmosis secret set WANDB_API_KEY" in msg
+
+
+def test_enrich_missing_secret_error_adds_hint() -> None:
+    from osmosis_ai.platform.auth.platform_client import PlatformAPIError
+
+    exc = PlatformAPIError(
+        "Secret(s) not found: OPENAI_API_KEY, WANDB_API_KEY",
+        404,
+        details={
+            "error": "Secret(s) not found: OPENAI_API_KEY, WANDB_API_KEY",
+            "platform_url": "https://platform.osmosis.ai/my-workspace/secrets",
+        },
+    )
+    enriched = shared_submit._enrich_missing_secret_error(exc)
+    assert enriched is not None
+    msg = str(enriched)
+    assert "osmosis secret set OPENAI_API_KEY" in msg
+    assert "osmosis secret set WANDB_API_KEY" in msg
+    assert "https://platform.osmosis.ai/my-workspace/secrets" in msg
+
+
+def test_enrich_missing_secret_error_returns_none_for_other_errors() -> None:
+    from osmosis_ai.platform.auth.platform_client import PlatformAPIError
+
+    exc = PlatformAPIError("Some other error", 500)
+    assert shared_submit._enrich_missing_secret_error(exc) is None

--- a/tests/unit/platform/cli/test_submit_secret_override_reminder.py
+++ b/tests/unit/platform/cli/test_submit_secret_override_reminder.py
@@ -1,0 +1,88 @@
+"""The submit confirmation reminds the user which referenced secrets resolve
+to their personal (user-scope) value vs the shared workspace value."""
+
+from __future__ import annotations
+
+import osmosis_ai.platform.cli.shared_submit as shared_submit
+from osmosis_ai.platform.api.models import (
+    EnvironmentSecretInfo,
+    PaginatedEnvironmentSecrets,
+)
+
+
+def _user_secrets_page(names: list[str]) -> PaginatedEnvironmentSecrets:
+    return PaginatedEnvironmentSecrets(
+        environment_secrets=[
+            EnvironmentSecretInfo(id=n, name=n, scope="user") for n in names
+        ],
+        total_count=len(names),
+        has_more=False,
+    )
+
+
+def test_annotates_rows_with_personal_vs_workspace() -> None:
+    rows = [
+        ("Rollout secrets (2)", "OPENAI_API_KEY, DATABASE_URL"),
+    ]
+    annotated = shared_submit._annotate_secret_override_row(
+        rows,
+        referenced=["OPENAI_API_KEY", "DATABASE_URL"],
+        user_secret_names={"OPENAI_API_KEY"},
+    )
+    # the secrets row value now spells out per-secret resolution
+    label, value = annotated[0]
+    assert label == "Rollout secrets (2)"
+    assert "OPENAI_API_KEY (personal)" in value
+    assert "DATABASE_URL (workspace)" in value
+
+
+def test_no_secrets_row_is_unchanged() -> None:
+    rows = [("Rollout", "calculator")]
+    annotated = shared_submit._annotate_secret_override_row(
+        rows, referenced=[], user_secret_names=set()
+    )
+    assert annotated == rows
+
+
+def test_fetch_user_secret_names_collects_all_pages(monkeypatch) -> None:
+    calls: list[dict] = []
+
+    class FakeClient:
+        def list_environment_secrets(
+            self, *, limit, offset, scope, credentials, git_identity
+        ):
+            calls.append({"scope": scope, "offset": offset})
+            if offset == 0:
+                return PaginatedEnvironmentSecrets(
+                    environment_secrets=[
+                        EnvironmentSecretInfo(id="A", name="A", scope="user")
+                    ],
+                    total_count=2,
+                    has_more=True,
+                    next_offset=1,
+                )
+            return PaginatedEnvironmentSecrets(
+                environment_secrets=[
+                    EnvironmentSecretInfo(id="B", name="B", scope="user")
+                ],
+                total_count=2,
+                has_more=False,
+            )
+
+    names = shared_submit._fetch_user_secret_names(
+        FakeClient(), credentials=object(), git_identity="acme/x"
+    )
+    assert names == {"A", "B"}
+    assert all(c["scope"] == "user" for c in calls)
+
+
+def test_fetch_user_secret_names_swallows_errors(monkeypatch) -> None:
+    class FakeClient:
+        def list_environment_secrets(self, **kwargs):
+            raise RuntimeError("network down")
+
+    # A failure to fetch the reminder must not block submit.
+    names = shared_submit._fetch_user_secret_names(
+        FakeClient(), credentials=object(), git_identity="acme/x"
+    )
+    assert names == set()

--- a/tests/unit/platform/cli/test_submit_summary.py
+++ b/tests/unit/platform/cli/test_submit_summary.py
@@ -1,8 +1,12 @@
-"""Tests for build_submit_summary_rows secrets rendering."""
+"""Tests for submit summary table builders."""
 
 from __future__ import annotations
 
-from osmosis_ai.platform.cli.shared_config import build_submit_summary_rows
+from osmosis_ai.platform.cli.shared_config import (
+    build_env_table_rows,
+    build_secret_table_rows,
+    build_submit_summary_rows,
+)
 
 
 def _rows(**kwargs) -> dict[str, str]:
@@ -19,11 +23,84 @@ def _rows(**kwargs) -> dict[str, str]:
     return dict(build_submit_summary_rows(**defaults))
 
 
-def test_secrets_row_omitted_when_empty() -> None:
-    rows = _rows(secrets=[])
+def test_summary_rows_no_env_or_secrets() -> None:
+    rows = _rows(env={"A": "1"}, secrets=["X"])
+    assert not any(label.startswith("Rollout env") for label in rows)
     assert not any(label.startswith("Rollout secrets") for label in rows)
 
 
-def test_secrets_row_lists_names_sorted_with_count() -> None:
-    rows = _rows(secrets=["OPENAI_API_KEY", "DATABASE_URL"])
-    assert rows["Rollout secrets (2)"] == "DATABASE_URL, OPENAI_API_KEY"
+def test_summary_rows_includes_core_fields() -> None:
+    rows = _rows()
+    assert rows["Rollout"] == "r"
+    assert rows["Entrypoint"] == "e.py"
+    assert rows["Model"] == "m"
+    assert rows["Dataset"] == "d"
+
+
+def test_summary_rows_includes_commit_sha() -> None:
+    rows = _rows(commit_sha="abc123")
+    assert rows["Commit"] == "abc123"
+
+
+# --- build_env_table_rows ---
+
+
+def test_env_table_rows_sorted_by_name() -> None:
+    rows = build_env_table_rows({"Z_VAR": "z", "A_VAR": "a"})
+    assert rows == [("A_VAR", "a"), ("Z_VAR", "z")]
+
+
+def test_env_table_rows_empty() -> None:
+    assert build_env_table_rows({}) == []
+
+
+# --- build_secret_table_rows ---
+
+
+def test_secret_table_rows_workspace_scope() -> None:
+    rows = build_secret_table_rows(
+        ["WANDB_API_KEY"],
+        user_secret_names=set(),
+        workspace_secret_names={"WANDB_API_KEY"},
+    )
+    assert rows == [("WANDB_API_KEY", "Workspace")]
+
+
+def test_secret_table_rows_personal_override_scope() -> None:
+    rows = build_secret_table_rows(
+        ["OPENAI_API_KEY"],
+        user_secret_names={"OPENAI_API_KEY"},
+        workspace_secret_names={"OPENAI_API_KEY"},
+    )
+    assert rows == [("OPENAI_API_KEY", "Personal (overrides workspace)")]
+
+
+def test_secret_table_rows_personal_only_is_not_an_override() -> None:
+    rows = build_secret_table_rows(
+        ["OPENAI_API_KEY"],
+        user_secret_names={"OPENAI_API_KEY"},
+        workspace_secret_names=set(),
+    )
+    assert rows == [("OPENAI_API_KEY", "Personal")]
+
+
+def test_secret_table_rows_mixed_scopes_sorted() -> None:
+    rows = build_secret_table_rows(
+        ["OPENAI_API_KEY", "GITHUB_TOKEN", "WANDB_API_KEY"],
+        user_secret_names={"OPENAI_API_KEY"},
+        workspace_secret_names={"OPENAI_API_KEY", "GITHUB_TOKEN"},
+    )
+    assert rows == [
+        ("GITHUB_TOKEN", "Workspace"),
+        ("OPENAI_API_KEY", "Personal (overrides workspace)"),
+        ("WANDB_API_KEY", "Workspace"),
+    ]
+
+
+def test_secret_table_rows_empty() -> None:
+    assert (
+        build_secret_table_rows(
+            [], user_secret_names=set(), workspace_secret_names=set()
+        )
+        == []
+    )

--- a/tests/unit/platform/cli/test_submit_summary.py
+++ b/tests/unit/platform/cli/test_submit_summary.py
@@ -1,0 +1,29 @@
+"""Tests for build_submit_summary_rows secrets rendering."""
+
+from __future__ import annotations
+
+from osmosis_ai.platform.cli.shared_config import build_submit_summary_rows
+
+
+def _rows(**kwargs) -> dict[str, str]:
+    defaults = {
+        "rollout": "r",
+        "entrypoint": "e.py",
+        "model": "m",
+        "dataset": "d",
+        "commit_sha": None,
+        "env": {},
+        "secrets": [],
+    }
+    defaults.update(kwargs)
+    return dict(build_submit_summary_rows(**defaults))
+
+
+def test_secrets_row_omitted_when_empty() -> None:
+    rows = _rows(secrets=[])
+    assert not any(label.startswith("Rollout secrets") for label in rows)
+
+
+def test_secrets_row_lists_names_sorted_with_count() -> None:
+    rows = _rows(secrets=["OPENAI_API_KEY", "DATABASE_URL"])
+    assert rows["Rollout secrets (2)"] == "DATABASE_URL, OPENAI_API_KEY"

--- a/tests/unit/platform/cli/test_submit_wiring.py
+++ b/tests/unit/platform/cli/test_submit_wiring.py
@@ -68,7 +68,5 @@ def test_submit_eval_forwards_secrets_list() -> None:
 
 def test_submit_eval_passes_none_when_empty() -> None:
     client = MagicMock()
-    eval_mod._submit_eval(
-        client, _eval_config([]), credentials=None, git_identity="g"
-    )
+    eval_mod._submit_eval(client, _eval_config([]), credentials=None, git_identity="g")
     assert client.submit_evaluation_run.call_args.kwargs["secrets"] is None

--- a/tests/unit/platform/cli/test_submit_wiring.py
+++ b/tests/unit/platform/cli/test_submit_wiring.py
@@ -1,0 +1,74 @@
+"""Tests that train/eval submit helpers forward secrets as a list."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from osmosis_ai.platform.cli import eval as eval_mod
+from osmosis_ai.platform.cli import train as train_mod
+from osmosis_ai.platform.cli.eval_config import EvalSubmitConfig
+from osmosis_ai.platform.cli.training_config import TrainSubmitConfig
+
+
+def _train_config(secrets: list[str]) -> TrainSubmitConfig:
+    return TrainSubmitConfig.model_validate(
+        {
+            "experiment": {
+                "rollout": "r",
+                "entrypoint": "rollouts/main.py",
+                "model_path": "m",
+                "dataset": "d",
+            },
+            "secrets": secrets,
+        }
+    )
+
+
+def _eval_config(secrets: list[str]) -> EvalSubmitConfig:
+    return EvalSubmitConfig.model_validate(
+        {
+            "experiment": {
+                "rollout": "r",
+                "entrypoint": "rollouts/main.py",
+                "model_path": "m",
+                "dataset": "d",
+            },
+            "secrets": secrets,
+        }
+    )
+
+
+def test_submit_training_forwards_secrets_list() -> None:
+    client = MagicMock()
+    train_mod._submit_training(
+        client, _train_config(["OPENAI_API_KEY"]), credentials=None, git_identity="g"
+    )
+    kwargs = client.submit_training_run.call_args.kwargs
+    assert kwargs["secrets"] == ["OPENAI_API_KEY"]
+    assert "secret_refs_config" not in kwargs
+
+
+def test_submit_training_passes_none_when_empty() -> None:
+    client = MagicMock()
+    train_mod._submit_training(
+        client, _train_config([]), credentials=None, git_identity="g"
+    )
+    assert client.submit_training_run.call_args.kwargs["secrets"] is None
+
+
+def test_submit_eval_forwards_secrets_list() -> None:
+    client = MagicMock()
+    eval_mod._submit_eval(
+        client, _eval_config(["DATABASE_URL"]), credentials=None, git_identity="g"
+    )
+    kwargs = client.submit_evaluation_run.call_args.kwargs
+    assert kwargs["secrets"] == ["DATABASE_URL"]
+    assert "secret_refs_config" not in kwargs
+
+
+def test_submit_eval_passes_none_when_empty() -> None:
+    client = MagicMock()
+    eval_mod._submit_eval(
+        client, _eval_config([]), credentials=None, git_identity="g"
+    )
+    assert client.submit_evaluation_run.call_args.kwargs["secrets"] is None

--- a/tests/unit/platform/cli/test_submit_wiring.py
+++ b/tests/unit/platform/cli/test_submit_wiring.py
@@ -59,10 +59,10 @@ def test_submit_training_passes_none_when_empty() -> None:
 def test_submit_eval_forwards_secrets_list() -> None:
     client = MagicMock()
     eval_mod._submit_eval(
-        client, _eval_config(["DATABASE_URL"]), credentials=None, git_identity="g"
+        client, _eval_config(["GITHUB_TOKEN"]), credentials=None, git_identity="g"
     )
     kwargs = client.submit_evaluation_run.call_args.kwargs
-    assert kwargs["secrets"] == ["DATABASE_URL"]
+    assert kwargs["secrets"] == ["GITHUB_TOKEN"]
     assert "secret_refs_config" not in kwargs
 
 

--- a/tests/unit/platform/cli/test_training_config.py
+++ b/tests/unit/platform/cli/test_training_config.py
@@ -146,8 +146,8 @@ dataset = "d"
     assert cfg.secrets == []
 
 
-def test_secrets_map_form_is_rejected_with_conversion_hint(tmp_path: Path) -> None:
-    path = tmp_path / "map_secrets.toml"
+def test_secrets_table_requires_required_field_for_training(tmp_path: Path) -> None:
+    path = tmp_path / "empty_secrets.toml"
     path.write_text(
         """
 [experiment]
@@ -157,7 +157,27 @@ model_path = "m"
 dataset = "d"
 
 [secrets]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CLIError) as exc_info:
+        load_train_submit_config(path)
+    assert "Missing 'required' in [secrets]" in str(exc_info.value)
+
+
+def test_secrets_rejects_unknown_keys(tmp_path: Path) -> None:
+    path = tmp_path / "map_secrets.toml"
+    path.write_text(
+        """
+[secrets]
 OPENAI_API_KEY = "OPENAI_API_KEY"
+
+[experiment]
+rollout = "r"
+entrypoint = "e.py"
+model_path = "m"
+dataset = "d"
 """.strip(),
         encoding="utf-8",
     )
@@ -165,15 +185,15 @@ OPENAI_API_KEY = "OPENAI_API_KEY"
     with pytest.raises(CLIError) as exc_info:
         load_train_submit_config(path)
     message = str(exc_info.value)
-    assert "uses key=value pairs" in message
-    assert "required = [" in message
+    assert "only supports the 'required' field" in message
+    assert "OPENAI_API_KEY" in message
 
 
-def test_secrets_must_be_a_table(tmp_path: Path) -> None:
-    path = tmp_path / "scalar_secrets.toml"
+def test_top_level_secrets_key_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "top_level_secrets.toml"
     path.write_text(
         """
-secrets = "OPENAI_API_KEY"
+secrets = ["OPENAI_API_KEY"]
 
 [experiment]
 rollout = "r"
@@ -186,11 +206,11 @@ dataset = "d"
 
     with pytest.raises(CLIError) as exc_info:
         load_train_submit_config(path)
-    assert "must be a table with a 'required' array" in str(exc_info.value)
+    assert "[secrets] must be a table" in str(exc_info.value)
 
 
-def test_secrets_required_must_be_a_list_of_strings(tmp_path: Path) -> None:
-    path = tmp_path / "scalar_required.toml"
+def test_secrets_must_be_a_list_of_strings(tmp_path: Path) -> None:
+    path = tmp_path / "non_string_secret.toml"
     path.write_text(
         """
 [experiment]
@@ -200,7 +220,7 @@ model_path = "m"
 dataset = "d"
 
 [secrets]
-required = "OPENAI_API_KEY"
+required = ["OPENAI_API_KEY", 123]
 """.strip(),
         encoding="utf-8",
     )

--- a/tests/unit/platform/cli/test_training_config.py
+++ b/tests/unit/platform/cli/test_training_config.py
@@ -145,6 +145,49 @@ dataset = "d"
     assert cfg.secrets == []
 
 
+def test_secrets_map_form_is_rejected_with_conversion_hint(tmp_path: Path) -> None:
+    path = tmp_path / "map_secrets.toml"
+    path.write_text(
+        """
+[experiment]
+rollout = "r"
+entrypoint = "e.py"
+model_path = "m"
+dataset = "d"
+
+[secrets]
+OPENAI_API_KEY = "OPENAI_API_KEY"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CLIError) as exc_info:
+        load_train_submit_config(path)
+    message = str(exc_info.value)
+    assert "[secrets] map form is no longer supported" in message
+    assert 'secrets = ["NAME", ...]' in message
+
+
+def test_secrets_must_be_a_list_of_strings(tmp_path: Path) -> None:
+    path = tmp_path / "scalar_secrets.toml"
+    path.write_text(
+        """
+secrets = "OPENAI_API_KEY"
+
+[experiment]
+rollout = "r"
+entrypoint = "e.py"
+model_path = "m"
+dataset = "d"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CLIError) as exc_info:
+        load_train_submit_config(path)
+    assert "must be a list of strings" in str(exc_info.value)
+
+
 # ---------------------------------------------------------------------------
 # API config sections
 # ---------------------------------------------------------------------------

--- a/tests/unit/platform/cli/test_training_config.py
+++ b/tests/unit/platform/cli/test_training_config.py
@@ -188,6 +188,70 @@ dataset = "d"
     assert "must be a list of strings" in str(exc_info.value)
 
 
+def _config_with_secrets(secrets_line: str, *, env_block: str = "") -> str:
+    return f"""
+{secrets_line}
+
+[experiment]
+rollout = "r"
+entrypoint = "e.py"
+model_path = "m"
+dataset = "d"
+{env_block}
+""".strip()
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["openai_api_key", "1OPENAI", "OPENAI-API-KEY", "_LEADING", "WITH SPACE"],
+)
+def test_secret_name_must_be_screaming_snake(tmp_path: Path, name: str) -> None:
+    path = tmp_path / "bad_name.toml"
+    path.write_text(
+        _config_with_secrets(f'secrets = ["{name}"]'), encoding="utf-8"
+    )
+    with pytest.raises(CLIError) as exc_info:
+        load_train_submit_config(path)
+    assert "^[A-Z][A-Z0-9_]*$" in str(exc_info.value)
+
+
+def test_secret_name_rejects_reserved_prefix(tmp_path: Path) -> None:
+    path = tmp_path / "reserved.toml"
+    path.write_text(
+        _config_with_secrets('secrets = ["_OSMOSIS_TOKEN"]'), encoding="utf-8"
+    )
+    with pytest.raises(CLIError) as exc_info:
+        load_train_submit_config(path)
+    assert "_OSMOSIS_" in str(exc_info.value)
+    assert "reserved" in str(exc_info.value)
+
+
+def test_secret_name_rejects_env_overlap(tmp_path: Path) -> None:
+    path = tmp_path / "overlap.toml"
+    path.write_text(
+        _config_with_secrets(
+            'secrets = ["OPENAI_API_KEY"]',
+            env_block='[env]\nOPENAI_API_KEY = "literal"',
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(CLIError) as exc_info:
+        load_train_submit_config(path)
+    message = str(exc_info.value)
+    assert "both [env] and secrets" in message
+    assert "OPENAI_API_KEY" in message
+
+
+def test_valid_secret_names_accepted(tmp_path: Path) -> None:
+    path = tmp_path / "ok.toml"
+    path.write_text(
+        _config_with_secrets('secrets = ["OPENAI_API_KEY", "DATABASE_URL", "X1"]'),
+        encoding="utf-8",
+    )
+    cfg = load_train_submit_config(path)
+    assert cfg.secrets == ["OPENAI_API_KEY", "DATABASE_URL", "X1"]
+
+
 # ---------------------------------------------------------------------------
 # API config sections
 # ---------------------------------------------------------------------------

--- a/tests/unit/platform/cli/test_training_config.py
+++ b/tests/unit/platform/cli/test_training_config.py
@@ -108,6 +108,8 @@ def test_load_config_accepts_top_level_env_and_secrets(tmp_path: Path) -> None:
     path = tmp_path / "env_secrets.toml"
     path.write_text(
         """
+secrets = ["OPENAI_API_KEY", "DATABASE_URL"]
+
 [experiment]
 rollout = "r"
 entrypoint = "e.py"
@@ -116,9 +118,6 @@ dataset = "d"
 
 [env]
 LOG_LEVEL = "INFO"
-
-[secrets]
-OPENAI_API_KEY = "openai-api-key"
 """.strip(),
         encoding="utf-8",
     )
@@ -126,7 +125,24 @@ OPENAI_API_KEY = "openai-api-key"
     cfg = load_train_submit_config(path)
 
     assert cfg.env == {"LOG_LEVEL": "INFO"}
-    assert cfg.secrets == {"OPENAI_API_KEY": "openai-api-key"}
+    assert cfg.secrets == ["OPENAI_API_KEY", "DATABASE_URL"]
+
+
+def test_secrets_defaults_to_empty_list(tmp_path: Path) -> None:
+    path = tmp_path / "no_secrets.toml"
+    path.write_text(
+        """
+[experiment]
+rollout = "r"
+entrypoint = "e.py"
+model_path = "m"
+dataset = "d"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    cfg = load_train_submit_config(path)
+    assert cfg.secrets == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/platform/cli/test_training_config.py
+++ b/tests/unit/platform/cli/test_training_config.py
@@ -238,7 +238,7 @@ def test_secret_name_must_be_screaming_snake(tmp_path: Path, name: str) -> None:
     assert "^[A-Z][A-Z0-9_]*$" in str(exc_info.value)
 
 
-def test_secret_name_rejects_reserved_prefix(tmp_path: Path) -> None:
+def test_secret_name_rejects_underscore_prefix(tmp_path: Path) -> None:
     path = tmp_path / "reserved.toml"
     path.write_text(
         _config_with_secrets('[secrets]\nrequired = ["_OSMOSIS_TOKEN"]'),
@@ -246,8 +246,7 @@ def test_secret_name_rejects_reserved_prefix(tmp_path: Path) -> None:
     )
     with pytest.raises(CLIError) as exc_info:
         load_train_submit_config(path)
-    assert "_OSMOSIS_" in str(exc_info.value)
-    assert "reserved" in str(exc_info.value)
+    assert "^[A-Z][A-Z0-9_]*$" in str(exc_info.value)
 
 
 def test_secret_name_rejects_env_overlap(tmp_path: Path) -> None:

--- a/tests/unit/platform/cli/test_training_config.py
+++ b/tests/unit/platform/cli/test_training_config.py
@@ -104,12 +104,10 @@ dataset = "id-1"
     assert cfg.checkpoints.eval_interval is None
 
 
-def test_load_config_accepts_top_level_env_and_secrets(tmp_path: Path) -> None:
+def test_load_config_accepts_env_and_secrets(tmp_path: Path) -> None:
     path = tmp_path / "env_secrets.toml"
     path.write_text(
         """
-secrets = ["OPENAI_API_KEY", "DATABASE_URL"]
-
 [experiment]
 rollout = "r"
 entrypoint = "e.py"
@@ -118,6 +116,9 @@ dataset = "d"
 
 [env]
 LOG_LEVEL = "INFO"
+
+[secrets]
+required = ["OPENAI_API_KEY", "GITHUB_TOKEN"]
 """.strip(),
         encoding="utf-8",
     )
@@ -125,7 +126,7 @@ LOG_LEVEL = "INFO"
     cfg = load_train_submit_config(path)
 
     assert cfg.env == {"LOG_LEVEL": "INFO"}
-    assert cfg.secrets == ["OPENAI_API_KEY", "DATABASE_URL"]
+    assert cfg.secrets == ["OPENAI_API_KEY", "GITHUB_TOKEN"]
 
 
 def test_secrets_defaults_to_empty_list(tmp_path: Path) -> None:
@@ -164,11 +165,11 @@ OPENAI_API_KEY = "OPENAI_API_KEY"
     with pytest.raises(CLIError) as exc_info:
         load_train_submit_config(path)
     message = str(exc_info.value)
-    assert "[secrets] map form is no longer supported" in message
-    assert 'secrets = ["NAME", ...]' in message
+    assert "uses key=value pairs" in message
+    assert "required = [" in message
 
 
-def test_secrets_must_be_a_list_of_strings(tmp_path: Path) -> None:
+def test_secrets_must_be_a_table(tmp_path: Path) -> None:
     path = tmp_path / "scalar_secrets.toml"
     path.write_text(
         """
@@ -185,19 +186,40 @@ dataset = "d"
 
     with pytest.raises(CLIError) as exc_info:
         load_train_submit_config(path)
+    assert "must be a table with a 'required' array" in str(exc_info.value)
+
+
+def test_secrets_required_must_be_a_list_of_strings(tmp_path: Path) -> None:
+    path = tmp_path / "scalar_required.toml"
+    path.write_text(
+        """
+[experiment]
+rollout = "r"
+entrypoint = "e.py"
+model_path = "m"
+dataset = "d"
+
+[secrets]
+required = "OPENAI_API_KEY"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CLIError) as exc_info:
+        load_train_submit_config(path)
     assert "must be a list of strings" in str(exc_info.value)
 
 
-def _config_with_secrets(secrets_line: str, *, env_block: str = "") -> str:
+def _config_with_secrets(secrets_block: str, *, env_block: str = "") -> str:
     return f"""
-{secrets_line}
-
 [experiment]
 rollout = "r"
 entrypoint = "e.py"
 model_path = "m"
 dataset = "d"
 {env_block}
+
+{secrets_block}
 """.strip()
 
 
@@ -208,7 +230,8 @@ dataset = "d"
 def test_secret_name_must_be_screaming_snake(tmp_path: Path, name: str) -> None:
     path = tmp_path / "bad_name.toml"
     path.write_text(
-        _config_with_secrets(f'secrets = ["{name}"]'), encoding="utf-8"
+        _config_with_secrets(f'[secrets]\nrequired = ["{name}"]'),
+        encoding="utf-8",
     )
     with pytest.raises(CLIError) as exc_info:
         load_train_submit_config(path)
@@ -218,7 +241,8 @@ def test_secret_name_must_be_screaming_snake(tmp_path: Path, name: str) -> None:
 def test_secret_name_rejects_reserved_prefix(tmp_path: Path) -> None:
     path = tmp_path / "reserved.toml"
     path.write_text(
-        _config_with_secrets('secrets = ["_OSMOSIS_TOKEN"]'), encoding="utf-8"
+        _config_with_secrets('[secrets]\nrequired = ["_OSMOSIS_TOKEN"]'),
+        encoding="utf-8",
     )
     with pytest.raises(CLIError) as exc_info:
         load_train_submit_config(path)
@@ -230,7 +254,7 @@ def test_secret_name_rejects_env_overlap(tmp_path: Path) -> None:
     path = tmp_path / "overlap.toml"
     path.write_text(
         _config_with_secrets(
-            'secrets = ["OPENAI_API_KEY"]',
+            '[secrets]\nrequired = ["OPENAI_API_KEY"]',
             env_block='[env]\nOPENAI_API_KEY = "literal"',
         ),
         encoding="utf-8",
@@ -238,18 +262,35 @@ def test_secret_name_rejects_env_overlap(tmp_path: Path) -> None:
     with pytest.raises(CLIError) as exc_info:
         load_train_submit_config(path)
     message = str(exc_info.value)
-    assert "both [env] and secrets" in message
+    assert "both [env] and [secrets]" in message
     assert "OPENAI_API_KEY" in message
 
 
 def test_valid_secret_names_accepted(tmp_path: Path) -> None:
     path = tmp_path / "ok.toml"
     path.write_text(
-        _config_with_secrets('secrets = ["OPENAI_API_KEY", "DATABASE_URL", "X1"]'),
+        _config_with_secrets(
+            '[secrets]\nrequired = ["OPENAI_API_KEY", "GITHUB_TOKEN", "X1"]'
+        ),
         encoding="utf-8",
     )
     cfg = load_train_submit_config(path)
-    assert cfg.secrets == ["OPENAI_API_KEY", "DATABASE_URL", "X1"]
+    assert cfg.secrets == ["OPENAI_API_KEY", "GITHUB_TOKEN", "X1"]
+
+
+def test_secrets_rejects_duplicate_names(tmp_path: Path) -> None:
+    path = tmp_path / "dupe.toml"
+    path.write_text(
+        _config_with_secrets(
+            '[secrets]\nrequired = ["OPENAI_API_KEY", "OPENAI_API_KEY"]'
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(CLIError) as exc_info:
+        load_train_submit_config(path)
+    message = str(exc_info.value)
+    assert "Duplicate" in message
+    assert "OPENAI_API_KEY" in message
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Replaces the old `[secrets]` table config form and `secret add` command with a scoped secrets system. Secrets are now either `workspace` (shared, admin/owner only) or `user` (personal, overrides workspace at run time). The config format changes from a TOML table (`[secrets]`) to a top-level list (`secrets = ["NAME", ...]`).

## Why

Users need personal secret overrides (e.g., their own API key) that take precedence over workspace-wide secrets without affecting other team members. The old map-based `[secrets]` table was unnecessarily complex — secret names and env var names are always identical, so a flat list is simpler.

## How to Test

```bash
# List secrets with scope filter
osmosis secret list --scope user
osmosis secret list --scope workspace
osmosis secret list              # defaults to --scope all

# Set a personal secret
OPENAI_API_KEY=sk-... osmosis secret set OPENAI_API_KEY --scope user --env OPENAI_API_KEY

# Delete a secret
osmosis secret delete OPENAI_API_KEY --scope user --yes

# Verify old [secrets] table form shows migration hint
# (use a config with [secrets]\nOPENAI_API_KEY = "..." — should error with conversion instructions)

# Run tests
pytest tests/unit/cli/test_secret_commands.py
pytest tests/unit/platform/api/test_client_environment_secrets.py
pytest tests/unit/platform/cli/test_training_config.py
pytest tests/unit/platform/cli/test_submit_secret_override_reminder.py
```

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

---

## Summary

### Breaking Changes
- Config `[secrets]` table replaced by top-level `secrets = [...]` list (old form raises error with migration hint)
- `osmosis secret add` renamed to `osmosis secret set` (upsert semantics)
- API payload key `secret_refs_config` (dict) replaced by `secrets` (list)
- Secret names now enforce `^[A-Z][A-Z0-9_]*$` (SCREAMING_SNAKE_CASE)

### New Features
- `--scope workspace|user` on `secret set` and `secret delete`
- `--scope all|workspace|user` on `secret list` (defaults to `all`)
- `osmosis secret delete` command with confirmation prompt
- Submit confirmation annotates each secret as `(personal)` or `(workspace)` based on caller's overrides
- Lenient name validation on delete allows removing legacy-named secrets

### Improvements
- Simplified config: `secrets` is a flat list of names instead of a name→name map
- Serializer and list display now include scope column

## Changelog

### Added
- `osmosis secret delete` command with `--scope` and `--yes` flags
- `--scope` option on `secret set` and `secret list`
- `delete_environment_secret` API client method
- `scope` field on `EnvironmentSecretInfo` model and serializer
- `read_toml_secrets_list()` config parser with `[secrets]` table migration error
- `validate_secret_names()` for SCREAMING_SNAKE_CASE enforcement
- `SECRET_NAME_RE` exported from shared_config
- Submit confirmation shows per-secret personal/workspace resolution
- 7 new test files/modules covering scoped secrets end-to-end

### Removed
- `osmosis secret add` subcommand (replaced by `set`)
- `[secrets]` TOML table config form
- `secret_refs_config` API payload key
- `create_environment_secret` client method (replaced by `set_environment_secret`)

### Changed
- `secrets` config field type: `dict[str, str]` → `list[str]`
- Secret name validation: `^[a-zA-Z0-9_-]+$` → `^[A-Z][A-Z0-9_]*$`
- `validate_env_var_keys` no longer validates secrets (split into `validate_secret_names`)
- `validate_env_values` no longer validates secrets (list form has no values)
- Docs updated: cli.md, eval.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds scoped secrets to the CLI and configs so you can set personal overrides that take precedence over workspace secrets. Switches configs to `[secrets].required = ["NAME", ...]`, enforces it for eval configs, adds `secret set/list/delete` with scope, and updates UI (12-hour local timestamps, clearer submit next steps, stop defaults to No).

- **New Features**
  - `osmosis secret set NAME [--scope workspace|user] [--env VARNAME]` (upsert) and `osmosis secret delete NAME [--scope workspace|user] [--yes]`.
  - `osmosis secret list [--scope all|workspace|user]` (defaults to `all`) with a Scope column (“Personal” or “Workspace”).
  - Submit confirmation shows a separate secrets table and annotates overrides, e.g., “Personal (overrides workspace)”.
  - API adds `set_environment_secret`, `delete_environment_secret`, and scoped list; `EnvironmentSecretInfo` includes `scope` and `updater_name` (“user” shows as “personal”).
  - Eval and train next steps include Rollout, Model, Dataset; timestamps show in 12-hour local time.

- **Migration**
  - Config: replace `[secrets]` map with `[secrets].required = ["NAME"]`; eval configs must include `[secrets]`; training may omit `[secrets]`, but if present it must include `required`. Names must match `^[A-Z][A-Z0-9_]*$`, cannot overlap with `[env]`, and `_OSMOSIS_` is reserved. The old map form now errors with a conversion hint.
  - CLI: `secret add` is now `secret set`; `secret delete` is new.
  - API submit: payload uses `secrets` (list) instead of `secret_refs_config`.
  - Docs updated (`cli.md`, `eval.md`) to show the `required` format and clarify personal vs workspace scope.
  - Deleting secrets accepts legacy names to clean up older records.

<sup>Written for commit e69a9902cb7c02d17f18cd2b3a88c4f84a35cc2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

