### PR TITLE
[eval][cli] feat: enrich eval/train run models and refine status output

### DIFF
--- a/docs/eval.md
+++ b/docs/eval.md
@@ -30,7 +30,7 @@ Evaluation submit configs also support optional `[experiment].commit_sha`, `[eva
 | Key | Description |
 |-----|-------------|
 | `limit` | Optional row cap. |
-| `n` | Number of evaluation attempts. |
+| `n` | Number of evaluation samples. |
 | `batch_size` | Rows evaluated per batch. |
 | `pass_threshold` | Minimum passing score. |
 | `agent_workflow_timeout_s` | Agent workflow timeout per row. |

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -30,7 +30,7 @@ Evaluation submit configs also support optional `[experiment].commit_sha`, `[eva
 | Key | Description |
 |-----|-------------|
 | `limit` | Optional row cap. |
-| `n` | Number of evaluation samples. |
+| `n` | Number of evaluation attempts per row. Total evaluations are `limit * n` (or `sampled_rows * n`). |
 | `batch_size` | Rows evaluated per batch. |
 | `pass_threshold` | Minimum passing score. |
 | `agent_workflow_timeout_s` | Agent workflow timeout per row. |

--- a/osmosis_ai/cli/output/renderer.py
+++ b/osmosis_ai/cli/output/renderer.py
@@ -19,7 +19,7 @@ from .result import (
 
 _RICH_STYLE_TAG_RE = re.compile(
     r"\[/?(?:bold|dim|italic|underline|blink|reverse|strike|"
-    r"black|red|green|yellow|blue|magenta|cyan|white)"
+    r"black|red|green|yellow|blue|magenta|cyan|white|orange3)"
     r"(?: [a-zA-Z0-9_#./ -]+)?\]"
 )
 

--- a/osmosis_ai/cli/output/serializers.py
+++ b/osmosis_ai/cli/output/serializers.py
@@ -57,6 +57,12 @@ def serialize_training_run(run: TrainingRun) -> dict[str, Any]:
     }
     if run.platform_url:
         data["platform_url"] = run.platform_url
+    if run.current_step is not None:
+        data["current_step"] = run.current_step
+    if run.total_steps is not None:
+        data["total_steps"] = run.total_steps
+    if run.reward is not None:
+        data["reward"] = run.reward
     return data
 
 
@@ -142,7 +148,12 @@ def serialize_eval_run(run: EvaluationRun) -> dict[str, Any]:
         "rollout": run.rollout.get("name") if run.rollout else None,
         "creator_name": run.creator_name,
         "creator_email": run.creator_email,
+        "row_index": run.row_index,
     }
+    if run.results is not None:
+        data["results"] = run.results
+    if run.config is not None:
+        data["config"] = run.config
     if run.platform_url:
         data["platform_url"] = run.platform_url
     return data

--- a/osmosis_ai/platform/api/models.py
+++ b/osmosis_ai/platform/api/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -9,9 +10,12 @@ from typing import Any, Literal
 # Single source of truth for status classification.
 
 STATUSES_SUCCESS: frozenset[str] = frozenset({"uploaded"})
-STATUSES_IN_PROGRESS: frozenset[str] = frozenset({"pending", "uploading", "processing"})
+# "pending" waits (amber); "uploading"/"processing" are active work (blue).
+STATUSES_PENDING: frozenset[str] = frozenset({"pending"})
+STATUSES_ACTIVE: frozenset[str] = frozenset({"uploading", "processing"})
+STATUSES_IN_PROGRESS: frozenset[str] = STATUSES_PENDING | STATUSES_ACTIVE
 STATUSES_ERROR: frozenset[str] = frozenset({"error"})
-STATUSES_INACTIVE: frozenset[str] = frozenset({"cancelled", "deleted"})
+STATUSES_INACTIVE: frozenset[str] = frozenset({"cancelled"})
 STATUSES_TERMINAL: frozenset[str] = (
     STATUSES_SUCCESS | STATUSES_ERROR | STATUSES_INACTIVE
 )
@@ -150,9 +154,13 @@ class PaginatedDatasets:
 # ── Training run status constants ────────────────────────────────
 
 RUN_STATUSES_SUCCESS: frozenset[str] = frozenset({"finished"})
-RUN_STATUSES_IN_PROGRESS: frozenset[str] = frozenset({"pending", "running"})
+# "pending"/"queued" wait (amber); "running" is active work (blue).
+RUN_STATUSES_PENDING: frozenset[str] = frozenset({"pending", "queued"})
+RUN_STATUSES_ACTIVE: frozenset[str] = frozenset({"running"})
+RUN_STATUSES_IN_PROGRESS: frozenset[str] = RUN_STATUSES_PENDING | RUN_STATUSES_ACTIVE
 RUN_STATUSES_ERROR: frozenset[str] = frozenset({"failed", "crashed"})
-RUN_STATUSES_STOPPED: frozenset[str] = frozenset({"stopped", "killed"})
+# "unknown" is a terminal, greyed-out state alongside stopped/killed.
+RUN_STATUSES_STOPPED: frozenset[str] = frozenset({"stopped", "killed", "unknown"})
 RUN_STATUSES_TERMINAL: frozenset[str] = (
     RUN_STATUSES_SUCCESS | RUN_STATUSES_ERROR | RUN_STATUSES_STOPPED
 )
@@ -160,10 +168,25 @@ RUN_STATUSES_TERMINAL: frozenset[str] = (
 # ── Evaluation run status constants ──────────────────────────────
 
 EVAL_RUN_STATUSES_SUCCESS: frozenset[str] = frozenset({"finished"})
-EVAL_RUN_STATUSES_IN_PROGRESS: frozenset[str] = frozenset({"pending", "running"})
-EVAL_RUN_STATUSES_TERMINAL: frozenset[str] = frozenset(
-    {"finished", "failed", "stopped"}
+# "pending" waits (amber); "running" is active work (blue).
+EVAL_RUN_STATUSES_PENDING: frozenset[str] = frozenset({"pending"})
+EVAL_RUN_STATUSES_ACTIVE: frozenset[str] = frozenset({"running"})
+EVAL_RUN_STATUSES_IN_PROGRESS: frozenset[str] = (
+    EVAL_RUN_STATUSES_PENDING | EVAL_RUN_STATUSES_ACTIVE
 )
+EVAL_RUN_STATUSES_ERROR: frozenset[str] = frozenset({"failed"})
+EVAL_RUN_STATUSES_STOPPED: frozenset[str] = frozenset({"stopped"})
+EVAL_RUN_STATUSES_TERMINAL: frozenset[str] = (
+    EVAL_RUN_STATUSES_SUCCESS | EVAL_RUN_STATUSES_ERROR | EVAL_RUN_STATUSES_STOPPED
+)
+
+
+def _number_or_none(value: Any) -> int | float | None:
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, int | float) or not math.isfinite(value):
+        return None
+    return value
 
 
 @dataclass
@@ -185,12 +208,18 @@ class TrainingRun:
     dataset_name: str | None = None
     rollout_id: str | None = None
     rollout_name: str | None = None
+    current_step: int | None = None
+    total_steps: int | None = None
+    reward: float | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TrainingRun:
         model = data.get("model") or {}
         dataset = data.get("dataset") or {}
         rollout = data.get("rollout") or {}
+        current_step = _number_or_none(data.get("current_step"))
+        total_steps = _number_or_none(data.get("total_steps"))
+        reward = _number_or_none(data.get("reward"))
         return cls(
             id=data["id"],
             name=data.get("name"),
@@ -207,6 +236,9 @@ class TrainingRun:
             dataset_name=dataset.get("file_name"),
             rollout_id=rollout.get("id"),
             rollout_name=rollout.get("name"),
+            current_step=int(current_step) if current_step is not None else None,
+            total_steps=int(total_steps) if total_steps is not None else None,
+            reward=float(reward) if reward is not None else None,
         )
 
 
@@ -224,6 +256,9 @@ class TrainingRunDetail(TrainingRun):
         model = data.get("model") or {}
         dataset = data.get("dataset") or {}
         rollout = data.get("rollout") or {}
+        current_step = _number_or_none(run.get("current_step"))
+        total_steps = _number_or_none(run.get("total_steps"))
+        reward = _number_or_none(run.get("reward"))
         return cls(
             id=run["id"],
             name=run.get("name"),
@@ -240,6 +275,9 @@ class TrainingRunDetail(TrainingRun):
             dataset_name=dataset.get("name"),
             rollout_id=rollout.get("id"),
             rollout_name=rollout.get("name"),
+            current_step=int(current_step) if current_step is not None else None,
+            total_steps=int(total_steps) if total_steps is not None else None,
+            reward=float(reward) if reward is not None else None,
             examples_processed_count=run.get("examples_processed_count"),
             notes=run.get("notes"),
         )
@@ -710,9 +748,14 @@ class EvaluationRun:
     creator_name: str | None = None
     creator_email: str | None = None
     platform_url: str | None = None
+    results: dict[str, Any] | None = None
+    row_index: int | None = None
+    config: dict[str, Any] | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> EvaluationRun:
+        row_index = _number_or_none(data.get("row_index"))
+        config = data.get("config")
         return cls(
             id=data["id"],
             name=data["name"],
@@ -726,6 +769,9 @@ class EvaluationRun:
             creator_name=data.get("creator_name"),
             creator_email=data.get("creator_email"),
             platform_url=data.get("platform_url"),
+            results=data.get("results"),
+            row_index=int(row_index) if row_index is not None else None,
+            config=config if isinstance(config, dict) else None,
         )
 
 
@@ -735,18 +781,28 @@ class EvaluationRunDetail(EvaluationRun):
 
     Mirrors :class:`TrainingRunDetail`: a typed subclass of the list row so
     callers read ``detail.status`` / ``detail.name`` with static safety instead
-    of stringly-typed ``eval_run.get(...)`` lookups. ``config`` / ``results``
-    are the detail-only payloads.
+    of stringly-typed ``eval_run.get(...)`` lookups.
     """
 
     config: dict[str, Any] | None = None
     results: dict[str, Any] | None = None
+    entrypoint: str | None = None
+    commit_sha: str | None = None
+    env_config: dict[str, Any] | None = None
+    resolved_secret_scopes: dict[str, Any] | None = None
+    dataset_df_stats: dict[str, Any] | None = None
+    recent_logs: list[dict[str, Any]] | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> EvaluationRunDetail:
         run = data["eval_run"]
         config = data.get("config")
         model_path = config.get("model_path") if isinstance(config, dict) else None
+        row_index = _number_or_none(run.get("row_index"))
+        env_config = data.get("env_config")
+        resolved_secret_scopes = data.get("resolved_secret_scopes")
+        dataset_df_stats = data.get("dataset_df_stats")
+        recent_logs = data.get("recent_logs")
         return cls(
             id=run["id"],
             name=run.get("name", ""),
@@ -760,8 +816,25 @@ class EvaluationRunDetail(EvaluationRun):
             model={"name": model_path} if isinstance(model_path, str) else None,
             dataset=data.get("dataset"),
             rollout=data.get("rollout"),
+            row_index=int(row_index) if row_index is not None else None,
             config=config,
             results=data.get("results"),
+            entrypoint=data.get("entrypoint")
+            if isinstance(data.get("entrypoint"), str)
+            else None,
+            commit_sha=data.get("commit_sha")
+            if isinstance(data.get("commit_sha"), str)
+            else None,
+            env_config=env_config if isinstance(env_config, dict) else None,
+            resolved_secret_scopes=(
+                resolved_secret_scopes
+                if isinstance(resolved_secret_scopes, dict)
+                else None
+            ),
+            dataset_df_stats=(
+                dataset_df_stats if isinstance(dataset_df_stats, dict) else None
+            ),
+            recent_logs=recent_logs if isinstance(recent_logs, list) else None,
         )
 
 

--- a/osmosis_ai/platform/cli/eval.py
+++ b/osmosis_ai/platform/cli/eval.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import json
+import math
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 from osmosis_ai.cli.console import console
 from osmosis_ai.cli.output import (
-    DetailField,
     DetailResult,
+    DetailSection,
     ListColumn,
     ListResult,
     OperationResult,
@@ -34,11 +37,328 @@ from osmosis_ai.platform.cli.eval_config import (
 from osmosis_ai.platform.cli.shared_submit import CloudSubmitSpec, run_cloud_submit
 from osmosis_ai.platform.cli.utils import (
     format_eval_status,
+    format_progress,
+    make_progress,
     paginated_fetch,
     require_git_workspace_directory_context,
     validate_list_options,
 )
 from osmosis_ai.platform.cli.workspace_directory_context import git_result_context
+
+
+def _ref_name(ref: dict[str, Any] | None) -> str | None:
+    if not ref:
+        return None
+    value = ref.get("name") or ref.get("file_name") or ref.get("model_name")
+    return value if isinstance(value, str) else None
+
+
+def _results_number(results: dict[str, Any] | None, key: str) -> int | float | None:
+    if not isinstance(results, dict):
+        return None
+    value = results.get(key)
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, int | float) or not math.isfinite(value):
+        return None
+    return value
+
+
+def _config_positive_int(config: dict[str, Any] | None, key: str) -> int | None:
+    if not isinstance(config, dict):
+        return None
+    value = config.get(key)
+    if isinstance(value, int) and value > 0:
+        return value
+    if isinstance(value, float) and value.is_integer() and value > 0:
+        return int(value)
+    return None
+
+
+def _eval_progress(detail: Any) -> dict[str, Any] | None:
+    """Single source of truth for eval progress (``completed`` / ``total``).
+
+    Total is ``sampled_rows * n`` but widened to ``completed`` when ``n`` is
+    unknown and more runs have completed than rows — ``total`` is only a lower
+    bound in that case, so widening (rather than clamping ``completed`` down)
+    avoids hiding real progress. Both the rendered string and the JSON
+    ``summary`` derive from this so they cannot diverge.
+    """
+    completed = _results_number(detail.results, "total_runs")
+    sampled_rows = _results_number(detail.results, "sampled_rows")
+    if completed is None or sampled_rows is None:
+        return None
+    n = _config_positive_int(getattr(detail, "config", None), "n") or 1
+    total = max(int(sampled_rows) * n, int(completed))
+    return make_progress(completed, total, "samples")
+
+
+def _format_eval_progress(detail: Any) -> str | None:
+    progress = format_progress(_eval_progress(detail))
+    if progress is not None:
+        return progress
+
+    completed = _results_number(detail.results, "total_runs")
+    if completed is None:
+        return "Waiting to start..." if detail.status == "pending" else None
+    return f"{int(completed):,} samples"
+
+
+def _format_avg_reward(results: dict[str, Any] | None, *, precision: int) -> str:
+    avg_reward = _results_number(results, "score")
+    if avg_reward is None:
+        return "—"
+    return f"{avg_reward:.{precision}f}"
+
+
+def _parse_iso_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed
+
+
+def _format_duration_ms(duration_ms: float) -> str:
+    duration_ms = max(0.0, duration_ms)
+    total_seconds = duration_ms / 1000
+    if total_seconds < 60:
+        return (
+            f"{total_seconds:.1f}s" if total_seconds % 1 else f"{int(total_seconds)}s"
+        )
+
+    total_seconds_int = int(total_seconds)
+    minutes, seconds = divmod(total_seconds_int, 60)
+    if minutes < 60:
+        return f"{minutes}m {seconds}s" if seconds else f"{minutes}m"
+
+    hours, minutes = divmod(minutes, 60)
+    if hours < 24:
+        return f"{hours}h {minutes}m" if minutes else f"{hours}h"
+
+    days, hours = divmod(hours, 24)
+    return f"{days}d {hours}h" if hours else f"{days}d"
+
+
+def _format_eval_duration(detail: Any) -> str | None:
+    started_at = _parse_iso_datetime(detail.started_at)
+    if started_at is None:
+        return None
+    completed_at = _parse_iso_datetime(detail.completed_at)
+    end = completed_at or datetime.now(UTC)
+    return _format_duration_ms((end - started_at).total_seconds() * 1000)
+
+
+def _format_decimal(value: int | float, *, precision: int = 4) -> str:
+    return f"{float(value):.{precision}f}"
+
+
+def _format_optional_int(value: int | float | None) -> str | None:
+    if value is None:
+        return None
+    return f"{int(value):,}"
+
+
+def _format_results_counts(results: dict[str, Any] | None) -> str | None:
+    graded = _results_number(results, "graded")
+    passed = _results_number(results, "passed")
+    failed = _results_number(results, "failed")
+    skipped = _results_number(results, "skipped")
+    values = [graded, passed, failed, skipped]
+    if all(value is None for value in values):
+        return None
+    return (
+        f"{int(graded or 0):,} graded, "
+        f"{int(passed or 0):,} passed, "
+        f"{int(failed or 0):,} failed, "
+        f"{int(skipped or 0):,} skipped"
+    )
+
+
+def _reward_stats(results: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(results, dict):
+        return None
+    reward_stats = results.get("reward_stats")
+    return reward_stats if isinstance(reward_stats, dict) else None
+
+
+def _format_reward_stats(results: dict[str, Any] | None) -> str | None:
+    reward_stats = _reward_stats(results)
+    if reward_stats is None:
+        return None
+    parts: list[str] = []
+    for key in ("min", "median", "max", "std"):
+        value = reward_stats.get(key)
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            continue
+        if not math.isfinite(value):
+            continue
+        parts.append(f"{key} {_format_decimal(value)}")
+    return ", ".join(parts) if parts else None
+
+
+def _format_pass_at_k(results: dict[str, Any] | None) -> str | None:
+    reward_stats = _reward_stats(results)
+    if reward_stats is None:
+        return None
+    pass_at_k = reward_stats.get("pass_at_k")
+    if not isinstance(pass_at_k, dict):
+        return None
+
+    formatted: list[str] = []
+    for key in sorted(
+        pass_at_k, key=lambda value: int(value) if str(value).isdigit() else str(value)
+    ):
+        value = pass_at_k.get(key)
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            continue
+        if not math.isfinite(value):
+            continue
+        formatted.append(f"{key}: {value:.1%}")
+    return ", ".join(formatted) if formatted else None
+
+
+def _format_secret_scopes(scopes: dict[str, Any] | None) -> str | None:
+    if not scopes:
+        return None
+
+    parts: list[str] = []
+    for name, raw_scope in sorted(scopes.items()):
+        if not isinstance(name, str) or not isinstance(raw_scope, str):
+            continue
+        if raw_scope == "workspace":
+            scope = "workspace"
+        elif raw_scope == "user_override":
+            scope = "personal, overrides workspace"
+        elif raw_scope == "user":
+            scope = "personal"
+        else:
+            scope = raw_scope
+        parts.append(f"{name} ({scope})")
+    return ", ".join(parts) if parts else None
+
+
+def _jsonish(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _format_env_config(env_config: dict[str, Any] | None) -> str | None:
+    if not env_config:
+        return None
+    parts = [
+        f"{key}={_jsonish(value)}"
+        for key, value in sorted(env_config.items())
+        if isinstance(key, str)
+    ]
+    return ", ".join(parts) if parts else None
+
+
+def _format_eval_config(config: dict[str, Any] | None) -> str | None:
+    if not config:
+        return None
+
+    ordered_keys = (
+        "limit",
+        "n",
+        "batch_size",
+        "pass_threshold",
+        "agent_workflow_timeout_s",
+        "grader_timeout_s",
+    )
+    keys = [
+        key
+        for key in ordered_keys
+        if key in config and key != "model_path" and config[key] is not None
+    ]
+    keys.extend(
+        sorted(
+            key
+            for key in config
+            if key not in ordered_keys
+            and key != "model_path"
+            and config[key] is not None
+        )
+    )
+    parts = [f"{key}={_jsonish(config[key])}" for key in keys]
+    return ", ".join(parts) if parts else None
+
+
+def _kv_section(title: str, rows: list[tuple[str, str]]) -> DetailSection | None:
+    """Build a titled key/value section mirroring the main detail table.
+
+    Values are passed through as plain text (never markup) so brackets and other
+    Rich-significant characters render literally. Returns ``None`` when there is
+    nothing to show so callers can append unconditionally.
+    """
+    if not rows:
+        return None
+
+    from rich import box
+    from rich.table import Table
+    from rich.text import Text
+
+    table = Table(title=title, box=box.ROUNDED, show_header=False, title_justify="left")
+    table.add_column("", style="cyan")
+    table.add_column("")
+    plain_lines = [f"{title}:"]
+    for label, value in rows:
+        table.add_row(label, Text(value))
+        plain_lines.append(f"{label}: {value}")
+    return DetailSection(rich=table, plain_lines=plain_lines)
+
+
+def _eval_summary(detail: Any, *, include_details: bool) -> dict[str, Any]:
+    results = detail.results if isinstance(detail.results, dict) else None
+    summary: dict[str, Any] = {}
+
+    avg_reward = _results_number(results, "score")
+    if avg_reward is not None:
+        summary["avg_reward"] = avg_reward
+
+    pass_rate = _results_number(results, "pass_rate")
+    if pass_rate is not None:
+        summary["pass_rate"] = pass_rate
+
+    for key in ("graded", "passed", "failed", "skipped"):
+        value = _results_number(results, key)
+        if value is not None:
+            summary[key] = int(value)
+
+    progress = _eval_progress(detail)
+    if progress is not None:
+        summary["progress"] = progress
+
+    if include_details:
+        pass_threshold = _results_number(results, "pass_threshold")
+        if pass_threshold is not None:
+            summary["pass_threshold"] = pass_threshold
+
+        total_tokens = _results_number(results, "total_tokens")
+        if total_tokens is not None:
+            summary["total_tokens"] = int(total_tokens)
+
+        dataset_rows = _results_number(results, "total_dataset_rows")
+        if dataset_rows is not None:
+            summary["dataset_rows"] = int(dataset_rows)
+
+        dominant_error_type = results.get("dominant_error_type") if results else None
+        if isinstance(dominant_error_type, str) and dominant_error_type:
+            summary["dominant_error_type"] = dominant_error_type
+
+        resumed_count = _results_number(results, "resumed_count")
+        if resumed_count is not None:
+            summary["resumed_count"] = int(resumed_count)
+
+    return summary
 
 
 def _submit_eval(
@@ -125,16 +445,22 @@ def list_eval_runs(*, limit: int, all_: bool) -> ListResult:
 
     return ListResult(
         title="Evaluation Runs",
-        items=[serialize_eval_run(r) for r in eval_runs],
+        items=[
+            {
+                **serialize_eval_run(r),
+                "summary": _eval_summary(r, include_details=False),
+            }
+            for r in eval_runs
+        ],
         total_count=total_count,
         has_more=has_more,
         next_offset=next_offset,
         extra=git_result_context(context),
         columns=[
             ListColumn(key="name", label="Name", ratio=4, overflow="fold"),
-            ListColumn(key="rollout", label="Rollout", ratio=2, overflow="fold"),
             ListColumn(key="status", label="Status", no_wrap=True, ratio=1),
-            ListColumn(key="model", label="Model", no_wrap=True, ratio=2),
+            ListColumn(key="rollout", label="Rollout", ratio=2, overflow="fold"),
+            ListColumn(key="avg_reward", label="Reward", no_wrap=True, ratio=1),
             ListColumn(key="created_at", label="Submitted", no_wrap=True, ratio=1),
             ListColumn(key="creator_name", label="Submitted By", no_wrap=True, ratio=1),
         ],
@@ -142,9 +468,9 @@ def list_eval_runs(*, limit: int, all_: bool) -> ListResult:
             {
                 **serialize_eval_run(run),
                 "name": run.name,
-                "rollout": run.rollout.get("name") if run.rollout else "—",
                 "status": format_eval_status(run),
-                "model": run.model.get("name") if run.model else "—",
+                "rollout": _ref_name(run.rollout) or "—",
+                "avg_reward": _format_avg_reward(run.results, precision=2),
                 "creator_name": run.creator_name or "—",
                 "created_at": format_local_date(run.created_at),
             }
@@ -168,47 +494,105 @@ def info(name_or_id: str) -> DetailResult:
             git_identity=context.git_identity,
         )
 
+    # Main info — mirrors the Platform detail page sidebar (identity + timing +
+    # what was run). Configuration and results live in their own sections below.
     rows: list[tuple[str, str]] = [
         ("Name", console.escape(detail.name or "(unnamed)")),
         ("ID", detail.id),
         ("Status", detail.status),
     ]
-    if detail.model and detail.model.get("name"):
-        rows.append(("Model", console.escape(detail.model["name"])))
-    if detail.dataset and detail.dataset.get("name"):
-        rows.append(("Dataset", console.escape(detail.dataset["name"])))
-    if detail.rollout and detail.rollout.get("name"):
-        rows.append(("Rollout", console.escape(detail.rollout["name"])))
-    if detail.creator_name:
-        rows.append(("Creator", console.escape(detail.creator_name)))
+
+    progress = _format_eval_progress(detail)
+    if progress:
+        rows.append(("Progress", progress))
+
+    duration = _format_eval_duration(detail)
+    if duration:
+        rows.append(("Duration", duration))
+
     if detail.created_at:
-        rows.append(("Created", format_local_datetime(detail.created_at)))
+        rows.append(("Submitted", format_local_datetime(detail.created_at)))
+    if detail.creator_name:
+        rows.append(("Submitted By", console.escape(detail.creator_name)))
     if detail.started_at:
         rows.append(("Started", format_local_datetime(detail.started_at)))
     if detail.completed_at:
         rows.append(("Completed", format_local_datetime(detail.completed_at)))
 
+    dataset_name = _ref_name(detail.dataset)
+    if dataset_name:
+        rows.append(("Dataset", console.escape(dataset_name)))
+    model_name = _ref_name(detail.model)
+    if model_name:
+        rows.append(("Model", console.escape(model_name)))
+    rollout_name = _ref_name(detail.rollout)
+    if rollout_name:
+        rows.append(("Rollout", console.escape(rollout_name)))
+
+    # Configuration section — what the run was launched with.
+    config_rows: list[tuple[str, str]] = []
+    if detail.entrypoint:
+        config_rows.append(("Entrypoint", detail.entrypoint))
+    config = _format_eval_config(detail.config)
+    if config:
+        config_rows.append(("Config", config))
+    if detail.commit_sha:
+        config_rows.append(("Commit", detail.commit_sha[:7]))
+    secret_scopes = _format_secret_scopes(detail.resolved_secret_scopes)
+    if secret_scopes:
+        config_rows.append(("Required Secrets", secret_scopes))
+    env_config = _format_env_config(detail.env_config)
+    if env_config:
+        config_rows.append(("Environment", env_config))
+
+    # Results section — scoring outcome.
+    result_rows: list[tuple[str, str]] = []
     if detail.results:
-        if detail.results.get("score") is not None:
-            rows.append(("Score", f"{detail.results['score']:.4f}"))
-        if detail.results.get("pass_rate") is not None:
-            rows.append(("Pass Rate", f"{detail.results['pass_rate']:.1%}"))
-        if detail.results.get("total_samples") is not None:
-            rows.append(("Samples", str(detail.results["total_samples"])))
+        results_counts = _format_results_counts(detail.results)
+        if results_counts:
+            result_rows.append(("Results", results_counts))
+
+        avg_reward = _format_avg_reward(detail.results, precision=4)
+        if avg_reward != "—":
+            result_rows.append(("Avg. Reward", avg_reward))
+        pass_rate = _results_number(detail.results, "pass_rate")
+        if pass_rate is not None:
+            result_rows.append(("Pass Rate", f"{pass_rate:.1%}"))
+        pass_threshold = _results_number(detail.results, "pass_threshold")
+        if pass_threshold is not None:
+            result_rows.append(("Pass Threshold", _format_decimal(pass_threshold)))
+        reward_stats = _format_reward_stats(detail.results)
+        if reward_stats:
+            result_rows.append(("Reward Stats", reward_stats))
+        pass_at_k = _format_pass_at_k(detail.results)
+        if pass_at_k:
+            result_rows.append(("Pass@k", pass_at_k))
+        total_tokens = _format_optional_int(
+            _results_number(detail.results, "total_tokens")
+        )
+        if total_tokens:
+            result_rows.append(("Total Tokens", total_tokens))
+        dataset_rows = _format_optional_int(
+            _results_number(detail.results, "total_dataset_rows")
+        )
+        if dataset_rows:
+            result_rows.append(("Dataset Rows", dataset_rows))
 
     fields = detail_fields(rows)
+    sections: list[DetailSection] = []
+    for section in (
+        _kv_section("Configuration", config_rows),
+        _kv_section("Results", result_rows),
+    ):
+        if section is not None:
+            sections.append(section)
+
     display_hints: list[str] = []
 
     if detail.platform_url:
         display_hints.append(f"View: {detail.platform_url}")
 
     if detail.status in EVAL_RUN_STATUSES_IN_PROGRESS:
-        fields.append(
-            DetailField(
-                label="Note",
-                value="Evaluation run is in progress. Results shown are a snapshot.",
-            )
-        )
         display_hints.append(
             f"Stop with: osmosis eval stop {detail.name or name_or_id}"
         )
@@ -217,14 +601,22 @@ def info(name_or_id: str) -> DetailResult:
         title="Evaluation Run",
         data={
             "eval_run": serialize_eval_run(detail),
+            "summary": _eval_summary(detail, include_details=True),
             "config": detail.config,
             "results": detail.results,
             "model": detail.model,
             "dataset": detail.dataset,
             "rollout": detail.rollout,
+            "entrypoint": detail.entrypoint,
+            "commit_sha": detail.commit_sha,
+            "env_config": detail.env_config,
+            "resolved_secret_scopes": detail.resolved_secret_scopes,
+            "dataset_df_stats": detail.dataset_df_stats,
+            "recent_logs": detail.recent_logs or [],
             **git_result_context(context),
         },
         fields=fields,
+        sections=sections,
         display_hints=display_hints,
     )
 

--- a/osmosis_ai/platform/cli/eval.py
+++ b/osmosis_ai/platform/cli/eval.py
@@ -214,7 +214,10 @@ def _format_pass_at_k(results: dict[str, Any] | None) -> str | None:
 
     formatted: list[str] = []
     for key in sorted(
-        pass_at_k, key=lambda value: int(value) if str(value).isdigit() else str(value)
+        pass_at_k,
+        key=lambda value: (
+            (0, int(value), "") if str(value).isdigit() else (1, 0, str(value))
+        ),
     ):
         value = pass_at_k.get(key)
         if isinstance(value, bool) or not isinstance(value, int | float):

--- a/osmosis_ai/platform/cli/train.py
+++ b/osmosis_ai/platform/cli/train.py
@@ -41,7 +41,9 @@ from osmosis_ai.platform.cli.training_config import (
 )
 from osmosis_ai.platform.cli.utils import (
     build_run_detail_rows,
+    format_progress,
     format_run_status,
+    make_progress,
     paginated_fetch,
     require_git_workspace_directory_context,
     validate_list_options,
@@ -59,6 +61,22 @@ def _default_filename(run_name: str | None, run_id: str) -> str:
     short_id = run_id[:8]
     safe = _safe_name(run_name) if run_name else None
     return f"{safe}_{short_id}.json" if safe else f"{short_id}.json"
+
+
+def _format_train_reward(run: Any) -> str:
+    if run.reward is None:
+        return "—"
+    return f"{run.reward:.2f}"
+
+
+def _train_summary(run: Any) -> dict[str, Any]:
+    summary: dict[str, Any] = {}
+    if run.reward is not None:
+        summary["reward"] = run.reward
+    progress = make_progress(run.current_step, run.total_steps, "steps")
+    if progress is not None:
+        summary["progress"] = progress
+    return summary
 
 
 def _resolve_output_path(output: str, run_name: str | None, run_id: str) -> Path:
@@ -185,7 +203,10 @@ def list_training_runs(*, limit: int, all_: bool) -> ListResult:
 
     return ListResult(
         title="Training Runs",
-        items=[serialize_training_run(r) for r in training_runs],
+        items=[
+            {**serialize_training_run(r), "summary": _train_summary(r)}
+            for r in training_runs
+        ],
         total_count=total_count,
         has_more=has_more,
         next_offset=next_offset,
@@ -193,9 +214,9 @@ def list_training_runs(*, limit: int, all_: bool) -> ListResult:
         columns=[
             ListColumn(key="name", label="Name", ratio=4, overflow="fold"),
             ListColumn(key="status", label="Status", no_wrap=True, ratio=1),
-            ListColumn(key="dataset_name", label="Dataset", ratio=2, overflow="fold"),
             ListColumn(key="model_name", label="Base Model", ratio=2, overflow="fold"),
             ListColumn(key="rollout_name", label="Rollout", ratio=2, overflow="fold"),
+            ListColumn(key="reward", label="Reward", no_wrap=True, ratio=1),
             ListColumn(key="created_at", label="Submitted", no_wrap=True, ratio=1),
             ListColumn(key="creator_name", label="Submitted By", no_wrap=True, ratio=1),
         ],
@@ -204,9 +225,9 @@ def list_training_runs(*, limit: int, all_: bool) -> ListResult:
                 **serialize_training_run(run),
                 "name": run.name or "(unnamed)",
                 "status": format_run_status(run),
-                "dataset_name": run.dataset_name or "—",
                 "model_name": run.model_name or "—",
                 "rollout_name": run.rollout_name or "—",
+                "reward": _format_train_reward(run),
                 "created_at": format_local_date(run.created_at),
                 "creator_name": run.creator_name or "—",
             }
@@ -231,8 +252,15 @@ def info(name: str, *, output: str | None) -> DetailResult:
         )
 
     rows = build_run_detail_rows(run)
+    summary = _train_summary(run)
     if run.status == "pending":
         rows.insert(3, ("Progress", "Waiting to start..."))
+    else:
+        progress = format_progress(summary.get("progress"))
+        if progress:
+            rows.insert(3, ("Progress", progress))
+    if run.reward is not None:
+        rows.insert(4, ("Reward", f"{run.reward:.4f}"))
     if run.started_at:
         rows.append(("Started", format_local_datetime(run.started_at)))
     if run.completed_at:
@@ -283,7 +311,7 @@ def info(name: str, *, output: str | None) -> DetailResult:
     save_warning: str | None = None
     if metrics_data is not None:
         export = build_export_dict(run, metrics_data)
-        if metrics_data.overview.total_steps is not None:
+        if "progress" not in summary and metrics_data.overview.total_steps is not None:
             latest = metrics_data.overview.latest_step or 0
             total = metrics_data.overview.total_steps
             rows.insert(3, ("Progress", f"{latest} / {total} rollout steps"))
@@ -297,8 +325,8 @@ def info(name: str, *, output: str | None) -> DetailResult:
         from rich.table import Table
         from rich.text import Text
 
-        table = Table(show_header=True, header_style="bold", expand=True)
-        table.add_column("Checkpoint", ratio=4, overflow="fold")
+        table = Table(show_header=True, header_style="bold", expand=False)
+        table.add_column("Checkpoint", overflow="fold")
         table.add_column("Step", no_wrap=True)
         table.add_column("Status", no_wrap=True)
         table.add_column("ID", no_wrap=True)
@@ -378,6 +406,7 @@ def info(name: str, *, output: str | None) -> DetailResult:
                 "examples_processed_count": run.examples_processed_count,
                 "notes": run.notes,
             },
+            "summary": summary,
             **({"platform_url": run.platform_url} if run.platform_url else {}),
             "checkpoints": [serialize_checkpoint(cp) for cp in checkpoints],
             "in_progress": is_in_progress,

--- a/osmosis_ai/platform/cli/utils.py
+++ b/osmosis_ai/platform/cli/utils.py
@@ -13,15 +13,20 @@ from osmosis_ai.platform.api.models import (
     DEPLOYMENT_STATUSES_ERROR,
     DEPLOYMENT_STATUSES_INACTIVE,
     DEPLOYMENT_STATUSES_SUCCESS,
-    EVAL_RUN_STATUSES_IN_PROGRESS,
+    EVAL_RUN_STATUSES_ACTIVE,
+    EVAL_RUN_STATUSES_ERROR,
+    EVAL_RUN_STATUSES_PENDING,
+    EVAL_RUN_STATUSES_STOPPED,
     EVAL_RUN_STATUSES_SUCCESS,
-    EVAL_RUN_STATUSES_TERMINAL,
+    RUN_STATUSES_ACTIVE,
     RUN_STATUSES_ERROR,
-    RUN_STATUSES_IN_PROGRESS,
+    RUN_STATUSES_PENDING,
     RUN_STATUSES_STOPPED,
     RUN_STATUSES_SUCCESS,
+    STATUSES_ACTIVE,
     STATUSES_ERROR,
-    STATUSES_IN_PROGRESS,
+    STATUSES_INACTIVE,
+    STATUSES_PENDING,
     STATUSES_SUCCESS,
 )
 from osmosis_ai.platform.auth import (
@@ -36,6 +41,48 @@ from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE
 
 if TYPE_CHECKING:
     from osmosis_ai.platform.auth.credentials import Credentials
+
+
+def make_progress(
+    completed: int | float | None,
+    total: int | float | None,
+    unit: str,
+) -> dict[str, Any] | None:
+    """Build a single source of truth for a run's progress.
+
+    Returns ``None`` unless ``total`` is a positive integer. ``completed`` is
+    clamped into ``[0, total]`` so the human-rendered string and the JSON
+    ``summary`` are derived from the same numbers and can never disagree or show
+    ``N / M`` with ``N > M``. Callers that cannot trust ``total`` as an upper
+    bound (e.g. when it is only a lower bound) should widen ``total`` before
+    calling.
+    """
+    if completed is None or total is None:
+        return None
+    total_int = int(total)
+    if total_int <= 0:
+        return None
+    return {
+        "completed": min(max(0, int(completed)), total_int),
+        "total": total_int,
+        "unit": unit,
+    }
+
+
+def format_progress(progress: dict[str, Any] | None) -> str | None:
+    """Render a progress dict produced by :func:`make_progress` as text."""
+    if not isinstance(progress, dict):
+        return None
+    completed = progress.get("completed")
+    total = progress.get("total")
+    unit = progress.get("unit")
+    if (
+        not isinstance(completed, int)
+        or not isinstance(total, int)
+        or not isinstance(unit, str)
+    ):
+        return None
+    return f"{completed:,} / {total:,} {unit}"
 
 
 def platform_call[T](message: str, call: Callable[[], T]) -> T:
@@ -70,18 +117,21 @@ def require_git_workspace_directory_context() -> GitWorkspaceDirectoryContext:
 
 # Ordered ``(statuses, style)`` buckets per domain. The first bucket whose set
 # contains the status wins, so order matters when a status is a member of more
-# than one set — eval's ``finished`` lives in both the success and terminal
-# sets, so the success bucket must precede the terminal bucket below.
+# than one set. Colors mirror the platform UI status dots: amber = waiting,
+# blue = active work, green = success, red = error, dim = stopped/inactive.
 _StatusStyleMap = Sequence[tuple[frozenset[str], str]]
 
 _DATASET_STATUS_STYLES: _StatusStyleMap = (
     (STATUSES_SUCCESS, "green"),
-    (STATUSES_IN_PROGRESS, "yellow"),
+    (STATUSES_PENDING, "orange3"),
+    (STATUSES_ACTIVE, "blue"),
     (STATUSES_ERROR, "red"),
+    (STATUSES_INACTIVE, "dim"),
 )
 _RUN_STATUS_STYLES: _StatusStyleMap = (
     (RUN_STATUSES_SUCCESS, "green"),
-    (RUN_STATUSES_IN_PROGRESS, "yellow"),
+    (RUN_STATUSES_PENDING, "orange3"),
+    (RUN_STATUSES_ACTIVE, "blue"),
     (RUN_STATUSES_ERROR, "red"),
     (RUN_STATUSES_STOPPED, "dim"),
 )
@@ -91,9 +141,11 @@ _DEPLOYMENT_STATUS_STYLES: _StatusStyleMap = (
     (DEPLOYMENT_STATUSES_ERROR, "red"),
 )
 _EVAL_STATUS_STYLES: _StatusStyleMap = (
-    (EVAL_RUN_STATUSES_SUCCESS, "green"),  # {"finished"} — precede TERMINAL
-    (EVAL_RUN_STATUSES_IN_PROGRESS, "yellow"),
-    (EVAL_RUN_STATUSES_TERMINAL, "red"),  # contains "finished"; green matched first
+    (EVAL_RUN_STATUSES_SUCCESS, "green"),
+    (EVAL_RUN_STATUSES_PENDING, "orange3"),
+    (EVAL_RUN_STATUSES_ACTIVE, "blue"),
+    (EVAL_RUN_STATUSES_ERROR, "red"),
+    (EVAL_RUN_STATUSES_STOPPED, "dim"),
 )
 
 

--- a/tests/unit/cli/test_eval_commands.py
+++ b/tests/unit/cli/test_eval_commands.py
@@ -1,0 +1,326 @@
+"""Tests for osmosis_ai.cli.commands.eval."""
+
+from __future__ import annotations
+
+from io import StringIO
+from types import SimpleNamespace
+
+import pytest
+
+import osmosis_ai.cli.commands.eval as eval_module
+import osmosis_ai.platform.api.client as api_client_module
+import osmosis_ai.platform.cli.eval as platform_eval_module
+import osmosis_ai.platform.cli.utils as utils_module
+from osmosis_ai.cli.console import Console
+from osmosis_ai.cli.output import DetailResult, ListResult
+from osmosis_ai.platform.api.models import (
+    EvaluationRun,
+    EvaluationRunDetail,
+    PaginatedEvaluationRuns,
+)
+
+GIT_IDENTITY = "acme/rollouts"
+REPO_URL = "https://github.com/acme/rollouts.git"
+FAKE_CREDENTIALS = object()
+
+
+@pytest.fixture()
+def console_capture(monkeypatch: pytest.MonkeyPatch) -> StringIO:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, width=200)
+    monkeypatch.setattr(platform_eval_module, "console", console)
+    monkeypatch.setattr(utils_module, "console", console)
+    return output
+
+
+@pytest.fixture(autouse=True)
+def _mock_git_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _git_context():
+        return SimpleNamespace(
+            workspace_directory="/repo",
+            git_identity=GIT_IDENTITY,
+            repo_url=REPO_URL,
+            credentials=FAKE_CREDENTIALS,
+        )
+
+    monkeypatch.setattr(
+        platform_eval_module,
+        "require_git_workspace_directory_context",
+        _git_context,
+    )
+
+
+class TestListEvalRuns:
+    def test_list_display_columns_and_json_items_include_result_summary(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        results = {
+            "score": 0.8123,
+            "total_runs": 90,
+            "sampled_rows": 100,
+            "graded": 80,
+            "passed": 60,
+            "failed": 20,
+            "skipped": 10,
+            "pass_rate": 0.75,
+        }
+        run = EvaluationRun(
+            id="eval-1",
+            name="math-eval",
+            status="stopped",
+            created_at="2026-01-01T00:00:00Z",
+            model={"name": "openai/gpt-5-mini"},
+            dataset={"id": "dataset-1", "name": "eval.jsonl"},
+            rollout={"id": "rollout-1", "name": "math-rollout"},
+            creator_name="alice",
+            results=results,
+            config={"n": 2},
+        )
+
+        class FakeClient:
+            def list_eval_runs(
+                self,
+                limit=30,
+                offset=0,
+                *,
+                git_identity,
+                credentials=None,
+            ):
+                assert credentials is FAKE_CREDENTIALS
+                assert git_identity == GIT_IDENTITY
+                return PaginatedEvaluationRuns(
+                    eval_runs=[run], total_count=1, has_more=False
+                )
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(platform_eval_module, "OsmosisClient", FakeClient)
+
+        result = eval_module.eval_list(limit=30, all_=False)
+
+        assert isinstance(result, ListResult)
+        assert [column.label for column in result.columns] == [
+            "Name",
+            "Status",
+            "Rollout",
+            "Reward",
+            "Submitted",
+            "Submitted By",
+        ]
+        assert [column.key for column in result.columns] == [
+            "name",
+            "status",
+            "rollout",
+            "avg_reward",
+            "created_at",
+            "creator_name",
+        ]
+        assert result.display_items is not None
+        item = result.display_items[0]
+        assert item["dataset"] == "eval.jsonl"
+        assert item["model"] == "openai/gpt-5-mini"
+        assert item["rollout"] == "math-rollout"
+        assert item["avg_reward"] == "0.81"
+        assert item["status"] == "[dim]\\[stopped][/dim]"
+
+        json_item = result.items[0]
+        assert json_item["results"] == results
+        assert json_item["summary"] == {
+            "avg_reward": 0.8123,
+            "pass_rate": 0.75,
+            "graded": 80,
+            "passed": 60,
+            "failed": 20,
+            "skipped": 10,
+            "progress": {
+                "completed": 90,
+                "total": 200,
+                "unit": "samples",
+            },
+        }
+
+
+class TestEvalInfo:
+    def test_info_displays_submitted_richer_results_and_debug_context(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        detail = EvaluationRunDetail(
+            id="eval-1",
+            name="math-eval",
+            status="running",
+            created_at="2026-01-01T00:00:00Z",
+            started_at="2026-01-01T00:01:00Z",
+            completed_at="2026-01-01T00:01:12.500Z",
+            model={"name": "openai/gpt-5-mini"},
+            dataset={"id": "dataset-1", "name": "eval.jsonl"},
+            rollout={"id": "rollout-1", "name": "math-rollout"},
+            creator_name="alice",
+            config={"n": 2, "batch_size": 5, "pass_threshold": 0.5},
+            entrypoint="main.py",
+            commit_sha="abcdef1234567890",
+            env_config={"PROMPT_MODE": "strict"},
+            resolved_secret_scopes={
+                "OPENAI_API_KEY": "workspace",
+                "ANTHROPIC_API_KEY": "user_override",
+            },
+            recent_logs=[
+                {
+                    "step": "eval",
+                    "level": "error",
+                    "message": "Missing API key",
+                    "timestamp": "2026-01-01T00:01:12Z",
+                }
+            ],
+            results={
+                "total_runs": 5,
+                "sampled_rows": 4,
+                "graded": 4,
+                "passed": 3,
+                "failed": 1,
+                "skipped": 0,
+                "score": 0.8123,
+                "pass_rate": 0.75,
+                "pass_threshold": 0.5,
+                "total_tokens": 12345,
+                "total_dataset_rows": 1000,
+                "reward_stats": {
+                    "min": 0.1,
+                    "median": 0.8,
+                    "max": 1.0,
+                    "std": 0.2,
+                    "pass_at_k": {"1": 0.5, "2": 0.75},
+                },
+            },
+        )
+
+        class FakeClient:
+            def get_eval_run(self, name_or_id, *, git_identity, credentials=None):
+                assert name_or_id == "math-eval"
+                assert credentials is FAKE_CREDENTIALS
+                assert git_identity == GIT_IDENTITY
+                return detail
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(platform_eval_module, "OsmosisClient", FakeClient)
+
+        result = eval_module.eval_info("math-eval")
+
+        assert isinstance(result, DetailResult)
+        field_rows = [(field.label, field.value) for field in result.fields]
+        # Main info mirrors the Platform detail page sidebar.
+        assert [label for label, _value in field_rows] == [
+            "Name",
+            "ID",
+            "Status",
+            "Progress",
+            "Duration",
+            "Submitted",
+            "Submitted By",
+            "Started",
+            "Completed",
+            "Dataset",
+            "Model",
+            "Rollout",
+        ]
+        fields = dict(field_rows)
+        assert fields["Progress"] == "5 / 8 samples"
+        assert fields["Duration"] == "12.5s"
+        assert fields["Submitted By"] == "alice"
+
+        # Configuration + results live in their own sections, not the main info.
+        section_plain = {
+            line.split(": ", 1)[0]: line.split(": ", 1)[1]
+            for section in result.sections
+            for line in section.plain_lines
+            if ": " in line
+        }
+        section_titles = [
+            section.plain_lines[0].rstrip(":")
+            for section in result.sections
+            if section.plain_lines
+        ]
+        assert section_titles == ["Configuration", "Results"]
+        assert section_plain["Entrypoint"] == "main.py"
+        assert section_plain["Config"] == "n=2, batch_size=5, pass_threshold=0.5"
+        assert section_plain["Commit"] == "abcdef1"
+        assert section_plain["Required Secrets"] == (
+            "ANTHROPIC_API_KEY (personal, overrides workspace), "
+            "OPENAI_API_KEY (workspace)"
+        )
+        assert section_plain["Environment"] == "PROMPT_MODE=strict"
+        assert section_plain["Results"] == "4 graded, 3 passed, 1 failed, 0 skipped"
+        assert section_plain["Avg. Reward"] == "0.8123"
+        assert section_plain["Pass Rate"] == "75.0%"
+        assert section_plain["Pass Threshold"] == "0.5000"
+        assert (
+            section_plain["Reward Stats"]
+            == "min 0.1000, median 0.8000, max 1.0000, std 0.2000"
+        )
+        assert section_plain["Pass@k"] == "1: 50.0%, 2: 75.0%"
+        assert section_plain["Total Tokens"] == "12,345"
+        assert section_plain["Dataset Rows"] == "1,000"
+
+        # Errors are dropped from the rendered output but kept in JSON data.
+        assert "Error" not in fields
+        assert "Error" not in section_plain
+        assert result.data["recent_logs"] == [
+            {
+                "step": "eval",
+                "level": "error",
+                "message": "Missing API key",
+                "timestamp": "2026-01-01T00:01:12Z",
+            }
+        ]
+        assert result.data["summary"] == {
+            "avg_reward": 0.8123,
+            "pass_rate": 0.75,
+            "graded": 4,
+            "passed": 3,
+            "failed": 1,
+            "skipped": 0,
+            "pass_threshold": 0.5,
+            "total_tokens": 12345,
+            "dataset_rows": 1000,
+            "progress": {
+                "completed": 5,
+                "total": 8,
+                "unit": "samples",
+            },
+        }
+        assert "Creator" not in fields
+        assert "Created" not in fields
+        assert "Score" not in fields
+        assert "Note" not in fields
+
+    def test_info_progress_and_summary_agree_when_runs_exceed_total(
+        self, monkeypatch: pytest.MonkeyPatch, console_capture: StringIO
+    ) -> None:
+        # ``total_runs`` > ``sampled_rows * n`` (e.g. resumed/retried runs):
+        # the rendered Progress string and the JSON summary must derive from the
+        # same clamped numbers and never show ``N / M`` with ``N > M``.
+        detail = EvaluationRunDetail(
+            id="eval-2",
+            name="overflow-eval",
+            status="running",
+            created_at="2026-01-01T00:00:00Z",
+            config={"n": 2},
+            results={"total_runs": 12, "sampled_rows": 4},
+        )
+
+        class FakeClient:
+            def get_eval_run(self, name_or_id, *, git_identity, credentials=None):
+                return detail
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(platform_eval_module, "OsmosisClient", FakeClient)
+
+        result = eval_module.eval_info("overflow-eval")
+
+        assert isinstance(result, DetailResult)
+        fields = {field.label: field.value for field in result.fields}
+        # total widened to completed (total is only a lower bound here).
+        assert fields["Progress"] == "12 / 12 samples"
+        assert result.data["summary"]["progress"] == {
+            "completed": 12,
+            "total": 12,
+            "unit": "samples",
+        }

--- a/tests/unit/cli/test_train_commands.py
+++ b/tests/unit/cli/test_train_commands.py
@@ -246,6 +246,9 @@ class TestListRuns:
             model_name="gpt-2",
             rollout_name="math-rollout",
             created_at="2026-01-01T00:00:00Z",
+            current_step=31,
+            total_steps=25,
+            reward=0.75,
         )
 
         class FakeClient:
@@ -265,9 +268,9 @@ class TestListRuns:
         assert [column.label for column in result.columns] == [
             "Name",
             "Status",
-            "Dataset",
             "Base Model",
             "Rollout",
+            "Reward",
             "Submitted",
             "Submitted By",
         ]
@@ -275,16 +278,28 @@ class TestListRuns:
         assert result.columns[0].ratio == 4
         assert result.columns[0].overflow == "fold"
         assert result.columns[1].key == "status"
-        assert result.columns[2].key == "dataset_name"
-        assert result.columns[3].key == "model_name"
-        assert result.columns[4].key == "rollout_name"
-        assert result.columns[4].overflow == "fold"
+        assert result.columns[2].key == "model_name"
+        assert result.columns[3].key == "rollout_name"
+        assert result.columns[3].overflow == "fold"
+        assert result.columns[4].key == "reward"
         assert result.columns[5].key == "created_at"
         assert result.columns[6].key == "creator_name"
         assert result.display_items is not None
         assert result.display_items[0]["dataset_name"] == "train.jsonl"
         assert result.display_items[0]["model_name"] == "gpt-2"
         assert result.display_items[0]["rollout_name"] == "math-rollout"
+        assert result.display_items[0]["reward"] == "0.75"
+        assert result.items[0]["current_step"] == 31
+        assert result.items[0]["total_steps"] == 25
+        assert result.items[0]["reward"] == 0.75
+        assert result.items[0]["summary"] == {
+            "reward": 0.75,
+            "progress": {
+                "completed": 25,
+                "total": 25,
+                "unit": "steps",
+            },
+        }
         assert result.display_hints == ["Use osmosis train info <name> for details."]
 
     def test_list_unnamed_run(
@@ -365,6 +380,9 @@ class TestInfo:
             dataset_name="train.jsonl",
             rollout_name="math-rollout",
             platform_url="https://platform.osmosis.ai/ws/training/abcdef1234567890abcdef1234567890",
+            current_step=31,
+            total_steps=25,
+            reward=0.75,
         )
         checkpoint = LoraCheckpointInfo(
             id="ckpt_abcdef123456",
@@ -428,8 +446,21 @@ class TestInfo:
         assert result.title == "Training Run Info"
         assert result.data["training_run"]["name"] == "run-1"
         field_rows = [(field.label, field.value) for field in result.fields]
+        assert ("Progress", "25 / 25 steps") in field_rows
+        assert ("Reward", "0.7500") in field_rows
         assert ("Dataset", "train.jsonl") in field_rows
         assert ("Rollout", "math-rollout") in field_rows
+        assert result.data["training_run"]["current_step"] == 31
+        assert result.data["training_run"]["total_steps"] == 25
+        assert result.data["training_run"]["reward"] == 0.75
+        assert result.data["summary"] == {
+            "reward": 0.75,
+            "progress": {
+                "completed": 25,
+                "total": 25,
+                "unit": "steps",
+            },
+        }
         assert result.data["checkpoints"][0]["checkpoint_name"] == "run-1-step-100"
         assert result.data["metrics_available"] is True
         assert result.data["metrics"]["summary"]["training_reward"]["latest"] == 0.75

--- a/tests/unit/cli/test_train_info_checkpoints.py
+++ b/tests/unit/cli/test_train_info_checkpoints.py
@@ -136,7 +136,7 @@ class TestStatusCheckpoints:
         assert all(field.label != "Checkpoint" for field in result.fields)
         assert all(field.label != "Deploy" for field in result.fields)
         assert result.sections
-        assert result.sections[0].rich.expand is True
+        assert result.sections[0].rich.expand is False
         expected_url = "https://platform.osmosis.ai/ws/training/run_1"
         assert result.display_hints == [
             f"View: {expected_url}",

--- a/tests/unit/platform/api/test_models.py
+++ b/tests/unit/platform/api/test_models.py
@@ -251,6 +251,9 @@ class TestTrainingRun:
                 "model": {"id": None, "model_name": "Qwen/Qwen3"},
                 "dataset": {"id": "dataset_1", "file_name": "train.jsonl"},
                 "rollout": {"id": "rollout_1", "name": "math-rollout"},
+                "current_step": 90,
+                "total_steps": 100,
+                "reward": 0.75,
             }
         )
 
@@ -260,6 +263,9 @@ class TestTrainingRun:
         assert run.dataset_name == "train.jsonl"
         assert run.rollout_id == "rollout_1"
         assert run.rollout_name == "math-rollout"
+        assert run.current_step == 90
+        assert run.total_steps == 100
+        assert run.reward == 0.75
 
     def test_from_dict_uses_nested_training_run_contract_only(self) -> None:
         run = api_models.TrainingRun.from_dict(
@@ -611,7 +617,11 @@ class TestEvaluationRunModels:
     def test_evaluation_run_detail_from_dict_uses_config_model_path(self) -> None:
         detail = EvaluationRunDetail.from_dict(
             {
-                "eval_run": {"id": "eval_1", "status": "succeeded"},
+                "eval_run": {
+                    "id": "eval_1",
+                    "status": "succeeded",
+                    "row_index": 4,
+                },
                 "config": {
                     "model_path": "openai/gpt-5-mini",
                     "evaluation": {"rubric": "grade correctness"},
@@ -619,6 +629,19 @@ class TestEvaluationRunModels:
                 "results": {"score": 0.92},
                 "dataset": {"id": "dataset_1"},
                 "rollout": {"id": "rollout_1"},
+                "entrypoint": "main.py",
+                "commit_sha": "abcdef1234567890",
+                "env_config": {"PROMPT_MODE": "strict"},
+                "resolved_secret_scopes": {"OPENAI_API_KEY": "workspace"},
+                "recent_logs": [
+                    {
+                        "step": "eval",
+                        "level": "error",
+                        "message": "Missing API key",
+                        "timestamp": "2026-01-01T00:00:00Z",
+                    }
+                ],
+                "dataset_df_stats": {"row_count": 1000},
             }
         )
 
@@ -632,6 +655,20 @@ class TestEvaluationRunModels:
         assert detail.model == {"name": "openai/gpt-5-mini"}
         assert detail.dataset == {"id": "dataset_1"}
         assert detail.rollout == {"id": "rollout_1"}
+        assert detail.row_index == 4
+        assert detail.entrypoint == "main.py"
+        assert detail.commit_sha == "abcdef1234567890"
+        assert detail.env_config == {"PROMPT_MODE": "strict"}
+        assert detail.resolved_secret_scopes == {"OPENAI_API_KEY": "workspace"}
+        assert detail.recent_logs == [
+            {
+                "step": "eval",
+                "level": "error",
+                "message": "Missing API key",
+                "timestamp": "2026-01-01T00:00:00Z",
+            }
+        ]
+        assert detail.dataset_df_stats == {"row_count": 1000}
 
     def test_paginated_evaluation_runs_uses_eval_runs_key(self) -> None:
         page = PaginatedEvaluationRuns.from_dict(

--- a/tests/unit/platform/cli/test_status_formatting.py
+++ b/tests/unit/platform/cli/test_status_formatting.py
@@ -26,8 +26,8 @@ def _make_rich_console() -> tuple[Console, StringIO]:
     return console, output
 
 
-@pytest.mark.parametrize("status", ["cancelled", "deleted"])
-def test_list_datasets_preserves_uncategorized_status_brackets(
+@pytest.mark.parametrize("status", ["cancelled"])
+def test_list_datasets_renders_inactive_statuses_dim(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     status: str,
@@ -77,11 +77,11 @@ def test_list_datasets_preserves_uncategorized_status_brackets(
     result = dataset_module.list_datasets()
 
     assert result.display_items is not None
-    assert f"\\[{status}]" == result.display_items[0]["status"]
+    assert f"[dim]\\[{status}][/dim]" == result.display_items[0]["status"]
 
 
-@pytest.mark.parametrize("status", ["cancelled", "deleted"])
-def test_dataset_status_format_preserves_uncategorized_status_brackets(
+@pytest.mark.parametrize("status", ["cancelled"])
+def test_dataset_status_format_renders_inactive_statuses_dim(
     monkeypatch: pytest.MonkeyPatch,
     status: str,
 ) -> None:
@@ -99,10 +99,10 @@ def test_dataset_status_format_preserves_uncategorized_status_brackets(
     assert f"[{status}]" in strip_ansi(output.getvalue())
 
 
-def test_dataset_status_format_preserves_plain_text_brackets() -> None:
+def test_dataset_status_format_returns_dim_markup_for_inactive_status() -> None:
     console = Console(file=StringIO(), force_terminal=False)
     dataset = SimpleNamespace(
-        status="deleted",
+        status="cancelled",
         processing_step=None,
         processing_percent=None,
     )
@@ -110,6 +110,6 @@ def test_dataset_status_format_preserves_plain_text_brackets() -> None:
     original_console = utils_module.console
     utils_module.console = console
     try:
-        assert utils_module.format_dataset_status(dataset) == "\\[deleted]"
+        assert utils_module.format_dataset_status(dataset) == "[dim]\\[cancelled][/dim]"
     finally:
         utils_module.console = original_console

--- a/tests/unit/platform/cli/test_utils.py
+++ b/tests/unit/platform/cli/test_utils.py
@@ -99,6 +99,10 @@ def test_format_dataset_status_error_styled(monkeypatch: pytest.MonkeyPatch) -> 
     assert "error" in result
 
 
+def test_format_dataset_status_cancelled_is_dim() -> None:
+    assert format_dataset_status(_dataset("cancelled")) == "[dim]\\[cancelled][/dim]"
+
+
 def test_format_dataset_status_unknown_uses_escape(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -200,10 +204,10 @@ def test_format_deployment_status_unknown_uses_escape() -> None:
 @pytest.mark.parametrize(
     "status, style",
     [
-        ("pending", "yellow"),
-        ("running", "yellow"),
+        ("pending", "orange3"),
+        ("running", "blue"),
         ("failed", "red"),
-        ("stopped", "red"),
+        ("stopped", "dim"),
     ],
 )
 def test_format_eval_status_styles(status: str, style: str) -> None:


### PR DESCRIPTION
## What

- Extend `TrainingRun` / `TrainingRunDetail` with `current_step`, `total_steps`, and `reward`, parsed safely via a shared `_number_or_none` helper in `osmosis_ai/platform/api/models.py`.
- Extend `EvaluationRun` with `results`, `row_index`, `config`; extend `EvaluationRunDetail` with `entrypoint`, `commit_sha`, `env_config`, `resolved_secret_scopes`, `dataset_df_stats`, and `recent_logs`.
- Split status constants into pending vs. active groups (dataset / training / eval) and add dedicated eval `ERROR`/`STOPPED` sets; treat `unknown` as terminal for training runs.
- Surface the new fields in `osmosis_ai/cli/output/serializers.py` and allow the `orange3` rich style tag in `renderer.py`.
- Expand `osmosis eval` CLI logic in `osmosis_ai/platform/cli/eval.py` and update `train.py` / `utils.py` formatting helpers.
- Add/extend unit tests for eval commands, train commands, status formatting, and model parsing.

## Why

The eval and training surfaces needed richer run metadata (progress, reward, results, config, logs) so the CLI can render fuller status detail. Splitting status groups into pending vs. active lets the UI distinguish queued/waiting work (amber) from in-flight work (blue), making `list`/`info` output more accurate. All new model fields are optional, so this is backward-compatible.

## How to Test

- `uv run pytest`
- `uv run ruff check .` and `uv run ruff format --check .`
- `uv run pyright osmosis_ai/`
- `osmosis eval info <name>` and `osmosis train info <name>` to inspect the new fields and status colors.

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enriches eval/train runs with progress, reward, and detailed results, and updates CLI status styling to distinguish pending vs. active work. Fixes pass@k rendering and clarifies `n` semantics so `osmosis eval` and `osmosis train` list/info views are more informative and consistent.

- **New Features**
  - Training models: added `current_step`, `total_steps`, `reward`; exposed in list JSON and detail with `summary.progress` and `summary.reward`.
  - Evaluation models: added `results`, `row_index`, `config`; detail includes `entrypoint`, `commit_sha`, `env_config`, `resolved_secret_scopes`, `dataset_df_stats`, `recent_logs`.
  - Lists: Train shows Reward; Eval shows avg reward and a `summary` (avg_reward, pass_rate, counts, progress).
  - Info: Eval sidebar adds progress and duration; new “Configuration” and “Results” sections (thresholds, pass@k, token counts, secret scopes, env).
  - Unified progress via `make_progress`/`format_progress`; renderer supports `orange3` style; status buckets split pending (amber) vs. active (blue); stopped/inactive render dim; training treats `unknown` as terminal.
  - Serialization includes new optional fields; tests expanded for commands, models, status formatting, and utils.

- **Bug Fixes**
  - Hardened pass@k sorting to handle mixed numeric/non-numeric keys without errors.
  - Docs clarify `n` is attempts per row; total evaluations are `limit * n` (or `sampled_rows * n`).

<sup>Written for commit 25e28fa3b32f4d8a8344e042c4c69e88509b5ae1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

