### PR TITLE
[cli][rollout] feat: validate and thread dataset metadata

### DIFF
--- a/osmosis_ai/platform/cli/dataset.py
+++ b/osmosis_ai/platform/cli/dataset.py
@@ -780,6 +780,178 @@ def _check_required_columns(columns: Iterable[str]) -> list[str]:
     return []
 
 
+# ── Optional "metadata" column validation ─────────────────────────
+# Datasets may carry an optional per-row "metadata" column. Its
+# canonical form is a JSON object (dict). Users may author it as a
+# native object (JSONL/Parquet) or as a JSON-object string (CSV;
+# tolerated in JSONL). String->object normalization happens only in
+# the platform; the SDK mirrors the platform's user-error rules over
+# the sampled rows for early feedback: a cell must be a JSON object
+# without empty nested objects, per-key value types must agree across
+# rows, and the sampled objects must not all be empty ({}).
+
+METADATA_COLUMN = "metadata"
+
+
+def _metadata_is_absent(value: Any) -> bool:
+    """Return True when a metadata cell should be treated as absent.
+
+    None and empty / whitespace-only strings are all "absent" and skip
+    further shape validation.
+    """
+    if value is None:
+        return True
+    return isinstance(value, str) and not value.strip()
+
+
+def _contains_nested_empty_object(value: Any, *, is_root: bool = True) -> bool:
+    """Return whether a metadata value contains a nested empty object."""
+    if isinstance(value, dict):
+        if not value:
+            return not is_root
+        return any(
+            _contains_nested_empty_object(child, is_root=False)
+            for child in value.values()
+        )
+    if isinstance(value, list):
+        return any(
+            _contains_nested_empty_object(child, is_root=False) for child in value
+        )
+    return False
+
+
+_INT64_MIN = -(2**63)
+_INT64_MAX = 2**63 - 1
+
+
+def _contains_oversized_int(value: Any) -> bool:
+    """Return whether a metadata value contains an int beyond 64 bits.
+
+    Valid JSON, but the platform stores metadata as a parquet struct and
+    Arrow cannot hold an integer outside the int64 range.
+    """
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return not _INT64_MIN <= value <= _INT64_MAX
+    if isinstance(value, dict):
+        return any(_contains_oversized_int(child) for child in value.values())
+    if isinstance(value, list):
+        return any(_contains_oversized_int(child) for child in value)
+    return False
+
+
+def _json_type_name(value: Any) -> str:
+    if isinstance(value, bool):
+        return "bool"
+    # JSON has a single "number" type: int and float for the same key are
+    # consistent (the platform promotes them to double).
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, str):
+        return "str"
+    if isinstance(value, dict):
+        return "object"
+    if isinstance(value, list):
+        return "array"
+    return type(value).__name__
+
+
+class _MetadataCrossRowTracker:
+    """Cross-row metadata checks over the sampled rows.
+
+    Mirrors the platform normalizer's user-error rules that cannot be
+    checked per cell: per-key JSON value types must agree across rows, and
+    metadata objects must not all be empty ({}) — an all-empty column has
+    no keys and cannot be stored as a parquet struct.
+    """
+
+    def __init__(self) -> None:
+        self._types: dict[str, str] = {}
+        self._saw_empty_object = False
+        self._saw_keyed_object = False
+
+    def observe(self, value: dict, *, location: str) -> list[str]:
+        """Record one metadata object; return cross-row type errors."""
+        if value:
+            self._saw_keyed_object = True
+        else:
+            self._saw_empty_object = True
+        return self._collect(value, "$", location)
+
+    def _collect(self, value: Any, path: str, location: str) -> list[str]:
+        if value is None:
+            return []
+        current = _json_type_name(value)
+        previous = self._types.setdefault(path, current)
+        if previous != current:
+            return [
+                f"{location}: invalid metadata - value type at {path} is "
+                f"inconsistent across rows ({previous} vs {current})"
+            ]
+        errors: list[str] = []
+        if isinstance(value, dict):
+            for key, child in value.items():
+                errors.extend(self._collect(child, f"{path}.{key}", location))
+        elif isinstance(value, list):
+            for child in value:
+                errors.extend(self._collect(child, f"{path}[]", location))
+        return errors
+
+    def finish(self) -> list[str]:
+        """Return errors only determinable after all sampled rows are seen."""
+        if self._saw_empty_object and not self._saw_keyed_object:
+            return [
+                "Invalid metadata column: all sampled metadata objects are "
+                "empty ({}); they carry no keys and cannot be stored. Remove "
+                "the metadata column or add at least one key."
+            ]
+        return []
+
+
+def _check_metadata_value(
+    value: Any,
+    *,
+    location: str,
+    tracker: _MetadataCrossRowTracker | None = None,
+) -> list[str]:
+    """Validate a single metadata cell, returning errors (empty if valid).
+
+    A cell must be a dict, or a string that JSON-parses to an object (dict),
+    without empty nested objects. When a ``tracker`` is given the object is
+    also recorded for cross-row consistency checks. ``location`` is a
+    human-readable prefix such as ``"Line 3"`` or ``"Near end of file"``.
+    """
+    import json
+
+    if _metadata_is_absent(value):
+        return []
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as e:
+            return [f"{location}: invalid metadata - not valid JSON ({e})"]
+    if not isinstance(value, dict):
+        return [
+            f"{location}: invalid metadata - must be a JSON object, "
+            f"got {type(value).__name__}"
+        ]
+    if _contains_nested_empty_object(value):
+        return [
+            f"{location}: invalid metadata - contains an empty nested "
+            "object ({}), which cannot be stored. Remove that key or add "
+            "at least one nested key."
+        ]
+    if _contains_oversized_int(value):
+        return [
+            f"{location}: invalid metadata - contains an integer too large "
+            "to store (must fit in 64 bits)"
+        ]
+    if tracker is not None:
+        return tracker.observe(value, location=location)
+    return []
+
+
 def _read_tail_lines(
     file_path: Path, n: int, chunk_size: int = 1024 * 1024
 ) -> list[str]:
@@ -820,6 +992,50 @@ def _read_tail_lines(
     return lines[-n:]
 
 
+def _check_parquet_metadata_column(pf: Any) -> list[str]:
+    """Validate the optional "metadata" column of a parquet file.
+
+    A struct dtype is accepted as-is: parquet enforces one uniform struct
+    schema per column and cannot store empty structs, so the cross-row
+    user-error rules cannot be violated. A string / large_string dtype is
+    accepted only when every cell in the first batch parses to a JSON
+    object (absent cells are skipped). Any other dtype is rejected.
+    """
+    import pyarrow as pa
+
+    schema = pf.schema_arrow
+    if METADATA_COLUMN not in schema.names:
+        return []
+
+    field_type = schema.field(METADATA_COLUMN).type
+    # A struct column is already an object; an all-null column means every
+    # cell is absent. Both are accepted without per-cell inspection.
+    if pa.types.is_struct(field_type) or pa.types.is_null(field_type):
+        return []
+    if not (pa.types.is_string(field_type) or pa.types.is_large_string(field_type)):
+        return [
+            f"Invalid metadata column: must be a struct or JSON-object string, "
+            f"got dtype {field_type}"
+        ]
+
+    # String dtype: validate parseability on the first batch.
+    errors: list[str] = []
+    tracker = _MetadataCrossRowTracker()
+    for batch in pf.iter_batches(columns=[METADATA_COLUMN]):
+        for value in batch.column(0).to_pylist():
+            errors.extend(
+                _check_metadata_value(
+                    value, location="metadata column", tracker=tracker
+                )
+            )
+            if len(errors) >= 5:
+                errors.append("... (showing first 5 errors)")
+                return errors
+        break
+    errors.extend(tracker.finish())
+    return errors
+
+
 def _validate_parquet(file_path: Path) -> list[str]:
     """Validate parquet file structure and required columns."""
     try:
@@ -845,6 +1061,7 @@ def _validate_parquet(file_path: Path) -> list[str]:
                         f"Dataset too small: {pf.metadata.num_rows} rows. "
                         f"A minimum of {MIN_ROW_COUNT} rows is required."
                     )
+                errors.extend(_check_parquet_metadata_column(pf))
     except Exception as e:
         errors.append(f"Invalid parquet file: {e}")
     return errors
@@ -857,6 +1074,7 @@ def _validate_jsonl(file_path: Path) -> list[str]:
     errors = []
     columns_checked = False
     file_fully_read = False
+    tracker = _MetadataCrossRowTracker()
 
     row_count = 0
     with open(file_path, encoding="utf-8") as f:
@@ -872,6 +1090,17 @@ def _validate_jsonl(file_path: Path) -> list[str]:
                 if not columns_checked and isinstance(obj, dict):
                     errors.extend(_check_required_columns(obj.keys()))
                     columns_checked = True
+                if isinstance(obj, dict) and METADATA_COLUMN in obj:
+                    errors.extend(
+                        _check_metadata_value(
+                            obj[METADATA_COLUMN],
+                            location=f"Line {i}",
+                            tracker=tracker,
+                        )
+                    )
+                    if len(errors) >= 5:
+                        errors.append("... (showing first 5 errors)")
+                        return errors
             except json.JSONDecodeError as e:
                 errors.append(f"Line {i}: invalid JSON - {e}")
                 if len(errors) >= 5:
@@ -882,6 +1111,7 @@ def _validate_jsonl(file_path: Path) -> list[str]:
             file_fully_read = True
 
     if file_fully_read:
+        errors.extend(tracker.finish())
         if row_count < MIN_ROW_COUNT:
             errors.append(
                 f"Dataset too small: {row_count} rows. "
@@ -907,11 +1137,25 @@ def _validate_jsonl(file_path: Path) -> list[str]:
             if not columns_checked and isinstance(obj, dict):
                 errors.extend(_check_required_columns(obj.keys()))
                 columns_checked = True
+            if isinstance(obj, dict) and METADATA_COLUMN in obj:
+                errors.extend(
+                    _check_metadata_value(
+                        obj[METADATA_COLUMN],
+                        location="Near end of file",
+                        tracker=tracker,
+                    )
+                )
+                if len(errors) >= 5:
+                    errors.append("... (showing first 5 errors)")
+                    break
         except json.JSONDecodeError as e:
             errors.append(f"Near end of file: invalid JSON - {e}")
             if len(errors) >= 5:
                 errors.append("... (showing first 5 errors)")
                 break
+
+    if len(errors) < 5:
+        errors.extend(tracker.finish())
 
     if row_count < MIN_ROW_COUNT:
         total = 0
@@ -938,6 +1182,7 @@ def _validate_csv(file_path: Path) -> list[str]:
     num_cols = 0
     row_count = 0
     file_fully_read = False
+    tracker = _MetadataCrossRowTracker()
 
     try:
         with open(file_path, encoding="utf-8", newline="") as f:
@@ -948,6 +1193,9 @@ def _validate_csv(file_path: Path) -> list[str]:
 
             errors.extend(_check_required_columns(header))
             num_cols = len(header)
+            metadata_idx = (
+                header.index(METADATA_COLUMN) if METADATA_COLUMN in header else None
+            )
 
             for i, row in enumerate(reader, 2):
                 if i > 101:
@@ -956,6 +1204,16 @@ def _validate_csv(file_path: Path) -> list[str]:
                 if len(row) != num_cols:
                     errors.append(
                         f"Row {i}: expected {num_cols} columns, got {len(row)}"
+                    )
+                    if len(errors) >= 5:
+                        errors.append("... (showing first 5 errors)")
+                        return errors
+                    continue
+                if metadata_idx is not None:
+                    errors.extend(
+                        _check_metadata_value(
+                            row[metadata_idx], location=f"Row {i}", tracker=tracker
+                        )
                     )
                     if len(errors) >= 5:
                         errors.append("... (showing first 5 errors)")
@@ -970,6 +1228,7 @@ def _validate_csv(file_path: Path) -> list[str]:
         return errors
 
     if file_fully_read:
+        errors.extend(tracker.finish())
         if row_count < MIN_ROW_COUNT:
             errors.append(
                 f"Dataset too small: {row_count} rows. "
@@ -996,7 +1255,22 @@ def _validate_csv(file_path: Path) -> list[str]:
                 if len(errors) >= 5:
                     errors.append("... (showing first 5 errors)")
                     break
+                continue
+            if metadata_idx is not None:
+                errors.extend(
+                    _check_metadata_value(
+                        row[metadata_idx],
+                        location="Near end of file",
+                        tracker=tracker,
+                    )
+                )
+                if len(errors) >= 5:
+                    errors.append("... (showing first 5 errors)")
+                    break
     except csv.Error as e:
         errors.append(f"Near end of file: CSV parse error - {e}")
+
+    if len(errors) < 5:
+        errors.extend(tracker.finish())
 
     return errors

--- a/osmosis_ai/rollout/backend/harbor/agent_runner.py
+++ b/osmosis_ai/rollout/backend/harbor/agent_runner.py
@@ -57,6 +57,7 @@ async def run_workflow(
     ctx = AgentWorkflowContext(
         prompt=prompt,
         config=workflow_config,
+        metadata=config.get("metadata"),
     )
 
     meta: dict[str, Any] = {"id": config.get("id", "")}

--- a/osmosis_ai/rollout/backend/harbor/backend.py
+++ b/osmosis_ai/rollout/backend/harbor/backend.py
@@ -342,6 +342,8 @@ class HarborBackend(ExecutionBackend):
             config["grader_config"] = self.grader_config_path
         if request.label is not None:
             config["label"] = request.label
+        if request.metadata is not None:
+            config["metadata"] = request.metadata
 
         ctx = get_rollout_context()
         if ctx:

--- a/osmosis_ai/rollout/backend/harbor/grader_runner.py
+++ b/osmosis_ai/rollout/backend/harbor/grader_runner.py
@@ -48,9 +48,10 @@ def main() -> None:
     args = parse_args()
     config = load_config(args.config)
     label = config.get("label")
+    metadata = config.get("metadata")
 
-    if not label:
-        print("No label in config, skipping grading")
+    if not label and metadata is None:
+        print("No label or metadata in config, skipping grading")
         write_rewards({})
         return
 
@@ -70,7 +71,7 @@ def main() -> None:
         resolve_object(config["grader_config"]) if "grader_config" in config else None
     )
 
-    ctx = GraderContext(label=label, samples=samples)
+    ctx = GraderContext(label=label, samples=samples, metadata=metadata)
     grader = grader_cls(grader_config)
     asyncio.run(grader.grade(ctx))
 

--- a/osmosis_ai/rollout/backend/local/backend.py
+++ b/osmosis_ai/rollout/backend/local/backend.py
@@ -81,7 +81,7 @@ class LocalBackend(ExecutionBackend):
 
             if (
                 self.grader_cls
-                and request.label is not None
+                and (request.label is not None or request.metadata is not None)
                 and result.status == RolloutStatus.SUCCESS
             ):
                 graded = await self.run_grader(request, result)
@@ -94,6 +94,7 @@ class LocalBackend(ExecutionBackend):
         ctx = AgentWorkflowContext(
             prompt=request.prompt,
             config=config,
+            metadata=request.metadata,
         )
 
         rollout_ctx = get_rollout_context()
@@ -123,7 +124,11 @@ class LocalBackend(ExecutionBackend):
         if not self.grader_cls:
             return result
 
-        grader_ctx = GraderContext(label=request.label, samples=result.samples)
+        grader_ctx = GraderContext(
+            label=request.label,
+            samples=result.samples,
+            metadata=request.metadata,
+        )
         try:
             grader = self.grader_cls(self.grader_config)
             await grader.grade(grader_ctx)

--- a/osmosis_ai/rollout/context.py
+++ b/osmosis_ai/rollout/context.py
@@ -96,6 +96,7 @@ class GraderContext:
     label: str | None = None
     samples: dict[str, RolloutSample] = field(default_factory=dict)
     project_path: str | None = None
+    metadata: dict[str, Any] | None = None
 
     def get_samples(self) -> dict[str, RolloutSample]:
         return self.samples
@@ -110,14 +111,17 @@ class GraderContext:
 class AgentWorkflowContext[TConfig: AgentWorkflowConfig]:
     prompt: list[dict[str, Any]]
     config: TConfig | None = None
+    metadata: dict[str, Any] | None = None
 
     def __init__(
         self,
         prompt: list[dict[str, Any]],
         config: TConfig | None = None,
+        metadata: dict[str, Any] | None = None,
     ):
         self.prompt = prompt
         self.config = config
+        self.metadata = metadata
 
 
 @dataclass
@@ -138,6 +142,7 @@ class HarborAgentWorkflowContext[TConfig: AgentWorkflowConfig](
         prompt: list[dict[str, Any]],
         config: TConfig,
         environment: Any = None,
+        metadata: dict[str, Any] | None = None,
     ):
-        super().__init__(prompt=prompt, config=config)
+        super().__init__(prompt=prompt, config=config, metadata=metadata)
         self.environment = environment

--- a/osmosis_ai/rollout/server/app.py
+++ b/osmosis_ai/rollout/server/app.py
@@ -108,6 +108,7 @@ async def _handle_rollout(
                     id=request.rollout_id,
                     prompt=request.initial_messages,
                     label=request.label,
+                    metadata=request.metadata,
                     agent_timeout_sec=request.agent_timeout_sec,
                     grader_timeout_sec=request.grader_timeout_sec,
                 ),

--- a/osmosis_ai/rollout/types/sample.py
+++ b/osmosis_ai/rollout/types/sample.py
@@ -42,6 +42,7 @@ class ExecutionRequest(BaseModel):
     id: str
     prompt: list[MessageDict]
     label: str | None = None
+    metadata: dict[str, Any] | None = None
     agent_timeout_sec: float | None = None
     grader_timeout_sec: float | None = None
 

--- a/tests/unit/platform/cli/test_dataset_validation.py
+++ b/tests/unit/platform/cli/test_dataset_validation.py
@@ -12,7 +12,9 @@ import pytest
 
 from osmosis_ai.platform.cli.dataset import (
     PARQUET_VALIDATION_SKIPPED_WARNING,
+    _check_metadata_value,
     _check_required_columns,
+    _metadata_is_absent,
     _read_tail_lines,
     _validate_csv,
     _validate_file_with_warnings,
@@ -377,3 +379,480 @@ class TestValidateParquet:
         f.write_bytes(b"not a parquet file")
         errors = _validate_parquet(f)
         assert any("Invalid parquet file" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Optional "metadata" column helpers
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataHelpers:
+    def test_absent_none(self):
+        assert _metadata_is_absent(None) is True
+
+    def test_absent_empty_string(self):
+        assert _metadata_is_absent("") is True
+
+    def test_absent_whitespace_string(self):
+        assert _metadata_is_absent("   ") is True
+
+    def test_not_absent_dict(self):
+        assert _metadata_is_absent({"a": 1}) is False
+
+    def test_not_absent_nonempty_string(self):
+        assert _metadata_is_absent('{"a": 1}') is False
+
+    def test_dict_passes(self):
+        assert _check_metadata_value({"tools": ["x"]}, location="Line 1") == []
+
+    def test_object_string_passes(self):
+        assert _check_metadata_value('{"tools": ["x"]}', location="Line 1") == []
+
+    def test_absent_passes(self):
+        assert _check_metadata_value(None, location="Line 1") == []
+        assert _check_metadata_value("", location="Line 1") == []
+
+    def test_number_rejected(self):
+        errors = _check_metadata_value(3, location="Line 1")
+        assert len(errors) == 1
+        assert "invalid metadata" in errors[0]
+
+    def test_array_rejected(self):
+        errors = _check_metadata_value([1, 2], location="Line 1")
+        assert len(errors) == 1
+        assert "invalid metadata" in errors[0]
+
+    def test_json_array_string_rejected(self):
+        errors = _check_metadata_value("[1, 2]", location="Line 1")
+        assert len(errors) == 1
+        assert "JSON object" in errors[0]
+
+    def test_garbage_string_rejected(self):
+        errors = _check_metadata_value("not json{{", location="Line 1")
+        assert len(errors) == 1
+        assert "not valid JSON" in errors[0]
+
+    def test_root_empty_object_passes_per_cell(self):
+        # {} mixed with keyed objects is valid; only an all-empty column is
+        # rejected, which is a cross-row check (see TestMetadataCrossRow).
+        assert _check_metadata_value({}, location="Line 1") == []
+        assert _check_metadata_value("{}", location="Line 1") == []
+
+    def test_nested_empty_object_rejected(self):
+        errors = _check_metadata_value({"a": {}}, location="Line 1")
+        assert len(errors) == 1
+        assert "empty nested object" in errors[0]
+
+    def test_nested_empty_object_string_rejected(self):
+        errors = _check_metadata_value('{"a": {}}', location="Line 1")
+        assert len(errors) == 1
+        assert "empty nested object" in errors[0]
+
+    def test_nested_empty_object_in_list_rejected(self):
+        errors = _check_metadata_value({"items": [{}]}, location="Line 1")
+        assert len(errors) == 1
+        assert "empty nested object" in errors[0]
+
+    def test_oversized_int_rejected(self):
+        # Valid JSON, but Arrow cannot store an int beyond 64 bits.
+        errors = _check_metadata_value({"big": 2**100}, location="Line 1")
+        assert len(errors) == 1
+        assert "too large" in errors[0]
+
+    def test_oversized_int_in_string_rejected(self):
+        errors = _check_metadata_value(
+            '{"big": 99999999999999999999999999999999}', location="Line 1"
+        )
+        assert len(errors) == 1
+        assert "too large" in errors[0]
+
+    def test_int64_boundary_accepted(self):
+        value = {"max": 2**63 - 1, "min": -(2**63)}
+        assert _check_metadata_value(value, location="Line 1") == []
+
+
+# ---------------------------------------------------------------------------
+# Metadata validation: JSONL
+# ---------------------------------------------------------------------------
+
+
+def _base_row() -> dict:
+    return {"system_prompt": "s", "user_prompt": "u", "ground_truth": "g"}
+
+
+class TestMetadataJsonl:
+    def test_object_metadata_accepted(self, tmp_path: Path):
+        rows = [{**_base_row(), "metadata": {"k": "v"}} for _ in range(5)]
+        f = _make_jsonl(tmp_path / "obj.jsonl", rows)
+        assert _validate_jsonl(f) == []
+
+    def test_object_string_metadata_accepted(self, tmp_path: Path):
+        rows = [{**_base_row(), "metadata": '{"k": "v"}'} for _ in range(5)]
+        f = _make_jsonl(tmp_path / "str.jsonl", rows)
+        assert _validate_jsonl(f) == []
+
+    def test_absent_metadata_accepted(self, tmp_path: Path):
+        rows = [{**_base_row(), "metadata": None} for _ in range(5)]
+        rows.extend(_base_row() for _ in range(5))  # column missing entirely
+        f = _make_jsonl(tmp_path / "absent.jsonl", rows)
+        assert _validate_jsonl(f) == []
+
+    def test_number_metadata_rejected(self, tmp_path: Path):
+        rows = [{**_base_row(), "metadata": 3} for _ in range(5)]
+        f = _make_jsonl(tmp_path / "num.jsonl", rows)
+        errors = _validate_jsonl(f)
+        assert any("invalid metadata" in e for e in errors)
+
+    def test_array_metadata_rejected(self, tmp_path: Path):
+        rows = [{**_base_row(), "metadata": [1, 2]} for _ in range(5)]
+        f = _make_jsonl(tmp_path / "arr.jsonl", rows)
+        errors = _validate_jsonl(f)
+        assert any("invalid metadata" in e for e in errors)
+
+    def test_json_array_string_metadata_rejected(self, tmp_path: Path):
+        rows = [{**_base_row(), "metadata": "[1, 2]"} for _ in range(5)]
+        f = _make_jsonl(tmp_path / "arr_str.jsonl", rows)
+        errors = _validate_jsonl(f)
+        assert any("JSON object" in e for e in errors)
+
+    def test_garbage_string_metadata_rejected(self, tmp_path: Path):
+        rows = [{**_base_row(), "metadata": "garbage{{"} for _ in range(5)]
+        f = _make_jsonl(tmp_path / "garbage.jsonl", rows)
+        errors = _validate_jsonl(f)
+        assert any("not valid JSON" in e for e in errors)
+
+    def test_metadata_tail_validation(self, tmp_path: Path):
+        f = tmp_path / "tail.jsonl"
+        good = json.dumps({**_base_row(), "metadata": {"k": "v"}})
+        lines = [good] * 200
+        lines[-1] = json.dumps({**_base_row(), "metadata": 3})
+        f.write_text("\n".join(lines) + "\n")
+        errors = _validate_jsonl(f)
+        assert any("invalid metadata" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Metadata validation: cross-row rules (mirror the platform normalizer)
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataCrossRow:
+    def test_jsonl_all_empty_objects_rejected(self, tmp_path: Path):
+        rows = [{**_base_row(), "metadata": {}} for _ in range(5)]
+        f = _make_jsonl(tmp_path / "all_empty.jsonl", rows)
+        errors = _validate_jsonl(f)
+        assert any("all sampled metadata objects are empty" in e for e in errors)
+
+    def test_jsonl_all_empty_object_strings_rejected(self, tmp_path: Path):
+        rows = [{**_base_row(), "metadata": "{}"} for _ in range(5)]
+        f = _make_jsonl(tmp_path / "all_empty_str.jsonl", rows)
+        errors = _validate_jsonl(f)
+        assert any("all sampled metadata objects are empty" in e for e in errors)
+
+    def test_jsonl_empty_mixed_with_keyed_accepted(self, tmp_path: Path):
+        # The platform only rejects a column whose non-null cells are ALL empty.
+        rows = [{**_base_row(), "metadata": {}} for _ in range(3)]
+        rows.extend({**_base_row(), "metadata": {"k": "v"}} for _ in range(3))
+        f = _make_jsonl(tmp_path / "mixed_empty.jsonl", rows)
+        assert _validate_jsonl(f) == []
+
+    def test_jsonl_nested_empty_object_rejected(self, tmp_path: Path):
+        rows = [{**_base_row(), "metadata": {"a": {}}} for _ in range(5)]
+        f = _make_jsonl(tmp_path / "nested_empty.jsonl", rows)
+        errors = _validate_jsonl(f)
+        assert any("empty nested object" in e for e in errors)
+
+    def test_jsonl_inconsistent_value_types_rejected(self, tmp_path: Path):
+        rows = [
+            {**_base_row(), "metadata": {"k": 1}},
+            {**_base_row(), "metadata": {"k": "x"}},
+        ]
+        rows.extend({**_base_row(), "metadata": {"k": 2}} for _ in range(3))
+        f = _make_jsonl(tmp_path / "mixed_types.jsonl", rows)
+        errors = _validate_jsonl(f)
+        assert any("inconsistent across rows" in e and "$.k" in e for e in errors)
+
+    def test_jsonl_int_and_float_are_consistent(self, tmp_path: Path):
+        # JSON has one "number" type; the platform promotes int+float to double.
+        rows = [
+            {**_base_row(), "metadata": {"k": 1}},
+            {**_base_row(), "metadata": {"k": 1.5}},
+        ]
+        rows.extend({**_base_row(), "metadata": {"k": 2}} for _ in range(3))
+        f = _make_jsonl(tmp_path / "num_mix.jsonl", rows)
+        assert _validate_jsonl(f) == []
+
+    def test_jsonl_bool_vs_number_rejected(self, tmp_path: Path):
+        rows = [
+            {**_base_row(), "metadata": {"k": True}},
+            {**_base_row(), "metadata": {"k": 1}},
+        ]
+        f = _make_jsonl(tmp_path / "bool_num.jsonl", rows)
+        errors = _validate_jsonl(f)
+        assert any("inconsistent across rows" in e for e in errors)
+
+    def test_jsonl_nested_type_mismatch_rejected(self, tmp_path: Path):
+        rows = [
+            {**_base_row(), "metadata": {"outer": {"k": 1}}},
+            {**_base_row(), "metadata": {"outer": {"k": [1]}}},
+        ]
+        f = _make_jsonl(tmp_path / "nested_types.jsonl", rows)
+        errors = _validate_jsonl(f)
+        assert any("$.outer.k" in e for e in errors)
+
+    def test_jsonl_type_mismatch_across_head_and_tail(self, tmp_path: Path):
+        # The tracker spans head and tail samples of large files.
+        f = tmp_path / "head_tail_types.jsonl"
+        head = json.dumps({**_base_row(), "metadata": {"k": 1}})
+        tail = json.dumps({**_base_row(), "metadata": {"k": "x"}})
+        f.write_text("\n".join([head] * 150 + [tail]) + "\n")
+        errors = _validate_jsonl(f)
+        assert any("inconsistent across rows" in e for e in errors)
+
+    def test_csv_all_empty_object_strings_rejected(self, tmp_path: Path):
+        f = tmp_path / "all_empty.csv"
+        header = "system_prompt,user_prompt,ground_truth,metadata"
+        row = "s,u,g,{}"
+        f.write_text("\n".join([header] + [row] * 5) + "\n")
+        errors = _validate_csv(f)
+        assert any("all sampled metadata objects are empty" in e for e in errors)
+
+    def test_csv_inconsistent_value_types_rejected(self, tmp_path: Path):
+        f = tmp_path / "mixed_types.csv"
+        header = "system_prompt,user_prompt,ground_truth,metadata"
+        rows = ['s,u,g,"{""k"": 1}"', 's,u,g,"{""k"": ""x""}"']
+        f.write_text("\n".join([header, *rows]) + "\n")
+        errors = _validate_csv(f)
+        assert any("inconsistent across rows" in e for e in errors)
+
+    def test_csv_nested_empty_object_rejected(self, tmp_path: Path):
+        f = tmp_path / "nested_empty.csv"
+        header = "system_prompt,user_prompt,ground_truth,metadata"
+        row = 's,u,g,"{""a"": {}}"'
+        f.write_text("\n".join([header] + [row] * 5) + "\n")
+        errors = _validate_csv(f)
+        assert any("empty nested object" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Metadata validation: CSV
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataCsv:
+    def _header(self) -> str:
+        return "system_prompt,user_prompt,ground_truth,metadata"
+
+    def test_object_string_metadata_accepted(self, tmp_path: Path):
+        f = tmp_path / "ok.csv"
+        row = 's,u,g,"{""k"": ""v""}"'
+        f.write_text("\n".join([self._header()] + [row] * 5) + "\n")
+        assert _validate_csv(f) == []
+
+    def test_absent_metadata_accepted(self, tmp_path: Path):
+        f = tmp_path / "absent.csv"
+        row = "s,u,g,"
+        f.write_text("\n".join([self._header()] + [row] * 5) + "\n")
+        assert _validate_csv(f) == []
+
+    def test_json_array_string_metadata_rejected(self, tmp_path: Path):
+        f = tmp_path / "arr.csv"
+        row = 's,u,g,"[1, 2]"'
+        f.write_text("\n".join([self._header()] + [row] * 5) + "\n")
+        errors = _validate_csv(f)
+        assert any("JSON object" in e for e in errors)
+
+    def test_garbage_string_metadata_rejected(self, tmp_path: Path):
+        f = tmp_path / "garbage.csv"
+        row = "s,u,g,garbage{{"
+        f.write_text("\n".join([self._header()] + [row] * 5) + "\n")
+        errors = _validate_csv(f)
+        assert any("not valid JSON" in e for e in errors)
+
+    def test_metadata_tail_validation(self, tmp_path: Path):
+        f = tmp_path / "tail.csv"
+        good = 's,u,g,"{""k"": ""v""}"'
+        bad = "s,u,g,garbage{{"
+        lines = [self._header()] + [good] * 200
+        lines[-1] = bad
+        f.write_text("\n".join(lines) + "\n")
+        errors = _validate_csv(f)
+        assert any("Near end of file" in e and "metadata" in e for e in errors)
+
+    def test_no_metadata_column_ok(self, tmp_path: Path):
+        f = tmp_path / "no_meta.csv"
+        header = "system_prompt,user_prompt,ground_truth"
+        f.write_text("\n".join([header] + ["s,u,g"] * 5) + "\n")
+        assert _validate_csv(f) == []
+
+
+# ---------------------------------------------------------------------------
+# Metadata validation: Parquet
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataParquet:
+    @pytest.fixture()
+    def _has_pyarrow(self):
+        pytest.importorskip("pyarrow")
+
+    @pytest.mark.usefixtures("_has_pyarrow")
+    def test_struct_dtype_accepted(self, tmp_path: Path):
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        table = pa.table(
+            {
+                "system_prompt": ["s"] * 5,
+                "user_prompt": ["u"] * 5,
+                "ground_truth": ["g"] * 5,
+                "metadata": [{"k": "v"}] * 5,
+            }
+        )
+        f = tmp_path / "struct.parquet"
+        pq.write_table(table, f)
+        assert _validate_parquet(f) == []
+
+    @pytest.mark.usefixtures("_has_pyarrow")
+    def test_object_string_dtype_accepted(self, tmp_path: Path):
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        table = pa.table(
+            {
+                "system_prompt": ["s"] * 5,
+                "user_prompt": ["u"] * 5,
+                "ground_truth": ["g"] * 5,
+                "metadata": ['{"k": "v"}'] * 5,
+            }
+        )
+        f = tmp_path / "str.parquet"
+        pq.write_table(table, f)
+        assert _validate_parquet(f) == []
+
+    @pytest.mark.usefixtures("_has_pyarrow")
+    def test_absent_string_metadata_accepted(self, tmp_path: Path):
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        # String-typed column with absent (null) cells: parseability check
+        # skips absent cells, so the column passes.
+        table = pa.table(
+            {
+                "system_prompt": ["s"] * 5,
+                "user_prompt": ["u"] * 5,
+                "ground_truth": ["g"] * 5,
+                "metadata": pa.array([None] * 5, type=pa.string()),
+            }
+        )
+        f = tmp_path / "absent.parquet"
+        pq.write_table(table, f)
+        assert _validate_parquet(f) == []
+
+    @pytest.mark.usefixtures("_has_pyarrow")
+    def test_null_dtype_metadata_accepted(self, tmp_path: Path):
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        # An all-null metadata column (null dtype) means every cell is absent.
+        table = pa.table(
+            {
+                "system_prompt": ["s"] * 5,
+                "user_prompt": ["u"] * 5,
+                "ground_truth": ["g"] * 5,
+                "metadata": pa.array([None] * 5, type=pa.null()),
+            }
+        )
+        f = tmp_path / "null.parquet"
+        pq.write_table(table, f)
+        assert _validate_parquet(f) == []
+
+    @pytest.mark.usefixtures("_has_pyarrow")
+    def test_int_dtype_rejected(self, tmp_path: Path):
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        table = pa.table(
+            {
+                "system_prompt": ["s"] * 5,
+                "user_prompt": ["u"] * 5,
+                "ground_truth": ["g"] * 5,
+                "metadata": [1, 2, 3, 4, 5],
+            }
+        )
+        f = tmp_path / "int.parquet"
+        pq.write_table(table, f)
+        errors = _validate_parquet(f)
+        assert any("Invalid metadata column" in e for e in errors)
+
+    @pytest.mark.usefixtures("_has_pyarrow")
+    def test_json_array_string_dtype_rejected(self, tmp_path: Path):
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        table = pa.table(
+            {
+                "system_prompt": ["s"] * 5,
+                "user_prompt": ["u"] * 5,
+                "ground_truth": ["g"] * 5,
+                "metadata": ["[1, 2]"] * 5,
+            }
+        )
+        f = tmp_path / "arr_str.parquet"
+        pq.write_table(table, f)
+        errors = _validate_parquet(f)
+        assert any("JSON object" in e for e in errors)
+
+    @pytest.mark.usefixtures("_has_pyarrow")
+    def test_all_empty_object_strings_rejected(self, tmp_path: Path):
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        table = pa.table(
+            {
+                "system_prompt": ["s"] * 5,
+                "user_prompt": ["u"] * 5,
+                "ground_truth": ["g"] * 5,
+                "metadata": ["{}"] * 5,
+            }
+        )
+        f = tmp_path / "all_empty.parquet"
+        pq.write_table(table, f)
+        errors = _validate_parquet(f)
+        assert any("all sampled metadata objects are empty" in e for e in errors)
+
+    @pytest.mark.usefixtures("_has_pyarrow")
+    def test_inconsistent_value_types_rejected(self, tmp_path: Path):
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        table = pa.table(
+            {
+                "system_prompt": ["s"] * 2,
+                "user_prompt": ["u"] * 2,
+                "ground_truth": ["g"] * 2,
+                "metadata": ['{"k": 1}', '{"k": "x"}'],
+            }
+        )
+        f = tmp_path / "mixed_types.parquet"
+        pq.write_table(table, f)
+        errors = _validate_parquet(f)
+        assert any("inconsistent across rows" in e for e in errors)
+
+    @pytest.mark.usefixtures("_has_pyarrow")
+    def test_nested_empty_object_string_rejected(self, tmp_path: Path):
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        table = pa.table(
+            {
+                "system_prompt": ["s"] * 5,
+                "user_prompt": ["u"] * 5,
+                "ground_truth": ["g"] * 5,
+                "metadata": ['{"a": {}}'] * 5,
+            }
+        )
+        f = tmp_path / "nested_empty.parquet"
+        pq.write_table(table, f)
+        errors = _validate_parquet(f)
+        assert any("empty nested object" in e for e in errors)

--- a/tests/unit/rollout/test_context.py
+++ b/tests/unit/rollout/test_context.py
@@ -132,6 +132,15 @@ class TestGraderContext:
         with pytest.raises(ValueError, match="Sample unknown not found"):
             ctx.set_sample_reward("unknown", 1.0)
 
+    def test_metadata_defaults_none(self):
+        ctx = GraderContext(samples={})
+        assert ctx.metadata is None
+
+    def test_metadata_carried(self):
+        metadata = {"tools": ["search"], "difficulty": 3}
+        ctx = GraderContext(samples={}, metadata=metadata)
+        assert ctx.metadata == metadata
+
 
 # ---------------------------------------------------------------------------
 # AgentWorkflowContext / HarborAgentWorkflowContext
@@ -152,6 +161,17 @@ class TestAgentWorkflowContext:
         )
         assert ctx.config is cfg
 
+    def test_metadata_defaults_none(self):
+        ctx = AgentWorkflowContext(prompt=[{"role": "user", "content": "hi"}])
+        assert ctx.metadata is None
+
+    def test_metadata_carried(self):
+        metadata = {"tools": ["search"]}
+        ctx = AgentWorkflowContext(
+            prompt=[{"role": "user", "content": "hi"}], metadata=metadata
+        )
+        assert ctx.metadata == metadata
+
 
 class TestHarborAgentWorkflowContext:
     def test_with_environment(self):
@@ -164,3 +184,29 @@ class TestHarborAgentWorkflowContext:
         )
         assert ctx.environment is env
         assert ctx.config is cfg
+
+    def test_positional_call_pattern_still_works(self):
+        """Existing positional call sites (prompt, config, environment) keep working."""
+        env = MagicMock()
+        cfg = AgentWorkflowConfig(name="harbor-test")
+        ctx = HarborAgentWorkflowContext(
+            [{"role": "user", "content": "hi"}],
+            cfg,
+            env,
+        )
+        assert ctx.environment is env
+        assert ctx.config is cfg
+        assert ctx.metadata is None
+
+    def test_metadata_threaded_through_super_init(self):
+        env = MagicMock()
+        cfg = AgentWorkflowConfig(name="harbor-test")
+        metadata = {"tools": ["search"], "difficulty": 3}
+        ctx = HarborAgentWorkflowContext(
+            prompt=[{"role": "user", "content": "hi"}],
+            config=cfg,
+            environment=env,
+            metadata=metadata,
+        )
+        assert ctx.metadata == metadata
+        assert ctx.environment is env

--- a/tests/unit/rollout/test_harbor_backend.py
+++ b/tests/unit/rollout/test_harbor_backend.py
@@ -1,13 +1,74 @@
+import json
 import logging
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock
 
+from osmosis_ai.rollout.agent_workflow import AgentWorkflow
 from osmosis_ai.rollout.backend.harbor.backend import HarborBackend, PendingTrial
+from osmosis_ai.rollout.context import (
+    AgentWorkflowContext,
+    GraderContext,
+    SampleSource,
+)
+from osmosis_ai.rollout.grader import Grader
 from osmosis_ai.rollout.types import (
+    ExecutionRequest,
     RolloutErrorCategory,
     RolloutSample,
     RolloutStatus,
 )
+
+# Module-level captures so importlib can resolve the workflow/grader by
+# "<module>:<qualname>" and round-trip them through the runners.
+_AGENT_CAPTURE: dict[str, Any] = {}
+_GRADER_CAPTURE: dict[str, Any] = {}
+
+
+class _StaticSampleSource(SampleSource):
+    def __init__(self, messages: list[dict[str, Any]]) -> None:
+        self.messages = messages
+
+    async def get_sample(self, name: str) -> RolloutSample:
+        return RolloutSample(id=name, messages=self.messages)
+
+
+class MetadataCapturingWorkflow(AgentWorkflow):
+    async def run(self, ctx: AgentWorkflowContext) -> Any:
+        from osmosis_ai.rollout.context import get_rollout_context
+
+        _AGENT_CAPTURE["metadata"] = ctx.metadata
+        rollout_ctx = get_rollout_context()
+        if rollout_ctx:
+            rollout_ctx.register_sample_source(
+                "sample-1",
+                _StaticSampleSource([{"role": "assistant", "content": "done"}]),
+            )
+
+
+class MetadataCapturingGrader(Grader):
+    async def grade(self, ctx: GraderContext) -> Any:
+        _GRADER_CAPTURE["metadata"] = ctx.metadata
+        _GRADER_CAPTURE["label"] = ctx.label
+        for sample_id in ctx.get_samples():
+            ctx.set_sample_reward(sample_id, 1.0)
+
+
+def _make_backend_for_config(*, grader: bool = False) -> HarborBackend:
+    """Build a HarborBackend skeleton sufficient for build_rollout_config."""
+    backend = HarborBackend.__new__(HarborBackend)
+    backend.workflow_path = (
+        f"{MetadataCapturingWorkflow.__module__}:"
+        f"{MetadataCapturingWorkflow.__qualname__}"
+    )
+    backend.workflow_config_path = None
+    backend.grader_path = (
+        f"{MetadataCapturingGrader.__module__}:{MetadataCapturingGrader.__qualname__}"
+        if grader
+        else None
+    )
+    backend.grader_config_path = None
+    return backend
 
 
 class TestHarborBackend:
@@ -52,3 +113,126 @@ class TestHarborBackend:
         assert result.status == RolloutStatus.FAILURE
         assert result.err_category == RolloutErrorCategory.VALIDATION_ERROR
         assert "Harbor verifier returned empty rewards for rollout r1" in caplog.text
+
+
+class TestBuildRolloutConfigMetadata:
+    def test_metadata_written_when_present(self):
+        backend = _make_backend_for_config()
+        request = ExecutionRequest(
+            id="r1",
+            prompt=[{"role": "user", "content": "hi"}],
+            metadata={"tools": ["search"], "difficulty": 3},
+        )
+        config = backend.build_rollout_config(request)
+        assert config["metadata"] == {"tools": ["search"], "difficulty": 3}
+
+    def test_metadata_omitted_when_none(self):
+        backend = _make_backend_for_config()
+        request = ExecutionRequest(
+            id="r1",
+            prompt=[{"role": "user", "content": "hi"}],
+            metadata=None,
+        )
+        config = backend.build_rollout_config(request)
+        assert "metadata" not in config
+
+
+class TestAgentRunnerRoundTrip:
+    async def test_metadata_surfaces_on_ctx(self, tmp_path, monkeypatch):
+        import osmosis_ai.rollout.backend.harbor.agent_runner as agent_runner
+
+        _AGENT_CAPTURE.clear()
+        monkeypatch.setattr(agent_runner, "AGENT_LOGS_DIR", tmp_path)
+
+        backend = _make_backend_for_config()
+        metadata = {"tools": ["search"], "difficulty": 3}
+        request = ExecutionRequest(
+            id="r1",
+            prompt=[{"role": "user", "content": "hi"}],
+            metadata=metadata,
+        )
+
+        # Round-trip the config through JSON, as the on-disk file would.
+        raw = json.dumps(backend.build_rollout_config(request), default=str)
+        config = json.loads(raw)
+        prompt = json.loads(json.dumps(request.prompt, default=str))
+
+        meta = await agent_runner.run_workflow(config, prompt)
+
+        assert meta["status"] == "success"
+        assert _AGENT_CAPTURE["metadata"] == metadata
+
+
+class TestGraderRunnerRoundTrip:
+    def _write_samples(self, path):
+        sample = RolloutSample(id="sample-1", messages=[])
+        path.write_text(json.dumps({"sample-1": sample.model_dump()}, default=str))
+
+    def test_grader_ctx_receives_metadata(self, tmp_path, monkeypatch):
+        import osmosis_ai.rollout.backend.harbor.grader_runner as grader_runner
+
+        _GRADER_CAPTURE.clear()
+        verifier_dir = tmp_path / "verifier"
+        monkeypatch.setattr(grader_runner, "VERIFIER_LOGS_DIR", verifier_dir)
+
+        backend = _make_backend_for_config(grader=True)
+        metadata = {"tools": ["search"]}
+        request = ExecutionRequest(
+            id="r1",
+            prompt=[{"role": "user", "content": "hi"}],
+            label="test-label",
+            metadata=metadata,
+        )
+        config_path = tmp_path / "rollout_config.json"
+        config_path.write_text(
+            json.dumps(backend.build_rollout_config(request), default=str)
+        )
+        samples_path = tmp_path / "samples.json"
+        self._write_samples(samples_path)
+
+        monkeypatch.setattr(
+            grader_runner,
+            "parse_args",
+            lambda: SimpleNamespace(config=config_path, samples=samples_path),
+        )
+
+        grader_runner.main()
+
+        assert _GRADER_CAPTURE["metadata"] == metadata
+        rewards = json.loads((verifier_dir / "reward.json").read_text())
+        assert rewards == {"sample-1": 1.0}
+
+    def test_metadata_only_config_still_grades(self, tmp_path, monkeypatch):
+        """A config with metadata but no label still triggers grading."""
+        import osmosis_ai.rollout.backend.harbor.grader_runner as grader_runner
+
+        _GRADER_CAPTURE.clear()
+        verifier_dir = tmp_path / "verifier"
+        monkeypatch.setattr(grader_runner, "VERIFIER_LOGS_DIR", verifier_dir)
+
+        backend = _make_backend_for_config(grader=True)
+        request = ExecutionRequest(
+            id="r1",
+            prompt=[{"role": "user", "content": "hi"}],
+            label=None,
+            metadata={"tools": ["search"]},
+        )
+        config_path = tmp_path / "rollout_config.json"
+        config_path.write_text(
+            json.dumps(backend.build_rollout_config(request), default=str)
+        )
+        samples_path = tmp_path / "samples.json"
+        self._write_samples(samples_path)
+
+        monkeypatch.setattr(
+            grader_runner,
+            "parse_args",
+            lambda: SimpleNamespace(config=config_path, samples=samples_path),
+        )
+
+        grader_runner.main()
+
+        assert _GRADER_CAPTURE["label"] is None
+        assert _GRADER_CAPTURE["metadata"] == {"tools": ["search"]}
+        rewards = json.loads((verifier_dir / "reward.json").read_text())
+        assert rewards == {"sample-1": 1.0}

--- a/tests/unit/rollout/test_local_backend.py
+++ b/tests/unit/rollout/test_local_backend.py
@@ -197,6 +197,108 @@ class TestLocalBackend:
         grader_result = on_grader.call_args[0][0]
         assert grader_result.status == RolloutStatus.FAILURE
 
+    async def test_grader_runs_with_metadata_only(self):
+        """A metadata-only row (no label) still triggers grading."""
+        backend = LocalBackend(
+            workflow=StubWorkflow,
+            workflow_config=AgentWorkflowConfig(name="test"),
+            grader=StubGrader,
+            grader_config=GraderConfig(name="test-grader"),
+        )
+        on_complete = AsyncMock()
+        on_grader = AsyncMock()
+
+        request = ExecutionRequest(
+            id="r1",
+            prompt=[{"role": "user", "content": "hi"}],
+            label=None,
+            metadata={"tools": ["search"]},
+        )
+        await backend.execute(
+            request,
+            on_workflow_complete=on_complete,
+            on_grader_complete=on_grader,
+        )
+
+        on_grader.assert_awaited_once()
+        grader_result = on_grader.call_args[0][0]
+        assert grader_result.status == RolloutStatus.SUCCESS
+        for sample in grader_result.samples.values():
+            assert sample.reward == 1.0
+
+    async def test_grader_runs_with_label_only(self):
+        """A label-only row (no metadata) still triggers grading."""
+        backend = LocalBackend(
+            workflow=StubWorkflow,
+            workflow_config=AgentWorkflowConfig(name="test"),
+            grader=StubGrader,
+            grader_config=GraderConfig(name="test-grader"),
+        )
+        on_complete = AsyncMock()
+        on_grader = AsyncMock()
+
+        request = ExecutionRequest(
+            id="r1",
+            prompt=[{"role": "user", "content": "hi"}],
+            label="test-label",
+            metadata=None,
+        )
+        await backend.execute(
+            request,
+            on_workflow_complete=on_complete,
+            on_grader_complete=on_grader,
+        )
+
+        on_grader.assert_awaited_once()
+        grader_result = on_grader.call_args[0][0]
+        assert grader_result.status == RolloutStatus.SUCCESS
+
+    async def test_metadata_reaches_both_contexts(self):
+        """Both the workflow ctx and grader ctx receive the request metadata."""
+        captured: dict[str, Any] = {}
+        metadata = {"tools": ["search"], "difficulty": 3}
+
+        class CapturingWorkflow(AgentWorkflow):
+            async def run(self, ctx: AgentWorkflowContext) -> Any:
+                from osmosis_ai.rollout.context import get_rollout_context
+
+                captured["workflow_metadata"] = ctx.metadata
+                rollout_ctx = get_rollout_context()
+                if rollout_ctx:
+                    rollout_ctx.register_sample_source(
+                        "sample-1",
+                        StaticSampleSource([{"role": "assistant", "content": "done"}]),
+                    )
+
+        class CapturingGrader(Grader):
+            async def grade(self, ctx: GraderContext) -> Any:
+                captured["grader_metadata"] = ctx.metadata
+                for sample_id in ctx.get_samples():
+                    ctx.set_sample_reward(sample_id, 1.0)
+
+        backend = LocalBackend(
+            workflow=CapturingWorkflow,
+            workflow_config=AgentWorkflowConfig(name="test"),
+            grader=CapturingGrader,
+            grader_config=GraderConfig(name="test-grader"),
+        )
+        on_complete = AsyncMock()
+        on_grader = AsyncMock()
+
+        request = ExecutionRequest(
+            id="r1",
+            prompt=[{"role": "user", "content": "hi"}],
+            metadata=metadata,
+        )
+        await backend.execute(
+            request,
+            on_workflow_complete=on_complete,
+            on_grader_complete=on_grader,
+        )
+
+        assert captured["workflow_metadata"] == metadata
+        assert captured["grader_metadata"] == metadata
+
     async def test_grader_failure_returns_error_result(self):
         backend = LocalBackend(
             workflow=StubWorkflow,

--- a/tests/unit/rollout/test_server_app_metadata.py
+++ b/tests/unit/rollout/test_server_app_metadata.py
@@ -1,0 +1,98 @@
+"""Tests that _handle_rollout threads metadata into ExecutionRequest."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from osmosis_ai.rollout.backend.base import ExecutionBackend, ResultCallback
+from osmosis_ai.rollout.server import app as app_module
+from osmosis_ai.rollout.server.app import _handle_rollout
+from osmosis_ai.rollout.types import (
+    ExecutionRequest,
+    ExecutionResult,
+    RolloutInitRequest,
+    RolloutStatus,
+)
+
+
+class CapturingBackend(ExecutionBackend):
+    """Records the ExecutionRequest it receives without running anything."""
+
+    def __init__(self) -> None:
+        self.request: ExecutionRequest | None = None
+
+    async def execute(
+        self,
+        request: ExecutionRequest,
+        on_workflow_complete: ResultCallback,
+        on_grader_complete: ResultCallback | None = None,
+    ) -> None:
+        self.request = request
+
+
+def _make_init_request(metadata: dict[str, Any] | None) -> RolloutInitRequest:
+    return RolloutInitRequest(
+        rollout_id="r1",
+        initial_messages=[{"role": "user", "content": "hi"}],
+        label="test-label",
+        metadata=metadata,
+        chat_completions_url="http://llm",
+        completion_callback_url="http://controller/complete",
+    )
+
+
+class TestHandleRolloutMetadata:
+    async def test_metadata_dict_threaded(self, monkeypatch):
+        # No callbacks fire from CapturingBackend, but stub HTTP to be safe.
+        async def _fail(*_args, **_kwargs):  # pragma: no cover - defensive
+            raise AssertionError("post_json_with_retry should not be called")
+
+        monkeypatch.setattr(app_module, "post_json_with_retry", _fail)
+
+        backend = CapturingBackend()
+        metadata = {"tools": ["search"], "difficulty": 3}
+        await _handle_rollout(backend, _make_init_request(metadata))
+
+        assert backend.request is not None
+        assert backend.request.metadata == metadata
+
+    async def test_metadata_none_threaded(self, monkeypatch):
+        async def _fail(*_args, **_kwargs):  # pragma: no cover - defensive
+            raise AssertionError("post_json_with_retry should not be called")
+
+        monkeypatch.setattr(app_module, "post_json_with_retry", _fail)
+
+        backend = CapturingBackend()
+        await _handle_rollout(backend, _make_init_request(None))
+
+        assert backend.request is not None
+        assert backend.request.metadata is None
+
+    async def test_failure_path_posts_error_callback(self, monkeypatch):
+        """If the backend raises, metadata still does not break the error path."""
+        posted: list[str] = []
+
+        async def _record(*, url, payload, headers):
+            posted.append(url)
+
+            class _Resp:
+                status_code = 200
+
+            return _Resp()
+
+        monkeypatch.setattr(app_module, "post_json_with_retry", _record)
+
+        class FailingBackend(ExecutionBackend):
+            async def execute(
+                self, request, on_workflow_complete, on_grader_complete=None
+            ):
+                raise RuntimeError("boom")
+
+        await _handle_rollout(FailingBackend(), _make_init_request({"k": "v"}))
+        assert "http://controller/complete" in posted
+
+
+def test_capturing_backend_smoke():
+    """ExecutionResult import is exercised to keep the contract obvious."""
+    result = ExecutionResult(status=RolloutStatus.SUCCESS)
+    assert result.status == RolloutStatus.SUCCESS


### PR DESCRIPTION
## What

- Validate optional dataset `metadata` columns for CSV, JSONL, and Parquet inputs.
- Mirror platform metadata rules for JSON-object shape, empty nested objects, all-empty object columns, cross-row type consistency, and oversized integers.
- Add `metadata` to rollout execution requests and thread it through server, local, and Harbor backends.
- Expose request metadata on `AgentWorkflowContext` and `GraderContext`.
- Allow metadata-only rollout rows to run graders even when `label` is absent.
- Add unit coverage for metadata validation and rollout metadata propagation.

## Why

Datasets can include row-level metadata that workflows and graders need during rollout execution. This keeps SDK-side validation aligned with platform preprocessing and preserves metadata across both local and Harbor execution paths.

## How to Test

- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check .`
- `uv run --extra dev pyright osmosis_ai/`
- `uv run --extra dev pytest`

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate the optional dataset metadata column and pass row metadata through rollout so workflows and graders can use it across local, Harbor, and server runs. Also allows metadata-only rows to be graded when label is missing.

- **New Features**
  - Dataset validation for metadata in CSV, JSONL, and Parquet: must be a JSON object; no empty nested objects; per-key types consistent across rows; reject all-empty object columns; integers fit in int64; CSV accepts JSON-object strings; Parquet accepts struct, null dtype, or JSON-object strings (string columns validated on first batch).
  - Threading and runners: added `metadata` to `ExecutionRequest`, included in Harbor rollout config, exposed on `AgentWorkflowContext` and `GraderContext`, and grading runs if either `label` or `metadata` is present; local, Harbor, and server paths propagate it (server `_handle_rollout` passes it through).

<sup>Written for commit 5aafad0be0e782404444a457d486e2d41e316432. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

