### PR TITLE
[cli] feat: send CLI version header and handle deprecation/upgrade signals

### DIFF
--- a/osmosis_ai/cli/commands/auth.py
+++ b/osmosis_ai/cli/commands/auth.py
@@ -141,7 +141,15 @@ def _cli_error_from_login_error(exc: Any) -> CLIError:
         return CLIError(str(exc), code="AUTH_REQUIRED")
 
     if status_code == 426:
-        return CLIError(str(exc), code="UPGRADE_REQUIRED", details={"status_code": 426})
+        details: dict[str, Any] = {"status_code": 426}
+        # Mirror the structured signal (status/message) a 426 carries on a
+        # regular API call so the UPGRADE_REQUIRED envelope looks the same
+        # whether it came from the login handshake or any other command.
+        signal = getattr(exc, "details", None)
+        if isinstance(signal, dict):
+            for key, value in signal.items():
+                details.setdefault(key, value)
+        return CLIError(str(exc), code="UPGRADE_REQUIRED", details=details)
 
     details: dict[str, Any] = {}
     if isinstance(status_code, int):

--- a/osmosis_ai/cli/commands/auth.py
+++ b/osmosis_ai/cli/commands/auth.py
@@ -140,6 +140,9 @@ def _cli_error_from_login_error(exc: Any) -> CLIError:
     ):
         return CLIError(str(exc), code="AUTH_REQUIRED")
 
+    if status_code == 426:
+        return CLIError(str(exc), code="UPGRADE_REQUIRED", details={"status_code": 426})
+
     details: dict[str, Any] = {}
     if isinstance(status_code, int):
         details["status_code"] = status_code

--- a/osmosis_ai/cli/console.py
+++ b/osmosis_ai/cli/console.py
@@ -159,16 +159,40 @@ class Console:
         self,
         message: str,
         *,
+        code: str | None = None,
         soft_wrap: bool | None = None,
         markup: bool = False,
     ) -> None:
-        """Print a non-fatal warning message to stderr.
+        """Print a non-fatal warning to stderr, honoring the output format.
+
+        Warnings are emitted automatically deep in the request path (e.g. from a
+        deprecation response header), so they are routed per output format to
+        avoid corrupting the machine contract:
+
+        - JSON: a one-line structured warning envelope on stderr, distinguished
+          from the error envelope by the ``warning`` key so the stream stays
+          parseable as JSON Lines.
+        - plain: unstyled ``warning: <message>`` text on stderr.
+        - rich: a yellow ``⚠`` line on stderr.
 
         Args:
             message: Warning message to print.
+            code: Optional machine-readable code (e.g. ``"DEPRECATION"``) carried
+                in the JSON envelope. Ignored in plain/rich modes.
             soft_wrap: Whether Rich should avoid inserting hard line breaks.
             markup: Whether to interpret Rich markup in the message.
         """
+        from osmosis_ai.cli.output.context import OutputFormat
+
+        fmt = self._output_format()
+        if fmt is OutputFormat.json:
+            from osmosis_ai.cli.output.error import emit_structured_warning_to_stderr
+
+            emit_structured_warning_to_stderr(message, code=code)
+            return
+        if fmt is OutputFormat.plain:
+            sys.stderr.write(f"warning: {message}\n")
+            return
         kwargs: dict[str, Any] = {"markup": markup}
         if soft_wrap is not None:
             kwargs["soft_wrap"] = soft_wrap

--- a/osmosis_ai/cli/console.py
+++ b/osmosis_ai/cli/console.py
@@ -155,6 +155,25 @@ class Console:
             kwargs["soft_wrap"] = soft_wrap
         self._rich_stderr.print(message, style="bold red", **kwargs)
 
+    def print_warning(
+        self,
+        message: str,
+        *,
+        soft_wrap: bool | None = None,
+        markup: bool = False,
+    ) -> None:
+        """Print a non-fatal warning message to stderr.
+
+        Args:
+            message: Warning message to print.
+            soft_wrap: Whether Rich should avoid inserting hard line breaks.
+            markup: Whether to interpret Rich markup in the message.
+        """
+        kwargs: dict[str, Any] = {"markup": markup}
+        if soft_wrap is not None:
+            kwargs["soft_wrap"] = soft_wrap
+        self._rich_stderr.print(f"⚠ {message}", style="yellow", **kwargs)
+
     def separator(self, title: str = "") -> None:
         """Print a separator line with optional title.
 

--- a/osmosis_ai/cli/console.py
+++ b/osmosis_ai/cli/console.py
@@ -90,6 +90,10 @@ class Console:
             highlight=False,
             **rich_size,
         )
+        # Rich Status of a currently-live spinner, if any. print_warning stops
+        # it before printing and restarts it after, so the transient spinner
+        # line is not left stranded on screen mid-spin.
+        self._active_status: Any = None
 
     @property
     def is_tty(self) -> bool:
@@ -196,7 +200,15 @@ class Console:
         kwargs: dict[str, Any] = {"markup": markup}
         if soft_wrap is not None:
             kwargs["soft_wrap"] = soft_wrap
+        # A live spinner owns the terminal via a Rich Live region; writing to the
+        # separate stderr console mid-spin would strand the spinner line. Pause
+        # it (a clean transient erase), print, then resume so it redraws below.
+        status = self._active_status
+        if status is not None:
+            status.stop()
         self._rich_stderr.print(f"⚠ {message}", style="yellow", **kwargs)
+        if status is not None:
+            status.start()
 
     def separator(self, title: str = "") -> None:
         """Print a separator line with optional title.
@@ -331,33 +343,44 @@ class Console:
 
     @contextmanager
     def spinner(self, message: str) -> Generator[None, None, None]:
-        """Show a spinner animation while work is in progress.
+        """Show a spinner while work is in progress (alias for :meth:`status`).
+
+        Historically this rendered the spinner to *stdout*, which leaked the
+        progress text into redirected output — ``osmosis dataset list > out.txt``
+        used to write ``Fetching datasets...`` into ``out.txt``. It now delegates
+        to :meth:`status` so progress goes to stderr and stays output-mode aware,
+        keeping stdout clean for piping/redirection. Kept as a named alias so the
+        existing call sites (dataset, auth) read naturally.
 
         Usage::
 
             with console.spinner("Loading workspaces..."):
                 result = api_call()
         """
-        from osmosis_ai.cli.output.context import OutputFormat
-
-        fmt = self._output_format()
-        if fmt is OutputFormat.json:
+        with self.status(message):
             yield
-            return
-        if fmt is OutputFormat.plain:
-            sys.stderr.write(message + "\n")
-            sys.stderr.flush()
-            yield
-            return
 
-        if self.is_tty:
-            from rich.status import Status
+    @contextmanager
+    def track_spinner(self, status: Any) -> Generator[None, None, None]:
+        """Register ``status`` as the process-wide active spinner while live.
 
-            with Status(message, console=self._rich, spinner="dots"):
-                yield
-        else:
-            self._rich.print(message)
+        A terminal can only show one spinner at a time, so the active Rich
+        ``Status`` is tracked on this (singleton) console regardless of which
+        spinner implementation created it — ``console.spinner`` here, or
+        ``OutputContext.status`` on its own stderr console. ``print_warning``
+        consults it to pause/resume the spinner around a stderr write, so a
+        warning fired mid-spin (e.g. the upgrade nudge from deep in the request
+        path) neither glues onto the spinner line nor strands it on screen.
+
+        Saves and restores any previously-active status so nested spinners
+        behave; the innermost live spinner is the one a warning pauses.
+        """
+        prev = self._active_status
+        self._active_status = status
+        try:
             yield
+        finally:
+            self._active_status = prev
 
     @contextmanager
     def status(self, message: str) -> Generator[None, None, None]:

--- a/osmosis_ai/cli/main.py
+++ b/osmosis_ai/cli/main.py
@@ -217,7 +217,7 @@ def _register_commands() -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Entry point for the osmosis CLI."""
+    """Entry point for the Osmosis CLI."""
     _register_commands()
     try:
         result = app(argv, standalone_mode=False)

--- a/osmosis_ai/cli/output/context.py
+++ b/osmosis_ai/cli/output/context.py
@@ -46,8 +46,14 @@ class OutputContext:
         from rich.console import Console as RichConsole
         from rich.status import Status
 
+        from osmosis_ai.cli.console import console
+
         rich_stderr = RichConsole(stderr=True)
-        with Status(message, console=rich_stderr, spinner="dots"):
+        status = Status(message, console=rich_stderr, spinner="dots")
+        # Register on the shared console so a warning emitted mid-spin (e.g. the
+        # upgrade nudge) can pause/resume this spinner instead of gluing onto or
+        # stranding its line. This is the dominant spinner path for the CLI.
+        with console.track_spinner(status), status:
             yield
 
 

--- a/osmosis_ai/cli/output/error.py
+++ b/osmosis_ai/cli/output/error.py
@@ -59,6 +59,8 @@ def _classify_platform_status(status: int | None) -> str:
         return "NOT_FOUND"
     if status == 409:
         return "CONFLICT"
+    if status == 426:
+        return "UPGRADE_REQUIRED"
     if status == 429:
         return "RATE_LIMITED"
     if status == 400:
@@ -179,6 +181,33 @@ def emit_structured_error_to_stderr(
             "message": err.message,
             "details": err.details,
             "request_id": err.request_id,
+        },
+    }
+    sys.stderr.write(json.dumps(envelope, ensure_ascii=False))
+    sys.stderr.write("\n")
+    sys.stderr.flush()
+
+
+def emit_structured_warning_to_stderr(
+    message: str,
+    *,
+    code: str | None = None,
+    cli_version: str | None = None,
+) -> None:
+    """Write a JSON-mode warning envelope (one line) to stderr.
+
+    Non-fatal warnings share stderr with the error envelope but are
+    distinguished by the top-level ``warning`` key (vs ``error``), so the stream
+    stays parseable as JSON Lines. Unlike errors, warnings are not tied to a
+    specific command (they originate from transport-level signals such as a
+    deprecation response header), so no ``command`` field is emitted.
+    """
+    envelope: dict[str, Any] = {
+        "schema_version": 1,
+        "cli_version": cli_version or PACKAGE_VERSION,
+        "warning": {
+            "code": code,
+            "message": message,
         },
     }
     sys.stderr.write(json.dumps(envelope, ensure_ascii=False))

--- a/osmosis_ai/platform/auth/__init__.py
+++ b/osmosis_ai/platform/auth/__init__.py
@@ -16,6 +16,7 @@ from .platform_client import (
     AuthenticationExpiredError,
     PlatformAPIError,
     SubscriptionRequiredError,
+    UpgradeRequiredError,
     platform_request,
 )
 
@@ -29,6 +30,7 @@ __all__ = [
     "LoginResult",
     "PlatformAPIError",
     "SubscriptionRequiredError",
+    "UpgradeRequiredError",
     "UserInfo",
     "delete_credentials",
     "device_login",

--- a/osmosis_ai/platform/auth/credentials.py
+++ b/osmosis_ai/platform/auth/credentials.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import json
 import os
-import sys
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from hashlib import sha256
@@ -51,6 +50,21 @@ KEYRING_ACCOUNT_PREFIX = "platform:"
 TOKEN_STORE_KEYRING = "keyring"
 TOKEN_STORE_FILE = "file"
 TOKEN_STORE_ENV = "env"
+
+
+def _warn(message: str, *, code: str) -> None:
+    """Emit an output-mode-aware warning from this low-level auth module.
+
+    Routes through ``console.print_warning`` (not a raw ``sys.stderr.write``) so
+    these best-effort diagnostics stay structured in ``--json`` mode instead of
+    corrupting the stderr JSON-lines contract, and pause any active spinner in
+    rich mode. The console is imported lazily to keep this module — imported on
+    nearly every authenticated command via ``load_credentials`` — free of a CLI
+    import at module load time.
+    """
+    from osmosis_ai.cli.console import console
+
+    console.print_warning(message, code=code)
 
 
 def keyring_account_for_platform(platform_url: str | None = None) -> str:
@@ -242,8 +256,9 @@ def _keyring_delete(account: str) -> bool:
         # Entry does not exist — nothing to clean up.
         return True
     except Exception:
-        sys.stderr.write(
-            f"Warning: failed to remove token from keyring for {account}\n"
+        _warn(
+            f"Could not remove token from keyring for {account}.",
+            code="KEYRING_DELETE_FAILED",
         )
         return False
 
@@ -377,9 +392,9 @@ def save_credentials(credentials: Credentials) -> str:
     data.pop("keyring_account", None)
     registry["platforms"][platform_url] = data
     atomic_write_json(CREDENTIALS_FILE, registry, mode=0o600)
-    sys.stderr.write(
-        "Warning: keyring unavailable — token stored in plain text at "
-        f"{CREDENTIALS_FILE}\n"
+    _warn(
+        f"Keyring unavailable — token stored in plain text at {CREDENTIALS_FILE}",
+        code="KEYRING_UNAVAILABLE",
     )
     return TOKEN_STORE_FILE
 
@@ -415,16 +430,18 @@ def load_credentials(*, include_env: bool = True) -> Credentials | None:
     except FileNotFoundError:
         return None
     except (json.JSONDecodeError, KeyError, ValueError) as exc:
-        sys.stderr.write(
-            f"Warning: could not parse credentials file ({type(exc).__name__}); "
-            "run 'osmosis auth login' to re-authenticate.\n"
+        _warn(
+            f"Could not parse credentials file ({type(exc).__name__}); "
+            "run 'osmosis auth login' to re-authenticate.",
+            code="CREDENTIALS_PARSE_FAILED",
         )
         return None
 
     if data.get("version") != CREDENTIALS_VERSION:
-        sys.stderr.write(
+        _warn(
             "Credentials format has changed. "
-            "Please run 'osmosis auth login' to re-authenticate.\n"
+            "Please run 'osmosis auth login' to re-authenticate.",
+            code="CREDENTIALS_VERSION_CHANGED",
         )
         return None
 
@@ -436,9 +453,10 @@ def load_credentials(*, include_env: bool = True) -> Credentials | None:
     credential_data.setdefault("version", CREDENTIALS_VERSION)
     token = _resolve_entry_token(credential_data, platform_url)
     if token is None:
-        sys.stderr.write(
+        _warn(
             "Token not found for the current Osmosis platform. "
-            "Please run 'osmosis auth login' to re-authenticate.\n"
+            "Please run 'osmosis auth login' to re-authenticate.",
+            code="TOKEN_NOT_FOUND",
         )
         return None
     credential_data["access_token"] = token
@@ -447,9 +465,10 @@ def load_credentials(*, include_env: bool = True) -> Credentials | None:
     try:
         return Credentials.from_dict(credential_data)
     except (KeyError, ValueError) as exc:
-        sys.stderr.write(
-            f"Warning: could not parse credentials ({type(exc).__name__}); "
-            "run 'osmosis auth login' to re-authenticate.\n"
+        _warn(
+            f"Could not parse credentials ({type(exc).__name__}); "
+            "run 'osmosis auth login' to re-authenticate.",
+            code="CREDENTIALS_PARSE_FAILED",
         )
         return None
 
@@ -481,9 +500,10 @@ def delete_credentials() -> bool:
     keyring_cleaned = _cleanup_platform_keyring_entries(old_entry, platform_url)
 
     if not keyring_cleaned:
-        sys.stderr.write(
-            "Warning: could not remove token from system keyring. "
-            "You may want to remove it manually.\n"
+        _warn(
+            "Could not remove token from system keyring. "
+            "You may want to remove it manually.",
+            code="KEYRING_CLEANUP_FAILED",
         )
 
     if metadata_missing:

--- a/osmosis_ai/platform/auth/flow.py
+++ b/osmosis_ai/platform/auth/flow.py
@@ -43,10 +43,12 @@ class LoginError(Exception):
         *,
         code: str | None = None,
         status_code: int | None = None,
+        details: dict[str, Any] | None = None,
     ):
         super().__init__(message)
         self.code = code
         self.status_code = status_code
+        self.details = details
 
 
 @dataclass
@@ -192,8 +194,17 @@ def _login_error_from_http(
     """
     if e.code == 426:
         body = _read_error_body(e)
-        message, _ = upgrade_required_message(body)
-        return LoginError(message, code="UPGRADE_REQUIRED", status_code=426)
+        message, version_signal = upgrade_required_message(body)
+        # Carry the parsed version signal so the command layer can attach the
+        # same structured ``details`` (status/message) a 426 on a regular API
+        # call produces, keeping the UPGRADE_REQUIRED JSON contract consistent
+        # across the login handshake and the rest of the CLI.
+        return LoginError(
+            message,
+            code="UPGRADE_REQUIRED",
+            status_code=426,
+            details=version_signal,
+        )
 
     detail = _read_error_detail(e)
     friendly = _HTTP_ERROR_MESSAGES.get(e.code)

--- a/osmosis_ai/platform/auth/flow.py
+++ b/osmosis_ai/platform/auth/flow.py
@@ -26,6 +26,7 @@ from osmosis_ai.consts import PACKAGE_VERSION
 from .config import PLATFORM_URL as _IMPORTED_PLATFORM_URL
 from .config import get_platform_url, normalize_platform_url
 from .credentials import Credentials, UserInfo
+from .platform_client import surface_version_status
 
 PLATFORM_URL = _IMPORTED_PLATFORM_URL
 
@@ -241,6 +242,10 @@ def verify_token(token: str) -> VerifyResult:
 
     try:
         with urlopen(request, timeout=30) as response:
+            surface_version_status(
+                response.headers.get("X-Osmosis-Deprecation"),
+                response.headers.get("X-Osmosis-Latest"),
+            )
             data = json.loads(response.read().decode())
 
             token_id = data.get("token_id")
@@ -308,6 +313,10 @@ def request_device_code(device_name: str | None = None) -> DeviceCodeResponse:
 
     try:
         with urlopen(request, timeout=30) as response:
+            surface_version_status(
+                response.headers.get("X-Osmosis-Deprecation"),
+                response.headers.get("X-Osmosis-Latest"),
+            )
             data = json.loads(response.read().decode())
             return DeviceCodeResponse(
                 device_code=data["device_code"],
@@ -346,6 +355,10 @@ def poll_device_token(
 
         try:
             with urlopen(request, timeout=30) as response:
+                surface_version_status(
+                    response.headers.get("X-Osmosis-Deprecation"),
+                    response.headers.get("X-Osmosis-Latest"),
+                )
                 data = json.loads(response.read().decode())
                 return data
         except HTTPError as e:

--- a/osmosis_ai/platform/auth/flow.py
+++ b/osmosis_ai/platform/auth/flow.py
@@ -186,6 +186,16 @@ def _login_error_from_http(
     Uses the platform's error detail when it adds meaningful context,
     otherwise falls back to a status-code-specific message or a generic one.
     """
+    if e.code == 426:
+        body = _read_error_body(e)
+        platform_message = body.get("message")
+        message = (
+            platform_message
+            if isinstance(platform_message, str) and platform_message
+            else "This version of the Osmosis CLI is no longer supported. Run: osmosis upgrade"
+        )
+        return LoginError(message, code="UPGRADE_REQUIRED", status_code=426)
+
     detail = _read_error_detail(e)
     friendly = _HTTP_ERROR_MESSAGES.get(e.code)
 
@@ -225,6 +235,7 @@ def verify_token(token: str) -> VerifyResult:
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
             "User-Agent": f"osmosis-cli/{PACKAGE_VERSION}",
+            "X-Osmosis-CLI-Version": PACKAGE_VERSION,
         },
     )
 
@@ -290,6 +301,7 @@ def request_device_code(device_name: str | None = None) -> DeviceCodeResponse:
         headers={
             "Content-Type": "application/json",
             "User-Agent": f"osmosis-cli/{PACKAGE_VERSION}",
+            "X-Osmosis-CLI-Version": PACKAGE_VERSION,
         },
         method="POST",
     )
@@ -324,6 +336,7 @@ def poll_device_token(
     req_headers = {
         "Content-Type": "application/json",
         "User-Agent": f"osmosis-cli/{PACKAGE_VERSION}",
+        "X-Osmosis-CLI-Version": PACKAGE_VERSION,
     }
     deadline = time.monotonic() + timeout
     current_interval = interval
@@ -336,7 +349,7 @@ def poll_device_token(
                 data = json.loads(response.read().decode())
                 return data
         except HTTPError as e:
-            if e.code in (429, 500, 502, 503, 504):
+            if e.code in (426, 429, 500, 502, 503, 504):
                 raise _login_error_from_http(e, "Polling failed") from e
             try:
                 error_data = json.loads(e.read().decode())

--- a/osmosis_ai/platform/auth/flow.py
+++ b/osmosis_ai/platform/auth/flow.py
@@ -26,7 +26,12 @@ from osmosis_ai.consts import PACKAGE_VERSION
 from .config import PLATFORM_URL as _IMPORTED_PLATFORM_URL
 from .config import get_platform_url, normalize_platform_url
 from .credentials import Credentials, UserInfo
-from .platform_client import surface_version_status
+from .platform_client import (
+    VERSION_MESSAGE_HEADER,
+    VERSION_STATUS_HEADER,
+    parse_version_signal,
+    surface_version_signal,
+)
 
 PLATFORM_URL = _IMPORTED_PLATFORM_URL
 
@@ -189,7 +194,10 @@ def _login_error_from_http(
     """
     if e.code == 426:
         body = _read_error_body(e)
-        platform_message = body.get("message")
+        version_signal = parse_version_signal(body)
+        platform_message = (
+            version_signal.get("message") if version_signal is not None else None
+        )
         message = (
             platform_message
             if isinstance(platform_message, str) and platform_message
@@ -242,9 +250,9 @@ def verify_token(token: str) -> VerifyResult:
 
     try:
         with urlopen(request, timeout=30) as response:
-            surface_version_status(
-                response.headers.get("X-Osmosis-Deprecation"),
-                response.headers.get("X-Osmosis-Latest"),
+            surface_version_signal(
+                response.headers.get(VERSION_STATUS_HEADER),
+                response.headers.get(VERSION_MESSAGE_HEADER),
             )
             data = json.loads(response.read().decode())
 
@@ -313,9 +321,9 @@ def request_device_code(device_name: str | None = None) -> DeviceCodeResponse:
 
     try:
         with urlopen(request, timeout=30) as response:
-            surface_version_status(
-                response.headers.get("X-Osmosis-Deprecation"),
-                response.headers.get("X-Osmosis-Latest"),
+            surface_version_signal(
+                response.headers.get(VERSION_STATUS_HEADER),
+                response.headers.get(VERSION_MESSAGE_HEADER),
             )
             data = json.loads(response.read().decode())
             return DeviceCodeResponse(
@@ -355,9 +363,9 @@ def poll_device_token(
 
         try:
             with urlopen(request, timeout=30) as response:
-                surface_version_status(
-                    response.headers.get("X-Osmosis-Deprecation"),
-                    response.headers.get("X-Osmosis-Latest"),
+                surface_version_signal(
+                    response.headers.get(VERSION_STATUS_HEADER),
+                    response.headers.get(VERSION_MESSAGE_HEADER),
                 )
                 data = json.loads(response.read().decode())
                 return data

--- a/osmosis_ai/platform/auth/flow.py
+++ b/osmosis_ai/platform/auth/flow.py
@@ -21,16 +21,14 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from osmosis_ai.cli.console import console
-from osmosis_ai.consts import PACKAGE_VERSION
 
 from .config import PLATFORM_URL as _IMPORTED_PLATFORM_URL
 from .config import get_platform_url, normalize_platform_url
 from .credentials import Credentials, UserInfo
 from .platform_client import (
-    VERSION_MESSAGE_HEADER,
-    VERSION_STATUS_HEADER,
-    parse_version_signal,
-    surface_version_signal,
+    cli_request_headers,
+    surface_response_version_signal,
+    upgrade_required_message,
 )
 
 PLATFORM_URL = _IMPORTED_PLATFORM_URL
@@ -194,15 +192,7 @@ def _login_error_from_http(
     """
     if e.code == 426:
         body = _read_error_body(e)
-        version_signal = parse_version_signal(body)
-        platform_message = (
-            version_signal.get("message") if version_signal is not None else None
-        )
-        message = (
-            platform_message
-            if isinstance(platform_message, str) and platform_message
-            else "This version of the Osmosis CLI is no longer supported. Run: osmosis upgrade"
-        )
+        message, _ = upgrade_required_message(body)
         return LoginError(message, code="UPGRADE_REQUIRED", status_code=426)
 
     detail = _read_error_detail(e)
@@ -240,20 +230,12 @@ def verify_token(token: str) -> VerifyResult:
 
     request = Request(
         verify_url,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-            "User-Agent": f"osmosis-cli/{PACKAGE_VERSION}",
-            "X-Osmosis-CLI-Version": PACKAGE_VERSION,
-        },
+        headers=cli_request_headers(token=token),
     )
 
     try:
         with urlopen(request, timeout=30) as response:
-            surface_version_signal(
-                response.headers.get(VERSION_STATUS_HEADER),
-                response.headers.get(VERSION_MESSAGE_HEADER),
-            )
+            surface_response_version_signal(response)
             data = json.loads(response.read().decode())
 
             token_id = data.get("token_id")
@@ -311,20 +293,13 @@ def request_device_code(device_name: str | None = None) -> DeviceCodeResponse:
     request = Request(
         url,
         data=body,
-        headers={
-            "Content-Type": "application/json",
-            "User-Agent": f"osmosis-cli/{PACKAGE_VERSION}",
-            "X-Osmosis-CLI-Version": PACKAGE_VERSION,
-        },
+        headers=cli_request_headers(),
         method="POST",
     )
 
     try:
         with urlopen(request, timeout=30) as response:
-            surface_version_signal(
-                response.headers.get(VERSION_STATUS_HEADER),
-                response.headers.get(VERSION_MESSAGE_HEADER),
-            )
+            surface_response_version_signal(response)
             data = json.loads(response.read().decode())
             return DeviceCodeResponse(
                 device_code=data["device_code"],
@@ -350,11 +325,7 @@ def poll_device_token(
     """Poll for device authorization completion. Returns token response dict."""
     url = f"{_platform_url()}/api/cli/device/token"
     body = json.dumps({"device_code": device_code}).encode()
-    req_headers = {
-        "Content-Type": "application/json",
-        "User-Agent": f"osmosis-cli/{PACKAGE_VERSION}",
-        "X-Osmosis-CLI-Version": PACKAGE_VERSION,
-    }
+    req_headers = cli_request_headers()
     deadline = time.monotonic() + timeout
     current_interval = interval
 
@@ -363,10 +334,7 @@ def poll_device_token(
 
         try:
             with urlopen(request, timeout=30) as response:
-                surface_version_signal(
-                    response.headers.get(VERSION_STATUS_HEADER),
-                    response.headers.get(VERSION_MESSAGE_HEADER),
-                )
+                surface_response_version_signal(response)
                 data = json.loads(response.read().decode())
                 return data
         except HTTPError as e:

--- a/osmosis_ai/platform/auth/platform_client.py
+++ b/osmosis_ai/platform/auth/platform_client.py
@@ -85,6 +85,8 @@ class UpgradeRequiredError(PlatformAPIError):
 
 # Warn at most once per process about a deprecated CLI version.
 _deprecation_warned = False
+# Nudge at most once per process about an available upgrade.
+_upgrade_nudged = False
 
 
 def _maybe_warn_deprecation(message: str | None) -> None:
@@ -94,6 +96,27 @@ def _maybe_warn_deprecation(message: str | None) -> None:
         return
     _deprecation_warned = True
     console.print_warning(message, code="DEPRECATION")
+
+
+def _maybe_nudge_upgrade(latest: str | None) -> None:
+    """Nudge once per process when the platform advertises a newer CLI version.
+
+    Reads the ``X-Osmosis-Latest`` header the platform sets on every response;
+    stays silent when we are already current or the version is unparseable.
+    """
+    global _upgrade_nudged
+    if not latest or _upgrade_nudged:
+        return
+    from osmosis_ai.cli.upgrade import _is_up_to_date
+
+    if _is_up_to_date(PACKAGE_VERSION, latest):
+        return
+    _upgrade_nudged = True
+    console.print_warning(
+        f"A newer version of the Osmosis CLI is available ({latest}). "
+        "Run: osmosis upgrade",
+        code="UPGRADE_AVAILABLE",
+    )
 
 
 def _credentials_match_env_token(credentials: Credentials | None) -> bool:
@@ -380,6 +403,7 @@ def platform_request(
     try:
         with urlopen(request, timeout=timeout) as response:
             _maybe_warn_deprecation(response.headers.get("X-Osmosis-Deprecation"))
+            _maybe_nudge_upgrade(response.headers.get("X-Osmosis-Latest"))
             if response.status == 204:
                 return {}
             raw = response.read()

--- a/osmosis_ai/platform/auth/platform_client.py
+++ b/osmosis_ai/platform/auth/platform_client.py
@@ -93,7 +93,7 @@ def _maybe_warn_deprecation(message: str | None) -> None:
     if not message or _deprecation_warned:
         return
     _deprecation_warned = True
-    console.print_warning(message)
+    console.print_warning(message, code="DEPRECATION")
 
 
 def _credentials_match_env_token(credentials: Credentials | None) -> bool:
@@ -411,7 +411,7 @@ def platform_request(
             raise UpgradeRequiredError(
                 message,
                 e.code,
-                error_code="upgrade_required",
+                error_code="UPGRADE_REQUIRED",
                 details=error_body or None,
             ) from e
 

--- a/osmosis_ai/platform/auth/platform_client.py
+++ b/osmosis_ai/platform/auth/platform_client.py
@@ -89,6 +89,13 @@ class UpgradeRequiredError(PlatformAPIError):
 VERSION_STATUS_HEADER = "X-Osmosis-Version-Status"
 VERSION_MESSAGE_HEADER = "X-Osmosis-Version-Message"
 
+# Shown for a 426 (Upgrade Required) when the server sends no usable message.
+# The platform is the authority and normally supplies the wording; this is only
+# the floor so the CLI never surfaces a bare "HTTP 426".
+UPGRADE_REQUIRED_FALLBACK_MESSAGE = (
+    "This version of the Osmosis CLI is no longer supported. Run: osmosis upgrade"
+)
+
 _VERSION_STATUSES = {"current", "upgrade_available", "deprecated", "unsupported"}
 # Non-fatal statuses surfaced as a warning on a successful response. "current"
 # stays silent and "unsupported" only ever arrives as a 426, so neither appears
@@ -119,6 +126,20 @@ def surface_version_signal(status: Any, message: Any) -> None:
     console.print_warning(message, code=_VERSION_WARNING_CODES[status])
 
 
+def surface_response_version_signal(response: Any) -> None:
+    """Surface the version signal carried on a successful response's headers.
+
+    Thin wrapper over :func:`surface_version_signal` for the standard
+    ``urlopen`` response object, so the auth handshake and API call sites share
+    one way of reading the atomic version headers.
+    """
+    headers = response.headers
+    surface_version_signal(
+        headers.get(VERSION_STATUS_HEADER),
+        headers.get(VERSION_MESSAGE_HEADER),
+    )
+
+
 def parse_version_signal(body: Any) -> dict[str, Any] | None:
     """Parse the server-computed version signal from a 426 response body.
 
@@ -134,6 +155,45 @@ def parse_version_signal(body: Any) -> dict[str, Any] | None:
     if message is not None and not isinstance(message, str):
         return None
     return {"status": status, "message": message}
+
+
+def upgrade_required_message(body: Any) -> tuple[str, dict[str, Any] | None]:
+    """Resolve the user-facing message and parsed signal for a 426 body.
+
+    Prefers the platform-supplied message and falls back to
+    ``UPGRADE_REQUIRED_FALLBACK_MESSAGE`` when the body carries none. Returns the
+    parsed signal (or ``None``) alongside so callers can attach it as structured
+    error details. Shared by the API client and the login handshake so both map a
+    426 the same way.
+    """
+    version_signal = parse_version_signal(body)
+    platform_message = (
+        version_signal.get("message") if version_signal is not None else None
+    )
+    message = (
+        platform_message
+        if isinstance(platform_message, str) and platform_message
+        else UPGRADE_REQUIRED_FALLBACK_MESSAGE
+    )
+    return message, version_signal
+
+
+def cli_request_headers(*, token: str | None = None) -> dict[str, str]:
+    """Build the base headers every CLI -> Platform request shares.
+
+    Always advertises the installed CLI version via ``X-Osmosis-CLI-Version`` so
+    the platform can negotiate support on any endpoint; adds a bearer
+    ``Authorization`` header when a token is supplied. Centralizing this keeps the
+    version stamp in exactly one place across the handshake and API calls.
+    """
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": f"osmosis-cli/{PACKAGE_VERSION}",
+        "X-Osmosis-CLI-Version": PACKAGE_VERSION,
+    }
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
 
 
 def _credentials_match_env_token(credentials: Credentials | None) -> bool:
@@ -321,12 +381,7 @@ def revoke_cli_token(credentials: Credentials) -> bool:
     url = f"{_platform_url()}/api/cli/tokens/{credentials.token_id}"
     request = Request(
         url,
-        headers={
-            "Authorization": f"Bearer {credentials.access_token}",
-            "Content-Type": "application/json",
-            "User-Agent": f"osmosis-cli/{PACKAGE_VERSION}",
-            "X-Osmosis-CLI-Version": PACKAGE_VERSION,
-        },
+        headers=cli_request_headers(token=credentials.access_token),
         method="DELETE",
     )
 
@@ -400,12 +455,7 @@ def platform_request(
 
     url = f"{_platform_url()}{endpoint}"
 
-    req_headers = {
-        "Authorization": f"Bearer {credentials.access_token}",
-        "Content-Type": "application/json",
-        "User-Agent": f"osmosis-cli/{PACKAGE_VERSION}",
-        "X-Osmosis-CLI-Version": PACKAGE_VERSION,
-    }
+    req_headers = cli_request_headers(token=credentials.access_token)
 
     if require_git_repo:
         if not git_identity:
@@ -423,10 +473,7 @@ def platform_request(
 
     try:
         with urlopen(request, timeout=timeout) as response:
-            surface_version_signal(
-                response.headers.get(VERSION_STATUS_HEADER),
-                response.headers.get(VERSION_MESSAGE_HEADER),
-            )
+            surface_response_version_signal(response)
             if response.status == 204:
                 return {}
             raw = response.read()
@@ -449,15 +496,7 @@ def platform_request(
 
         if e.code == 426:
             error_body = _read_error_body(e)
-            version_signal = parse_version_signal(error_body)
-            platform_message = (
-                version_signal.get("message") if version_signal is not None else None
-            )
-            message = (
-                platform_message
-                if isinstance(platform_message, str) and platform_message
-                else "This version of the Osmosis CLI is no longer supported. Run: osmosis upgrade"
-            )
+            message, version_signal = upgrade_required_message(error_body)
             raise UpgradeRequiredError(
                 message,
                 e.code,

--- a/osmosis_ai/platform/auth/platform_client.py
+++ b/osmosis_ai/platform/auth/platform_client.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import contextlib
 import json
 import os
-import sys
 from typing import TYPE_CHECKING, Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
@@ -117,6 +116,21 @@ def _maybe_nudge_upgrade(latest: str | None) -> None:
         "Run: osmosis upgrade",
         code="UPGRADE_AVAILABLE",
     )
+
+
+def surface_version_status(deprecation: str | None, latest: str | None) -> None:
+    """Surface at most one version warning, highest severity first.
+
+    Deprecation supersedes the upgrade nudge: a deprecated client is also out of
+    date, and its warning already says to upgrade. Shared by ``platform_request``
+    and the ``flow.py`` handshake; non-str header values coerce to absent.
+    """
+    deprecation = deprecation if isinstance(deprecation, str) else None
+    latest = latest if isinstance(latest, str) else None
+    if deprecation:
+        _maybe_warn_deprecation(deprecation)
+        return
+    _maybe_nudge_upgrade(latest)
 
 
 def _credentials_match_env_token(credentials: Credentials | None) -> bool:
@@ -320,8 +334,12 @@ def revoke_cli_token(credentials: Credentials) -> bool:
         if e.code == 401:
             # Token already expired/revoked — goal achieved.
             return True
-        sys.stderr.write(
-            f"Warning: failed to revoke CLI token server-side: HTTP {e.code}\n"
+        # Route through print_warning (not a raw stderr write) so this best-effort
+        # warning pauses any active "Revoking session..." spinner instead of
+        # gluing onto it, and stays output-mode aware (structured in JSON mode).
+        console.print_warning(
+            f"Failed to revoke CLI token server-side: HTTP {e.code}",
+            code="TOKEN_REVOKE_FAILED",
         )
         return False
     except (URLError, OSError):
@@ -402,8 +420,10 @@ def platform_request(
 
     try:
         with urlopen(request, timeout=timeout) as response:
-            _maybe_warn_deprecation(response.headers.get("X-Osmosis-Deprecation"))
-            _maybe_nudge_upgrade(response.headers.get("X-Osmosis-Latest"))
+            surface_version_status(
+                response.headers.get("X-Osmosis-Deprecation"),
+                response.headers.get("X-Osmosis-Latest"),
+            )
             if response.status == 204:
                 return {}
             raw = response.read()

--- a/osmosis_ai/platform/auth/platform_client.py
+++ b/osmosis_ai/platform/auth/platform_client.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from osmosis_ai.cli.console import console
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.consts import PACKAGE_VERSION
 from osmosis_ai.platform.constants import (
@@ -73,6 +74,23 @@ class SubscriptionRequiredError(PlatformAPIError):
             field=field,
             details=details,
         )
+
+
+class UpgradeRequiredError(PlatformAPIError):
+    """Raised when the installed CLI is below the platform's minimum supported version (HTTP 426)."""
+
+
+# Warn at most once per process about a deprecated CLI version.
+_deprecation_warned = False
+
+
+def _maybe_warn_deprecation(message: str | None) -> None:
+    """Emit a deprecation warning at most once per process."""
+    global _deprecation_warned
+    if not message or _deprecation_warned:
+        return
+    _deprecation_warned = True
+    console.print_warning(message)
 
 
 def _credentials_match_env_token(credentials: Credentials | None) -> bool:
@@ -185,15 +203,18 @@ _REPO_SCOPE_RENAME_DIAGNOSTIC_CODES = {
 }
 
 
-def _reject_scope_headers(headers: dict[str, str] | None) -> None:
+def _reject_reserved_headers(headers: dict[str, str] | None) -> None:
     if not headers:
         return
-    forbidden = {"x-osmosis-org", "x-osmosis-git"}
+    # Workspace scope and CLI version are derived from local state; callers must
+    # not override them. Compared case-insensitively since HTTP header names are.
+    reserved = {"x-osmosis-org", "x-osmosis-git", "x-osmosis-cli-version"}
     supplied = {name.casefold() for name in headers}
-    if supplied & forbidden:
+    if supplied & reserved:
         raise PlatformAPIError(
-            "Osmosis scope headers are managed by the SDK and cannot be supplied by callers.",
-            error_code="SCOPE_HEADER_FORBIDDEN",
+            "These headers are set automatically by the Osmosis CLI "
+            "and cannot be supplied by callers.",
+            error_code="RESERVED_HEADER_FORBIDDEN",
         )
 
 
@@ -255,6 +276,7 @@ def revoke_cli_token(credentials: Credentials) -> bool:
             "Authorization": f"Bearer {credentials.access_token}",
             "Content-Type": "application/json",
             "User-Agent": f"osmosis-cli/{PACKAGE_VERSION}",
+            "X-Osmosis-CLI-Version": PACKAGE_VERSION,
         },
         method="DELETE",
     )
@@ -315,7 +337,7 @@ def platform_request(
             when cleanup_on_401 is True)
         PlatformAPIError: For other API errors
     """
-    _reject_scope_headers(headers)
+    _reject_reserved_headers(headers)
 
     if credentials is None:
         credentials = load_credentials()
@@ -329,6 +351,7 @@ def platform_request(
         "Authorization": f"Bearer {credentials.access_token}",
         "Content-Type": "application/json",
         "User-Agent": f"osmosis-cli/{PACKAGE_VERSION}",
+        "X-Osmosis-CLI-Version": PACKAGE_VERSION,
     }
 
     if require_git_repo:
@@ -347,6 +370,7 @@ def platform_request(
 
     try:
         with urlopen(request, timeout=timeout) as response:
+            _maybe_warn_deprecation(response.headers.get("X-Osmosis-Deprecation"))
             if response.status == 204:
                 return {}
             raw = response.read()
@@ -365,6 +389,21 @@ def platform_request(
             raise AuthenticationExpiredError(
                 _auth_error_message(error_code, using_env_token=using_env_token),
                 code=error_code,
+            ) from e
+
+        if e.code == 426:
+            error_body = _read_error_body(e)
+            platform_message = error_body.get("message")
+            message = (
+                platform_message
+                if isinstance(platform_message, str) and platform_message
+                else "This version of the Osmosis CLI is no longer supported. Run: osmosis upgrade"
+            )
+            raise UpgradeRequiredError(
+                message,
+                e.code,
+                error_code="upgrade_required",
+                details=error_body or None,
             ) from e
 
         # Best-effort capture of structured error message from response body

--- a/osmosis_ai/platform/auth/platform_client.py
+++ b/osmosis_ai/platform/auth/platform_client.py
@@ -82,55 +82,58 @@ class UpgradeRequiredError(PlatformAPIError):
     """Raised when the installed CLI is below the platform's minimum supported version (HTTP 426)."""
 
 
-# Warn at most once per process about a deprecated CLI version.
-_deprecation_warned = False
-# Nudge at most once per process about an available upgrade.
-_upgrade_nudged = False
+# Atomic response headers carrying the server-computed version status. The
+# server is the authority for version comparisons; the SDK never compares
+# locally. A 426 (handled at the call sites) carries the same fields in its JSON
+# body instead.
+VERSION_STATUS_HEADER = "X-Osmosis-Version-Status"
+VERSION_MESSAGE_HEADER = "X-Osmosis-Version-Message"
+
+_VERSION_STATUSES = {"current", "upgrade_available", "deprecated", "unsupported"}
+# Non-fatal statuses surfaced as a warning on a successful response. "current"
+# stays silent and "unsupported" only ever arrives as a 426, so neither appears
+# here — which is why this path has no fatal branch.
+_VERSION_WARNING_CODES = {
+    "upgrade_available": "UPGRADE_AVAILABLE",
+    "deprecated": "DEPRECATED",
+}
+
+# Surface each non-fatal server-computed version status at most once per process.
+_version_signal_warned: set[str] = set()
 
 
-def _maybe_warn_deprecation(message: str | None) -> None:
-    """Emit a deprecation warning at most once per process."""
-    global _deprecation_warned
-    if not message or _deprecation_warned:
-        return
-    _deprecation_warned = True
-    console.print_warning(message, code="DEPRECATION")
+def surface_version_signal(status: Any, message: Any) -> None:
+    """Display a server-computed CLI version status from response headers.
 
-
-def _maybe_nudge_upgrade(latest: str | None) -> None:
-    """Nudge once per process when the platform advertises a newer CLI version.
-
-    Reads the ``X-Osmosis-Latest`` header the platform sets on every response;
-    stays silent when we are already current or the version is unparseable.
+    Reads the atomic ``X-Osmosis-Version-Status`` / ``X-Osmosis-Version-Message``
+    headers. The platform owns the comparison; the SDK only presents the result,
+    once per process per status.
     """
-    global _upgrade_nudged
-    if not latest or _upgrade_nudged:
+    if status not in _VERSION_WARNING_CODES:
         return
-    from osmosis_ai.cli.upgrade import _is_up_to_date
-
-    if _is_up_to_date(PACKAGE_VERSION, latest):
+    if not isinstance(message, str) or not message:
         return
-    _upgrade_nudged = True
-    console.print_warning(
-        f"A newer version of the Osmosis CLI is available ({latest}). "
-        "Run: osmosis upgrade",
-        code="UPGRADE_AVAILABLE",
-    )
+    if status in _version_signal_warned:
+        return
+    _version_signal_warned.add(status)
+    console.print_warning(message, code=_VERSION_WARNING_CODES[status])
 
 
-def surface_version_status(deprecation: str | None, latest: str | None) -> None:
-    """Surface at most one version warning, highest severity first.
+def parse_version_signal(body: Any) -> dict[str, Any] | None:
+    """Parse the server-computed version signal from a 426 response body.
 
-    Deprecation supersedes the upgrade nudge: a deprecated client is also out of
-    date, and its warning already says to upgrade. Shared by ``platform_request``
-    and the ``flow.py`` handshake; non-str header values coerce to absent.
+    The platform is the authority; the SDK validates only enough to avoid
+    surfacing a malformed message.
     """
-    deprecation = deprecation if isinstance(deprecation, str) else None
-    latest = latest if isinstance(latest, str) else None
-    if deprecation:
-        _maybe_warn_deprecation(deprecation)
-        return
-    _maybe_nudge_upgrade(latest)
+    if not isinstance(body, dict):
+        return None
+    status = body.get("status")
+    if status not in _VERSION_STATUSES:
+        return None
+    message = body.get("message")
+    if message is not None and not isinstance(message, str):
+        return None
+    return {"status": status, "message": message}
 
 
 def _credentials_match_env_token(credentials: Credentials | None) -> bool:
@@ -420,9 +423,9 @@ def platform_request(
 
     try:
         with urlopen(request, timeout=timeout) as response:
-            surface_version_status(
-                response.headers.get("X-Osmosis-Deprecation"),
-                response.headers.get("X-Osmosis-Latest"),
+            surface_version_signal(
+                response.headers.get(VERSION_STATUS_HEADER),
+                response.headers.get(VERSION_MESSAGE_HEADER),
             )
             if response.status == 204:
                 return {}
@@ -446,7 +449,10 @@ def platform_request(
 
         if e.code == 426:
             error_body = _read_error_body(e)
-            platform_message = error_body.get("message")
+            version_signal = parse_version_signal(error_body)
+            platform_message = (
+                version_signal.get("message") if version_signal is not None else None
+            )
             message = (
                 platform_message
                 if isinstance(platform_message, str) and platform_message
@@ -456,7 +462,7 @@ def platform_request(
                 message,
                 e.code,
                 error_code="UPGRADE_REQUIRED",
-                details=error_body or None,
+                details=version_signal or error_body or None,
             ) from e
 
         # Best-effort capture of structured error message from response body

--- a/osmosis_ai/platform/cli/dataset.py
+++ b/osmosis_ai/platform/cli/dataset.py
@@ -61,10 +61,10 @@ def _abort_upload(
             git_identity=git_identity,
         )
     except Exception as exc:
-        console.print(
-            f"Warning: failed to abort upload: {exc}",
-            style="dim yellow",
-        )
+        # print_warning (stderr, output-mode aware) rather than console.print,
+        # which would write this warning to stdout — polluting piped/redirected
+        # output and risking a collision with the live upload progress bar.
+        console.print_warning(f"Failed to abort upload: {exc}", code="ABORT_FAILED")
 
 
 # ── Complete-upload retry (P0 reliability fix) ───────────────────────

--- a/tests/unit/auth/test_credentials.py
+++ b/tests/unit/auth/test_credentials.py
@@ -210,7 +210,7 @@ def test_save_always_cleans_up_keyring_before_saving(tmp_path, monkeypatch) -> N
     assert "user@example.com" in deleted_accounts
 
 
-def test_save_falls_back_to_file(tmp_path, monkeypatch, capsys) -> None:
+def test_save_falls_back_to_file(tmp_path, monkeypatch) -> None:
     creds_file = tmp_path / "creds.json"
     monkeypatch.setattr(
         "osmosis_ai.platform.auth.credentials.CREDENTIALS_FILE", creds_file
@@ -221,6 +221,7 @@ def test_save_falls_back_to_file(tmp_path, monkeypatch, capsys) -> None:
         patch(
             "osmosis_ai.platform.auth.credentials._keyring_delete", return_value=True
         ),
+        patch("osmosis_ai.cli.console.console.print_warning") as mock_warn,
     ):
         from osmosis_ai.platform.auth.credentials import save_credentials
 
@@ -232,8 +233,11 @@ def test_save_falls_back_to_file(tmp_path, monkeypatch, capsys) -> None:
     entry = _platform_entry(data)
     assert entry["access_token"] == "test-token"
     assert entry["token_store"] == TOKEN_STORE_FILE
-    captured = capsys.readouterr()
-    assert "keyring unavailable" in captured.err
+    # Warning routes through print_warning (output-mode aware) with a code,
+    # not a raw stderr write that would corrupt the --json stderr contract.
+    mock_warn.assert_called_once()
+    assert "Keyring unavailable" in mock_warn.call_args.args[0]
+    assert mock_warn.call_args.kwargs.get("code") == "KEYRING_UNAVAILABLE"
 
 
 def test_load_from_keyring(tmp_path, monkeypatch) -> None:
@@ -268,9 +272,7 @@ def test_load_from_keyring(tmp_path, monkeypatch) -> None:
     assert loaded.user.email == "user@example.com"
 
 
-def test_load_returns_none_when_keyring_entry_missing(
-    tmp_path, monkeypatch, capsys
-) -> None:
+def test_load_returns_none_when_keyring_entry_missing(tmp_path, monkeypatch) -> None:
     creds_file = tmp_path / "creds.json"
     monkeypatch.setattr(
         "osmosis_ai.platform.auth.credentials.CREDENTIALS_FILE", creds_file
@@ -284,14 +286,21 @@ def test_load_returns_none_when_keyring_entry_missing(
     creds_file.write_text(json.dumps(data))
 
     # Both fixed account and legacy email return None
-    with patch("osmosis_ai.platform.auth.credentials._keyring_get", return_value=None):
+    with (
+        patch("osmosis_ai.platform.auth.credentials._keyring_get", return_value=None),
+        patch("osmosis_ai.cli.console.console.print_warning") as mock_warn,
+    ):
         from osmosis_ai.platform.auth.credentials import load_credentials
 
         loaded = load_credentials()
 
     assert loaded is None
-    captured = capsys.readouterr()
-    assert "Token not found for the current Osmosis platform" in captured.err
+    mock_warn.assert_called_once()
+    assert (
+        "Token not found for the current Osmosis platform"
+        in (mock_warn.call_args.args[0])
+    )
+    assert mock_warn.call_args.kwargs.get("code") == "TOKEN_NOT_FOUND"
 
 
 def test_load_from_file_fallback(tmp_path, monkeypatch) -> None:
@@ -438,7 +447,7 @@ def test_load_credentials_can_skip_env_token(tmp_path, monkeypatch) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_load_returns_none_for_version_mismatch(tmp_path, monkeypatch, capsys) -> None:
+def test_load_returns_none_for_version_mismatch(tmp_path, monkeypatch) -> None:
     creds_file = tmp_path / "creds.json"
     monkeypatch.setattr(
         "osmosis_ai.platform.auth.credentials.CREDENTIALS_FILE", creds_file
@@ -448,9 +457,41 @@ def test_load_returns_none_for_version_mismatch(tmp_path, monkeypatch, capsys) -
 
     from osmosis_ai.platform.auth.credentials import load_credentials
 
-    assert load_credentials() is None
-    captured = capsys.readouterr()
-    assert "osmosis auth login" in captured.err
+    with patch("osmosis_ai.cli.console.console.print_warning") as mock_warn:
+        assert load_credentials() is None
+    mock_warn.assert_called_once()
+    assert "osmosis auth login" in mock_warn.call_args.args[0]
+    assert mock_warn.call_args.kwargs.get("code") == "CREDENTIALS_VERSION_CHANGED"
+
+
+def test_credentials_warning_is_structured_json_in_json_mode(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """In --json mode a credentials warning is a JSON-lines envelope on stderr.
+
+    This is the contract that the old raw ``sys.stderr.write`` broke: a plain
+    "Warning: ..." line on stderr is not valid JSON Lines, so a machine reading
+    `osmosis ... --json 2>err` would fail to parse err. Routing through
+    print_warning emits a structured ``{"warning": {...}}`` envelope instead.
+    """
+    from osmosis_ai.cli.output.context import OutputFormat, override_output_context
+    from osmosis_ai.platform.auth.credentials import load_credentials
+
+    creds_file = tmp_path / "creds.json"
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.credentials.CREDENTIALS_FILE", creds_file
+    )
+    monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
+    creds_file.write_text(json.dumps({"version": 1, "workspaces": {}}))
+
+    with override_output_context(format=OutputFormat.json):
+        assert load_credentials() is None
+
+    # stderr must be parseable as JSON Lines, not raw text.
+    payload = json.loads(capsys.readouterr().err.strip())
+    assert payload["schema_version"] == 1
+    assert payload["warning"]["code"] == "CREDENTIALS_VERSION_CHANGED"
+    assert "osmosis auth login" in payload["warning"]["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -491,7 +532,7 @@ def test_delete_clears_keyring_and_file(tmp_path, monkeypatch) -> None:
     assert not creds_file.exists()
 
 
-def test_delete_warns_when_keyring_delete_fails(tmp_path, monkeypatch, capsys) -> None:
+def test_delete_warns_when_keyring_delete_fails(tmp_path, monkeypatch) -> None:
     creds_file = tmp_path / "creds.json"
     monkeypatch.setattr(
         "osmosis_ai.platform.auth.credentials.CREDENTIALS_FILE", creds_file
@@ -503,18 +544,23 @@ def test_delete_warns_when_keyring_delete_fails(tmp_path, monkeypatch, capsys) -
     data["token_store"] = TOKEN_STORE_KEYRING
     creds_file.write_text(json.dumps(data))
 
-    with patch(
-        "osmosis_ai.platform.auth.credentials._keyring_delete", return_value=False
+    with (
+        patch(
+            "osmosis_ai.platform.auth.credentials._keyring_delete", return_value=False
+        ),
+        patch("osmosis_ai.cli.console.console.print_warning") as mock_warn,
     ):
         from osmosis_ai.platform.auth.credentials import delete_credentials
 
         result = delete_credentials()
 
-    # File is still deleted, but warning is emitted about keyring failure
+    # File is still deleted, but a keyring-failure warning is emitted via
+    # print_warning (output-mode aware) with a code.
     assert result is True  # file deletion counts
     assert not creds_file.exists()
-    captured = capsys.readouterr()
-    assert "could not remove token from system keyring" in captured.err
+    mock_warn.assert_called_once()
+    assert "Could not remove token from system keyring" in mock_warn.call_args.args[0]
+    assert mock_warn.call_args.kwargs.get("code") == "KEYRING_CLEANUP_FAILED"
 
 
 def test_delete_with_corrupt_json_still_cleans_keyring(tmp_path, monkeypatch) -> None:

--- a/tests/unit/auth/test_flow.py
+++ b/tests/unit/auth/test_flow.py
@@ -338,8 +338,9 @@ class TestUpgradeRequiredAtLogin:
     def test_verify_token_426_uses_platform_message(self) -> None:
         body = json.dumps(
             {
-                "error": "upgrade_required",
+                "status": "unsupported",
                 "message": "A newer osmosis CLI is required, run osmosis upgrade",
+                "latest": "9.9.9",
             }
         ).encode()
         error = HTTPError(
@@ -375,7 +376,7 @@ class TestUpgradeRequiredAtLogin:
 
 
 # ---------------------------------------------------------------------------
-# Soft version signals on the auth handshake (X-Osmosis-Deprecation / -Latest)
+# Soft version signals on the auth handshake (X-Osmosis-Version)
 # Warning is emitted via platform_client's console, so that is the patch target.
 # ---------------------------------------------------------------------------
 
@@ -390,40 +391,21 @@ class TestVerifyTokenVersionSignals:
         mock_resp.__exit__ = MagicMock(return_value=False)
         return mock_resp
 
-    def test_verify_token_surfaces_deprecation_warning(
+    def test_verify_token_surfaces_deprecated_version_signal(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A deprecation header on /api/cli/verify surfaces a warning."""
+        """A deprecated version signal on /api/cli/verify surfaces a warning."""
         from osmosis_ai.platform.auth import platform_client
 
-        monkeypatch.setattr(platform_client, "_deprecation_warned", False)
-        monkeypatch.setattr(platform_client, "_upgrade_nudged", False)
-        deprecation_msg = (
-            "This version is deprecated. Latest is 9.9.9. Run: osmosis upgrade"
-        )
-        mock_resp = self._make_resp({"X-Osmosis-Deprecation": deprecation_msg})
-
-        with patch.object(platform_client, "console") as mock_console:
-            with patch("osmosis_ai.platform.auth.flow.urlopen", return_value=mock_resp):
-                verify_token("test-token")
-
-        mock_console.print_warning.assert_called_once_with(
-            deprecation_msg, code="DEPRECATION"
-        )
-
-    def test_verify_token_deprecation_supersedes_nudge(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Both headers present on the handshake still yields a single warning."""
-        from osmosis_ai.platform.auth import platform_client
-
-        monkeypatch.setattr(platform_client, "_deprecation_warned", False)
-        monkeypatch.setattr(platform_client, "_upgrade_nudged", False)
+        monkeypatch.setattr(platform_client, "_version_signal_warned", set())
         deprecation_msg = (
             "This version is deprecated. Latest is 9.9.9. Run: osmosis upgrade"
         )
         mock_resp = self._make_resp(
-            {"X-Osmosis-Deprecation": deprecation_msg, "X-Osmosis-Latest": "9.9.9"}
+            {
+                "X-Osmosis-Version-Status": "deprecated",
+                "X-Osmosis-Version-Message": deprecation_msg,
+            }
         )
 
         with patch.object(platform_client, "console") as mock_console:
@@ -431,5 +413,28 @@ class TestVerifyTokenVersionSignals:
                 verify_token("test-token")
 
         mock_console.print_warning.assert_called_once_with(
-            deprecation_msg, code="DEPRECATION"
+            deprecation_msg, code="DEPRECATED"
+        )
+
+    def test_verify_token_surfaces_upgrade_available_version_signal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An upgrade_available version signal uses the server-composed message."""
+        from osmosis_ai.platform.auth import platform_client
+
+        monkeypatch.setattr(platform_client, "_version_signal_warned", set())
+        upgrade_msg = "A newer CLI is available. Run: osmosis upgrade"
+        mock_resp = self._make_resp(
+            {
+                "X-Osmosis-Version-Status": "upgrade_available",
+                "X-Osmosis-Version-Message": upgrade_msg,
+            }
+        )
+
+        with patch.object(platform_client, "console") as mock_console:
+            with patch("osmosis_ai.platform.auth.flow.urlopen", return_value=mock_resp):
+                verify_token("test-token")
+
+        mock_console.print_warning.assert_called_once_with(
+            upgrade_msg, code="UPGRADE_AVAILABLE"
         )

--- a/tests/unit/auth/test_flow.py
+++ b/tests/unit/auth/test_flow.py
@@ -358,6 +358,12 @@ class TestUpgradeRequiredAtLogin:
 
         assert exc_info.value.code == "UPGRADE_REQUIRED"
         assert exc_info.value.status_code == 426
+        # The parsed version signal rides along so the command layer can attach
+        # the same structured details a 426 on a regular API call produces.
+        assert exc_info.value.details == {
+            "status": "unsupported",
+            "message": "A newer osmosis CLI is required, run osmosis upgrade",
+        }
 
     def test_verify_token_426_falls_back_to_default_message(self) -> None:
         error = HTTPError(
@@ -373,6 +379,9 @@ class TestUpgradeRequiredAtLogin:
 
         assert exc_info.value.code == "UPGRADE_REQUIRED"
         assert exc_info.value.status_code == 426
+        # No usable signal in the body — details stay empty rather than carrying
+        # a half-parsed envelope.
+        assert exc_info.value.details is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/auth/test_flow.py
+++ b/tests/unit/auth/test_flow.py
@@ -372,3 +372,64 @@ class TestUpgradeRequiredAtLogin:
 
         assert exc_info.value.code == "UPGRADE_REQUIRED"
         assert exc_info.value.status_code == 426
+
+
+# ---------------------------------------------------------------------------
+# Soft version signals on the auth handshake (X-Osmosis-Deprecation / -Latest)
+# Warning is emitted via platform_client's console, so that is the patch target.
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyTokenVersionSignals:
+    def _make_resp(self, headers: dict[str, str]) -> MagicMock:
+        expires_str = (datetime.now(UTC) + timedelta(days=90)).isoformat()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = _make_verify_response(expires_at=expires_str)
+        mock_resp.headers = headers
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        return mock_resp
+
+    def test_verify_token_surfaces_deprecation_warning(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A deprecation header on /api/cli/verify surfaces a warning."""
+        from osmosis_ai.platform.auth import platform_client
+
+        monkeypatch.setattr(platform_client, "_deprecation_warned", False)
+        monkeypatch.setattr(platform_client, "_upgrade_nudged", False)
+        deprecation_msg = (
+            "This version is deprecated. Latest is 9.9.9. Run: osmosis upgrade"
+        )
+        mock_resp = self._make_resp({"X-Osmosis-Deprecation": deprecation_msg})
+
+        with patch.object(platform_client, "console") as mock_console:
+            with patch("osmosis_ai.platform.auth.flow.urlopen", return_value=mock_resp):
+                verify_token("test-token")
+
+        mock_console.print_warning.assert_called_once_with(
+            deprecation_msg, code="DEPRECATION"
+        )
+
+    def test_verify_token_deprecation_supersedes_nudge(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both headers present on the handshake still yields a single warning."""
+        from osmosis_ai.platform.auth import platform_client
+
+        monkeypatch.setattr(platform_client, "_deprecation_warned", False)
+        monkeypatch.setattr(platform_client, "_upgrade_nudged", False)
+        deprecation_msg = (
+            "This version is deprecated. Latest is 9.9.9. Run: osmosis upgrade"
+        )
+        mock_resp = self._make_resp(
+            {"X-Osmosis-Deprecation": deprecation_msg, "X-Osmosis-Latest": "9.9.9"}
+        )
+
+        with patch.object(platform_client, "console") as mock_console:
+            with patch("osmosis_ai.platform.auth.flow.urlopen", return_value=mock_resp):
+                verify_token("test-token")
+
+        mock_console.print_warning.assert_called_once_with(
+            deprecation_msg, code="DEPRECATION"
+        )

--- a/tests/unit/auth/test_flow.py
+++ b/tests/unit/auth/test_flow.py
@@ -12,11 +12,13 @@ from urllib.error import HTTPError, URLError
 
 import pytest
 
+from osmosis_ai.consts import PACKAGE_VERSION
 from osmosis_ai.platform.auth.credentials import UserInfo
 from osmosis_ai.platform.auth.flow import (
     LoginError,
     VerifyResult,
     _get_device_name,
+    request_device_code,
     verify_token,
 )
 
@@ -278,3 +280,95 @@ class TestVerifyAndGetUserInfo:
             result = verify_token("token")
 
         assert result.token_id is None
+
+
+# ---------------------------------------------------------------------------
+# CLI version header
+# ---------------------------------------------------------------------------
+
+
+class TestCliVersionHeader:
+    def test_verify_token_sends_cli_version_header(self) -> None:
+        expires_str = (datetime.now(UTC) + timedelta(days=90)).isoformat()
+        body = _make_verify_response(expires_at=expires_str)
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = body
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch(
+            "osmosis_ai.platform.auth.flow.urlopen", return_value=mock_resp
+        ) as open_mock:
+            verify_token("test-token")
+
+        request_obj = open_mock.call_args[0][0]
+        # urllib capitalizes header names; query the normalized form.
+        assert request_obj.get_header("X-osmosis-cli-version") == PACKAGE_VERSION
+
+    def test_request_device_code_sends_cli_version_header(self) -> None:
+        body = json.dumps(
+            {
+                "device_code": "dev_abc",
+                "user_code": "USER-CODE",
+                "verification_uri": "https://platform.osmosis.ai/device",
+                "expires_in": 600,
+                "interval": 5,
+            }
+        ).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = body
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch(
+            "osmosis_ai.platform.auth.flow.urlopen", return_value=mock_resp
+        ) as open_mock:
+            request_device_code()
+
+        request_obj = open_mock.call_args[0][0]
+        assert request_obj.get_header("X-osmosis-cli-version") == PACKAGE_VERSION
+
+
+# ---------------------------------------------------------------------------
+# HTTP 426 Upgrade Required
+# ---------------------------------------------------------------------------
+
+
+class TestUpgradeRequiredAtLogin:
+    def test_verify_token_426_uses_platform_message(self) -> None:
+        body = json.dumps(
+            {
+                "error": "upgrade_required",
+                "message": "A newer osmosis CLI is required, run osmosis upgrade",
+            }
+        ).encode()
+        error = HTTPError(
+            url="http://test",
+            code=426,
+            msg="Upgrade Required",
+            hdrs=None,
+            fp=BytesIO(body),
+        )
+        with patch("osmosis_ai.platform.auth.flow.urlopen", side_effect=error):
+            with pytest.raises(
+                LoginError, match="A newer osmosis CLI is required"
+            ) as exc_info:
+                verify_token("old-cli-token")
+
+        assert exc_info.value.code == "UPGRADE_REQUIRED"
+        assert exc_info.value.status_code == 426
+
+    def test_verify_token_426_falls_back_to_default_message(self) -> None:
+        error = HTTPError(
+            url="http://test",
+            code=426,
+            msg="Upgrade Required",
+            hdrs=None,
+            fp=BytesIO(b"{}"),
+        )
+        with patch("osmosis_ai.platform.auth.flow.urlopen", side_effect=error):
+            with pytest.raises(LoginError, match="no longer supported") as exc_info:
+                verify_token("old-cli-token")
+
+        assert exc_info.value.code == "UPGRADE_REQUIRED"
+        assert exc_info.value.status_code == 426

--- a/tests/unit/auth/test_platform_client.py
+++ b/tests/unit/auth/test_platform_client.py
@@ -21,6 +21,7 @@ from osmosis_ai.platform.auth.platform_client import (
     AuthenticationExpiredError,
     PlatformAPIError,
     SubscriptionRequiredError,
+    UpgradeRequiredError,
     platform_request,
     revoke_cli_token,
 )
@@ -49,6 +50,8 @@ def _make_http_response(data: dict[str, Any]) -> MagicMock:
     body = json.dumps(data).encode()
     mock_resp = MagicMock()
     mock_resp.read.return_value = body
+    mock_resp.status = 200
+    mock_resp.headers = {}  # real dict: .get() returns None, no spurious warning
     mock_resp.__enter__ = MagicMock(return_value=mock_resp)
     mock_resp.__exit__ = MagicMock(return_value=False)
     return mock_resp
@@ -251,10 +254,17 @@ class TestPlatformRequest:
 
     @pytest.mark.parametrize(
         "header_name",
-        ["X-Osmosis-Org", "x-osmosis-org", "X-Osmosis-Git", "x-osmosis-git"],
+        [
+            "X-Osmosis-Org",
+            "x-osmosis-org",
+            "X-Osmosis-Git",
+            "x-osmosis-git",
+            "X-Osmosis-CLI-Version",
+            "x-osmosis-cli-version",
+        ],
     )
     @patch("osmosis_ai.platform.auth.platform_client.urlopen")
-    def test_rejects_caller_supplied_scope_headers_case_insensitively(
+    def test_rejects_caller_supplied_reserved_headers_case_insensitively(
         self, mock_urlopen: MagicMock, header_name: str
     ) -> None:
         creds = _make_credentials()
@@ -267,8 +277,8 @@ class TestPlatformRequest:
                 require_git_repo=False,
             )
 
-        assert exc_info.value.error_code == "SCOPE_HEADER_FORBIDDEN"
-        assert "managed by the SDK" in str(exc_info.value)
+        assert exc_info.value.error_code == "RESERVED_HEADER_FORBIDDEN"
+        assert "set automatically by the Osmosis CLI" in str(exc_info.value)
         mock_urlopen.assert_not_called()
 
     @patch("osmosis_ai.platform.auth.platform_client.urlopen")
@@ -451,7 +461,7 @@ class TestPlatformRequest:
         ],
     )
     @patch("osmosis_ai.platform.auth.platform_client.urlopen")
-    def test_repo_scope_codes_use_sdk_guidance(
+    def test_repo_scope_codes_use_cli_guidance(
         self,
         mock_urlopen: MagicMock,
         status_code: int,
@@ -773,6 +783,98 @@ class TestPlatformRequest:
         with pytest.raises(CLIError, match="Not logged in"):
             platform_request("/api/test", credentials=None)
 
+    # -------------------------------------------------------------------------
+    # CLI Version Header
+    # -------------------------------------------------------------------------
+
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_platform_request_emits_cli_version_header(
+        self, mock_urlopen: MagicMock
+    ) -> None:
+        """platform_request sends X-Osmosis-CLI-Version equal to PACKAGE_VERSION."""
+        from osmosis_ai.consts import PACKAGE_VERSION
+
+        mock_urlopen.return_value = _make_http_response({"ok": True})
+        creds = _make_credentials()
+
+        platform_request("/api/cli/verify", credentials=creds, require_git_repo=False)
+
+        request_obj = mock_urlopen.call_args[0][0]
+        # urllib stores header names via str.capitalize() (first char upper,
+        # rest lower), so we must query the normalized form.
+        assert request_obj.get_header("X-osmosis-cli-version") == PACKAGE_VERSION
+
+    # -------------------------------------------------------------------------
+    # Deprecation Warning
+    # -------------------------------------------------------------------------
+
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    @patch("osmosis_ai.platform.auth.platform_client.console")
+    def test_platform_request_warns_on_deprecation_header(
+        self,
+        mock_console: MagicMock,
+        mock_urlopen: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A X-Osmosis-Deprecation response header triggers a single warning."""
+        from osmosis_ai.platform.auth import platform_client
+
+        # Reset the module-level dedup flag so this test is isolated.
+        monkeypatch.setattr(platform_client, "_deprecation_warned", False)
+
+        deprecation_msg = (
+            "This version of the Osmosis CLI is deprecated. Run: osmosis upgrade"
+        )
+
+        def _make_response_with_deprecation_header() -> MagicMock:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = b"{}"
+            mock_resp.status = 200
+            mock_resp.headers = {"X-Osmosis-Deprecation": deprecation_msg}
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        mock_urlopen.return_value = _make_response_with_deprecation_header()
+        creds = _make_credentials()
+
+        platform_request("/api/cli/verify", credentials=creds, require_git_repo=False)
+        # Second call should NOT emit another warning (dedup flag is now True).
+        mock_urlopen.return_value = _make_response_with_deprecation_header()
+        platform_request("/api/cli/verify", credentials=creds, require_git_repo=False)
+
+        # print_warning should have been called exactly once (dedup flag prevents a second call).
+        mock_console.print_warning.assert_called_once_with(deprecation_msg)
+
+    # -------------------------------------------------------------------------
+    # 426 Upgrade Required
+    # -------------------------------------------------------------------------
+
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_platform_request_maps_426_to_upgrade_required(
+        self, mock_urlopen: MagicMock
+    ) -> None:
+        """A 426 response raises UpgradeRequiredError with the platform message."""
+        import io
+
+        body = b'{"error":"upgrade_required","message":"osmosis >= 1.0.0 required. Run: pip install -U osmosis-ai","minimum":"1.0.0"}'
+        mock_urlopen.side_effect = HTTPError(
+            "https://platform.osmosis.ai/api/cli/verify",
+            426,
+            "Upgrade Required",
+            {},
+            io.BytesIO(body),
+        )
+        creds = _make_credentials()
+
+        with pytest.raises(UpgradeRequiredError) as exc_info:
+            platform_request(
+                "/api/cli/verify", credentials=creds, require_git_repo=False
+            )
+
+        assert "osmosis >= 1.0.0 required" in str(exc_info.value)
+        assert exc_info.value.status_code == 426
+
 
 # =============================================================================
 # revoke_cli_token Tests
@@ -802,6 +904,13 @@ class TestRevokeCLIToken:
 
         assert revoke_cli_token(creds) is True
         mock_urlopen.assert_called_once()
+
+        from osmosis_ai.consts import PACKAGE_VERSION
+
+        request_obj = mock_urlopen.call_args[0][0]
+        # urllib stores header names via str.capitalize() (first char upper,
+        # rest lower), so we must query the normalized form.
+        assert request_obj.get_header("X-osmosis-cli-version") == PACKAGE_VERSION
 
     @patch("osmosis_ai.platform.auth.platform_client.urlopen")
     def test_returns_true_on_401(self, mock_urlopen: MagicMock) -> None:

--- a/tests/unit/auth/test_platform_client.py
+++ b/tests/unit/auth/test_platform_client.py
@@ -400,16 +400,24 @@ class TestPlatformRequest:
         mock_resp.read.assert_not_called()
 
     @patch("osmosis_ai.platform.auth.platform_client.console")
-    @patch("osmosis_ai.platform.auth.platform_client._deprecation_warned", False)
     @patch("osmosis_ai.platform.auth.platform_client.urlopen")
-    def test_deprecation_header_emits_warning_once(
-        self, mock_urlopen: MagicMock, mock_console: MagicMock
+    def test_version_signal_emits_warning_once(
+        self,
+        mock_urlopen: MagicMock,
+        mock_console: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Verify the X-Osmosis-Deprecation header surfaces a single warning."""
+        """Verify the X-Osmosis-Version signal surfaces a single warning."""
+        from osmosis_ai.platform.auth import platform_client
+
+        monkeypatch.setattr(platform_client, "_version_signal_warned", set())
         mock_resp = MagicMock()
         mock_resp.status = 200
         mock_resp.read.return_value = json.dumps({"ok": True}).encode()
-        mock_resp.headers = {"X-Osmosis-Deprecation": "Upgrade soon"}
+        mock_resp.headers = {
+            "X-Osmosis-Version-Status": "deprecated",
+            "X-Osmosis-Version-Message": "Upgrade soon",
+        }
         mock_resp.__enter__ = MagicMock(return_value=mock_resp)
         mock_resp.__exit__ = MagicMock(return_value=False)
         mock_urlopen.return_value = mock_resp
@@ -419,7 +427,7 @@ class TestPlatformRequest:
         platform_request("/api/test", credentials=creds, git_identity="git_test")
 
         mock_console.print_warning.assert_called_once_with(
-            "Upgrade soon", code="DEPRECATION"
+            "Upgrade soon", code="DEPRECATED"
         )
 
     # -------------------------------------------------------------------------
@@ -491,7 +499,13 @@ class TestPlatformRequest:
         self, mock_urlopen: MagicMock
     ) -> None:
         """Verify 426 uses the platform-supplied message when present."""
-        body = json.dumps({"message": "Please upgrade to v2.0.0"})
+        body = json.dumps(
+            {
+                "status": "unsupported",
+                "message": "Please upgrade to v2.0.0",
+                "latest": "2.0.0",
+            }
+        )
         mock_urlopen.side_effect = _make_http_error(426, body)
         creds = _make_credentials()
 
@@ -501,7 +515,10 @@ class TestPlatformRequest:
         assert str(exc_info.value) == "Please upgrade to v2.0.0"
         assert exc_info.value.status_code == 426
         assert exc_info.value.error_code == "UPGRADE_REQUIRED"
-        assert exc_info.value.details == {"message": "Please upgrade to v2.0.0"}
+        assert exc_info.value.details == {
+            "status": "unsupported",
+            "message": "Please upgrade to v2.0.0",
+        }
 
     @patch("osmosis_ai.platform.auth.platform_client.urlopen")
     def test_426_falls_back_to_default_message(self, mock_urlopen: MagicMock) -> None:
@@ -901,22 +918,22 @@ class TestPlatformRequest:
         assert request_obj.get_header("X-osmosis-cli-version") == PACKAGE_VERSION
 
     # -------------------------------------------------------------------------
-    # Deprecation Warning
+    # CLI Version Signals
     # -------------------------------------------------------------------------
 
     @patch("osmosis_ai.platform.auth.platform_client.urlopen")
     @patch("osmosis_ai.platform.auth.platform_client.console")
-    def test_platform_request_warns_on_deprecation_header(
+    def test_platform_request_warns_on_deprecated_version_signal(
         self,
         mock_console: MagicMock,
         mock_urlopen: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A X-Osmosis-Deprecation response header triggers a single warning."""
+        """A deprecated X-Osmosis-Version signal triggers a single warning."""
         from osmosis_ai.platform.auth import platform_client
 
         # Reset the module-level dedup flag so this test is isolated.
-        monkeypatch.setattr(platform_client, "_deprecation_warned", False)
+        monkeypatch.setattr(platform_client, "_version_signal_warned", set())
 
         deprecation_msg = (
             "This version of the Osmosis CLI is deprecated. Run: osmosis upgrade"
@@ -926,7 +943,10 @@ class TestPlatformRequest:
             mock_resp = MagicMock()
             mock_resp.read.return_value = b"{}"
             mock_resp.status = 200
-            mock_resp.headers = {"X-Osmosis-Deprecation": deprecation_msg}
+            mock_resp.headers = {
+                "X-Osmosis-Version-Status": "deprecated",
+                "X-Osmosis-Version-Message": deprecation_msg,
+            }
             mock_resp.__enter__ = MagicMock(return_value=mock_resp)
             mock_resp.__exit__ = MagicMock(return_value=False)
             return mock_resp
@@ -941,67 +961,64 @@ class TestPlatformRequest:
 
         # print_warning should have been called exactly once (dedup flag prevents a second call).
         mock_console.print_warning.assert_called_once_with(
-            deprecation_msg, code="DEPRECATION"
+            deprecation_msg, code="DEPRECATED"
         )
-
-    # -------------------------------------------------------------------------
-    # Upgrade Nudge (X-Osmosis-Latest)
-    # -------------------------------------------------------------------------
 
     @patch("osmosis_ai.platform.auth.platform_client.urlopen")
     @patch("osmosis_ai.platform.auth.platform_client.console")
-    def test_platform_request_nudges_on_newer_latest_header(
+    def test_platform_request_nudges_on_upgrade_available_signal_without_local_compare(
         self,
         mock_console: MagicMock,
         mock_urlopen: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A higher X-Osmosis-Latest triggers a single upgrade nudge."""
+        """Server-computed upgrade_available is presented without client comparison."""
         from osmosis_ai.platform.auth import platform_client
 
-        monkeypatch.setattr(platform_client, "_upgrade_nudged", False)
+        monkeypatch.setattr(platform_client, "_version_signal_warned", set())
 
-        def _make_response_with_latest_header() -> MagicMock:
+        def _make_response_with_upgrade_signal() -> MagicMock:
             mock_resp = MagicMock()
             mock_resp.read.return_value = b"{}"
             mock_resp.status = 200
-            mock_resp.headers = {"X-Osmosis-Latest": "99.0.0"}
+            mock_resp.headers = {
+                "X-Osmosis-Version-Status": "upgrade_available",
+                "X-Osmosis-Version-Message": "Server says upgrade. Run: osmosis upgrade",
+            }
             mock_resp.__enter__ = MagicMock(return_value=mock_resp)
             mock_resp.__exit__ = MagicMock(return_value=False)
             return mock_resp
 
-        mock_urlopen.return_value = _make_response_with_latest_header()
+        mock_urlopen.return_value = _make_response_with_upgrade_signal()
         creds = _make_credentials()
 
         platform_request("/api/cli/verify", credentials=creds, require_git_repo=False)
         # Second call should NOT nudge again (dedup flag is now True).
-        mock_urlopen.return_value = _make_response_with_latest_header()
+        mock_urlopen.return_value = _make_response_with_upgrade_signal()
         platform_request("/api/cli/verify", credentials=creds, require_git_repo=False)
 
         mock_console.print_warning.assert_called_once_with(
-            "A newer version of the Osmosis CLI is available (99.0.0). "
-            "Run: osmosis upgrade",
+            "Server says upgrade. Run: osmosis upgrade",
             code="UPGRADE_AVAILABLE",
         )
 
     @patch("osmosis_ai.platform.auth.platform_client.urlopen")
     @patch("osmosis_ai.platform.auth.platform_client.console")
-    def test_platform_request_no_nudge_when_already_current(
+    def test_platform_request_stays_silent_on_current_version_signal(
         self,
         mock_console: MagicMock,
         mock_urlopen: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A X-Osmosis-Latest equal to the installed version stays silent."""
-        from osmosis_ai.consts import PACKAGE_VERSION
+        """A current X-Osmosis-Version signal stays silent."""
         from osmosis_ai.platform.auth import platform_client
 
-        monkeypatch.setattr(platform_client, "_upgrade_nudged", False)
+        monkeypatch.setattr(platform_client, "_version_signal_warned", set())
 
         mock_resp = MagicMock()
         mock_resp.read.return_value = b"{}"
         mock_resp.status = 200
-        mock_resp.headers = {"X-Osmosis-Latest": PACKAGE_VERSION}
+        mock_resp.headers = {"X-Osmosis-Version-Status": "current"}
         mock_resp.__enter__ = MagicMock(return_value=mock_resp)
         mock_resp.__exit__ = MagicMock(return_value=False)
         mock_urlopen.return_value = mock_resp
@@ -1013,32 +1030,23 @@ class TestPlatformRequest:
 
     @patch("osmosis_ai.platform.auth.platform_client.urlopen")
     @patch("osmosis_ai.platform.auth.platform_client.console")
-    def test_deprecation_supersedes_nudge_when_both_headers_present(
+    def test_platform_request_ignores_malformed_version_signal(
         self,
         mock_console: MagicMock,
         mock_urlopen: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Both headers present -> only the deprecation warning, never the nudge.
-
-        Pins the precedence assumption, not just the message text.
-        """
+        """An unrecognized X-Osmosis-Version-Status stays silent."""
         from osmosis_ai.platform.auth import platform_client
 
-        monkeypatch.setattr(platform_client, "_deprecation_warned", False)
-        monkeypatch.setattr(platform_client, "_upgrade_nudged", False)
-
-        deprecation_msg = (
-            "This version of the Osmosis CLI is deprecated. "
-            "Latest is 99.0.0. Run: osmosis upgrade"
-        )
+        monkeypatch.setattr(platform_client, "_version_signal_warned", set())
 
         mock_resp = MagicMock()
         mock_resp.read.return_value = b"{}"
         mock_resp.status = 200
         mock_resp.headers = {
-            "X-Osmosis-Deprecation": deprecation_msg,
-            "X-Osmosis-Latest": "99.0.0",
+            "X-Osmosis-Version-Status": "bogus-status",
+            "X-Osmosis-Version-Message": "should be ignored",
         }
         mock_resp.__enter__ = MagicMock(return_value=mock_resp)
         mock_resp.__exit__ = MagicMock(return_value=False)
@@ -1047,10 +1055,39 @@ class TestPlatformRequest:
 
         platform_request("/api/cli/verify", credentials=creds, require_git_repo=False)
 
-        # Exactly one warning, and it is the deprecation — never the nudge.
-        mock_console.print_warning.assert_called_once_with(
-            deprecation_msg, code="DEPRECATION"
-        )
+        mock_console.print_warning.assert_not_called()
+
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    @patch("osmosis_ai.platform.auth.platform_client.console")
+    def test_platform_request_ignores_legacy_version_headers(
+        self,
+        mock_console: MagicMock,
+        mock_urlopen: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Legacy headers (bare X-Osmosis-Latest, single-JSON X-Osmosis-Version)
+        are ignored; only the atomic status/message headers are read."""
+        from osmosis_ai.platform.auth import platform_client
+
+        monkeypatch.setattr(platform_client, "_version_signal_warned", set())
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"{}"
+        mock_resp.status = 200
+        mock_resp.headers = {
+            "X-Osmosis-Latest": "99.0.0",
+            "X-Osmosis-Version": json.dumps(
+                {"status": "deprecated", "message": "legacy json header"}
+            ),
+        }
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+        creds = _make_credentials()
+
+        platform_request("/api/cli/verify", credentials=creds, require_git_repo=False)
+
+        mock_console.print_warning.assert_not_called()
 
     # -------------------------------------------------------------------------
     # 426 Upgrade Required
@@ -1063,7 +1100,7 @@ class TestPlatformRequest:
         """A 426 response raises UpgradeRequiredError with the platform message."""
         import io
 
-        body = b'{"error":"upgrade_required","message":"osmosis >= 1.0.0 required. Run: pip install -U osmosis-ai","minimum":"1.0.0"}'
+        body = b'{"status":"unsupported","message":"osmosis >= 1.0.0 required. Run: osmosis upgrade","latest":"1.0.0"}'
         mock_urlopen.side_effect = HTTPError(
             "https://platform.osmosis.ai/api/cli/verify",
             426,

--- a/tests/unit/auth/test_platform_client.py
+++ b/tests/unit/auth/test_platform_client.py
@@ -945,6 +945,73 @@ class TestPlatformRequest:
         )
 
     # -------------------------------------------------------------------------
+    # Upgrade Nudge (X-Osmosis-Latest)
+    # -------------------------------------------------------------------------
+
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    @patch("osmosis_ai.platform.auth.platform_client.console")
+    def test_platform_request_nudges_on_newer_latest_header(
+        self,
+        mock_console: MagicMock,
+        mock_urlopen: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A higher X-Osmosis-Latest triggers a single upgrade nudge."""
+        from osmosis_ai.platform.auth import platform_client
+
+        monkeypatch.setattr(platform_client, "_upgrade_nudged", False)
+
+        def _make_response_with_latest_header() -> MagicMock:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = b"{}"
+            mock_resp.status = 200
+            mock_resp.headers = {"X-Osmosis-Latest": "99.0.0"}
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        mock_urlopen.return_value = _make_response_with_latest_header()
+        creds = _make_credentials()
+
+        platform_request("/api/cli/verify", credentials=creds, require_git_repo=False)
+        # Second call should NOT nudge again (dedup flag is now True).
+        mock_urlopen.return_value = _make_response_with_latest_header()
+        platform_request("/api/cli/verify", credentials=creds, require_git_repo=False)
+
+        mock_console.print_warning.assert_called_once_with(
+            "A newer version of the Osmosis CLI is available (99.0.0). "
+            "Run: osmosis upgrade",
+            code="UPGRADE_AVAILABLE",
+        )
+
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    @patch("osmosis_ai.platform.auth.platform_client.console")
+    def test_platform_request_no_nudge_when_already_current(
+        self,
+        mock_console: MagicMock,
+        mock_urlopen: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A X-Osmosis-Latest equal to the installed version stays silent."""
+        from osmosis_ai.consts import PACKAGE_VERSION
+        from osmosis_ai.platform.auth import platform_client
+
+        monkeypatch.setattr(platform_client, "_upgrade_nudged", False)
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"{}"
+        mock_resp.status = 200
+        mock_resp.headers = {"X-Osmosis-Latest": PACKAGE_VERSION}
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+        creds = _make_credentials()
+
+        platform_request("/api/cli/verify", credentials=creds, require_git_repo=False)
+
+        mock_console.print_warning.assert_not_called()
+
+    # -------------------------------------------------------------------------
     # 426 Upgrade Required
     # -------------------------------------------------------------------------
 

--- a/tests/unit/auth/test_platform_client.py
+++ b/tests/unit/auth/test_platform_client.py
@@ -381,6 +381,45 @@ class TestPlatformRequest:
 
         assert result == expected
 
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_204_response_returns_empty_dict(self, mock_urlopen: MagicMock) -> None:
+        """Verify a 204 No Content response yields an empty dict without reading."""
+        mock_resp = MagicMock()
+        mock_resp.status = 204
+        mock_resp.headers = {}
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+        creds = _make_credentials()
+
+        result = platform_request(
+            "/api/test", credentials=creds, git_identity="git_test"
+        )
+
+        assert result == {}
+        mock_resp.read.assert_not_called()
+
+    @patch("osmosis_ai.platform.auth.platform_client.console")
+    @patch("osmosis_ai.platform.auth.platform_client._deprecation_warned", False)
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_deprecation_header_emits_warning_once(
+        self, mock_urlopen: MagicMock, mock_console: MagicMock
+    ) -> None:
+        """Verify the X-Osmosis-Deprecation header surfaces a single warning."""
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = json.dumps({"ok": True}).encode()
+        mock_resp.headers = {"X-Osmosis-Deprecation": "Upgrade soon"}
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+        creds = _make_credentials()
+
+        platform_request("/api/test", credentials=creds, git_identity="git_test")
+        platform_request("/api/test", credentials=creds, git_identity="git_test")
+
+        mock_console.print_warning.assert_called_once_with("Upgrade soon")
+
     # -------------------------------------------------------------------------
     # HTTP Error Handling
     # -------------------------------------------------------------------------
@@ -444,6 +483,36 @@ class TestPlatformRequest:
         assert "OSMOSIS_TOKEN environment variable has expired" in str(exc_info.value)
         assert "unset OSMOSIS_TOKEN" in str(exc_info.value)
         mock_reset.assert_not_called()
+
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_426_raises_upgrade_required_with_platform_message(
+        self, mock_urlopen: MagicMock
+    ) -> None:
+        """Verify 426 uses the platform-supplied message when present."""
+        body = json.dumps({"message": "Please upgrade to v2.0.0"})
+        mock_urlopen.side_effect = _make_http_error(426, body)
+        creds = _make_credentials()
+
+        with pytest.raises(UpgradeRequiredError) as exc_info:
+            platform_request("/api/test", credentials=creds, git_identity="git_test")
+
+        assert str(exc_info.value) == "Please upgrade to v2.0.0"
+        assert exc_info.value.status_code == 426
+        assert exc_info.value.error_code == "upgrade_required"
+        assert exc_info.value.details == {"message": "Please upgrade to v2.0.0"}
+
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_426_falls_back_to_default_message(self, mock_urlopen: MagicMock) -> None:
+        """Verify 426 uses a default message when the body lacks one."""
+        mock_urlopen.side_effect = _make_http_error(426, "")
+        creds = _make_credentials()
+
+        with pytest.raises(UpgradeRequiredError) as exc_info:
+            platform_request("/api/test", credentials=creds, git_identity="git_test")
+
+        assert "no longer supported" in str(exc_info.value)
+        assert "osmosis upgrade" in str(exc_info.value)
+        assert exc_info.value.details is None
 
     @pytest.mark.parametrize(
         ("status_code", "error_code", "expected_message"),

--- a/tests/unit/auth/test_platform_client.py
+++ b/tests/unit/auth/test_platform_client.py
@@ -1011,6 +1011,47 @@ class TestPlatformRequest:
 
         mock_console.print_warning.assert_not_called()
 
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    @patch("osmosis_ai.platform.auth.platform_client.console")
+    def test_deprecation_supersedes_nudge_when_both_headers_present(
+        self,
+        mock_console: MagicMock,
+        mock_urlopen: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Both headers present -> only the deprecation warning, never the nudge.
+
+        Pins the precedence assumption, not just the message text.
+        """
+        from osmosis_ai.platform.auth import platform_client
+
+        monkeypatch.setattr(platform_client, "_deprecation_warned", False)
+        monkeypatch.setattr(platform_client, "_upgrade_nudged", False)
+
+        deprecation_msg = (
+            "This version of the Osmosis CLI is deprecated. "
+            "Latest is 99.0.0. Run: osmosis upgrade"
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"{}"
+        mock_resp.status = 200
+        mock_resp.headers = {
+            "X-Osmosis-Deprecation": deprecation_msg,
+            "X-Osmosis-Latest": "99.0.0",
+        }
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+        creds = _make_credentials()
+
+        platform_request("/api/cli/verify", credentials=creds, require_git_repo=False)
+
+        # Exactly one warning, and it is the deprecation — never the nudge.
+        mock_console.print_warning.assert_called_once_with(
+            deprecation_msg, code="DEPRECATION"
+        )
+
     # -------------------------------------------------------------------------
     # 426 Upgrade Required
     # -------------------------------------------------------------------------
@@ -1087,27 +1128,28 @@ class TestRevokeCLIToken:
         )
         assert revoke_cli_token(creds) is True
 
+    @patch("osmosis_ai.platform.auth.platform_client.console.print_warning")
     @patch("osmosis_ai.platform.auth.platform_client.urlopen")
-    def test_logs_warning_to_stderr_on_failure(self, mock_urlopen: MagicMock) -> None:
-        """Verify revoke_cli_token writes a warning to stderr when revocation fails."""
+    def test_logs_warning_on_failure(
+        self, mock_urlopen: MagicMock, mock_warn: MagicMock
+    ) -> None:
+        """A failed revoke routes through print_warning (not a raw stderr write).
+
+        Going through print_warning is what lets the warning pause an active
+        "Revoking session..." spinner and stay output-mode aware (structured in
+        JSON mode) instead of gluing raw text onto the spinner line.
+        """
         creds = _make_credentials()
         creds.token_id = "tok_456"
         mock_urlopen.side_effect = HTTPError(
             url="http://test", code=500, msg="Server Error", hdrs=None, fp=None
         )
 
-        import io
-        import sys
-
-        captured = io.StringIO()
-        old_stderr = sys.stderr
-        sys.stderr = captured
-        try:
-            result = revoke_cli_token(creds)
-        finally:
-            sys.stderr = old_stderr
+        result = revoke_cli_token(creds)
 
         assert result is False
-        warning = captured.getvalue()
-        assert "Warning: failed to revoke CLI token server-side" in warning
-        assert "HTTP 500" in warning
+        mock_warn.assert_called_once()
+        message = mock_warn.call_args.args[0]
+        assert "Failed to revoke CLI token server-side" in message
+        assert "HTTP 500" in message
+        assert mock_warn.call_args.kwargs.get("code") == "TOKEN_REVOKE_FAILED"

--- a/tests/unit/auth/test_platform_client.py
+++ b/tests/unit/auth/test_platform_client.py
@@ -418,7 +418,9 @@ class TestPlatformRequest:
         platform_request("/api/test", credentials=creds, git_identity="git_test")
         platform_request("/api/test", credentials=creds, git_identity="git_test")
 
-        mock_console.print_warning.assert_called_once_with("Upgrade soon")
+        mock_console.print_warning.assert_called_once_with(
+            "Upgrade soon", code="DEPRECATION"
+        )
 
     # -------------------------------------------------------------------------
     # HTTP Error Handling
@@ -498,7 +500,7 @@ class TestPlatformRequest:
 
         assert str(exc_info.value) == "Please upgrade to v2.0.0"
         assert exc_info.value.status_code == 426
-        assert exc_info.value.error_code == "upgrade_required"
+        assert exc_info.value.error_code == "UPGRADE_REQUIRED"
         assert exc_info.value.details == {"message": "Please upgrade to v2.0.0"}
 
     @patch("osmosis_ai.platform.auth.platform_client.urlopen")
@@ -938,7 +940,9 @@ class TestPlatformRequest:
         platform_request("/api/cli/verify", credentials=creds, require_git_repo=False)
 
         # print_warning should have been called exactly once (dedup flag prevents a second call).
-        mock_console.print_warning.assert_called_once_with(deprecation_msg)
+        mock_console.print_warning.assert_called_once_with(
+            deprecation_msg, code="DEPRECATION"
+        )
 
     # -------------------------------------------------------------------------
     # 426 Upgrade Required

--- a/tests/unit/cli/output/test_console_facade.py
+++ b/tests/unit/cli/output/test_console_facade.py
@@ -60,6 +60,25 @@ def test_console_spinner_writes_to_stderr_in_plain_mode() -> None:
     assert "Loading..." in err.getvalue()
 
 
+def test_console_spinner_does_not_leak_into_stdout_under_redirection() -> None:
+    """Regression: spinner progress must never land in stdout.
+
+    `osmosis dataset list > out.txt` used to write "Fetching datasets..." into
+    out.txt because spinner() rendered to stdout. Now it delegates to status(),
+    so progress goes to stderr and stdout stays clean for redirection/piping —
+    matching train/model/eval, which always used the stderr path.
+    """
+    out, err = io.StringIO(), io.StringIO()
+    # rich format with a non-interactive (redirected) stdin is exactly the
+    # `> out.txt` case; the old stdout path would have failed this.
+    with override_output_context(format=OutputFormat.rich, interactive=False):
+        with redirect_stdout(out), redirect_stderr(err):
+            with Console(file=out).spinner("Fetching datasets..."):
+                out.write("REAL_RESULT_ROW\n")
+    assert out.getvalue() == "REAL_RESULT_ROW\n"
+    assert "Fetching datasets..." in err.getvalue()
+
+
 def test_output_context_status_no_op_in_json() -> None:
     out, err = io.StringIO(), io.StringIO()
     output = OutputContext(format=OutputFormat.json, interactive=False)

--- a/tests/unit/cli/output/test_console_facade.py
+++ b/tests/unit/cli/output/test_console_facade.py
@@ -76,3 +76,46 @@ def test_console_table_is_silent_in_json_mode() -> None:
         with redirect_stdout(out):
             Console().table([("ID", "ds_1")])
     assert out.getvalue() == ""
+
+
+def test_console_print_warning_is_structured_json_on_stderr() -> None:
+    # JSON mode emits a one-line warning envelope to stderr (not free text), so
+    # stdout stays clean and stderr remains parseable as JSON Lines, while the
+    # deprecation signal is still visible to machine consumers.
+    import json
+
+    out, err = io.StringIO(), io.StringIO()
+    with override_output_context(format=OutputFormat.json):
+        with redirect_stdout(out), redirect_stderr(err):
+            Console().print_warning("Deprecated CLI version.", code="DEPRECATION")
+
+    assert out.getvalue() == ""
+    payload = json.loads(err.getvalue())
+    assert payload["schema_version"] == 1
+    assert "cli_version" in payload
+    assert payload["warning"] == {
+        "code": "DEPRECATION",
+        "message": "Deprecated CLI version.",
+    }
+    # Distinguishable from the error envelope.
+    assert "error" not in payload
+
+
+def test_console_print_warning_plain_mode_is_unstyled() -> None:
+    err = io.StringIO()
+    with override_output_context(format=OutputFormat.plain):
+        with redirect_stderr(err):
+            Console().print_warning("Deprecated CLI version.")
+    value = err.getvalue()
+    assert "warning: Deprecated CLI version." in value
+    assert "⚠" not in value
+
+
+def test_console_print_warning_writes_glyph_in_rich_mode() -> None:
+    err = io.StringIO()
+    with override_output_context(format=OutputFormat.rich):
+        with redirect_stderr(err):
+            Console().print_warning("Deprecated CLI version.")
+    value = err.getvalue()
+    assert "Deprecated CLI version." in value
+    assert "⚠" in value

--- a/tests/unit/cli/output/test_context.py
+++ b/tests/unit/cli/output/test_context.py
@@ -135,3 +135,29 @@ def test_override_output_context_helper_round_trip() -> None:
         assert output.format is OutputFormat.json
         assert _output_context_var.get() is output
     assert _output_context_var.get() is None
+
+
+def test_rich_status_registers_active_spinner_on_shared_console() -> None:
+    """The dominant `output.status(...)` path must register on the console.
+
+    A warning emitted mid-spin (the upgrade nudge) pauses/resumes whatever
+    `console._active_status` points at; if this spinner path failed to register,
+    the spinner line would glue onto the warning and linger on screen — the
+    exact regression this wiring prevents. Covers train/eval/secret/etc.
+    """
+    from osmosis_ai.cli.console import console
+
+    ctx = OutputContext(format=OutputFormat.rich, interactive=True)
+    assert console._active_status is None
+    with ctx.status("Fetching training runs..."):
+        assert console._active_status is not None
+    assert console._active_status is None
+
+
+def test_rich_status_skips_registration_in_non_interactive_mode() -> None:
+    """Non-interactive rich falls back to a plain line, so nothing to pause."""
+    from osmosis_ai.cli.console import console
+
+    ctx = OutputContext(format=OutputFormat.rich, interactive=False)
+    with ctx.status("Fetching training runs..."):
+        assert console._active_status is None

--- a/tests/unit/cli/output/test_error.py
+++ b/tests/unit/cli/output/test_error.py
@@ -82,6 +82,7 @@ def test_envelope_includes_platform_details() -> None:
         (403, "PLATFORM_ERROR"),
         (404, "NOT_FOUND"),
         (409, "CONFLICT"),
+        (426, "UPGRADE_REQUIRED"),
         (429, "RATE_LIMITED"),
         (500, "PLATFORM_ERROR"),
         (502, "PLATFORM_ERROR"),
@@ -95,6 +96,15 @@ def test_platform_error_status_mapping(status: int, expected_code: str) -> None:
 def test_authentication_expired_error_maps_to_auth_required() -> None:
     cli_err = classify_error(AuthenticationExpiredError("expired"))
     assert cli_err.code == "AUTH_REQUIRED"
+
+
+def test_upgrade_required_error_maps_to_upgrade_required() -> None:
+    # UpgradeRequiredError is a PlatformAPIError subclass exported from the
+    # package's public surface (parity with SubscriptionRequiredError).
+    from osmosis_ai.platform.auth import UpgradeRequiredError
+
+    cli_err = classify_error(UpgradeRequiredError("upgrade", status_code=426))
+    assert cli_err.code == "UPGRADE_REQUIRED"
 
 
 def test_unknown_exception_maps_to_internal_with_safe_details() -> None:

--- a/tests/unit/cli/test_auth_login_json.py
+++ b/tests/unit/cli/test_auth_login_json.py
@@ -245,6 +245,45 @@ def test_login_json_with_platform_verify_error_is_platform_error(
     assert "internal error" in envelope["error"]["message"]
 
 
+def test_login_json_with_426_is_upgrade_required_with_structured_details(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.delenv("OSMOSIS_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.load_credentials",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "osmosis_ai.platform.auth.verify_token",
+        lambda token: (_ for _ in ()).throw(
+            LoginError(
+                "A newer osmosis CLI is required, run osmosis upgrade",
+                code="UPGRADE_REQUIRED",
+                status_code=426,
+                details={
+                    "status": "unsupported",
+                    "message": "A newer osmosis CLI is required, run osmosis upgrade",
+                },
+            )
+        ),
+    )
+
+    exit_code = cli.main(["--json", "auth", "login", "--token", "secret"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    envelope = json.loads(captured.err)
+    assert envelope["error"]["code"] == "UPGRADE_REQUIRED"
+    # The handshake 426 carries the same structured signal a regular API 426
+    # produces, so machine consumers see one consistent UPGRADE_REQUIRED shape.
+    assert envelope["error"]["details"] == {
+        "status_code": 426,
+        "status": "unsupported",
+        "message": "A newer osmosis CLI is required, run osmosis upgrade",
+    }
+
+
 def test_login_json_with_malformed_verify_response_is_platform_error(
     monkeypatch, capsys
 ) -> None:

--- a/tests/unit/cli/test_console.py
+++ b/tests/unit/cli/test_console.py
@@ -234,6 +234,37 @@ def test_print_warning_does_not_parse_rich_markup(monkeypatch) -> None:
     assert warning_output.getvalue() == "⚠ Missing [experiment] section\n"
 
 
+def test_print_warning_pauses_live_spinner(monkeypatch) -> None:
+    """A warning emitted while a spinner is live pauses and resumes it.
+
+    Writing to the separate stderr console mid-spin corrupts Rich's Live cursor
+    bookkeeping, stranding the spinner line on screen. print_warning must stop
+    the active Status before printing and start it again afterwards so the
+    spinner redraws cleanly and still vanishes when the spinner context exits.
+    """
+
+    class _FakeStatus:
+        def __init__(self) -> None:
+            self.events: list[str] = []
+
+        def stop(self) -> None:
+            self.events.append("stop")
+
+        def start(self) -> None:
+            self.events.append("start")
+
+    warning_output = StringIO()
+    monkeypatch.setattr(sys, "stderr", warning_output)
+    console = Console(file=StringIO(), force_terminal=True, no_color=True, width=120)
+    status = _FakeStatus()
+    console._active_status = status
+
+    console.print_warning("A newer version is available")
+
+    assert status.events == ["stop", "start"]
+    assert warning_output.getvalue() == "⚠ A newer version is available\n"
+
+
 def test_table_url_emits_terminal_hyperlink(monkeypatch) -> None:
     monkeypatch.delenv("NO_COLOR", raising=False)
     monkeypatch.setenv("TERM", "xterm-256color")

--- a/tests/unit/cli/test_console.py
+++ b/tests/unit/cli/test_console.py
@@ -195,6 +195,45 @@ def test_print_error_does_not_parse_rich_markup(monkeypatch) -> None:
     assert error_output.getvalue() == "Missing [experiment] section\n"
 
 
+# ── print_warning ───────────────────────────────────────────────────
+
+
+def test_print_warning_writes_to_stderr(monkeypatch) -> None:
+    """print_warning writes a prefixed message to stderr."""
+    warning_output = StringIO()
+    monkeypatch.setattr(sys, "stderr", warning_output)
+    console = Console(file=StringIO(), force_terminal=True, no_color=True, width=120)
+
+    console.print_warning("Token expires soon")
+
+    assert warning_output.getvalue() == "⚠ Token expires soon\n"
+
+
+def test_print_warning_preserves_url_with_soft_wrap(monkeypatch) -> None:
+    """URL-bearing warnings should stay copyable when soft_wrap is set."""
+    warning_output = StringIO()
+    monkeypatch.setattr(sys, "stderr", warning_output)
+    console = Console(file=StringIO(), force_terminal=True, no_color=True, width=92)
+    url = (
+        "https://platform.osmosis.ai/osmosis-shared/settings/billing/"
+        "328be61c-ef39-45e1-9b33-1e3c7c482e97"
+    )
+
+    console.print_warning(f"Upgrade at: {url}", soft_wrap=True)
+
+    assert warning_output.getvalue() == f"⚠ Upgrade at: {url}\n"
+
+
+def test_print_warning_does_not_parse_rich_markup(monkeypatch) -> None:
+    warning_output = StringIO()
+    monkeypatch.setattr(sys, "stderr", warning_output)
+    console = Console(file=StringIO(), force_terminal=True, no_color=True, width=120)
+
+    console.print_warning("Missing [experiment] section", soft_wrap=True)
+
+    assert warning_output.getvalue() == "⚠ Missing [experiment] section\n"
+
+
 def test_table_url_emits_terminal_hyperlink(monkeypatch) -> None:
     monkeypatch.delenv("NO_COLOR", raising=False)
     monkeypatch.setenv("TERM", "xterm-256color")


### PR DESCRIPTION
## What

Adds CLI version negotiation with the Osmosis platform:

- Sends `X-Osmosis-CLI-Version` header on every platform API request (including token revocation)
- Handles `X-Osmosis-Deprecation` response header by emitting a once-per-process yellow warning via a new `console.print_warning` method
- Maps HTTP 426 (Upgrade Required) responses to a new `UpgradeRequiredError` exception with the platform-provided message
- Renames `_reject_scope_headers` → `_reject_reserved_headers` and adds `x-osmosis-cli-version` to the reserved header set to prevent caller overrides

## Why

Enables the platform to enforce minimum CLI version requirements (hard block via 426) and signal deprecation (soft warning via response header), giving users clear upgrade guidance before and 
ter version support is dropped.

## How to Test

1. Run existing and new unit tests:
   ```bash
   pytest tests/unit/auth/test_platform_client.py -v
   ```
2. Verify the version header is sent:
   - `test_platform_request_emits_cli_version_header`
   - `test_revoke_cli_token` (now asserts the header)
3. Verify deprecation warning deduplication:
   - `test_platform_request_warns_on_deprecation_header`
4. Verify 426 handling:
   - `test_platform_request_maps_426_to_upgrade_required`
5. Verify reserved header rejection:
   - `test_rejects_caller_supplied_reserved_headers_case_insensitively`

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send the CLI version on all API and login requests, surface server-computed version signals once per process, and block unsupported CLIs with clear, structured upgrade guidance. Keeps progress on stderr and warnings output-mode aware so JSON remains machine-parseable and stdout stays clean.

- **New Features**
  - Send `X-Osmosis-CLI-Version` on all platform API calls and the login handshake (`verify_token`, `request_device_code`, `poll_device_token`), plus token revocation.
  - Read unified version headers (`X-Osmosis-Version-Status`/`X-Osmosis-Version-Message`) and show one warning per process via `console.print_warning` (deprecation > upgrade); pause/resume any live spinner; JSON mode emits a one-line structured `warning` envelope on stderr.
  - Map HTTP 426 to `UpgradeRequiredError` on regular requests and to `LoginError(code="UPGRADE_REQUIRED")` during login; include structured details (`status_code`, `status`, `message`) so `--json` UPGRADE_REQUIRED errors have a consistent shape; use a fallback message when the server omits one.
  - Reject caller-supplied reserved headers (`X-Osmosis-Org`, `X-Osmosis-Git`, `X-Osmosis-CLI-Version`) with `RESERVED_HEADER_FORBIDDEN`.

- **Refactors**
  - Standardized request headers and version-signal handling across auth flow and API calls via `cli_request_headers`, `surface_response_version_signal`, and `upgrade_required_message`; `console.spinner` now delegates to `status` and active spinners are tracked so warnings cleanly pause/resume them.

<sup>Written for commit 4030d46af03d6e5ec359ee445bdc8e06f75da909. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

