### PR TITLE
[auth] feat: scope CLI credentials by platform URL

### DIFF
--- a/osmosis_ai/cli/commands/auth.py
+++ b/osmosis_ai/cli/commands/auth.py
@@ -58,11 +58,13 @@ def _login_operation_result(
 ) -> Any:
     """Build the structured login result for JSON/plain output."""
     from osmosis_ai.cli.output import OperationResult
+    from osmosis_ai.platform.auth.config import get_platform_url
 
     resource: dict[str, Any] = {
         "email": email,
         "name": name,
         "expires_at": expires_at.isoformat(),
+        "platform_url": get_platform_url(),
         "workspace": None,
         "source": source,
         "verified": True,
@@ -226,6 +228,7 @@ def _machine_login_with_token(*, token: str, force: bool) -> Any:
 def _machine_login_with_env_token(*, env_token: str) -> Any:
     """Verify OSMOSIS_TOKEN without mutating local credential/session state."""
     from osmosis_ai.cli.output import OperationResult, get_output_context
+    from osmosis_ai.platform.auth.config import get_platform_url
 
     output = get_output_context()
     with output.status("Verifying environment token..."):
@@ -238,6 +241,7 @@ def _machine_login_with_env_token(*, env_token: str) -> Any:
             "email": verified.user.email,
             "name": verified.user.name,
             "expires_at": verified.expires_at.isoformat(),
+            "platform_url": get_platform_url(),
             "workspace": None,
             "source": "environment",
             "verified": True,
@@ -262,6 +266,7 @@ def _rich_login(force: bool, token: str | None) -> Any:
         load_credentials,
         verify_token,
     )
+    from osmosis_ai.platform.auth.config import get_platform_url
     from osmosis_ai.platform.auth.credentials import (
         Credentials,
         save_credentials,
@@ -325,6 +330,7 @@ def _rich_login(force: bool, token: str | None) -> Any:
         info_lines = [f"Email: {esc(result.user.email)}"]
         if result.user.name:
             info_lines.append(f"Name: {esc(result.user.name)}")
+        info_lines.append(f"Platform: {esc(get_platform_url())}")
         info_lines.append(f"Expires: {result.expires_at.strftime('%Y-%m-%d')}")
 
         console.panel("Login Successful", "\n".join(info_lines), style="green")
@@ -384,6 +390,7 @@ def logout(
     from osmosis_ai.cli.output import OperationResult, OutputFormat, get_output_context
     from osmosis_ai.cli.prompts import confirm
     from osmosis_ai.platform.auth import load_credentials
+    from osmosis_ai.platform.auth.config import get_platform_url
     from osmosis_ai.platform.auth.local_config import reset_session
     from osmosis_ai.platform.auth.platform_client import revoke_cli_token
 
@@ -400,7 +407,11 @@ def logout(
             return OperationResult(
                 operation="auth.logout",
                 status="noop",
-                resource={"logged_in": True, "env_token_set": True},
+                resource={
+                    "logged_in": True,
+                    "env_token_set": True,
+                    "platform_url": get_platform_url(),
+                },
                 message=message,
                 display_next_steps=["Run 'unset OSMOSIS_TOKEN' to logout."],
                 next_steps_structured=[
@@ -413,7 +424,7 @@ def logout(
         return OperationResult(
             operation="auth.logout",
             status="noop",
-            resource={"logged_in": False},
+            resource={"logged_in": False, "platform_url": get_platform_url()},
             message="Not logged in.",
         )
 
@@ -447,6 +458,7 @@ def logout(
                 "logged_in": False,
                 "revoked": revoked,
                 "env_token_set": env_token_set,
+                "platform_url": get_platform_url(),
             },
             message="Logged out successfully.",
             display_next_steps=(
@@ -486,6 +498,7 @@ def whoami() -> Any:
         load_credentials,
         verify_token,
     )
+    from osmosis_ai.platform.auth.config import get_platform_url
     from osmosis_ai.platform.constants import MSG_NOT_LOGGED_IN
 
     output = get_output_context()
@@ -532,6 +545,7 @@ def whoami() -> Any:
         "email": credentials.user.email,
         "name": credentials.user.name,
         "expires_at": credentials.expires_at.isoformat(),
+        "platform_url": get_platform_url(),
         "source": source,
     }
     if credentials.token_id:
@@ -541,6 +555,7 @@ def whoami() -> Any:
         "email": credentials.user.email,
         "name": credentials.user.name,
         "expires_at": credentials.expires_at.isoformat(),
+        "platform_url": get_platform_url(),
         "source": source,
         "workspace": None,
         "linked_project": None,
@@ -556,6 +571,7 @@ def whoami() -> Any:
         fields.append(
             DetailField(label="Name", value=console.format_text(credentials.user.name))
         )
+    fields.append(DetailField(label="Platform", value=get_platform_url()))
     fields.append(DetailField(label="Auth Source", value=source))
     fields.append(
         DetailField(label="Expires", value=credentials.expires_at.strftime("%Y-%m-%d"))

--- a/osmosis_ai/platform/auth/__init__.py
+++ b/osmosis_ai/platform/auth/__init__.py
@@ -1,6 +1,6 @@
 """Osmosis CLI authentication module."""
 
-from .config import CONFIG_DIR, CREDENTIALS_FILE, PLATFORM_URL
+from .config import CONFIG_DIR, CREDENTIALS_FILE, PLATFORM_URL, get_platform_url
 from .credentials import (
     Credentials,
     UserInfo,
@@ -33,6 +33,7 @@ __all__ = [
     "delete_credentials",
     "device_login",
     "get_credential_store",
+    "get_platform_url",
     "get_valid_credentials",
     "load_credentials",
     "platform_request",

--- a/osmosis_ai/platform/auth/config.py
+++ b/osmosis_ai/platform/auth/config.py
@@ -35,13 +35,15 @@ def normalize_platform_url(url: str | None) -> str:
     try:
         port = parsed.port
     except ValueError:
-        port = None
+        raise ValueError(f"Invalid OSMOSIS_PLATFORM_URL port in '{raw}'") from None
+    # IPv6 literals contain colons and must stay bracketed inside the netloc.
+    host_for_netloc = f"[{hostname}]" if ":" in hostname else hostname
     if port is not None and not (
         (scheme == "https" and port == 443) or (scheme == "http" and port == 80)
     ):
-        netloc = f"{hostname}:{port}"
+        netloc = f"{host_for_netloc}:{port}"
     else:
-        netloc = hostname
+        netloc = host_for_netloc
 
     path = parsed.path.rstrip("/")
     return urlunparse((scheme, netloc, path, "", "", ""))

--- a/osmosis_ai/platform/auth/config.py
+++ b/osmosis_ai/platform/auth/config.py
@@ -6,11 +6,10 @@ import os
 import warnings
 from ipaddress import ip_address
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 # Platform URL - can be overridden via environment variable for local development
 DEFAULT_PLATFORM_URL = "https://platform.osmosis.ai"
-PLATFORM_URL = os.environ.get("OSMOSIS_PLATFORM_URL", DEFAULT_PLATFORM_URL)
 
 
 def _is_loopback(hostname: str) -> bool:
@@ -23,17 +22,55 @@ def _is_loopback(hostname: str) -> bool:
         return False
 
 
-_parsed_platform_url = urlparse(PLATFORM_URL)
-if (
-    PLATFORM_URL != DEFAULT_PLATFORM_URL
-    and _parsed_platform_url.scheme.lower() != "https"
-    and not _is_loopback(_parsed_platform_url.hostname or "")
-):
-    warnings.warn(
-        f"OSMOSIS_PLATFORM_URL is not HTTPS ({PLATFORM_URL}). "
-        "Tokens will be transmitted in plaintext.",
-        stacklevel=2,
+def normalize_platform_url(url: str | None) -> str:
+    """Return the canonical platform base URL used for requests and storage keys."""
+    raw = (url or DEFAULT_PLATFORM_URL).strip() or DEFAULT_PLATFORM_URL
+    raw = raw.rstrip("/")
+    parsed = urlparse(raw)
+    if not parsed.scheme or not parsed.netloc:
+        return raw
+
+    scheme = parsed.scheme.lower()
+    hostname = (parsed.hostname or "").lower()
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    if port is not None and not (
+        (scheme == "https" and port == 443) or (scheme == "http" and port == 80)
+    ):
+        netloc = f"{hostname}:{port}"
+    else:
+        netloc = hostname
+
+    path = parsed.path.rstrip("/")
+    return urlunparse((scheme, netloc, path, "", "", ""))
+
+
+def _warn_if_insecure_platform_url(platform_url: str) -> None:
+    parsed = urlparse(platform_url)
+    if (
+        platform_url != DEFAULT_PLATFORM_URL
+        and parsed.scheme.lower() != "https"
+        and not _is_loopback(parsed.hostname or "")
+    ):
+        warnings.warn(
+            f"OSMOSIS_PLATFORM_URL is not HTTPS ({platform_url}). "
+            "Tokens will be transmitted in plaintext.",
+            stacklevel=2,
+        )
+
+
+def get_platform_url() -> str:
+    """Resolve the active platform URL from the current process environment."""
+    platform_url = normalize_platform_url(
+        os.environ.get("OSMOSIS_PLATFORM_URL", DEFAULT_PLATFORM_URL)
     )
+    _warn_if_insecure_platform_url(platform_url)
+    return platform_url
+
+
+PLATFORM_URL = get_platform_url()
 
 # Configuration directory and credentials file
 CONFIG_DIR = Path.home() / ".config" / "osmosis"

--- a/osmosis_ai/platform/auth/credentials.py
+++ b/osmosis_ai/platform/auth/credentials.py
@@ -4,7 +4,8 @@ Supports three token sources with descending priority:
 
     1. ``OSMOSIS_TOKEN`` environment variable  (CI / headless)
     2. System keyring  (macOS Keychain, GNOME Keyring, …)
-    3. Plain-text JSON file  (``~/.config/osmosis/credentials.json``)
+    3. Platform-scoped plain-text JSON file
+       (``~/.config/osmosis/credentials.json``)
 
 When *saving*, the module tries the keyring first.  If successful the
 JSON metadata file is written **without** the token.  If the keyring is
@@ -19,6 +20,7 @@ import os
 import sys
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from hashlib import sha256
 from typing import TYPE_CHECKING, Any
 
 import keyring
@@ -26,7 +28,13 @@ from keyring.backends.fail import Keyring as FailKeyring
 from keyring.errors import PasswordDeleteError
 
 from ._fileutil import atomic_write_json
-from .config import CREDENTIALS_FILE, CREDENTIALS_VERSION
+from .config import (
+    CREDENTIALS_FILE,
+    CREDENTIALS_VERSION,
+    DEFAULT_PLATFORM_URL,
+    get_platform_url,
+    normalize_platform_url,
+)
 
 if TYPE_CHECKING:
     from .flow import VerifyResult
@@ -37,11 +45,37 @@ if TYPE_CHECKING:
 
 KEYRING_SERVICE = "osmosis-cli"
 KEYRING_ACCOUNT = "default"
+KEYRING_ACCOUNT_PREFIX = "platform:"
 
 # Token store backend identifiers (persisted in credentials.json)
 TOKEN_STORE_KEYRING = "keyring"
 TOKEN_STORE_FILE = "file"
 TOKEN_STORE_ENV = "env"
+
+
+def keyring_account_for_platform(platform_url: str | None = None) -> str:
+    """Return the keyring account for a platform-scoped CLI token."""
+    normalized_url = normalize_platform_url(platform_url or get_platform_url())
+    digest = sha256(normalized_url.encode("utf-8")).hexdigest()[:24]
+    return f"{KEYRING_ACCOUNT_PREFIX}{digest}"
+
+
+def _default_platform_url() -> str:
+    return normalize_platform_url(DEFAULT_PLATFORM_URL)
+
+
+def _is_default_platform_url(platform_url: str) -> bool:
+    return normalize_platform_url(platform_url) == _default_platform_url()
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value and value not in seen:
+            result.append(value)
+            seen.add(value)
+    return result
 
 
 def _cleanup_legacy_keyring_entries(metadata: dict | None = None) -> None:
@@ -68,6 +102,116 @@ def _cleanup_legacy_keyring_entries(metadata: dict | None = None) -> None:
         old_account = metadata.get("user", {}).get("email", "")
         if old_account and old_account != KEYRING_ACCOUNT:
             _keyring_delete(old_account)
+
+
+def _is_platform_registry(data: dict[str, Any]) -> bool:
+    return isinstance(data.get("platforms"), dict)
+
+
+def _legacy_entry_from_metadata(data: dict[str, Any]) -> dict[str, Any]:
+    entry = {
+        key: value
+        for key, value in data.items()
+        if key not in {"platforms", "active_platform_url"}
+    }
+    entry["platform_url"] = _default_platform_url()
+    if entry.get("token_store", TOKEN_STORE_FILE) == TOKEN_STORE_KEYRING:
+        entry.setdefault("keyring_account", KEYRING_ACCOUNT)
+    return entry
+
+
+def _registry_from_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]:
+    registry: dict[str, Any] = {
+        "version": CREDENTIALS_VERSION,
+        "platforms": {},
+    }
+    if not isinstance(metadata, dict):
+        return registry
+    if metadata.get("version") != CREDENTIALS_VERSION:
+        return registry
+
+    if _is_platform_registry(metadata):
+        platforms = metadata.get("platforms", {})
+        for raw_platform_url, raw_entry in platforms.items():
+            if not isinstance(raw_entry, dict):
+                continue
+            platform_url = normalize_platform_url(
+                raw_entry.get("platform_url") or str(raw_platform_url)
+            )
+            entry = dict(raw_entry)
+            entry["platform_url"] = platform_url
+            registry["platforms"][platform_url] = entry
+
+        return registry
+
+    default_platform_url = _default_platform_url()
+    registry["platforms"][default_platform_url] = _legacy_entry_from_metadata(metadata)
+    return registry
+
+
+def _entry_for_platform(
+    metadata: dict[str, Any], platform_url: str
+) -> dict[str, Any] | None:
+    if metadata.get("version") != CREDENTIALS_VERSION:
+        return None
+
+    normalized_url = normalize_platform_url(platform_url)
+    if _is_platform_registry(metadata):
+        entry = metadata.get("platforms", {}).get(normalized_url)
+        return entry if isinstance(entry, dict) else None
+
+    if normalized_url == _default_platform_url():
+        return metadata
+    return None
+
+
+def _keyring_accounts_for_entry(
+    entry: dict[str, Any] | None,
+    platform_url: str,
+) -> list[str]:
+    accounts = [keyring_account_for_platform(platform_url)]
+    if _is_default_platform_url(platform_url):
+        accounts.append(KEYRING_ACCOUNT)
+
+    if entry and entry.get("token_store", TOKEN_STORE_FILE) == TOKEN_STORE_KEYRING:
+        account = entry.get("keyring_account")
+        if isinstance(account, str):
+            accounts.append(account)
+        old_account = entry.get("user", {}).get("email", "")
+        if (
+            isinstance(old_account, str)
+            and old_account
+            and old_account != KEYRING_ACCOUNT
+        ):
+            accounts.append(old_account)
+
+    return _dedupe(accounts)
+
+
+def _cleanup_platform_keyring_entries(
+    entry: dict[str, Any] | None,
+    platform_url: str,
+) -> bool:
+    cleaned = True
+    for account in _keyring_accounts_for_entry(entry, platform_url):
+        cleaned = _keyring_delete(account) and cleaned
+    return cleaned
+
+
+def _resolve_entry_token(
+    entry: dict[str, Any],
+    platform_url: str,
+) -> str | None:
+    token_store = entry.get("token_store", TOKEN_STORE_FILE)
+    if token_store != TOKEN_STORE_KEYRING:
+        token = entry.get("access_token")
+        return token if isinstance(token, str) else None
+
+    for account in _keyring_accounts_for_entry(entry, platform_url):
+        token = _keyring_get(account)
+        if token is not None:
+            return token
+    return None
 
 
 def _keyring_set(account: str, token: str) -> bool:
@@ -131,7 +275,7 @@ class UserInfo:
 
 @dataclass
 class Credentials:
-    """User-scoped credentials (single token for all workspaces)."""
+    """User-scoped credentials for the active platform."""
 
     access_token: str
     token_type: str
@@ -196,19 +340,14 @@ def save_credentials(credentials: Credentials) -> str:
     """Save user credentials.
 
     Tries the system keyring first; falls back to plain-text JSON.
-    Always cleans up any previous keyring entries to avoid orphaned tokens
-    (e.g. when re-logging, switching accounts, or falling back to file storage).
+    Always cleans up previous keyring entries for the active platform to avoid
+    orphaned tokens (e.g. when re-logging, switching accounts, or falling back
+    to file storage).
 
     Returns:
         The storage backend used: ``"keyring"`` or ``"file"``.
     """
-    # Always clean up previous keyring entries before saving new credentials.
-    # This prevents orphaned tokens when:
-    #   - The user re-logs as a different account
-    #   - The storage backend switches from keyring to file
-    #   - A previous login used an email-based account name (legacy)
-    # Read existing metadata once to pass to _cleanup_legacy_keyring_entries,
-    # avoiding a redundant file read inside that function.
+    platform_url = get_platform_url()
     old_metadata: dict | None = None
     try:
         with open(CREDENTIALS_FILE, encoding="utf-8") as f:
@@ -216,21 +355,28 @@ def save_credentials(credentials: Credentials) -> str:
     except (OSError, json.JSONDecodeError, ValueError):
         pass
 
-    _keyring_delete(KEYRING_ACCOUNT)
-    _cleanup_legacy_keyring_entries(old_metadata)
+    registry = _registry_from_metadata(old_metadata)
+    old_entry = registry["platforms"].get(platform_url)
+    _cleanup_platform_keyring_entries(old_entry, platform_url)
 
     data = credentials.to_dict()
+    data["platform_url"] = platform_url
 
     # Try keyring first
-    if _keyring_set(KEYRING_ACCOUNT, credentials.access_token):
+    keyring_account = keyring_account_for_platform(platform_url)
+    if _keyring_set(keyring_account, credentials.access_token):
         data.pop("access_token", None)
         data["token_store"] = TOKEN_STORE_KEYRING
-        atomic_write_json(CREDENTIALS_FILE, data, mode=0o600)
+        data["keyring_account"] = keyring_account
+        registry["platforms"][platform_url] = data
+        atomic_write_json(CREDENTIALS_FILE, registry, mode=0o600)
         return TOKEN_STORE_KEYRING
 
     # Fallback: store everything in the JSON file
     data["token_store"] = TOKEN_STORE_FILE
-    atomic_write_json(CREDENTIALS_FILE, data, mode=0o600)
+    data.pop("keyring_account", None)
+    registry["platforms"][platform_url] = data
+    atomic_write_json(CREDENTIALS_FILE, registry, mode=0o600)
     sys.stderr.write(
         "Warning: keyring unavailable — token stored in plain text at "
         f"{CREDENTIALS_FILE}\n"
@@ -260,6 +406,8 @@ def load_credentials(*, include_env: bool = True) -> Credentials | None:
             token_id=None,
         )
 
+    platform_url = get_platform_url()
+
     # 2. Load metadata file
     try:
         with open(CREDENTIALS_FILE, encoding="utf-8") as f:
@@ -280,28 +428,24 @@ def load_credentials(*, include_env: bool = True) -> Credentials | None:
         )
         return None
 
-    token_store = data.get("token_store", TOKEN_STORE_FILE)
+    entry = _entry_for_platform(data, platform_url)
+    if entry is None:
+        return None
 
-    # 3. Resolve token
-    if token_store == TOKEN_STORE_KEYRING:
-        # Try the fixed account name first, then fall back to legacy
-        # email-based account for backward compatibility.
-        token = _keyring_get(KEYRING_ACCOUNT)
-        if token is None:
-            legacy_account = data.get("user", {}).get("email", "")
-            if legacy_account and legacy_account != KEYRING_ACCOUNT:
-                token = _keyring_get(legacy_account)
-        if token is None:
-            sys.stderr.write(
-                "Token not found in keyring. "
-                "Please run 'osmosis auth login' to re-authenticate.\n"
-            )
-            return None
-        data["access_token"] = token
+    credential_data = dict(entry)
+    credential_data.setdefault("version", CREDENTIALS_VERSION)
+    token = _resolve_entry_token(credential_data, platform_url)
+    if token is None:
+        sys.stderr.write(
+            "Token not found for the current Osmosis platform. "
+            "Please run 'osmosis auth login' to re-authenticate.\n"
+        )
+        return None
+    credential_data["access_token"] = token
 
     # 4. Parse into Credentials
     try:
-        return Credentials.from_dict(data)
+        return Credentials.from_dict(credential_data)
     except (KeyError, ValueError) as exc:
         sys.stderr.write(
             f"Warning: could not parse credentials ({type(exc).__name__}); "
@@ -311,34 +455,30 @@ def load_credentials(*, include_env: bool = True) -> Credentials | None:
 
 
 def delete_credentials() -> bool:
-    """Delete all stored credentials (keyring entry + file).
+    """Delete credentials for the current platform.
 
-    Always attempts to clean up the keyring entry using the fixed account
-    name, regardless of metadata state.  Also cleans up any legacy
-    email-based keyring entries if the metadata file is readable.
-    A corrupt or missing JSON file cannot prevent keyring cleanup.
-
-    Returns:
-        ``True`` if credentials were found and removed, ``False`` if no
-        credentials existed.  The metadata file is the source of truth:
-        ``save_credentials`` always writes it, so its presence indicates
-        that credentials were stored.
+    Legacy single-platform files are treated as credentials for the default
+    production platform.  A corrupt metadata file is still removed because it
+    cannot be safely merged with platform-scoped entries.
     """
-    # 1. Read metadata once for legacy cleanup (before we delete the file).
-    old_metadata: dict | None = None
+    platform_url = get_platform_url()
+    metadata_missing = False
+    metadata_corrupt = False
+    old_metadata: dict[str, Any] | None = None
     try:
         with open(CREDENTIALS_FILE, encoding="utf-8") as f:
             old_metadata = json.load(f)
+    except FileNotFoundError:
+        metadata_missing = True
     except (OSError, json.JSONDecodeError, ValueError):
-        pass
+        metadata_corrupt = True
 
-    # 2. Always attempt keyring cleanup with the fixed account name.
-    #    This does not depend on metadata — it works even if the file
-    #    is missing or corrupt.
-    keyring_cleaned = _keyring_delete(KEYRING_ACCOUNT)
-
-    # 3. Also clean up any legacy email-based keyring entry.
-    _cleanup_legacy_keyring_entries(old_metadata)
+    old_entry = (
+        _entry_for_platform(old_metadata, platform_url)
+        if isinstance(old_metadata, dict)
+        else None
+    )
+    keyring_cleaned = _cleanup_platform_keyring_entries(old_entry, platform_url)
 
     if not keyring_cleaned:
         sys.stderr.write(
@@ -346,9 +486,42 @@ def delete_credentials() -> bool:
             "You may want to remove it manually.\n"
         )
 
-    # 4. Remove the metadata file — this is the canonical indicator of
-    #    whether credentials existed, since save_credentials() always
-    #    writes this file regardless of keyring availability.
+    if metadata_missing:
+        return False
+
+    if metadata_corrupt or not isinstance(old_metadata, dict):
+        try:
+            CREDENTIALS_FILE.unlink()
+            return True
+        except FileNotFoundError:
+            return False
+
+    if old_metadata.get("version") != CREDENTIALS_VERSION:
+        try:
+            CREDENTIALS_FILE.unlink()
+            return True
+        except FileNotFoundError:
+            return False
+
+    if _is_platform_registry(old_metadata):
+        registry = _registry_from_metadata(old_metadata)
+        if platform_url not in registry["platforms"]:
+            return False
+
+        del registry["platforms"][platform_url]
+        if registry["platforms"]:
+            atomic_write_json(CREDENTIALS_FILE, registry, mode=0o600)
+            return True
+
+        try:
+            CREDENTIALS_FILE.unlink()
+            return True
+        except FileNotFoundError:
+            return False
+
+    if platform_url != _default_platform_url():
+        return False
+
     try:
         CREDENTIALS_FILE.unlink()
         return True
@@ -378,6 +551,9 @@ def get_credential_store() -> str | None:
     try:
         with open(CREDENTIALS_FILE, encoding="utf-8") as f:
             data = json.load(f)
-        return data.get("token_store", TOKEN_STORE_FILE)
+        entry = _entry_for_platform(data, get_platform_url())
+        if entry is None:
+            return None
+        return entry.get("token_store", TOKEN_STORE_FILE)
     except Exception:
         return None

--- a/osmosis_ai/platform/auth/flow.py
+++ b/osmosis_ai/platform/auth/flow.py
@@ -23,8 +23,11 @@ from urllib.request import Request, urlopen
 from osmosis_ai.cli.console import console
 from osmosis_ai.consts import PACKAGE_VERSION
 
-from .config import PLATFORM_URL
+from .config import PLATFORM_URL as _IMPORTED_PLATFORM_URL
+from .config import get_platform_url, normalize_platform_url
 from .credentials import Credentials, UserInfo
+
+PLATFORM_URL = _IMPORTED_PLATFORM_URL
 
 
 class LoginError(Exception):
@@ -79,6 +82,12 @@ class DeviceCodeResponse:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _platform_url() -> str:
+    if PLATFORM_URL != _IMPORTED_PLATFORM_URL:
+        return normalize_platform_url(PLATFORM_URL)
+    return get_platform_url()
 
 
 def _parse_expires_at(raw: str | None) -> datetime:
@@ -208,7 +217,7 @@ def verify_token(token: str) -> VerifyResult:
     Raises:
         LoginError: If verification fails.
     """
-    verify_url = f"{PLATFORM_URL}/api/cli/verify"
+    verify_url = f"{_platform_url()}/api/cli/verify"
 
     request = Request(
         verify_url,
@@ -268,7 +277,7 @@ def verify_token(token: str) -> VerifyResult:
 
 def request_device_code(device_name: str | None = None) -> DeviceCodeResponse:
     """Request a device code from the platform."""
-    url = f"{PLATFORM_URL}/api/cli/device/authorize"
+    url = f"{_platform_url()}/api/cli/device/authorize"
     body = json.dumps(
         {
             "deviceName": device_name or _get_device_name(),
@@ -310,7 +319,7 @@ def poll_device_token(
     on_poll: Callable[[], None] | None = None,
 ) -> dict[str, Any]:
     """Poll for device authorization completion. Returns token response dict."""
-    url = f"{PLATFORM_URL}/api/cli/device/token"
+    url = f"{_platform_url()}/api/cli/device/token"
     body = json.dumps({"device_code": device_code}).encode()
     req_headers = {
         "Content-Type": "application/json",

--- a/osmosis_ai/platform/auth/local_config.py
+++ b/osmosis_ai/platform/auth/local_config.py
@@ -20,11 +20,11 @@ def clear_all_local_data() -> None:
 
 
 def reset_session() -> None:
-    """Complete session teardown: credentials and legacy session config.
+    """Complete current-platform session teardown: credentials and legacy config.
 
     Single entry point for all "end session" paths (logout, login --force,
-    401 expiry, user identity change) to ensure no stale auth-local session
-    state remains.
+    401 expiry, user identity change) to ensure no stale auth-local state
+    remains for the active platform.
     """
     from .credentials import delete_credentials
 

--- a/osmosis_ai/platform/auth/platform_client.py
+++ b/osmosis_ai/platform/auth/platform_client.py
@@ -20,12 +20,15 @@ from osmosis_ai.platform.constants import (
     MSG_SESSION_EXPIRED,
 )
 
-from .config import PLATFORM_URL
+from .config import PLATFORM_URL as _IMPORTED_PLATFORM_URL
+from .config import get_platform_url, normalize_platform_url
 from .credentials import load_credentials
 from .local_config import reset_session
 
 if TYPE_CHECKING:
     from .credentials import Credentials
+
+PLATFORM_URL = _IMPORTED_PLATFORM_URL
 
 
 class AuthenticationExpiredError(Exception):
@@ -80,6 +83,12 @@ def _credentials_match_env_token(credentials: Credentials | None) -> bool:
     return bool(
         env_token and credentials is not None and credentials.access_token == env_token
     )
+
+
+def _platform_url() -> str:
+    if PLATFORM_URL != _IMPORTED_PLATFORM_URL:
+        return normalize_platform_url(PLATFORM_URL)
+    return get_platform_url()
 
 
 def _read_error_body(e: HTTPError) -> dict[str, Any]:
@@ -248,7 +257,7 @@ def revoke_cli_token(credentials: Credentials) -> bool:
     if not credentials.token_id:
         return False
 
-    url = f"{PLATFORM_URL}/api/cli/tokens/{credentials.token_id}"
+    url = f"{_platform_url()}/api/cli/tokens/{credentials.token_id}"
     request = Request(
         url,
         headers={
@@ -323,7 +332,7 @@ def platform_request(
         raise CLIError(MSG_NOT_LOGGED_IN)
     using_env_token = _credentials_match_env_token(credentials)
 
-    url = f"{PLATFORM_URL}{endpoint}"
+    url = f"{_platform_url()}{endpoint}"
 
     req_headers = {
         "Authorization": f"Bearer {credentials.access_token}",

--- a/tests/unit/auth/test_config.py
+++ b/tests/unit/auth/test_config.py
@@ -1,0 +1,31 @@
+"""Tests for Osmosis auth configuration."""
+
+from __future__ import annotations
+
+import pytest
+
+from osmosis_ai.platform.auth.config import get_platform_url, normalize_platform_url
+
+
+@pytest.mark.parametrize(
+    ("raw_url", "expected"),
+    [
+        ("https://platform.osmosis.ai/", "https://platform.osmosis.ai"),
+        ("https://platform.osmosis.ai///", "https://platform.osmosis.ai"),
+        (" https://platform.osmosis.ai/ ", "https://platform.osmosis.ai"),
+        ("https://staging.osmosis.ai/", "https://staging.osmosis.ai"),
+    ],
+)
+def test_normalize_platform_url_strips_trailing_slashes(
+    raw_url: str,
+    expected: str,
+) -> None:
+    assert normalize_platform_url(raw_url) == expected
+
+
+def test_get_platform_url_normalizes_env_trailing_slash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OSMOSIS_PLATFORM_URL", "https://platform.osmosis.ai/")
+
+    assert get_platform_url() == "https://platform.osmosis.ai"

--- a/tests/unit/auth/test_credentials.py
+++ b/tests/unit/auth/test_credentials.py
@@ -6,6 +6,9 @@ import json
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
+import pytest
+
+from osmosis_ai.platform.auth.config import DEFAULT_PLATFORM_URL, normalize_platform_url
 from osmosis_ai.platform.auth.credentials import (
     KEYRING_ACCOUNT,
     TOKEN_STORE_ENV,
@@ -14,7 +17,16 @@ from osmosis_ai.platform.auth.credentials import (
     Credentials,
     UserInfo,
     get_credential_store,
+    keyring_account_for_platform,
 )
+
+DEFAULT_PLATFORM = normalize_platform_url(DEFAULT_PLATFORM_URL)
+STAGING_PLATFORM = "https://staging.osmosis.ai"
+
+
+@pytest.fixture(autouse=True)
+def _default_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OSMOSIS_PLATFORM_URL", raising=False)
 
 
 def _make_credentials(
@@ -32,6 +44,13 @@ def _make_credentials(
         user=UserInfo(id="user_1", email="user@example.com", name="User"),
         token_id=token_id,
     )
+
+
+def _platform_entry(
+    data: dict,
+    platform_url: str = DEFAULT_PLATFORM,
+) -> dict:
+    return data["platforms"][normalize_platform_url(platform_url)]
 
 
 def test_credentials_roundtrip_preserves_tz_aware_expires_at() -> None:
@@ -88,11 +107,15 @@ def test_save_uses_keyring_when_available(tmp_path, monkeypatch) -> None:
         store = save_credentials(_make_credentials())
 
     assert store == TOKEN_STORE_KEYRING
-    # Token should be stored under the fixed KEYRING_ACCOUNT, not the email
-    assert stored.get(KEYRING_ACCOUNT) == "test-token"
+    platform_account = keyring_account_for_platform(DEFAULT_PLATFORM)
+    assert stored.get(platform_account) == "test-token"
+    assert stored.get(KEYRING_ACCOUNT) is None
     data = json.loads(creds_file.read_text())
-    assert "access_token" not in data
-    assert data["token_store"] == TOKEN_STORE_KEYRING
+    assert "active_platform_url" not in data
+    entry = _platform_entry(data)
+    assert "access_token" not in entry
+    assert entry["token_store"] == TOKEN_STORE_KEYRING
+    assert entry["keyring_account"] == platform_account
 
 
 def test_save_cleans_up_old_keyring_on_account_change(tmp_path, monkeypatch) -> None:
@@ -205,8 +228,10 @@ def test_save_falls_back_to_file(tmp_path, monkeypatch, capsys) -> None:
 
     assert store == TOKEN_STORE_FILE
     data = json.loads(creds_file.read_text())
-    assert data["access_token"] == "test-token"
-    assert data["token_store"] == TOKEN_STORE_FILE
+    assert "active_platform_url" not in data
+    entry = _platform_entry(data)
+    assert entry["access_token"] == "test-token"
+    assert entry["token_store"] == TOKEN_STORE_FILE
     captured = capsys.readouterr()
     assert "keyring unavailable" in captured.err
 
@@ -266,7 +291,7 @@ def test_load_returns_none_when_keyring_entry_missing(
 
     assert loaded is None
     captured = capsys.readouterr()
-    assert "not found in keyring" in captured.err
+    assert "Token not found for the current Osmosis platform" in captured.err
 
 
 def test_load_from_file_fallback(tmp_path, monkeypatch) -> None:
@@ -287,6 +312,63 @@ def test_load_from_file_fallback(tmp_path, monkeypatch) -> None:
     assert loaded is not None
     assert loaded.access_token == "test-token"
     assert loaded.token_id == "tok_abc"
+
+
+def test_load_legacy_default_file_ignores_non_default_platform(
+    tmp_path, monkeypatch
+) -> None:
+    creds_file = tmp_path / "creds.json"
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.CREDENTIALS_FILE", creds_file
+    )
+    monkeypatch.setenv("OSMOSIS_PLATFORM_URL", STAGING_PLATFORM)
+    monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
+
+    stored = _make_credentials()
+    data = stored.to_dict()
+    data["token_store"] = TOKEN_STORE_FILE
+    creds_file.write_text(json.dumps(data))
+
+    from osmosis_ai.platform.auth.credentials import load_credentials
+
+    assert load_credentials() is None
+
+
+def test_platform_registry_loads_current_platform_entry(tmp_path, monkeypatch) -> None:
+    creds_file = tmp_path / "creds.json"
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.CREDENTIALS_FILE", creds_file
+    )
+    monkeypatch.setenv("OSMOSIS_PLATFORM_URL", STAGING_PLATFORM)
+    monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
+
+    prod = _make_credentials()
+    prod_data = prod.to_dict()
+    prod_data["platform_url"] = DEFAULT_PLATFORM
+    prod_data["token_store"] = TOKEN_STORE_FILE
+    staging = _make_credentials(token_id="tok_staging")
+    staging_data = staging.to_dict()
+    staging_data["access_token"] = "staging-token"
+    staging_data["platform_url"] = STAGING_PLATFORM
+    staging_data["token_store"] = TOKEN_STORE_FILE
+    creds_file.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "platforms": {
+                    DEFAULT_PLATFORM: prod_data,
+                    STAGING_PLATFORM: staging_data,
+                },
+            }
+        )
+    )
+
+    from osmosis_ai.platform.auth.credentials import load_credentials
+
+    loaded = load_credentials()
+    assert loaded is not None
+    assert loaded.access_token == "staging-token"
+    assert loaded.token_id == "tok_staging"
 
 
 # ---------------------------------------------------------------------------
@@ -526,6 +608,60 @@ def test_save_fallback_to_file_cleans_up_old_keyring(tmp_path, monkeypatch) -> N
     assert KEYRING_ACCOUNT in deleted_accounts
 
 
+def test_save_non_default_platform_preserves_legacy_default_keyring(
+    tmp_path, monkeypatch
+) -> None:
+    creds_file = tmp_path / "creds.json"
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.CREDENTIALS_FILE", creds_file
+    )
+    monkeypatch.setenv("OSMOSIS_PLATFORM_URL", STAGING_PLATFORM)
+
+    old_data = _make_credentials().to_dict()
+    old_data.pop("access_token")
+    old_data["token_store"] = TOKEN_STORE_KEYRING
+    creds_file.write_text(json.dumps(old_data))
+
+    deleted_accounts: list[str] = []
+    stored: dict[str, str] = {}
+
+    def fake_delete(account: str) -> bool:
+        deleted_accounts.append(account)
+        return True
+
+    def fake_set(account: str, token: str) -> bool:
+        stored[account] = token
+        return True
+
+    with (
+        patch(
+            "osmosis_ai.platform.auth.credentials._keyring_delete",
+            side_effect=fake_delete,
+        ),
+        patch(
+            "osmosis_ai.platform.auth.credentials._keyring_set",
+            side_effect=fake_set,
+        ),
+    ):
+        from osmosis_ai.platform.auth.credentials import save_credentials
+
+        store = save_credentials(_make_credentials())
+
+    assert store == TOKEN_STORE_KEYRING
+    assert KEYRING_ACCOUNT not in deleted_accounts
+    assert keyring_account_for_platform(STAGING_PLATFORM) in deleted_accounts
+    assert stored[keyring_account_for_platform(STAGING_PLATFORM)] == "test-token"
+
+    data = json.loads(creds_file.read_text())
+    assert "active_platform_url" not in data
+    assert DEFAULT_PLATFORM in data["platforms"]
+    assert STAGING_PLATFORM in data["platforms"]
+    assert data["platforms"][DEFAULT_PLATFORM]["keyring_account"] == KEYRING_ACCOUNT
+    assert data["platforms"][STAGING_PLATFORM]["keyring_account"] == (
+        keyring_account_for_platform(STAGING_PLATFORM)
+    )
+
+
 # ---------------------------------------------------------------------------
 # Backward compat: load credentials from legacy email-based keyring
 # ---------------------------------------------------------------------------
@@ -561,6 +697,54 @@ def test_load_falls_back_to_legacy_email_keyring(tmp_path, monkeypatch) -> None:
 
     assert loaded is not None
     assert loaded.access_token == "legacy-keyring-secret"
+
+
+def test_delete_credentials_removes_only_current_platform(
+    tmp_path, monkeypatch
+) -> None:
+    creds_file = tmp_path / "creds.json"
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.CREDENTIALS_FILE", creds_file
+    )
+    monkeypatch.setenv("OSMOSIS_PLATFORM_URL", STAGING_PLATFORM)
+
+    prod = _make_credentials(token_id="tok_prod").to_dict()
+    prod["platform_url"] = DEFAULT_PLATFORM
+    prod["token_store"] = TOKEN_STORE_FILE
+    staging = _make_credentials(token_id="tok_staging").to_dict()
+    staging["access_token"] = "staging-token"
+    staging["platform_url"] = STAGING_PLATFORM
+    staging["token_store"] = TOKEN_STORE_FILE
+    creds_file.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "platforms": {
+                    DEFAULT_PLATFORM: prod,
+                    STAGING_PLATFORM: staging,
+                },
+            }
+        )
+    )
+
+    deleted_accounts: list[str] = []
+
+    def fake_delete(account: str) -> bool:
+        deleted_accounts.append(account)
+        return True
+
+    with patch(
+        "osmosis_ai.platform.auth.credentials._keyring_delete",
+        side_effect=fake_delete,
+    ):
+        from osmosis_ai.platform.auth.credentials import delete_credentials
+
+        assert delete_credentials() is True
+
+    data = json.loads(creds_file.read_text())
+    assert DEFAULT_PLATFORM in data["platforms"]
+    assert STAGING_PLATFORM not in data["platforms"]
+    assert KEYRING_ACCOUNT not in deleted_accounts
 
 
 # ---------------------------------------------------------------------------
@@ -643,7 +827,10 @@ def test_get_credential_store_keyring(tmp_path, monkeypatch) -> None:
         "osmosis_ai.platform.auth.credentials.CREDENTIALS_FILE", creds_file
     )
     monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
-    creds_file.write_text(json.dumps({"token_store": TOKEN_STORE_KEYRING}))
+    data = _make_credentials().to_dict()
+    data.pop("access_token")
+    data["token_store"] = TOKEN_STORE_KEYRING
+    creds_file.write_text(json.dumps(data))
     assert get_credential_store() == TOKEN_STORE_KEYRING
 
 
@@ -653,8 +840,41 @@ def test_get_credential_store_file(tmp_path, monkeypatch) -> None:
         "osmosis_ai.platform.auth.credentials.CREDENTIALS_FILE", creds_file
     )
     monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
-    creds_file.write_text(json.dumps({"token_store": TOKEN_STORE_FILE}))
+    data = _make_credentials().to_dict()
+    data["token_store"] = TOKEN_STORE_FILE
+    creds_file.write_text(json.dumps(data))
     assert get_credential_store() == TOKEN_STORE_FILE
+
+
+def test_get_credential_store_uses_current_platform(tmp_path, monkeypatch) -> None:
+    creds_file = tmp_path / "creds.json"
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.CREDENTIALS_FILE", creds_file
+    )
+    monkeypatch.setenv("OSMOSIS_PLATFORM_URL", STAGING_PLATFORM)
+    monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
+
+    prod = _make_credentials().to_dict()
+    prod["platform_url"] = DEFAULT_PLATFORM
+    prod["token_store"] = TOKEN_STORE_FILE
+    staging = _make_credentials().to_dict()
+    staging.pop("access_token")
+    staging["platform_url"] = STAGING_PLATFORM
+    staging["token_store"] = TOKEN_STORE_KEYRING
+    staging["keyring_account"] = keyring_account_for_platform(STAGING_PLATFORM)
+    creds_file.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "platforms": {
+                    DEFAULT_PLATFORM: prod,
+                    STAGING_PLATFORM: staging,
+                },
+            }
+        )
+    )
+
+    assert get_credential_store() == TOKEN_STORE_KEYRING
 
 
 def test_get_credential_store_none(tmp_path, monkeypatch) -> None:

--- a/tests/unit/auth/test_flow.py
+++ b/tests/unit/auth/test_flow.py
@@ -84,6 +84,41 @@ class TestVerifyAndGetUserInfo:
         assert result.expires_at.tzinfo is not None
         assert result.token_id == "tok_abc"
 
+    @pytest.mark.parametrize(
+        ("platform_url", "expected_url"),
+        [
+            (
+                "https://platform.osmosis.ai/",
+                "https://platform.osmosis.ai/api/cli/verify",
+            ),
+            (
+                "https://staging.osmosis.ai/",
+                "https://staging.osmosis.ai/api/cli/verify",
+            ),
+        ],
+    )
+    def test_verification_uses_runtime_platform_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        platform_url: str,
+        expected_url: str,
+    ) -> None:
+        expires_str = (datetime.now(UTC) + timedelta(days=90)).isoformat()
+        body = _make_verify_response(expires_at=expires_str)
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = body
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        monkeypatch.setenv("OSMOSIS_PLATFORM_URL", platform_url)
+
+        with patch(
+            "osmosis_ai.platform.auth.flow.urlopen", return_value=mock_resp
+        ) as open_mock:
+            verify_token("test-token")
+
+        request_obj = open_mock.call_args[0][0]
+        assert request_obj.full_url == expected_url
+
     def test_verification_with_no_expires_at_defaults_to_90_days(self) -> None:
         body = _make_verify_response(expires_at=None)
         mock_resp = MagicMock()

--- a/tests/unit/auth/test_platform_client.py
+++ b/tests/unit/auth/test_platform_client.py
@@ -183,6 +183,31 @@ class TestPlatformRequest:
         request_obj = mock_urlopen.call_args[0][0]
         assert request_obj.full_url == "https://test.osmosis.ai/api/v1/verify"
 
+    @pytest.mark.parametrize(
+        ("platform_url", "expected_url"),
+        [
+            ("https://platform.osmosis.ai/", "https://platform.osmosis.ai/api/test"),
+            ("https://staging.osmosis.ai/", "https://staging.osmosis.ai/api/test"),
+        ],
+    )
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_constructs_url_from_runtime_platform_env(
+        self,
+        mock_urlopen: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        platform_url: str,
+        expected_url: str,
+    ) -> None:
+        """Changing OSMOSIS_PLATFORM_URL after import should affect requests."""
+        mock_urlopen.return_value = _make_http_response({"ok": True})
+        creds = _make_credentials()
+        monkeypatch.setenv("OSMOSIS_PLATFORM_URL", platform_url)
+
+        platform_request("/api/test", credentials=creds, git_identity="git_test")
+
+        request_obj = mock_urlopen.call_args[0][0]
+        assert request_obj.full_url == expected_url
+
     @patch("osmosis_ai.platform.auth.platform_client.urlopen")
     def test_sets_required_headers(self, mock_urlopen: MagicMock) -> None:
         """Verify Authorization, Content-Type, and User-Agent headers are set."""


### PR DESCRIPTION
## What

- Store persisted credentials in a per-platform registry keyed by normalized platform URL, with platform-scoped keyring accounts (`platform:<sha256-prefix>`), so local / staging / production sessions no longer overwrite each other (`platform/auth/credentials.py`).
- Migrate existing single-session credentials into the default platform slot on read, so prior logins keep working without re-authenticating (`_registry_from_metadata` / `_legacy_entry_from_metadata`).
- Resolve auth request URLs from the runtime environment and surface the active platform in auth command output (`cli/commands/auth.py`, `platform/auth/config.py`, `platform/auth/flow.py`, `platform/auth/platform_client.py`, `platform/auth/local_config.py`).
- Add focused coverage for platform-scoped credential save/load/delete, runtime platform URL resolution, and auth CLI JSON/plain flows (`tests/unit/auth/*`).

## Why

CLI credentials were stored as a single session without scoping to a platform URL, so logging into a second platform overwrote the first. Scoping credentials by platform URL lets users authenticate against multiple platforms (e.g. local, staging, production) independently. Legacy credentials are migrated into the default platform slot on first read, so this change is backward-compatible and requires no re-login.

## How to Test

- `uv run pytest tests/unit/auth/`
- `uv run ruff check . && uv run ruff format --check .`
- `uv run pyright osmosis_ai/`
- Manual: `osmosis auth login` against two different platform URLs and confirm both sessions persist; `osmosis auth whoami` shows the active platform.

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included
