### PR TITLE
[ci] chore: update publish workflow environment to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
   publish:
     needs: [tests, check-version]
     runs-on: ubuntu-latest
-    environment: Release-secret
+    environment: PyPI
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
Changed the environment setting in the GitHub Actions publish workflow from `Release-secret` to `PyPI` to align with the new publishing strategy. This update ensures that the workflow correctly targets the PyPI environment for package distribution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update GitHub Actions publish workflow to use the `PyPI` environment instead of `Release-secret`. This aligns with our publishing strategy and ensures releases target PyPI with the correct OIDC permissions.

<sup>Written for commit 2a590868463b8ae25a3c1fd4ab534e695d89640f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

