### PR TITLE
[cli] feat: preflight pinned commit_sha on train/eval submit

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -254,6 +254,12 @@ evaluation run before a training run.
 | `model_path` | Supported base model path |
 | `dataset` | Platform dataset name (`osmosis dataset list`) |
 
+#### Optional `[experiment]` fields
+
+| Key | Description |
+|-----|-------------|
+| `commit_sha` | Optional pinned commit. When omitted, the platform chooses source from the connected repository. Must be a hexadecimal SHA (7–40 chars); `submit` preflights it against origin and fails fast if the commit is not found on the connected repository. |
+
 #### Optional `[training]` fields
 
 All fields are optional. Omitted fields use platform defaults.

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -23,7 +23,7 @@ Evaluation submit configs also support optional `[experiment].commit_sha`, `[eva
 
 | Key | Description |
 |-----|-------------|
-| `commit_sha` | Optional pinned commit. When omitted, the platform chooses source from the connected repository. |
+| `commit_sha` | Optional pinned commit. When omitted, the platform chooses source from the connected repository. Must be a hexadecimal SHA (7–40 chars); `submit` preflights it against origin and fails fast if the commit is not found on the connected repository. |
 
 **`[evaluation]`**
 

--- a/osmosis_ai/platform/cli/shared_config.py
+++ b/osmosis_ai/platform/cli/shared_config.py
@@ -7,13 +7,16 @@ import tomllib
 from pathlib import Path
 from typing import Any, ClassVar
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 from pydantic_core import ErrorDetails
 
 from osmosis_ai.cli.errors import CLIError
 
 ENV_VAR_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
 SECRET_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+# A pinned commit SHA is a hex string. Git's default short form is 7 chars and a
+# full SHA-1 is 40; anything outside that range is almost certainly a typo.
+COMMIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
 RESERVED_ENV_PREFIX = "_OSMOSIS_"
 
 _EXPECTED_TYPE_BY_ERROR: dict[str, str] = {
@@ -344,6 +347,18 @@ class ExperimentSection(BaseModel):
     model_path: str
     dataset: str
     commit_sha: str | None = None
+
+    @field_validator("commit_sha")
+    @classmethod
+    def _validate_commit_sha(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        if not COMMIT_SHA_RE.fullmatch(value):
+            raise ValueError(
+                "must be a hexadecimal Git commit SHA (7-40 hex characters), "
+                f"e.g. a full 40-character SHA; got {value!r}"
+            )
+        return value
 
 
 _EXPERIMENT_REQUIRED_KEYS: tuple[str, ...] = (

--- a/osmosis_ai/platform/cli/shared_submit.py
+++ b/osmosis_ai/platform/cli/shared_submit.py
@@ -45,6 +45,7 @@ from osmosis_ai.platform.cli.workspace_directory_contract import (
     validate_rollout_backend,
     validate_workspace_directory_contract,
 )
+from osmosis_ai.platform.cli.workspace_repo import check_pinned_commit
 
 _MISSING_SECRET_RE = re.compile(r"Secret\(s\) not found: (.+)")
 
@@ -210,6 +211,21 @@ def run_cloud_submit[ConfigT: BaseSubmitConfig](
         command_label=spec.command_label,
     )
 
+    # Preflight a pinned commit before doing any further work: a confirmed-bad
+    # SHA would fail server-side after the platform clones the repo, so fail fast
+    # with a clear message instead. Best-effort warnings are folded into the
+    # remote-fetch notice below.
+    commit_preflight_warnings: list[str] = []
+    if config.experiment_commit_sha:
+        commit_check = check_pinned_commit(
+            workspace_directory=workspace_directory,
+            git_identity=context.git_identity,
+            commit_sha=config.experiment_commit_sha,
+        )
+        if commit_check.error:
+            raise CLIError(commit_check.error)
+        commit_preflight_warnings = list(commit_check.warnings)
+
     summary_rows = build_submit_summary_rows(
         rollout=config.experiment_rollout,
         entrypoint=config.experiment_entrypoint,
@@ -270,6 +286,7 @@ def run_cloud_submit[ConfigT: BaseSubmitConfig](
     notes, warnings = print_remote_fetch_notice(
         workspace_directory,
         pinned_commit_sha=config.experiment_commit_sha,
+        extra_warnings=commit_preflight_warnings,
     )
 
     require_confirmation(

--- a/osmosis_ai/platform/cli/utils.py
+++ b/osmosis_ai/platform/cli/utils.py
@@ -479,6 +479,7 @@ def print_remote_fetch_notice(
     workspace_directory: Path,
     *,
     pinned_commit_sha: str | None,
+    extra_warnings: list[str] | None = None,
 ) -> tuple[list[str], list[str]]:
     """Remind the user that remote submissions pull *code* from the connected
     Git remote while reading *config values* from the local TOML file.
@@ -490,6 +491,10 @@ def print_remote_fetch_notice(
     values are sent verbatim in the submit payload — local edits to the
     config take effect immediately, even if they are uncommitted.
 
+    ``extra_warnings`` lets callers fold in advisories computed elsewhere (e.g.
+    the pinned-commit preflight) so they appear in the same Rich panel and in
+    the returned ``warnings`` list.
+
     Returns ``(notes, warnings)`` as plain-text lists so callers can surface
     the same context in non-rich modes (e.g. the JSON error envelope when
     ``--yes`` is missing). The Rich panel is rendered only when the output
@@ -500,7 +505,7 @@ def print_remote_fetch_notice(
 
     state = summarize_local_git_state(workspace_directory)
 
-    warnings: list[str] = []
+    warnings: list[str] = list(extra_warnings or [])
     if state is not None:
         if state.is_dirty:
             warnings.append(

--- a/osmosis_ai/platform/cli/workspace_repo.py
+++ b/osmosis_ai/platform/cli/workspace_repo.py
@@ -139,7 +139,8 @@ def _resolve_via_gh(owner: str, repo: str) -> str | None:
     return result.stdout.strip() or None
 
 
-def _resolve_via_git_credentials(owner: str, repo: str) -> str | None:
+def _github_token_from_git_credentials() -> str | None:
+    """Best-effort GitHub token from the local ``git credential`` helper."""
     if shutil.which("git") is None:
         return None
     try:
@@ -157,7 +158,11 @@ def _resolve_via_git_credentials(owner: str, repo: str) -> str | None:
     if result.returncode != 0:
         return None
 
-    token = _password_from_git_credentials(result.stdout)
+    return _password_from_git_credentials(result.stdout)
+
+
+def _resolve_via_git_credentials(owner: str, repo: str) -> str | None:
+    token = _github_token_from_git_credentials()
     if token is None:
         return None
 
@@ -347,9 +352,169 @@ def summarize_local_git_state(workspace_directory: Path) -> LocalGitState | None
     )
 
 
+def _local_commit_exists(workspace_directory: Path, commit_sha: str) -> bool | None:
+    """Return whether ``commit_sha`` resolves to a commit object in the local repo.
+
+    Returns ``True``/``False`` when the check ran, or ``None`` when it could not
+    (``git`` missing, or ``workspace_directory`` is not a git working tree).
+    ``None`` is intentionally distinct from ``False`` so callers can treat
+    "can't tell" differently from "definitely absent".
+    """
+    if shutil.which("git") is None:
+        return None
+    if not (workspace_directory / ".git").exists():
+        return None
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(workspace_directory),
+                "cat-file",
+                "-e",
+                f"{commit_sha}^{{commit}}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    return result.returncode == 0
+
+
+def _commit_exists_via_gh(owner: str, repo: str, commit_sha: str) -> bool | None:
+    if shutil.which("gh") is None:
+        return None
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{owner}/{repo}/commits/{commit_sha}", "--jq", ".sha"],
+            capture_output=True,
+            env=_noninteractive_git_env(),
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+    if result.returncode == 0:
+        return True
+    # GitHub returns HTTP 422 ("No commit found for SHA") for a well-formed SHA
+    # that is absent. A 404 means the repo/visibility is the problem (not the
+    # commit), so we treat only the 422 signal as authoritative absence.
+    stderr = (result.stderr or "").lower()
+    if "no commit found" in stderr or "http 422" in stderr:
+        return False
+    return None
+
+
+def _commit_exists_via_git_credentials(
+    owner: str, repo: str, commit_sha: str
+) -> bool | None:
+    token = _github_token_from_git_credentials()
+    if token is None:
+        return None
+    try:
+        response = requests.get(
+            f"https://api.github.com/repos/{owner}/{repo}/commits/{commit_sha}",
+            headers={
+                "Authorization": f"token {token}",
+                "Accept": "application/vnd.github+json",
+            },
+            allow_redirects=True,
+            timeout=10,
+        )
+    except requests.RequestException:
+        return None
+
+    if response.status_code == 200:
+        return True
+    if response.status_code == 422:
+        return False
+    return None
+
+
+def _remote_commit_exists(identity: str, commit_sha: str) -> bool | None:
+    """Return whether ``commit_sha`` exists on the GitHub repo ``identity``.
+
+    ``identity`` is a normalized ``owner/repo`` string. Tries the ``gh`` CLI
+    first, then a token from the local git credential helper. Returns
+    ``True``/``False`` only when GitHub answers authoritatively, or ``None`` when
+    the check could not run (no ``gh`` and no token, or a transport/visibility
+    error) so callers never block a submit on missing tooling.
+    """
+    if _GITHUB_REPOSITORY_IDENTITY_RE.fullmatch(identity) is None:
+        return None
+    owner, repo = identity.split("/", maxsplit=1)
+    via_gh = _commit_exists_via_gh(owner, repo, commit_sha)
+    if via_gh is not None:
+        return via_gh
+    return _commit_exists_via_git_credentials(owner, repo, commit_sha)
+
+
+@dataclass(frozen=True, slots=True)
+class PinnedCommitCheck:
+    """Outcome of a pinned ``commit_sha`` preflight.
+
+    ``error`` is set only when the commit is *confirmed* unusable (the platform
+    would fail to fetch it); raising on it fails the submit fast. ``warnings``
+    carries non-blocking advisories shown before the confirmation prompt.
+    """
+
+    error: str | None = None
+    warnings: tuple[str, ...] = ()
+
+
+def check_pinned_commit(
+    *, workspace_directory: Path, git_identity: str, commit_sha: str
+) -> PinnedCommitCheck:
+    """Preflight a pinned ``commit_sha`` before a cloud submit.
+
+    The platform fetches the pinned commit from the connected GitHub repository,
+    so a remote answer is authoritative. The local repo is only a fast,
+    offline signal — a commit may exist on origin without being fetched locally,
+    so a local miss alone is never treated as an error (only a warning when the
+    remote can't be reached).
+    """
+    local = _local_commit_exists(workspace_directory, commit_sha)
+    remote = _remote_commit_exists(git_identity, commit_sha)
+
+    if remote is False:
+        if local is True:
+            return PinnedCommitCheck(
+                error=(
+                    f"Pinned commit {commit_sha} exists locally but was not found on "
+                    f"origin ({git_identity}). Push it before submitting — the platform "
+                    "fetches the pinned commit from the connected repository."
+                )
+            )
+        return PinnedCommitCheck(
+            error=(
+                f"Pinned commit {commit_sha} was not found on the connected repository "
+                f"({git_identity}). Double-check experiment.commit_sha and make sure the "
+                "commit is pushed to origin."
+            )
+        )
+
+    if remote is True:
+        return PinnedCommitCheck()
+
+    # remote is None → GitHub could not confirm. Fall back to the local signal.
+    if local is False:
+        return PinnedCommitCheck(
+            warnings=(
+                f"Could not find pinned commit {commit_sha} in the local repository, "
+                "and could not reach GitHub to confirm it. Make sure "
+                "experiment.commit_sha is correct and pushed to origin.",
+            )
+        )
+    return PinnedCommitCheck()
+
+
 __all__ = [
     "GitRemoteIdentity",
     "LocalGitState",
+    "check_pinned_commit",
     "get_local_git_remote_url",
     "git_worktree_top_level",
     "normalize_git_identity",

--- a/tests/unit/cli/test_train_commands.py
+++ b/tests/unit/cli/test_train_commands.py
@@ -32,6 +32,11 @@ from osmosis_ai.platform.api.models import (
     TrainingRunMetricsOverview,
 )
 from osmosis_ai.platform.auth import PlatformAPIError
+from tests.unit.submit_preflight_helpers import (
+    assert_submit_aborts_on_invalid_commit,
+    assert_submit_surfaces_commit_warning,
+    disable_commit_preflight,
+)
 
 GIT_IDENTITY = "acme/rollouts"
 REPO_URL = "https://github.com/acme/rollouts.git"
@@ -175,6 +180,9 @@ def _mock_workspace_repo(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda *args, **kwargs: None,
         raising=False,
     )
+    # Disable the pinned-commit preflight by default so submit tests don't make
+    # real git/GitHub calls; tests that exercise it patch this explicitly.
+    disable_commit_preflight(monkeypatch)
 
 
 # ---------------------------------------------------------------------------
@@ -1219,6 +1227,72 @@ rollout_batch_size = 64
         assert isinstance(result, OperationResult)
         assert result.resource is not None
         assert result.resource["config"]["commit_sha"] == "deadbeef"
+
+    def _write_commit_sha_config(self, tmp_path: Path) -> Path:
+        workspace_directory = self._write_project(tmp_path, rollout="r")
+        path = workspace_directory / "configs" / "training" / "train.toml"
+        path.write_text(
+            """
+[experiment]
+rollout = "r"
+entrypoint = "main.py"
+model_path = "m"
+dataset = "d"
+commit_sha = "deadbeef"
+
+[training]
+n_samples_per_prompt = 8
+rollout_batch_size = 64
+""".strip(),
+            encoding="utf-8",
+        )
+        return path
+
+    def test_submit_aborts_on_invalid_pinned_commit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        path = self._write_commit_sha_config(tmp_path)
+        monkeypatch.chdir(path.parents[2])
+
+        class FakeClient:
+            def submit_training_run(self, **kwargs):
+                raise AssertionError(
+                    "submit must not run when the commit preflight fails"
+                )
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(platform_train_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(shared_submit_module, "OsmosisClient", FakeClient)
+
+        assert_submit_aborts_on_invalid_commit(
+            monkeypatch,
+            submit=lambda: train_module.submit(config_path=path, yes=True),
+        )
+
+    def test_submit_surfaces_pinned_commit_warning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        console_capture: StringIO,
+        tmp_path: Path,
+    ) -> None:
+        path = self._write_commit_sha_config(tmp_path)
+        monkeypatch.chdir(path.parents[2])
+
+        class FakeClient:
+            def submit_training_run(self, **kwargs):
+                return TestSubmit.SUBMIT_RESULT
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(platform_train_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(shared_submit_module, "OsmosisClient", FakeClient)
+
+        assert_submit_surfaces_commit_warning(
+            monkeypatch,
+            submit=lambda: train_module.submit(config_path=path, yes=True),
+            console_output=console_capture.getvalue,
+        )
 
     def test_submit_passes_config_to_api(
         self,

--- a/tests/unit/platform/cli/test_commit_preflight.py
+++ b/tests/unit/platform/cli/test_commit_preflight.py
@@ -1,0 +1,114 @@
+"""Tests for the pinned ``commit_sha`` preflight (check_pinned_commit)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import osmosis_ai.platform.cli.workspace_repo as workspace_repo
+from osmosis_ai.platform.cli.workspace_repo import (
+    PinnedCommitCheck,
+    check_pinned_commit,
+)
+
+IDENTITY = "acme/rollouts"
+SHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+
+def _patch_existence(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    local: bool | None,
+    remote: bool | None,
+) -> None:
+    monkeypatch.setattr(workspace_repo, "_local_commit_exists", lambda *_a, **_k: local)
+    monkeypatch.setattr(
+        workspace_repo, "_remote_commit_exists", lambda *_a, **_k: remote
+    )
+
+
+def _check() -> PinnedCommitCheck:
+    return check_pinned_commit(
+        workspace_directory=Path("/repo"), git_identity=IDENTITY, commit_sha=SHA
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy paths: nothing actionable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("local", "remote"),
+    [
+        (True, True),  # exists everywhere
+        (None, True),  # not fetched locally but confirmed on origin
+        (True, None),  # exists locally, remote unreachable -> existing notice covers it
+        (None, None),  # nothing could be determined
+    ],
+)
+def test_check_pinned_commit_passes_without_error_or_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    local: bool | None,
+    remote: bool | None,
+) -> None:
+    _patch_existence(monkeypatch, local=local, remote=remote)
+    result = _check()
+    assert result.error is None
+    assert result.warnings == ()
+
+
+# ---------------------------------------------------------------------------
+# Hard errors: remote authoritatively reports the commit is absent
+# ---------------------------------------------------------------------------
+
+
+def test_check_pinned_commit_errors_when_local_but_not_pushed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_existence(monkeypatch, local=True, remote=False)
+    result = _check()
+    assert result.error is not None
+    assert "exists locally but was not found on origin" in result.error
+    assert IDENTITY in result.error
+
+
+@pytest.mark.parametrize("local", [False, None])
+def test_check_pinned_commit_errors_when_remote_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    local: bool | None,
+) -> None:
+    _patch_existence(monkeypatch, local=local, remote=False)
+    result = _check()
+    assert result.error is not None
+    assert "was not found on the connected repository" in result.error
+
+
+# ---------------------------------------------------------------------------
+# Soft warning: local miss + remote unreachable
+# ---------------------------------------------------------------------------
+
+
+def test_check_pinned_commit_warns_when_local_miss_and_remote_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_existence(monkeypatch, local=False, remote=None)
+    result = _check()
+    assert result.error is None
+    assert len(result.warnings) == 1
+    assert SHA in result.warnings[0]
+
+
+# ---------------------------------------------------------------------------
+# Low-level helper edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_local_commit_exists_returns_none_outside_git_repo(tmp_path: Path) -> None:
+    # tmp_path has no .git directory.
+    assert workspace_repo._local_commit_exists(tmp_path, SHA) is None
+
+
+def test_remote_commit_exists_returns_none_for_invalid_identity() -> None:
+    assert workspace_repo._remote_commit_exists("not-a-valid-identity", SHA) is None

--- a/tests/unit/platform/cli/test_eval_config.py
+++ b/tests/unit/platform/cli/test_eval_config.py
@@ -69,6 +69,66 @@ required = ["OPENAI_API_KEY", "GITHUB_TOKEN"]
     }
 
 
+def test_load_eval_submit_config_accepts_full_length_commit_sha(
+    tmp_path: Path,
+) -> None:
+    full_sha = "a" * 40
+    path = _write_config(
+        tmp_path / "eval.toml",
+        f"""
+[experiment]
+rollout = "calculator"
+entrypoint = "main.py"
+model_path = "openai/gpt-5-mini"
+dataset = "multiply"
+commit_sha = "{full_sha}"
+
+[secrets]
+required = []
+""",
+    )
+
+    config = load_eval_submit_config(path)
+
+    assert config.experiment_commit_sha == full_sha
+
+
+@pytest.mark.parametrize(
+    "bad_sha",
+    [
+        "main",  # branch name, not a SHA
+        "abc123",  # too short (6 chars)
+        "z" * 12,  # non-hex characters
+        "a" * 41,  # too long
+        "dead beef",  # contains whitespace
+    ],
+)
+def test_load_eval_submit_config_rejects_malformed_commit_sha(
+    tmp_path: Path,
+    bad_sha: str,
+) -> None:
+    path = _write_config(
+        tmp_path / "eval.toml",
+        f"""
+[experiment]
+rollout = "calculator"
+entrypoint = "main.py"
+model_path = "openai/gpt-5-mini"
+dataset = "multiply"
+commit_sha = "{bad_sha}"
+
+[secrets]
+required = []
+""",
+    )
+
+    with pytest.raises(CLIError) as exc_info:
+        load_eval_submit_config(path)
+    message = str(exc_info.value)
+    assert "experiment.commit_sha" in message
+    assert "hexadecimal Git commit SHA" in message
+
+
 def test_load_eval_submit_config_defaults_optional_evaluation_fields(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/platform/cli/test_eval_submit.py
+++ b/tests/unit/platform/cli/test_eval_submit.py
@@ -14,6 +14,11 @@ import osmosis_ai.platform.cli.utils as utils_module
 from osmosis_ai.cli.console import Console
 from osmosis_ai.cli.output import OperationResult
 from osmosis_ai.platform.api.models import SubmitRunResult
+from tests.unit.submit_preflight_helpers import (
+    assert_submit_aborts_on_invalid_commit,
+    assert_submit_surfaces_commit_warning,
+    disable_commit_preflight,
+)
 
 GIT_IDENTITY = "acme/rollouts"
 REPO_URL = "https://github.com/acme/rollouts.git"
@@ -142,6 +147,9 @@ def _mock_workspace_repo(monkeypatch: pytest.MonkeyPatch) -> None:
             },
         )(),
     )
+    # Disable the pinned-commit preflight by default so submit tests don't make
+    # real git/GitHub calls; tests that exercise it patch this explicitly.
+    disable_commit_preflight(monkeypatch)
 
 
 def test_eval_submit_passes_new_schema_to_evaluation_run_api(
@@ -203,6 +211,62 @@ def test_eval_submit_passes_new_schema_to_evaluation_run_api(
         "dataset": "multiply",
         "commit_sha": "deadbeef",
     }
+
+
+def test_eval_submit_aborts_on_invalid_pinned_commit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace_directory = _make_workspace_directory(tmp_path / "project")
+    config_path = _write_eval_config(
+        workspace_directory / "configs" / "eval" / "default.toml",
+        commit_sha="deadbeef",
+    )
+    monkeypatch.chdir(workspace_directory)
+
+    class FakeClient:
+        def submit_evaluation_run(self, **kwargs: Any) -> SubmitRunResult:
+            raise AssertionError("submit must not run when the commit preflight fails")
+
+    monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+    monkeypatch.setattr(shared_submit_module, "OsmosisClient", FakeClient)
+
+    assert_submit_aborts_on_invalid_commit(
+        monkeypatch,
+        submit=lambda: eval_module.submit(config_path=config_path, yes=True),
+    )
+
+
+def test_eval_submit_surfaces_pinned_commit_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    console_capture: StringIO,
+) -> None:
+    workspace_directory = _make_workspace_directory(tmp_path / "project")
+    config_path = _write_eval_config(
+        workspace_directory / "configs" / "eval" / "default.toml",
+        commit_sha="deadbeef",
+    )
+    monkeypatch.chdir(workspace_directory)
+
+    class FakeClient:
+        def submit_evaluation_run(self, **kwargs: Any) -> SubmitRunResult:
+            return SubmitRunResult(
+                id="eval-1",
+                name="eval-run",
+                status="pending",
+                created_at="2026-05-27T00:00:00Z",
+                platform_url=None,
+            )
+
+    monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+    monkeypatch.setattr(shared_submit_module, "OsmosisClient", FakeClient)
+
+    assert_submit_surfaces_commit_warning(
+        monkeypatch,
+        submit=lambda: eval_module.submit(config_path=config_path, yes=True),
+        console_output=console_capture.getvalue,
+    )
 
 
 def test_eval_submit_does_not_pin_local_head_without_config_commit_sha(

--- a/tests/unit/platform/cli/test_training_config.py
+++ b/tests/unit/platform/cli/test_training_config.py
@@ -79,6 +79,27 @@ custom_flag = true
     assert cfg.advanced_config == {"optimizer": "adam", "custom_flag": True}
 
 
+def test_load_config_rejects_malformed_commit_sha(tmp_path: Path) -> None:
+    path = tmp_path / "train.toml"
+    path.write_text(
+        """
+[experiment]
+rollout = "r"
+entrypoint = "main.py"
+model_path = "m"
+dataset = "d"
+commit_sha = "not-a-sha"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CLIError) as exc_info:
+        load_train_submit_config(path)
+    message = str(exc_info.value)
+    assert "experiment.commit_sha" in message
+    assert "hexadecimal Git commit SHA" in message
+
+
 def test_load_minimal_config(tmp_path: Path) -> None:
     path = tmp_path / "minimal.toml"
     path.write_text(

--- a/tests/unit/submit_preflight_helpers.py
+++ b/tests/unit/submit_preflight_helpers.py
@@ -1,0 +1,79 @@
+"""Shared helpers for the pinned-commit submit preflight tests.
+
+``train submit`` and ``eval submit`` both route through
+``osmosis_ai.platform.cli.shared_submit.run_cloud_submit``, so the
+``check_pinned_commit`` seam and the assertions around it are identical. These
+helpers let each command's test suite exercise that shared behavior without
+duplicating the stubbing logic — callers only supply the command-specific
+``submit`` callable and console accessor.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import osmosis_ai.platform.cli.shared_submit as shared_submit_module
+from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.cli.output import OperationResult
+
+# Wording mirrors osmosis_ai.platform.cli.workspace_repo.check_pinned_commit so
+# the assertions below stay coupled to the real user-facing messages.
+REMOTE_MISSING_ERROR = (
+    "Pinned commit deadbeef was not found on the connected repository (acme/rollouts)."
+)
+LOCAL_MISS_WARNING = "Could not find pinned commit deadbeef in the local repository."
+
+
+def _stub_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    error: str | None,
+    warnings: tuple[str, ...],
+) -> None:
+    monkeypatch.setattr(
+        shared_submit_module,
+        "check_pinned_commit",
+        lambda **_kwargs: SimpleNamespace(error=error, warnings=warnings),
+    )
+
+
+def disable_commit_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the pinned-commit preflight a no-op (no real git/GitHub calls).
+
+    Used by submit-test autouse fixtures so configs that set ``commit_sha`` do
+    not reach out to git or GitHub during unrelated assertions.
+    """
+    _stub_preflight(monkeypatch, error=None, warnings=())
+
+
+def assert_submit_aborts_on_invalid_commit(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    submit: Callable[[], Any],
+) -> None:
+    """A confirmed-bad pinned commit must raise before the API call.
+
+    ``submit`` should invoke the command's submit entry point with a
+    FakeClient whose submit method raises if it is ever called, so this also
+    proves the preflight fails fast.
+    """
+    _stub_preflight(monkeypatch, error=REMOTE_MISSING_ERROR, warnings=())
+    with pytest.raises(CLIError, match="was not found on the connected repository"):
+        submit()
+
+
+def assert_submit_surfaces_commit_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    submit: Callable[[], OperationResult],
+    console_output: Callable[[], str],
+) -> None:
+    """A non-blocking preflight warning must surface and still let submit run."""
+    _stub_preflight(monkeypatch, error=None, warnings=(LOCAL_MISS_WARNING,))
+    result = submit()
+    assert isinstance(result, OperationResult)
+    assert "Could not find pinned commit deadbeef" in console_output()


### PR DESCRIPTION
## What

- Add a `commit_sha` field validator on `ExperimentSection` (`platform/cli/shared_config.py`) that rejects malformed pins at config load (hexadecimal, 7-40 chars) — shared by train and eval submit.
- Add `check_pinned_commit()` in `platform/cli/workspace_repo.py` combining a local `git cat-file` signal with an authoritative GitHub lookup (`gh` CLI, then a git-credential token); refactor out `_github_token_from_git_credentials()` for reuse.
- Wire the preflight into `run_cloud_submit()` (`platform/cli/shared_submit.py`): a remote-confirmed miss fails the submit fast; a local miss with an unreachable remote only warns.
- Extend `print_remote_fetch_notice()` with `extra_warnings` so preflight advisories render in the same panel and the JSON/plain envelopes.
- Keep the new helpers internal (underscore-prefixed; only `check_pinned_commit` exported via `__all__`).
- Document the behavior in `docs/cli.md` and `docs/eval.md`.
- Add unit coverage for all three layers (`test_eval_config.py`, `test_training_config.py`, new `test_commit_preflight.py`), plus integration tests via shared helpers (`submit_preflight_helpers.py`).

## Why

When `experiment.commit_sha` is pinned, an invalid or unpushed SHA would only fail server-side after the platform clones the repo, producing a slow, opaque error. This preflights the pin so a confirmed-bad commit fails fast locally with an actionable message, while missing tooling (no `gh`, no token, offline) never blocks a submit.

## How to Test

- `uv run pytest tests/unit/platform/cli/test_commit_preflight.py tests/unit/platform/cli/test_eval_submit.py tests/unit/platform/cli/test_eval_config.py tests/unit/platform/cli/test_training_config.py "tests/unit/cli/test_train_commands.py::TestSubmit"`
- `uv run pytest`
- `uv run ruff check . && uv run ruff format --check .`
- `uv run pyright osmosis_ai/`

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fast, local preflight for pinned `experiment.commit_sha` on train/eval submit to catch invalid or not-pushed SHAs before hitting the server, with clear errors or non-blocking warnings.

- New Features
  - Validate `experiment.commit_sha` format at config load (hex, 7–40 chars) in `ExperimentSection`.
  - Preflight pinned SHAs: check locally via `git cat-file` and remotely via GitHub (`gh` or a `git-credential` token). Fail submit if GitHub confirms the SHA is missing; warn if local check fails and GitHub is unreachable.
  - Integrate preflight into `run_cloud_submit()` and surface advisories through `print_remote_fetch_notice()` (now supports `extra_warnings`).
  - Documented in `docs/cli.md` and `docs/eval.md`. Added unit and integration tests for config validation, preflight logic, and submit behavior.

<sup>Written for commit 716f7153f5895c2aeb098d60108242637c04b6ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

