### PR TITLE
[misc] chore: update README image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset=".github/osmosis-logo-dark.svg">
-    <source media="(prefers-color-scheme: light)" srcset=".github/osmosis-logo-light.svg">
-    <img alt="Osmosis" src=".github/osmosis-logo-light.svg" width="218">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Osmosis-AI/osmosis-sdk-python/main/.github/osmosis-logo-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Osmosis-AI/osmosis-sdk-python/main/.github/osmosis-logo-light.svg">
+    <img alt="Osmosis" src="https://raw.githubusercontent.com/Osmosis-AI/osmosis-sdk-python/main/.github/osmosis-logo-light.svg" width="218">
   </picture>
 </p>
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix broken README logo rendering in non‑GitHub contexts by replacing relative `.github` paths with absolute raw.githubusercontent.com links for dark/light sources and the fallback image.

<sup>Written for commit aed035622e9e840c27441a92aafbe40f6c6cbcc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

