### PR TITLE
[misc] chore: bump version to 0.2.26

### DIFF
--- a/osmosis_ai/consts.py
+++ b/osmosis_ai/consts.py
@@ -1,3 +1,3 @@
 # package metadata
 package_name = "osmosis-ai"
-PACKAGE_VERSION = "0.2.25"
+PACKAGE_VERSION = "0.2.26"

--- a/osmosis_ai/templates/_scaffolds/rollout/pyproject.toml.tpl
+++ b/osmosis_ai/templates/_scaffolds/rollout/pyproject.toml.tpl
@@ -4,7 +4,7 @@ description = "Placeholder rollout scaffolded by `osmosis rollout init`."
 version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
-    "osmosis-ai[server]>=0.2.25",
+    "osmosis-ai[server]>=0.2.26",
 ]
 
 [build-system]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `osmosis-ai` to 0.2.26 and update the rollout scaffold to depend on `osmosis-ai[server]>=0.2.26`. Keeps package metadata and new project templates in sync with the latest release.

<sup>Written for commit 8983286586bef69038ee2c3b6f67da515eecb33d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

