### PR TITLE
[ci] chore: migrate publishing to GitHub Release workflow and prune unused deps

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -18,3 +18,6 @@ changelog:
         - ci
         - dependencies
         - refactor
+    - title: "Other Changes"
+      labels:
+        - "*"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,55 +1,48 @@
 name: Publish
 
 on:
-  push:
-    branches:
-      - release
-  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
 
 jobs:
-  build-and-publish:
-    environment: Release-secret
+  tests:
+    uses: ./.github/workflows/tests.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  check-version:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
 
-      - name: Build distribution artifacts
+      - name: Verify consts.py version matches the release tag
         run: |
-          rm -rf dist/ build/ *.egg-info/
-          uv build
-          uvx twine check --strict dist/*
+          VERSION=$(uv run --no-project --python 3.12 python -c 'import re, pathlib; text = pathlib.Path("osmosis_ai/consts.py").read_text(); print(re.search(r"^PACKAGE_VERSION\s*=\s*\"([^\"]+)\"", text, re.MULTILINE).group(1))')
+          TAG="${{ github.event.release.tag_name }}"
+          if [ "v$VERSION" != "$TAG" ]; then
+            echo "::error::consts.py PACKAGE_VERSION ($VERSION) does not match release tag ($TAG)"
+            exit 1
+          fi
+
+  publish:
+    needs: [tests, check-version]
+    runs-on: ubuntu-latest
+    environment: Release-secret
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-
-      - name: Extract version from consts.py
-        id: version
-        run: |
-          VERSION=$(python -c "exec(open('osmosis_ai/consts.py').read()); print(PACKAGE_VERSION)")
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Create Git tag
-        run: |
-          git tag ${{ steps.version.outputs.tag }}
-          git push origin ${{ steps.version.outputs.tag }}
-
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release create ${{ steps.version.outputs.tag }} \
-            --title "${{ steps.version.outputs.tag }}" \
-            --generate-notes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
   pull_request:
+  workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 permissions:
   contents: read
@@ -94,12 +98,13 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@v7
         with:
+          python-version: "3.12"
           enable-cache: true
 
       - name: Build package
@@ -107,3 +112,50 @@ jobs:
 
       - name: Check package
         run: uvx twine check --strict dist/*
+
+      - name: Verify artifact filenames match package version
+        run: |
+          VERSION=$(uv run --no-project --python 3.12 python -c 'import re, pathlib; text = pathlib.Path("osmosis_ai/consts.py").read_text(); print(re.search(r"^PACKAGE_VERSION\s*=\s*\"([^\"]+)\"", text, re.MULTILINE).group(1))')
+          uv run --no-project --python 3.12 python - "$VERSION" <<'PY'
+          import pathlib
+          import re
+          import sys
+
+          version = sys.argv[1]
+          artifacts = {
+              path.name
+              for path in pathlib.Path("dist").iterdir()
+              if path.suffix == ".whl" or path.name.endswith(".tar.gz")
+          }
+          expected_sdist = f"osmosis_ai-{version}.tar.gz"
+          matching_wheels = [
+              name
+              for name in artifacts
+              if re.fullmatch(rf"osmosis_ai-{re.escape(version)}-.+\.whl", name)
+          ]
+
+          if expected_sdist not in artifacts:
+              print(f"::error::Missing source distribution for version {version}: {expected_sdist}")
+              sys.exit(1)
+          if not matching_wheels:
+              print(f"::error::Missing wheel artifact for version {version}")
+              sys.exit(1)
+
+          mismatched = sorted(name for name in artifacts if version not in name)
+          if mismatched:
+              print(f"::error::Artifacts do not match PACKAGE_VERSION {version}: {', '.join(mismatched)}")
+              sys.exit(1)
+          PY
+
+      - name: Smoke-test the built wheel
+        run: |
+          uv venv --python 3.12 /tmp/osmosis-wheel-smoke
+          uv pip install --python /tmp/osmosis-wheel-smoke/bin/python dist/*.whl
+          /tmp/osmosis-wheel-smoke/bin/python -c "import osmosis_ai; print(osmosis_ai.__version__)"
+          /tmp/osmosis-wheel-smoke/bin/osmosis --version
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,7 +9,6 @@ Common errors when using the Osmosis SDK CLI.
 | Error | Install |
 |-------|---------|
 | `No module named 'fastapi'` / `uvicorn` | `pip install osmosis-ai[server]` |
-| `No module named 'pydantic_settings'` | `pip install osmosis-ai[server]` |
 | `No module named 'pyarrow'` | `pip install pyarrow` or `pip install osmosis-ai[server]` |
 | `No module named 'rich'` | `pip install osmosis-ai[server]` |
 | `No module named 'litellm'` | Should ship with core; reinstall `osmosis-ai` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "PyYAML>=6.0,<7.0",
     "python-dotenv>=0.1.0,<2.0.0",
     "requests>=2.0.0,<3.0.0",
     "litellm>=1.83.0,<2.0.0",
@@ -52,7 +51,6 @@ server = [
     "osmosis-ai[platform]",
     "fastapi>=0.100.0,<1.0.0",
     "uvicorn>=0.23.0,<1.0.0",
-    "pydantic-settings>=2.0.0,<3.0.0",
 ]
 
 # Development dependencies (testing, formatting, type checking, etc.)
@@ -62,11 +60,9 @@ dev = [
     "pytest>=9.0.3,<10.0.0",
     "pytest-asyncio>=1.4.0,<2.0.0",
     "pytest-cov>=7.1.0",
-    "anyio>=4.0.0",
     "ruff==0.15.15",  # Keep in sync with pre-commit and CI
     "pre-commit>=4.6.0,<5.0.0",
     "pyright[nodejs]==1.1.410",
-    "types-PyYAML>=6.0",
     "types-requests>=2.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+# setuptools>=77 is required for PEP 639 license metadata
+# (SPDX `license = "MIT"` expression + `license-files`).
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -10,12 +12,12 @@ readme = "README.md"
 authors = [
     {name = "Osmosis AI", email = "jake@osmosis.ai"}
 ]
-license = {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1952,7 +1952,6 @@ dependencies = [
     { name = "openai-agents", extra = ["litellm"] },
     { name = "pydantic" },
     { name = "python-dotenv" },
-    { name = "pyyaml" },
     { name = "questionary" },
     { name = "requests" },
     { name = "rich" },
@@ -1963,24 +1962,20 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
-    { name = "anyio" },
     { name = "fastapi" },
     { name = "pre-commit" },
     { name = "pyarrow" },
-    { name = "pydantic-settings" },
     { name = "pyright", extra = ["nodejs"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
-    { name = "types-pyyaml" },
     { name = "types-requests" },
     { name = "uvicorn" },
 ]
 full = [
     { name = "fastapi" },
     { name = "pyarrow" },
-    { name = "pydantic-settings" },
     { name = "uvicorn" },
 ]
 platform = [
@@ -1989,13 +1984,11 @@ platform = [
 server = [
     { name = "fastapi" },
     { name = "pyarrow" },
-    { name = "pydantic-settings" },
     { name = "uvicorn" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "anyio", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.100.0,<1.0.0" },
     { name = "harbor", extras = ["daytona"], specifier = "==0.6.1" },
     { name = "httpx", specifier = ">=0.25.0,<1.0.0" },
@@ -2008,13 +2001,11 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.6.0,<5.0.0" },
     { name = "pyarrow", marker = "extra == 'platform'", specifier = ">=14.0.0" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
-    { name = "pydantic-settings", marker = "extra == 'server'", specifier = ">=2.0.0,<3.0.0" },
     { name = "pyright", extras = ["nodejs"], marker = "extra == 'dev'", specifier = "==1.1.410" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3,<10.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.4.0,<2.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "python-dotenv", specifier = ">=0.1.0,<2.0.0" },
-    { name = "pyyaml", specifier = ">=6.0,<7.0" },
     { name = "questionary", specifier = ">=2.1.0,<3.0.0" },
     { name = "requests", specifier = ">=2.0.0,<3.0.0" },
     { name = "rich", specifier = ">=14.2.0" },
@@ -2022,7 +2013,6 @@ requires-dist = [
     { name = "strands-agents", extras = ["litellm"], specifier = ">=1.29.0" },
     { name = "tqdm", specifier = ">=4.0.0,<5.0.0" },
     { name = "typer", specifier = ">=0.16.0,<0.26" },
-    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.23.0,<1.0.0" },
 ]
@@ -3289,15 +3279,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/17/d4/064570dec6358aa9049d4708e4a10407d74c99258f8b2136bb8702303f1a/typer_slim-0.21.1.tar.gz", hash = "sha256:73495dd08c2d0940d611c5a8c04e91c2a0a98600cbd4ee19192255a233b6dbfd", size = 110478, upload-time = "2026-01-06T11:21:11.176Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/0a/4aca634faf693e33004796b6cee0ae2e1dba375a800c16ab8d3eff4bb800/typer_slim-0.21.1-py3-none-any.whl", hash = "sha256:6e6c31047f171ac93cc5a973c9e617dbc5ab2bddc4d0a3135dc161b4e2020e0d", size = 47444, upload-time = "2026-01-06T11:21:12.441Z" },
-]
-
-[[package]]
-name = "types-pyyaml"
-version = "6.0.12.20250915"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

- Rework `.github/workflows/publish.yml` to trigger on `release: [published]` instead of pushes to a `release` branch; it now reuses the `tests` workflow, verifies `consts.py` `PACKAGE_VERSION` matches the release tag, and publishes to PyPI via OIDC (`id-token: write`) using the artifact built in CI.
- Extend `.github/workflows/tests.yml` with `workflow_call` (optional `CODECOV_TOKEN`), pin the build job to Python 3.12, add artifact-filename/version verification, a built-wheel smoke test, and upload the `dist` artifact for the publish job to consume.
- Add an "Other Changes" catch-all section to `.github/release.yml` changelog config.
- Adopt PEP 639 license metadata in `pyproject.toml` (`license = "MIT"` + `license-files`, `setuptools>=77`).
- Prune unused dependencies: drop `PyYAML`/`types-PyYAML`, `pydantic-settings`, and `anyio` from `pyproject.toml` and `uv.lock`.
- Remove the stale `pydantic_settings` row from `docs/troubleshooting.md`.

## Why

Publishing previously relied on pushing to a `release` branch and minting the tag/release from CI. Driving publish off a GitHub Release (with a tag/version consistency check and OIDC trusted publishing) makes releases explicit, auditable, and removes the long-lived PyPI token. The dependency pruning removes packages the SDK no longer imports, shrinking the install footprint and lockfile.

## How to Test

- `uv run ruff check .` and `uv run ruff format --check .`
- `uv run pyright osmosis_ai/`
- `rg -n "pyyaml|pydantic_settings|import anyio" osmosis_ai/` returns no runtime imports of the removed deps.
- Release flow is exercised by cutting a GitHub Release whose tag matches `vPACKAGE_VERSION`; the `check-version` job fails the publish on mismatch.

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shifted publishing to trigger from GitHub Releases and use OIDC with the CI-built artifact, making releases safer and clearer. Also cleaned up unused dependencies and adopted PEP 639 license metadata.

- CI/Release
  - Publish on Release publish, reusing `tests` workflow.
  - Verify `consts.py` `PACKAGE_VERSION` matches the release tag before publishing.
  - Publish to PyPI via OIDC using the uploaded `dist` artifact.
  - Tests: pin build to Python 3.12, verify artifact filenames, smoke-test the wheel, upload `dist`.
  - Changelog: add an "Other Changes" catch-all section in `.github/release.yml`.

- Dependencies
  - Adopt PEP 639 license metadata in `pyproject.toml` (`license = "MIT"`, `license-files`, `setuptools>=77`).
  - Remove unused deps: `PyYAML`, `types-PyYAML`, `pydantic-settings`, `anyio`.
  - Docs: drop stale `pydantic_settings` troubleshooting entry.

<sup>Written for commit c8ae07bc4ad036db6d6423a8b8495a15c2c10744. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

