### PR TITLE
[cli] feat: use complete verification URI for device login browser flow

### DIFF
--- a/osmosis_ai/platform/auth/flow.py
+++ b/osmosis_ai/platform/auth/flow.py
@@ -98,6 +98,7 @@ class DeviceCodeResponse:
     verification_uri: str
     expires_in: int
     interval: int
+    verification_uri_complete: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -343,6 +344,7 @@ def request_device_code(device_name: str | None = None) -> DeviceCodeResponse:
                 verification_uri=data["verification_uri"],
                 expires_in=data["expires_in"],
                 interval=data["interval"],
+                verification_uri_complete=data.get("verification_uri_complete"),
             )
     except HTTPError as e:
         raise _login_error_from_http(e, "Failed to request device code") from e
@@ -409,7 +411,7 @@ def poll_device_token(
     raise LoginError("Device authorization timed out. Please try again.")
 
 
-def device_login(timeout: float = 600.0) -> tuple[LoginResult, Credentials]:
+def device_login(timeout: float = 900.0) -> tuple[LoginResult, Credentials]:
     """Execute the device code login flow for headless environments.
 
     Returns:
@@ -431,7 +433,11 @@ def device_login(timeout: float = 600.0) -> tuple[LoginResult, Credentials]:
     console.print(f"Code expires in {expires_minutes} minutes.", style="dim")
     console.print()
 
-    verification_url = device_code_resp.verification_uri
+    # The complete URI carries the device code so the browser lands on a
+    # pre-filled authorize page; older servers may not send it.
+    verification_url = (
+        device_code_resp.verification_uri_complete or device_code_resp.verification_uri
+    )
     console.print_url(
         "Open this URL in your browser: ", verification_url, style="yellow"
     )

--- a/tests/unit/auth/test_device_flow.py
+++ b/tests/unit/auth/test_device_flow.py
@@ -18,15 +18,18 @@ from osmosis_ai.platform.auth.flow import (
 )
 
 
-def _make_device_code_response() -> bytes:
+def _make_device_code_response(include_complete_uri: bool = True) -> bytes:
     data = {
         "device_code": "device_abc123",
         "user_code": "ABCD-1234",
         "verification_uri": "https://platform.osmosis.ai/device",
-        "verification_uri_complete": "https://platform.osmosis.ai/device?code=ABCD-1234",
         "expires_in": 600,
         "interval": 5,
     }
+    if include_complete_uri:
+        data["verification_uri_complete"] = (
+            "https://platform.osmosis.ai/device?code=ABCD-1234"
+        )
     return json.dumps(data).encode()
 
 
@@ -57,6 +60,22 @@ class TestRequestDeviceCode:
         assert isinstance(result, DeviceCodeResponse)
         assert result.device_code == "device_abc123"
         assert result.user_code == "ABCD-1234"
+        assert (
+            result.verification_uri_complete
+            == "https://platform.osmosis.ai/device?code=ABCD-1234"
+        )
+
+    def test_missing_complete_uri_defaults_to_none(self) -> None:
+        body = _make_device_code_response(include_complete_uri=False)
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = body
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("osmosis_ai.platform.auth.flow.urlopen", return_value=mock_resp):
+            result = request_device_code()
+
+        assert result.verification_uri_complete is None
 
     def test_http_error_raises_login_error(self) -> None:
         error = HTTPError(
@@ -202,12 +221,42 @@ class TestDeviceLogin:
             patch("osmosis_ai.platform.auth.flow.time.sleep"),
             patch("sys.stdin") as mock_stdin,
             patch("builtins.input", return_value=""),
-            patch("webbrowser.open", return_value=True),
+            patch("webbrowser.open", return_value=True) as mock_open,
         ):
             mock_stdin.isatty.return_value = True
             result, creds = device_login(timeout=10.0)
 
+        mock_open.assert_called_once_with(
+            "https://platform.osmosis.ai/device?code=ABCD-1234"
+        )
         assert result.user.email == "u@test.com"
         assert creds.access_token == "jwt-user-token"
         assert creds.token_id == "tok_123"
         assert creds.expires_at.tzinfo is not None
+
+    def test_browser_falls_back_to_plain_uri_without_complete(self) -> None:
+        device_resp_body = _make_device_code_response(include_complete_uri=False)
+        device_resp = MagicMock()
+        device_resp.read.return_value = device_resp_body
+        device_resp.__enter__ = MagicMock(return_value=device_resp)
+        device_resp.__exit__ = MagicMock(return_value=False)
+
+        token_resp = MagicMock()
+        token_resp.read.return_value = _make_token_response()
+        token_resp.__enter__ = MagicMock(return_value=token_resp)
+        token_resp.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch(
+                "osmosis_ai.platform.auth.flow.urlopen",
+                side_effect=[device_resp, token_resp],
+            ),
+            patch("osmosis_ai.platform.auth.flow.time.sleep"),
+            patch("sys.stdin") as mock_stdin,
+            patch("builtins.input", return_value=""),
+            patch("webbrowser.open", return_value=True) as mock_open,
+        ):
+            mock_stdin.isatty.return_value = True
+            device_login(timeout=10.0)
+
+        mock_open.assert_called_once_with("https://platform.osmosis.ai/device")


### PR DESCRIPTION
## What

Adds support for the `verification_uri_complete` field in the device code login flow. When the auth server returns a complete verification URI (one that embeds the device/user code), the CLI now opens that pre-filled authorize page in the browser instead of the bare verification URI. Falls back gracefully to the plain `verification_uri` when older servers don't provide the complete variant. Also extends the device login timeout from 600s to 900s.

## Why

Opening the complete verification URI lets users land directly on a pre-filled authorize page, removing the manual step of entering the device code and reducing login friction. The longer timeout gives users more time to complete authorization in headless environments.

## How to Test

- Run `pytest tests/unit/auth/test_device_flow.py` to verify the new coverage:
  - `verification_uri_complete` is parsed from the device code response.
  - Missing `verification_uri_complete` defaults to `None`.
  - The browser opens the complete URI when available, and falls back to the plain URI otherwise.
- Manually: trigger the device login flow against a server that returns `verification_uri_complete` and confirm the browser opens the pre-filled page.

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [ ] `pytest` passes (new tests added if applicable)
- [ ] Public API changes are documented
- [x] No secrets or credentials included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the complete verification URI in the device login flow so the browser opens a pre-filled authorization page. Also increases the default login timeout to 900s.

- **New Features**
  - Use `verification_uri_complete` when available; fallback to `verification_uri` for older servers.
  - Extend default device login timeout to 900s (from 600s).

<sup>Written for commit cb7380f7c2e428b6463f8e6e6af8c9a6cb2112de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

