### PR TITLE
[doc] doc: restructure developer docs and add link-resolution test

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -38,7 +38,7 @@ body:
       label: SDK Component
       description: Which part of the SDK does this relate to?
       options:
-        - Reward / Rubric decorators
+        - Graders & rewards
         - Remote rollout (`osmosis_ai.rollout`)
         - Rollout server (`create_rollout_server`)
         - CLI (`osmosis` command)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
 <!--
 PR Title Format: [module] type: description
-  modules: reward, rollout, server, cli, auth, eval, misc, ci, doc
+  modules: rollout, server, cli, auth, eval, misc, ci, doc
   types:   feat, fix, refactor, chore, test, doc
 
 Examples:
   [rollout] feat: add streaming support for chat completions
-  [BREAKING][reward] refactor: rename decorator parameters
+  [BREAKING][rollout] refactor: change Grader.grade signature
   [ci] chore: update GitHub Actions versions
 -->
 

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -17,19 +17,19 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PATTERN='^(\[BREAKING\])?(\[(reward|rollout|server|cli|auth|eval|misc|ci|doc)\]){1,3} (feat|fix|refactor|chore|test|doc): .+'
+          PATTERN='^(\[BREAKING\])?(\[(rollout|server|cli|auth|eval|misc|ci|doc)\]){1,3} (feat|fix|refactor|chore|test|doc): .+'
           if [[ ! "$PR_TITLE" =~ $PATTERN ]]; then
             echo "::error::PR title does not match required format."
             echo ""
             echo "Expected format: [module] type: description"
             echo "  Multi-module:  [mod1][mod2] type: description (up to 3 modules)"
-            echo "  modules: reward, rollout, server, cli, auth, eval, misc, ci, doc"
+            echo "  modules: rollout, server, cli, auth, eval, misc, ci, doc"
             echo "  types:   feat, fix, refactor, chore, test, doc"
             echo ""
             echo "Examples:"
             echo "  [rollout] feat: add streaming support for chat completions"
             echo "  [rollout][auth] refactor: extract LifecycleManager"
-            echo "  [BREAKING][reward] refactor: rename decorator parameters"
+            echo "  [BREAKING][rollout] refactor: change Grader.grade signature"
             echo "  [ci] chore: update GitHub Actions versions"
             echo ""
             echo "Got: $PR_TITLE"

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ todo.md
 .DS_Store
 
 /CLAUDE.md
+/AGENTS.md
 **/superpowers/
 
 .claude/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ All PR titles **must** follow this format (enforced by CI):
 [mod1][mod2] type: description          # multi-module (up to 3)
 ```
 
-- **Modules**: `reward`, `rollout`, `server`, `cli`, `auth`, `eval`, `misc`, `ci`, `doc`
+- **Modules**: `rollout`, `server`, `cli`, `auth`, `eval`, `misc`, `ci`, `doc`
 - **Types**: `feat`, `fix`, `refactor`, `chore`, `test`, `doc`
 
 For breaking changes, add `[BREAKING]` before the modules:
@@ -98,7 +98,7 @@ For breaking changes, add `[BREAKING]` before the modules:
 [rollout][auth] refactor: extract LifecycleManager
 [server] fix: handle timeout in rollout init
 [cli] chore: update dependency versions
-[BREAKING][reward] refactor: rename decorator parameters
+[BREAKING][rollout] refactor: change Grader.grade signature
 ```
 
 PR titles appear directly in auto-generated GitHub Release Notes, so keep them clear and descriptive.
@@ -115,7 +115,7 @@ Add a label to your PR so it gets categorized correctly in Release Notes:
 | `documentation` | Docs update |
 | `chore` / `ci` / `refactor` / `dependencies` | Maintenance work |
 
-Module-specific labels (`reward`, `rollout`, `server`, `cli`, `auth`, `eval`) can also be added for filtering. Rollout work typically touches `osmosis_ai.rollout` and related CLI commands.
+Module-specific labels (`rollout`, `server`, `cli`, `auth`, `eval`) can also be added for filtering. Rollout work typically touches `osmosis_ai.rollout` and related CLI commands.
 
 ### Workflow
 

--- a/README.md
+++ b/README.md
@@ -19,97 +19,30 @@
 
 > ⚠️ **Warning**: osmosis-ai is still in active development. APIs may change between versions.
 
-Python SDK and CLI for [Osmosis AI](https://platform.osmosis.ai), a platform for training LLMs with reinforcement learning. Implement an **AgentWorkflow** in Python, add a concrete **Grader** for evaluation runs and managed training runs, submit evaluation runs with the CLI, then submit training runs from an Osmosis workspace directory.
-
-## Quick start
-
-| Step | What you do |
-|------|-------------|
-| **Define agents** | One `AgentWorkflow` subclass (+ optional `AgentWorkflowConfig`) in your repo. The training/evaluation entrypoint must also expose a concrete `Grader` (typically with a `GraderConfig`). |
-| **Layout** | Use a rollout pack directory under `rollouts/<name>/` when loading by rollout name; the CLI adds that directory to `sys.path`. |
-| **Workspace directory** | Create or open a workspace in the Osmosis Platform, then clone the repository created there. |
-| **Check workspace** | `osmosis doctor` — run from the workspace directory so platform commands resolve the repository from the `origin` remote. Add `--fix` to restore missing scaffold paths. |
-| **Evaluate** | `osmosis eval submit configs/eval/<name>.toml` — submit an evaluation run using the same platform dataset naming as training runs. |
-
-**Example repository:** [osmosis-remote-rollout-example](https://github.com/Osmosis-AI/osmosis-remote-rollout-example) (reference server usage - align with current SDK exports when upgrading).
-
-**Documentation index:** [docs/README.md](docs/README.md)
-
-## Agent-friendly CLI output
-
-The `osmosis` CLI keeps Rich as the default output for humans, but every public command also speaks structured JSON and low-noise plain text for AI agents, CI/CD, and shell automation. The global output flags work at any position on the command line:
-
-```bash
-osmosis dataset list                         # human-friendly Rich table
-osmosis --json dataset list                  # recommended for AI agents and CI/CD
-osmosis dataset list --json                  # postfix placement works too
-osmosis --plain dataset list                 # low-noise text for shell pipelines
-```
-
-JSON is the stable machine contract: every successful response includes `schema_version: 1`; list envelopes include `items`, `total_count`, `has_more`, and `next_offset`; detail envelopes include `data`; operation envelopes include `status`, `operation`, optional `resource`, and optional `next_steps_structured`. Sectioned list envelopes (e.g. `osmosis model list`) compose the list shape under named section keys such as `base_models` and `lora_models`, each section carrying its own `items`, `total_count`, `has_more`, and `next_offset`. Errors are JSON-structured on stderr with `code`, `message`, `details`, optional `request_id`, plus the command path and SDK `cli_version`.
-
-Plain mode is for humans and simple shell pipelines, not a strict schema. `--json` and `--plain` are global flags accepted anywhere in the command line; prefer `osmosis --json <command>` or `osmosis <command> --json` over the default Rich output in non-interactive environments. Command-local `--output` always means a file path, not a format selector, so `osmosis dataset download my-dataset --output ./data.jsonl` works in every mode.
-
-In JSON or plain mode, interactive commands fail fast with `INTERACTIVE_REQUIRED` unless a non-interactive flow exists, typically by passing `--yes` or `--token`. `OSMOSIS_TOKEN` is verify-only across the CLI: it activates authentication for the current process but is never written to the on-disk credentials store, never revoked, and never deletes existing credentials.
-
-## Workspace Directory Flow
-
-Create or open a workspace in the Osmosis Platform, clone the repository created there,
-then run CLI commands from that workspace directory.
-
-```bash
-git clone <repo-url>
-cd <repo>
-osmosis auth login
-osmosis doctor
-osmosis template apply multiply              # or add your rollout under rollouts/
-cp configs/training/default.toml configs/training/<run>.toml
-$EDITOR configs/training/<run>.toml          # set rollout, dataset, and model_path
-git add rollouts configs data
-git commit -m "configure training run"
-git push
-osmosis train submit configs/training/<run>.toml
-```
-
-Platform-scoped commands derive scope from the workspace directory's `origin` remote and
-send `X-Osmosis-Git: namespace/repo_name`. The CLI does not store or send a
-workspace ID for commands scoped by the workspace directory.
-
-Before submitting training runs from CI, push the repository and authenticate with a
-token:
-
-```bash
-export OSMOSIS_TOKEN=<token>
-osmosis train submit configs/training/<run>.toml --yes
-```
+Python SDK and CLI for [Osmosis AI](https://platform.osmosis.ai), a platform for training LLMs with reinforcement learning. Implement an **AgentWorkflow** and a concrete **Grader** in Python, then use the CLI to submit evaluation and training runs from an Osmosis workspace directory.
 
 ## Installation
 
-Requires **Python 3.12+**. For development setup, see [CONTRIBUTING.md](CONTRIBUTING.md).
-
-- **An LLM API key** (e.g., OpenAI, Anthropic, Groq) — required for `osmosis eval rubric` (LLM-as-judge) when using hosted models. See [supported providers](https://docs.litellm.ai/docs/providers).
-- **Osmosis account** (optional) — needed for `osmosis auth login` and platform-backed commands such as datasets, models, and training runs. Sign up at [platform.osmosis.ai](https://platform.osmosis.ai).
-
-**pip**
+Requires **Python 3.12+**.
 
 ```bash
 pip install osmosis-ai            # Core SDK
-pip install osmosis-ai[server]    # + FastAPI rollout server (pulls in platform extra)
-pip install osmosis-ai[full]      # Same as [server] (all packaged optional features)
+pip install osmosis-ai[server]    # + FastAPI rollout server
+# or with uv:  uv add osmosis-ai
 ```
 
-**uv**
+See [Installation](https://docs.osmosis.ai/cli/installation) for the full extras matrix and [CONTRIBUTING.md](CONTRIBUTING.md) for development setup.
 
-```bash
-uv add osmosis-ai                 # Core SDK
-uv add osmosis-ai[server]         # + FastAPI rollout server (pulls in platform extra)
-uv add osmosis-ai[full]           # Same as [server] (all packaged optional features)
-```
+## Documentation
 
-## Testing and evaluation
+Guides, quickstart, and the full CLI reference live at **[docs.osmosis.ai](https://docs.osmosis.ai)**.
 
-- [Eval](docs/eval.md) — evaluation run configs and `osmosis eval submit`
-- [CLI reference](docs/cli.md)
+- [Quickstart](https://docs.osmosis.ai/platform/quickstart) — run the multiply example end to end, from onboarding to evaluation run to training run
+- [CLI command reference](https://docs.osmosis.ai/cli/command-reference) — every `osmosis` command and flag, plus the `--json` / `--plain` output contract for AI agents and CI/CD
+- [Workspace setup](https://docs.osmosis.ai/cli/workspace/overview) — repository layout, config files, and Git Sync
+- [Rollouts](https://docs.osmosis.ai/cli/rollout/overview) — AgentWorkflow, Grader, integrations, and execution backends
+
+Building on or contributing to the SDK itself? See the code-anchored developer docs in [`docs/`](docs/) (start with [`docs/architecture.md`](docs/architecture.md)) alongside [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Guides, quickstart, and the full CLI reference live at **[docs.osmosis.ai](https
 - [CLI command reference](https://docs.osmosis.ai/cli/command-reference) — every `osmosis` command and flag, plus the `--json` / `--plain` output contract for AI agents and CI/CD
 - [Workspace setup](https://docs.osmosis.ai/cli/workspace/overview) — repository layout, config files, and Git Sync
 - [Rollouts](https://docs.osmosis.ai/cli/rollout/overview) — AgentWorkflow, Grader, integrations, and execution backends
+- [Releases](https://github.com/Osmosis-AI/osmosis-sdk-python/releases) — version history and breaking changes between releases
 
 Building on or contributing to the SDK itself? See the code-anchored developer docs in [`docs/`](docs/) (start with [`docs/architecture.md`](docs/architecture.md)) alongside [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,13 @@
 # Osmosis SDK developer docs
 
-> Product concepts and end-user CLI usage live at **[docs.osmosis.ai](https://docs.osmosis.ai)**. This `docs/` directory is the **code-anchored** reference for developers building on the SDK and for AI agents working inside this repository. Every page points at the source it documents; when code and a doc disagree, the code wins — fix the doc in the same PR.
+> Product concepts and end-user CLI usage live at **[docs.osmosis.ai](https://docs.osmosis.ai)**. This `docs/` directory is the **code-anchored** reference for developers building on the SDK. Every page points at the source it documents; when code and a doc disagree, the code wins — fix the doc in the same PR.
 
 ## Who reads what
 
 | Audience | Home | Orientation |
 |----------|------|-------------|
 | End users / everyone | [docs.osmosis.ai](https://docs.osmosis.ai) | Platform concepts, onboarding, CLI usage, quickstart |
-| SDK developers + AI agents in this repo | this `docs/` directory | Importable APIs, contracts, architecture, behavior — anchored to source |
+| SDK developers in this repo | this `docs/` directory | Importable APIs, contracts, architecture, behavior — anchored to source |
 
 We accept small, deliberate duplication only for entry facts (e.g. a one-line install). For everything else there is one source of truth: usage and product concepts link out to the site; code contracts live here next to the code.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,32 +1,38 @@
-# Osmosis SDK documentation
+# Osmosis SDK developer docs
 
-## Workspace Directory Flow
+> Product concepts and end-user CLI usage live at **[docs.osmosis.ai](https://docs.osmosis.ai)**. This `docs/` directory is the **code-anchored** reference for developers building on the SDK and for AI agents working inside this repository. Every page points at the source it documents; when code and a doc disagree, the code wins — fix the doc in the same PR.
 
-Create or open a workspace in the Osmosis Platform, clone the repository created there,
-then run CLI commands from that workspace directory.
+## Who reads what
 
-```bash
-git clone <repo-url>
-cd <repo>
-osmosis auth login
-osmosis doctor
-osmosis template apply multiply              # or add your rollout under rollouts/
-cp configs/training/default.toml configs/training/<run>.toml
-$EDITOR configs/training/<run>.toml          # set rollout, dataset, and model_path
-git add rollouts configs data
-git commit -m "configure training run"
-git push
-osmosis train submit configs/training/<run>.toml
-```
+| Audience | Home | Orientation |
+|----------|------|-------------|
+| End users / everyone | [docs.osmosis.ai](https://docs.osmosis.ai) | Platform concepts, onboarding, CLI usage, quickstart |
+| SDK developers + AI agents in this repo | this `docs/` directory | Importable APIs, contracts, architecture, behavior — anchored to source |
 
-Platform-scoped commands derive scope from the workspace directory's `origin` remote and
-send `X-Osmosis-Git: namespace/repo_name`. The CLI does not store or send a
-workspace ID for commands scoped by the workspace directory.
+We accept small, deliberate duplication only for entry facts (e.g. a one-line install). For everything else there is one source of truth: usage and product concepts link out to the site; code contracts live here next to the code.
 
-## Workflow commands
+## Package map
 
-- [Dataset format](./datasets.md) — Parquet / JSONL / CSV columns
-- [Eval](./eval.md) — `osmosis eval submit` and evaluation run configs
-- [CLI reference](./cli.md) — all `osmosis` commands and options, including
-  `train submit` with `[env]` / `[secrets]`
-- [Troubleshooting](./troubleshooting.md)
+The package (`osmosis_ai/`) is organized into top-level domains. See [architecture.md](./architecture.md) for the full layout and the rollout protocol.
+
+| Domain | Source | Purpose | Primary import |
+|--------|--------|---------|----------------|
+| CLI framework + commands | [../osmosis_ai/cli/](../osmosis_ai/cli/) | Typer entry point, command shells, output/JSON envelopes | `from osmosis_ai.cli.errors import CLIError` |
+| Platform integration | [../osmosis_ai/platform/](../osmosis_ai/platform/) | Auth, platform API client, CLI business logic | `from osmosis_ai.platform.auth import load_credentials` |
+| Remote rollout SDK | [../osmosis_ai/rollout/](../osmosis_ai/rollout/) | `AgentWorkflow` + `Grader`, contexts, server, backends | `from osmosis_ai.rollout import AgentWorkflow, Grader` |
+| Eval helpers | [../osmosis_ai/eval/](../osmosis_ai/eval/) | Rubric (LLM-as-judge) + workflow/grader loader | `from osmosis_ai.eval.rubric import evaluate_rubric` |
+| Workspace templates | [../osmosis_ai/templates/](../osmosis_ai/templates/) | `osmosis template` recipe catalog + source resolution | (internal) |
+
+## Pages
+
+- [architecture.md](./architecture.md) — package layout, domain boundaries, import paths, lazy-loading rules, and the remote rollout protocol (controller <-> rollout server). Start here.
+- [rollout-sdk.md](./rollout-sdk.md) — the library API you implement against: `AgentWorkflow`, `Grader`, contexts, configs, `create_rollout_server`, execution backends, and framework integrations.
+- [eval.md](./eval.md) — the `osmosis eval submit` config contract (SDK-vs-backend validation, submit flow), plus a brief note on the `evaluate_rubric` / `osmosis eval rubric` LLM-as-judge API.
+- [datasets.md](./datasets.md) — the dataset row contract enforced by the SDK validator.
+- [troubleshooting.md](./troubleshooting.md) — engineering issues (rollout timeouts, event-loop blocking, concurrency tuning).
+- [cli.md](./cli.md) — CLI internals for contributors (command shells, lazy imports, JSON envelopes).
+
+## See also
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — dev environment, tests, lint, type checking, PR conventions
+- [docs.osmosis.ai/cli/command-reference](https://docs.osmosis.ai/cli/command-reference) — the user-facing command reference

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,108 @@
+# Architecture
+
+> Code-anchored map of the `osmosis_ai` package for developers and AI agents. For platform concepts and CLI usage see [docs.osmosis.ai](https://docs.osmosis.ai).
+
+## Package layout
+
+```text
+osmosis_ai/
+├── cli/               # CLI framework + all command groups (Typer)
+│   ├── main.py        # Entry point & command registration (osmosis_ai.cli.main:main)
+│   ├── errors.py      # CLIError — the single error type used by every domain
+│   ├── console.py     # Console (rich + plain fallback)
+│   ├── output/        # Output context, result types, JSON/plain envelopes
+│   └── commands/      # Thin Typer shells; delegate to platform/cli + eval
+├── platform/          # Everything that talks to the Osmosis Platform API
+│   ├── auth/          # Device-code login, credential store, HTTP client
+│   ├── api/           # OsmosisClient
+│   └── cli/           # Platform CLI business logic (no Typer registration)
+├── rollout/           # Remote Rollout SDK (see rollout-sdk.md)
+│   ├── agent_workflow.py  # AgentWorkflow ABC
+│   ├── grader.py          # Grader ABC
+│   ├── context.py         # RolloutContext / AgentWorkflowContext / GraderContext
+│   ├── driver.py          # RolloutDriver — eval-facing execution contract
+│   ├── validator.py       # Static backend validation
+│   ├── server/            # create_rollout_server (FastAPI) + ControllerAuth
+│   ├── backend/           # ExecutionBackend ABC + Local / Harbor backends
+│   ├── types/             # protocol.py, config.py, sample.py
+│   └── integrations/      # Strands / OpenAI Agents adapters
+├── eval/              # Eval helpers
+│   ├── rubric/        # evaluate_rubric() LLM-as-judge engine
+│   └── common/cli.py  # Workflow + grader loader (used by cloud submit preflight)
+├── templates/         # `osmosis template` recipe catalog + source resolution
+├── __init__.py        # Top-level exports (lazy __getattr__)
+├── _litellm_compat.py # LiteLLM import shim (shared by rubric + eval)
+└── consts.py          # PACKAGE_VERSION
+```
+
+## Domain boundaries
+
+- `cli/` — the CLI framework layer plus every command group. Files in [../osmosis_ai/cli/commands/](../osmosis_ai/cli/commands/) are thin shells that delegate to business logic; see [cli.md](./cli.md).
+- `platform/` — anything that calls the Osmosis Platform API. Business-logic helpers (no Typer registration) live in [../osmosis_ai/platform/cli/](../osmosis_ai/platform/cli/).
+- `rollout/` — the remote rollout protocol SDK: the `AgentWorkflow` + `Grader` abstraction, execution backends, and the FastAPI server. See [rollout-sdk.md](./rollout-sdk.md).
+- `eval/` — `rubric/` powers `osmosis eval rubric` (see [eval.md](./eval.md)); `common/cli.py` exposes the workflow + grader loader that cloud `eval submit` / `train submit` preflight uses.
+
+## Key import paths
+
+```python
+from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.cli.console import Console
+from osmosis_ai.platform.auth import load_credentials
+from osmosis_ai.eval.rubric import evaluate_rubric, RubricResult
+from osmosis_ai.rollout import AgentWorkflow, Grader, create_rollout_server
+```
+
+`osmosis_ai.rollout` is **not** re-exported at the package top level — import it directly.
+
+## Lazy loading
+
+CLI startup must stay fast (~150 ms vs ~1 s), so heavy dependencies load on first use, not at import time:
+
+- **Top-level package** — [../osmosis_ai/__init__.py](../osmosis_ai/__init__.py) resolves rubric exports (`evaluate_rubric`, `RubricResult`, error types) through `__getattr__`. Only `__version__` is eager.
+- **Command shells** — every file in [../osmosis_ai/cli/commands/](../osmosis_ai/cli/commands/) uses function-level imports for heavy deps (`rollout.*`, `platform.api.*`, `platform.cli.*`, `eval.*`). Module-level imports stay light: `typer`, `cli.console`, `cli.errors`, the lightweight `platform.constants`, and stdlib.
+- **No eager `cli.main`** — [../osmosis_ai/cli/__init__.py](../osmosis_ai/cli/__init__.py) does not import `cli.main`, which prevents circular imports when rollout/server modules import `cli.console`. The entry point is `osmosis_ai.cli.main:main` directly.
+- **`_litellm_compat.py`** stays at the package top level because `eval/rubric/` depends on it.
+
+## Remote rollout protocol
+
+The core design separates **LLM inference** (on the training cluster) from **agent logic** (on your RolloutServer). The controller (Traingate/slime) drives inference; your `AgentWorkflow` runs the agent and your `Grader` attaches rewards. Inference weights stay on the training cluster so PPO sees consistent model weights, while agent/tool code can run anywhere.
+
+```mermaid
+sequenceDiagram
+    participant C as RolloutController
+    participant S as RolloutServer (create_rollout_server)
+    participant W as AgentWorkflow.run
+    participant G as Grader.grade
+    C->>S: POST /rollout (RolloutInitRequest)
+    Note over S: background task; returns RolloutInitResponse immediately
+    S->>W: backend.execute(ExecutionRequest)
+    W->>C: POST chat_completions_url (messages + tools)
+    C-->>W: LLM response (tool_calls)
+    Note over W: repeat until done
+    S->>C: POST completion_callback_url (RolloutCompleteRequest)
+    S->>G: grade collected samples
+    S->>C: POST grader_callback_url (GraderCompleteRequest)
+```
+
+Anchors:
+
+- Server + endpoints + callbacks: [../osmosis_ai/rollout/server/app.py](../osmosis_ai/rollout/server/app.py) (`create_rollout_server`, `POST /rollout`, `GET /health`, `_handle_rollout`).
+- Wire types: [../osmosis_ai/rollout/types/protocol.py](../osmosis_ai/rollout/types/protocol.py) (`RolloutInitRequest`, `RolloutCompleteRequest`, `GraderCompleteRequest`, `GraderStatus`).
+- Execution contract: [../osmosis_ai/rollout/backend/base.py](../osmosis_ai/rollout/backend/base.py) — `ExecutionBackend.execute(request, on_workflow_complete, on_grader_complete)`, where the two callbacks are `ResultCallback` parameters (not methods).
+- Sample/result types: [../osmosis_ai/rollout/types/sample.py](../osmosis_ai/rollout/types/sample.py) (`RolloutSample`, `RolloutStatus`, `RolloutErrorCategory`, `ExecutionRequest`, `ExecutionResult`).
+
+The controller delivers results asynchronously via the two callback URLs, so it can manage many concurrent rollouts. `grader_callback_url` is optional; when omitted, grading is skipped.
+
+### Eval path
+
+For local evaluation the same workflow/grader run behind a different driver. The eval-facing contract is `RolloutDriver` / `RolloutOutcome` in [../osmosis_ai/rollout/driver.py](../osmosis_ai/rollout/driver.py): eval supplies data + an LLM endpoint and consumes trace + reward, without caring whether execution was in-process or over HTTP.
+
+## Static validation
+
+During cloud `eval submit` / `train submit` **preflight**, `validate_rollout_backend` ([../osmosis_ai/platform/cli/workspace_directory_contract.py](../osmosis_ai/platform/cli/workspace_directory_contract.py)) calls `validate_backend` ([../osmosis_ai/rollout/validator.py](../osmosis_ai/rollout/validator.py)), which checks the workflow/grader classes the way `LocalBackend` instantiates them: concrete subclasses of `AgentWorkflow` / `Grader`, `async` `run` / `grade`, a resolvable agent name (1–256 chars), and successful instantiation with the provided config. It aggregates every applicable error into one `ValidationResult` instead of stopping at the first failure. (There is no separate "serve" step — see [rollout-sdk.md](./rollout-sdk.md).)
+
+## See also
+
+- [rollout-sdk.md](./rollout-sdk.md) — the library API surface
+- [cli.md](./cli.md) — CLI internals
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — dev workflow

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-> Code-anchored map of the `osmosis_ai` package for developers and AI agents. For platform concepts and CLI usage see [docs.osmosis.ai](https://docs.osmosis.ai).
+> Code-anchored map of the `osmosis_ai` package for developers. For platform concepts and CLI usage see [docs.osmosis.ai](https://docs.osmosis.ai).
 
 ## Package layout
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,7 +74,7 @@ sequenceDiagram
     participant W as AgentWorkflow.run
     participant G as Grader.grade
     C->>S: POST /rollout (RolloutInitRequest)
-    Note over S: background task, returns RolloutInitResponse immediately
+    Note over S: returns RolloutInitResponse immediately (background task)
     S->>W: backend.execute(ExecutionRequest)
     W->>C: POST chat_completions_url (messages + tools)
     C-->>W: LLM response (tool_calls)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,7 +74,7 @@ sequenceDiagram
     participant W as AgentWorkflow.run
     participant G as Grader.grade
     C->>S: POST /rollout (RolloutInitRequest)
-    Note over S: background task; returns RolloutInitResponse immediately
+    Note over S: background task, returns RolloutInitResponse immediately
     S->>W: backend.execute(ExecutionRequest)
     W->>C: POST chat_completions_url (messages + tools)
     C-->>W: LLM response (tool_calls)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,490 +1,65 @@
-# CLI reference
+# CLI internals (for contributors)
 
-Installing the SDK provides a lightweight CLI as `osmosis` (aliases: `osmosis_ai`, `osmosis-ai`). The CLI loads `.env` from the current working directory via `python-dotenv`.
+> The user-facing command + flag reference lives at [docs.osmosis.ai/cli/command-reference](https://docs.osmosis.ai/cli/command-reference). This page explains how the CLI is wired so you can add or change commands correctly.
 
-The global output flags `--json` and `--plain` are accepted anywhere on the command line: `osmosis --json dataset list` and `osmosis dataset list --json` are equivalent.
+## Entry point and registration
 
-## Authentication
+The console script is `osmosis_ai.cli.main:main` (aliases: `osmosis`, `osmosis-ai`, `osmosis_ai`). [../osmosis_ai/cli/main.py](../osmosis_ai/cli/main.py):
 
-Credentials are stored at `~/.config/osmosis/credentials.json`.
+- `main()` calls `_register_commands()` once, then runs the Typer `app` with `standalone_mode=False` so it can map exceptions to exit codes itself.
+- `_register_commands()` imports each command group **lazily inside the function**. Groups attach via `app.add_typer(...)`; the standalone `doctor` / `upgrade` commands attach via `app.command(...)`. Two `rich_help_panel`s split the help: `Workflow Commands` (`dataset`, `train`, `model`, `eval`, `rollout`, `template`, `doctor`) and `Platform Commands` (`auth`, `secret`, `upgrade`).
+- The root `_callback` resolves `--json` / `--plain`, builds an `OutputContext`, installs it on the Typer context, registers `verify_output_emitted` on close, and loads `.env` via `python-dotenv`. `hoist_format_selectors` lets the format flags appear anywhere on the line.
 
-### osmosis auth login
+## Command shells delegate; they don't do work
 
-Device code flow:
+Files in [../osmosis_ai/cli/commands/](../osmosis_ai/cli/commands/) are thin Typer shells. Each command parses options and delegates to business logic:
 
-```bash
-osmosis auth login
-osmosis auth login --force
-```
+- platform-facing logic lives in [../osmosis_ai/platform/cli/](../osmosis_ai/platform/cli/) (e.g. `dataset.py`, `train.py`, `eval.py`, `secret.py`);
+- eval/rubric logic lives in [../osmosis_ai/eval/](../osmosis_ai/eval/).
 
-### osmosis auth logout
+Module-level imports in `commands/` are kept light: `typer`, `cli.console`, `cli.errors`, the lightweight `osmosis_ai.platform.constants` (pagination limits), and stdlib. Everything heavy (`rollout.*`, `platform.api.*`, `platform.cli.*`, `eval.*`) must be imported **inside the function** to keep CLI startup fast — see the lazy-loading section of [architecture.md](./architecture.md).
 
-```bash
-osmosis auth logout
-osmosis auth logout -y
-```
-
-### osmosis auth whoami
-
-```bash
-osmosis auth whoami
-```
-
-`whoami` verifies the active credentials and reports the authenticated account.
-When run inside a workspace directory with a Platform-connected `origin`
-remote, the platform also resolves the linked workspace, reported as a
-`workspace` object (`id`, `name`, `role`) in `--json` output and as
-`Workspace` / `Role` rows otherwise. Outside a workspace repository,
-`workspace` is `null`. Manage workspaces, repositories, secrets, and account
-settings in the Osmosis Platform product.
-
-## Workspace Directory Flow
-
-Create or open a workspace in the Osmosis Platform, clone the repository created there,
-then run CLI commands from that workspace directory.
-
-```bash
-git clone <repo-url>
-cd <repo>
-osmosis auth login
-osmosis doctor
-osmosis template apply multiply-local-openai # or add your rollout under rollouts/
-cp configs/training/default.toml configs/training/<run>.toml
-$EDITOR configs/training/<run>.toml          # set rollout, dataset, and model_path
-git add rollouts configs data
-git commit -m "configure training run"
-git push
-osmosis train submit configs/training/<run>.toml
-```
-
-Platform-scoped commands derive scope from the workspace directory's `origin` remote and
-send `X-Osmosis-Git: namespace/repo_name`. The CLI does not store or send a
-workspace ID for commands scoped by the workspace directory. Running a
-workspace-scoped command outside a workspace directory fails with the
-`WORKSPACE_REQUIRED` error code.
-
-For CI:
-
-```bash
-export OSMOSIS_TOKEN=<token>
-osmosis train submit configs/training/<run>.toml --yes
-```
+## Commands return results; they don't print
 
-### osmosis doctor
+The Typer app is created with `result_callback=render_command_result` ([../osmosis_ai/cli/main.py](../osmosis_ai/cli/main.py)). A command function **returns** a `CommandResult`; the callback renders it in the active format. Do not `print()` from a command — return a typed result instead.
 
-```bash
-osmosis doctor
-osmosis doctor ./path/to/workspace-directory
-osmosis doctor --fix
-```
+Result types ([../osmosis_ai/cli/output/result.py](../osmosis_ai/cli/output/result.py)):
 
-Inspect and optionally repair the scaffold in the current workspace directory. Without
-`--fix`, the command reports the workspace directory, Git identity, required scaffold
-paths, and missing paths. Add `--fix` to create missing scaffold paths and
-check for official scaffold file updates without overwriting local edits.
-
-When you are logged in and the workspace directory has a Platform-connected
-`origin` remote, doctor also reports the linked workspace
-(`Linked workspace: <name>`; the `workspace` resource field in `--json`).
-The lookup is best-effort: offline or logged out, the field is `null` and
-doctor still works. Doctor exits non-zero with `status: "failed"` when
-required scaffold paths are missing (`valid: false`); run with `--fix` to
-restore them.
-
-## Rollout
-
-### osmosis rollout list
-
-List rollouts for the current workspace directory.
-
-```bash
-osmosis rollout list
-osmosis rollout list --limit 50
-osmosis rollout list --all
-```
-
-## Evaluation
-
-### osmosis eval submit
-
-Submit an evaluation run using a TOML config under `configs/eval/`. Evaluation
-run configs align with training run configs for rollout identity and platform dataset
-selection: `[experiment].dataset` is a platform dataset name from
-`osmosis dataset list`, not a local `data/*.jsonl` path.
-
-```toml
-[experiment]
-rollout = "my-rollout"
-entrypoint = "main.py"
-model_path = "openai/gpt-5-mini"      # LiteLLM-style model name
-dataset = "my-platform-dataset"
-# commit_sha =
-
-[evaluation]
-# Optional. Omit values to use platform defaults.
-# limit = 200
-# n = 1
-# batch_size = 1
-# pass_threshold = 1.0
-# agent_workflow_timeout_s = 450
-# grader_timeout_s = 150
-
-# [env]
-# LOG_LEVEL = "INFO"
-
-[secrets]
-# Default OpenAI eval models need this platform secret.
-# Use [] only when this evaluation needs no secret refs.
-required = ["OPENAI_API_KEY"]
-```
-
-```bash
-osmosis eval submit configs/eval/my-rollout.toml
-```
-
-### osmosis eval info
-
-Show evaluation run details, results, and metrics. In Rich output mode, metrics JSON is saved under `.osmosis/metrics/` by default when metrics are available. In JSON or plain output mode, pass `-o` / `--output` to write the metrics file.
-
-```bash
-osmosis eval info <eval-run-name-or-id>
-osmosis --json eval info <eval-run-name-or-id>
-osmosis eval info <eval-run-name-or-id> -o ./eval-metrics.json
-```
-
-### osmosis eval logs
-
-Show the most recent lifecycle logs for an evaluation run, oldest first.
-Useful for diagnosing failed runs.
-
-```bash
-osmosis eval logs <eval-run-name-or-id>
-osmosis eval logs <eval-run-name-or-id> --limit 100
-osmosis eval logs <eval-run-name-or-id> --json
-```
-
-`--limit` accepts 1–200 entries (default: 50). When older entries exist, the
-JSON output includes a non-null `next_cursor`; pass it back with `--cursor` to
-page further back in time.
-
-### osmosis eval rubric
-
-LLM-as-judge on a JSONL conversation file:
-
-```bash
-osmosis eval rubric -d data.jsonl \
-  --rubric "Evaluate the assistant's helpfulness..." \
-  --model openai/gpt-5.4
-```
-
-| Flag | Description |
-|------|-------------|
-| `-d` / `--data` | JSONL path (required) |
-| `-r` / `--rubric` | Inline rubric or `@file.txt` (required) |
-| `--model` | Judge model, LiteLLM form (required) |
-| `-n` / `--number` | Runs per record |
-| `-o` / `--output` | JSON results path |
-| `--api-key` | Judge API key |
-| `--timeout` | Seconds |
-| `--score-min` / `--score-max` | Score range |
-
-## Dataset
-
-### osmosis dataset upload
-
-Upload a local dataset file to the linked platform workspace. The dataset
-name is derived from the file name without its extension.
-
-```bash
-osmosis dataset upload data.jsonl
-osmosis dataset upload data.jsonl --yes
-osmosis dataset upload data.jsonl --overwrite
-```
-
-| Flag | Description |
-|------|-------------|
-| `--yes` / `-y` | Skip the interactive confirmation prompt |
-| `--overwrite` | Replace an existing dataset with the same derived name |
-
-When `--overwrite` is used, the CLI first confirms the duplicate-name conflict
-with the platform, then creates a replacement dataset record and soft-deletes
-the old one. The platform may reject overwrites while the existing dataset is
-still uploading, still processing, or used by an active training run.
-
-### osmosis dataset logs
-
-Show the most recent lifecycle logs for a dataset, oldest first. Useful for
-diagnosing failed uploads.
-
-```bash
-osmosis dataset logs <dataset-name>
-osmosis dataset logs <dataset-name> --limit 100
-osmosis dataset logs <dataset-name> --json
-```
-
-`--limit` accepts 1–200 entries (default: 50). When older entries exist, the
-JSON output includes a non-null `next_cursor`; pass it back with `--cursor` to
-page further back in time.
-
-## Training
-
-### osmosis train submit
-
-Submit a training run from a TOML config.
-
-```bash
-osmosis train submit configs/training/my-run.toml
-osmosis train submit configs/training/my-run.toml --yes   # skip confirmation
-```
-
-The config file must live under `configs/training/` inside a structured Osmosis
-workspace directory. The CLI reads the config locally and sends it to the platform, which
-clones the repository identified by the workspace directory's `origin` remote for the
-actual rollout code.
-`osmosis train submit` includes the training run preflight checks before launch;
-run `osmosis eval submit configs/eval/<name>.toml` first when you want an
-evaluation run before a training run.
-
-#### Required `[experiment]` fields
-
-| Key | Description |
-|-----|-------------|
-| `rollout` | Directory name under `rollouts/` |
-| `entrypoint` | Python file relative to the rollout directory |
-| `model_path` | Supported base model path |
-| `dataset` | Platform dataset name (`osmosis dataset list`) |
-
-#### Optional `[experiment]` fields
-
-| Key | Description |
-|-----|-------------|
-| `commit_sha` | Optional pinned commit. When omitted, the platform chooses source from the connected repository. Must be a hexadecimal SHA (7–40 chars); `submit` preflights it against origin and fails fast if the commit is not found on the connected repository. |
-
-#### Optional `[training]` fields
-
-All fields are optional. Omitted fields use platform defaults.
-
-| Key | Type | Description |
-|-----|------|-------------|
-| `total_epochs` | int | Number of passes over the dataset |
-| `n_samples_per_prompt` | int | Rollout samples generated per prompt (GRPO group size) |
-| `rollout_batch_size` | int | Prompts rolled out per training step. **Controls how many rollouts run concurrently on the rollout server** — set this to avoid overwhelming the LLM inference engine. Default: 64. For a 32-row dataset with a remote rollout server, `8` or `32` is a safe starting point. |
-| `max_prompt_length` | int | Token limit for prompt inputs |
-| `max_response_length` | int | Token limit for model responses |
-| `lr` | float | Learning rate |
-| `agent_workflow_timeout_s` | float | Seconds osmosis waits for the rollout server to complete one rollout before marking it failed (default: 450 s). Increase for long-horizon agent tasks where each rollout can take several minutes. |
-| `grader_timeout_s` | float | Seconds osmosis waits for the grader callback after rollout completes (default: 150 s). Increase if your grader runs expensive verification. |
-
-> **Sizing `rollout_batch_size`**: the rollout server processes `rollout_batch_size × n_samples_per_prompt` concurrent LLM calls per step. Too high a value overwhelms the inference engine and causes all rollouts to timeout. A good rule of thumb: `rollout_batch_size ≤ 32` when using a remote MCP-based rollout server with a 35B+ model.
-
-#### Optional `[sampling]` fields
+| Type | Use |
+|------|-----|
+| `ListResult` | A single list/table |
+| `SectionedListResult` | Multiple named lists (e.g. base + LoRA models) |
+| `DetailResult` | One resource's fields/sections |
+| `OperationResult` | A mutation's outcome |
+| `MessageResult` | A plain message |
 
-| Key | Type | Description |
-|-----|------|-------------|
-| `rollout_temperature` | float | Sampling temperature (default: 1.0) |
-| `rollout_top_p` | float | Top-p nucleus sampling (default: 1.0) |
-
-#### Optional `[checkpoints]` fields
+Serializers that turn API models into these shapes live in [../osmosis_ai/cli/output/serializers.py](../osmosis_ai/cli/output/serializers.py).
 
-| Key | Type | Description |
-|-----|------|-------------|
-| `checkpoint_save_freq` | int | Save a checkpoint every N rollout steps |
-| `eval_interval` | int | Run evaluation every N rollout steps |
+## Output envelopes
 
-#### Environment variables — `[env]`
+[../osmosis_ai/cli/output/renderer.py](../osmosis_ai/cli/output/renderer.py) builds the machine contract. Every JSON success envelope carries `schema_version: 1` and a shape matching the result type (`_envelope_list`, `_envelope_sectioned_list`, `_envelope_detail`, `_envelope_operation`, `_envelope_message`). Rich is the default for humans; `--plain` is intentionally low-noise text (not a strict schema).
 
-Literal key/value pairs injected verbatim into the rollout container. Values
-are visible in the config file and in CLI output — do **not** use this section
-for secrets.
-
-```toml
-[env]
-LOG_LEVEL = "INFO"
-DEFAULT_REGION = "us-west-2"
-```
+The output context, format enum, and selector resolution live in [../osmosis_ai/cli/output/context.py](../osmosis_ai/cli/output/context.py); the full output surface is re-exported from [../osmosis_ai/cli/output/__init__.py](../osmosis_ai/cli/output/__init__.py).
 
-#### Secrets — `[secrets]`
-
-The `[secrets]` section must contain a `required` list of secret names to inject
-into the rollout container. The platform resolves each name to its encrypted
-value server-side and sets it as an env var of the same name. Secret values
-never appear in the config file, in the API payload, or in CLI output.
-
-Each name must match `^[A-Z][A-Z0-9_]*$`.
-
-```toml
-[secrets]
-required = ["OPENAI_API_KEY", "DATABASE_URL"]
-```
-
-Evaluation configs must include `[secrets]`; use `required = []` when
-the evaluation needs no secret refs. The default OpenAI eval examples use
-`required = ["OPENAI_API_KEY"]`. Training configs may omit the `[secrets]` table
-when the training run does not need secret refs. If a config includes
-`[secrets]`, that table must include `required`.
-
-Secrets are scoped. A **workspace** secret is shared across the workspace; a
-**personal** secret is private to you. When a workspace and a personal secret
-share a name, your personal value wins at run time. Register secrets with
-`osmosis secret set` (below) or at `/:orgName/secrets` in the platform UI
-before submitting a run that references them. `osmosis secret set NAME` creates
-a personal secret by default; pass `--scope workspace` for workspace-shared
-secrets.
-
-#### Rules
-
-- `[env]` keys must match `^[A-Z_][A-Z0-9_]*$`; `[secrets]` names must match `^[A-Z][A-Z0-9_]*$`.
-- A name cannot appear in both `[env]` and `[secrets]`.
-- `[env]` names starting with `_OSMOSIS_` are reserved by the platform.
-- Both are optional.
-
-### osmosis train info
-
-Show details, checkpoints, and metrics for a training run.
-
-```bash
-osmosis train info <run-name>
-osmosis --json train info <run-name>
-osmosis train info <run-name> -o ./my-metrics.json
-```
-
-### osmosis train list
-
-List training runs for the current workspace directory.
-
-```bash
-osmosis train list
-osmosis train list --limit 50
-osmosis train list --all
-```
-
-### osmosis train logs
-
-Show the most recent lifecycle logs for a training run, oldest first. Useful
-for diagnosing failed or crashed runs.
-
-```bash
-osmosis train logs <run-name>
-osmosis train logs <run-name> --limit 100
-osmosis train logs <run-name> --json
-```
-
-`--limit` accepts 1–200 entries (default: 50). When older entries exist, the
-JSON output includes a non-null `next_cursor`; pass it back with `--cursor` to
-page further back in time.
-
-### osmosis train stop
-
-Stop an in-progress training run.
-
-```bash
-osmosis train stop <run-name>
-osmosis train stop <run-name> --yes
-```
-
-## Model
-
-Models cover base (foundation) models and LoRA models produced by training
-runs. Deploying a LoRA model exposes it for inference.
-
-### osmosis model list
-
-List base models and LoRA models for the current workspace directory as two
-separate tables (base models first, then LoRA models). The base models table
-shows Name, Created, and Created By; the LoRA models table shows Name, Base
-Model, Training Run, Checkpoint Step, Training Reward, Created, and Deployment
-Status. `--limit` and `--all` apply to each type independently, and each list
-carries its own pagination cursor (`next_offset`) straight from its endpoint.
-Filter with `--type base` or `--type lora` to show a single list.
-
-When the LoRA models list is included, a deployment-quota summary is shown
-under the LoRA table (e.g. `2 of 5 deployment slots used`), matching the
-platform web UI.
-
-```bash
-osmosis model list
-osmosis model list --type lora
-osmosis model list --limit 50
-osmosis model list --all
-osmosis --json model list
-```
-
-`--json` output keys each list separately, so the structure itself says which
-list is which:
-
-```json
-{
-  "schema_version": 1,
-  "base_models": {
-    "items": [{"id": "...", "model_name": "Qwen/Qwen3", "...": "..."}],
-    "total_count": 1,
-    "has_more": false,
-    "next_offset": null
-  },
-  "lora_models": {
-    "items": [{"id": "...", "model_name": "run-step-1", "reward": 0.87, "deployed_at": null, "deployed_by": null, "...": "..."}],
-    "total_count": 1,
-    "has_more": false,
-    "next_offset": null
-  },
-  "git": {"identity": "...", "remote_url": "..."},
-  "workspace_directory": "...",
-  "active_deployments": 2,
-  "max_active_deployments": 5
-}
-```
-
-Each LoRA item carries `deployed_at` / `deployed_by` (null when the model has
-never been deployed). The top-level `active_deployments` /
-`max_active_deployments` quota keys appear for `--type all` and `--type lora`,
-but not for `--type base`.
-
-### osmosis model deploy
-
-Deploy or reactivate a LoRA model by name.
-
-```bash
-osmosis model deploy <lora-model-name>
-```
-
-### osmosis model undeploy
-
-Transition a LoRA model's deployment to inactive (idempotent).
-
-```bash
-osmosis model undeploy <lora-model-name>
-```
-
-## Secrets
-
-### `osmosis secret`
-
-Manage secrets. The platform never returns secret values; these
-commands show or accept names + metadata only.
-
-| Command | Description |
-| --- | --- |
-| `osmosis secret list [--scope all\|workspace\|personal] [--limit N] [--all]` | List secret names + scope (no values). |
-| `osmosis secret set NAME [--scope workspace\|personal] [--env VARNAME]` | Create or update (upsert) a secret. Defaults to personal scope. Value read from `--env VARNAME` or a hidden prompt — never a plaintext argument. |
-| `osmosis secret delete NAME [--scope workspace\|personal] [--yes]` | Delete a secret within the given scope. Defaults to personal scope. |
-
-`--scope` defaults to `personal` for `set`/`delete` and `all` for `list`.
-Workspace secrets require an admin/owner role; personal secrets are private to you.
-
-```bash
-# Read the value from an env var (recommended for scripts).
-# This creates or updates your personal secret by default:
-OPENAI_API_KEY=sk-... osmosis secret set OPENAI_API_KEY --env OPENAI_API_KEY
-
-# Workspace-shared secret:
-OPENAI_API_KEY=sk-... osmosis secret set OPENAI_API_KEY --scope workspace --env OPENAI_API_KEY
-
-osmosis secret list --scope personal
-osmosis secret delete OPENAI_API_KEY --scope personal --yes
-```
+## Errors
+
+Raise `CLIError` ([../osmosis_ai/cli/errors.py](../osmosis_ai/cli/errors.py)) — the single error type shared by every domain. `main()` funnels all exceptions through `_handle_cli_error`:
+
+- in JSON mode, `classify_error()` + `emit_structured_error_to_stderr()` write a structured error envelope (with a CLI error `code`, command path, and SDK version) to **stderr** ([../osmosis_ai/cli/output/error.py](../osmosis_ai/cli/output/error.py));
+- otherwise a plain `Error: …` line is printed.
+
+`KeyboardInterrupt` / `click.Abort` exit `130`; `typer.Exit` / `SystemExit` preserve their code.
+
+## Conventions when adding a command
+
+1. Put the Typer shell in `cli/commands/`; put the logic in `platform/cli/` or `eval/`.
+2. Keep module-level imports minimal; lazy-import heavy deps inside the function.
+3. Return a `CommandResult`; never print directly.
+4. Raise `CLIError` for user-facing failures.
+5. Support non-interactive flows (`--yes`, `--token`, `--env`) so `--json` / `--plain` don't dead-end on a prompt (`INTERACTIVE_REQUIRED`).
 
 ## See also
 
-- [Eval](./eval.md)
-- [Dataset format](./datasets.md)
-- [Troubleshooting](./troubleshooting.md)
+- [architecture.md](./architecture.md) — package layout + lazy loading
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — dev workflow, tests, lint
+- [docs.osmosis.ai/cli/command-reference](https://docs.osmosis.ai/cli/command-reference) — user-facing reference

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -1,45 +1,53 @@
-# Dataset format
+# Dataset contract
 
-Datasets supply prompts and reference answers for cloud `osmosis eval submit` and `osmosis train submit` runs. Each row becomes a short message list (system + user) plus optional extra fields carried on the row dict.
+> The dataset shape the SDK validates locally before upload. Uploading and managing datasets (`osmosis dataset upload`, overwrite/processing semantics) is covered at [docs.osmosis.ai](https://docs.osmosis.ai/platform/datasets).
 
-## Supported formats
+Datasets supply prompts (and optional reference answers) for cloud `osmosis eval submit` and `osmosis train submit` runs. The contract below is enforced by the local validator before any bytes hit the platform.
 
-- **Parquet** (recommended) — compact and fast for large tables
-- **JSONL** — one JSON object per line
-- **CSV** — header row required
+## What the SDK checks
+
+Constants: [../osmosis_ai/platform/cli/constants.py](../osmosis_ai/platform/cli/constants.py). Validation: [../osmosis_ai/platform/cli/dataset.py](../osmosis_ai/platform/cli/dataset.py) (`_validate_file`, `_check_required_columns`).
+
+| Rule | Value | Source |
+|------|-------|--------|
+| Allowed extensions | `csv`, `jsonl`, `parquet` | `VALID_EXTENSIONS` |
+| Required columns | `system_prompt`, `user_prompt` | `REQUIRED_COLUMNS` |
+| Minimum rows | `4` | `MIN_ROW_COUNT` |
+| Max file size | 5 GB | `MAX_FILE_SIZE` |
 
 ## Required columns
 
-Each row must include (case-insensitive column names):
+Each row must include exactly these column names — `_check_required_columns` does a **case-sensitive** set match (`REQUIRED_COLUMNS - set(columns)`), so `User_Prompt` or `USER_PROMPT` will not satisfy it:
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `ground_truth` | `str` | Reference answer (used by graders and some tooling) |
-| `user_prompt` | `str` | User turn |
 | `system_prompt` | `str` | System instruction |
+| `user_prompt` | `str` | User turn |
 
-## Example (Parquet)
+`ground_truth` is **not** required by the validator. It is a conventional optional column that graders and tooling read for reference answers — include it when your `Grader` needs it.
+
+## Additional columns
+
+The validator only checks that the required columns are *present*; it never rejects extra columns. Any other columns ride along on the row and are available to downstream code (workflows, graders, platform metadata).
+
+## Examples
 
 ```python
 import pyarrow as pa
 import pyarrow.parquet as pq
 
 table = pa.table({
-    "system_prompt": ["You are a helpful calculator.", "You are a helpful calculator."],
-    "user_prompt": ["What is 2 + 2?", "What is 10 * 5?"],
-    "ground_truth": ["4", "50"],
+    "system_prompt": ["You are a helpful calculator."] * 4,
+    "user_prompt": ["What is 2 + 2?", "What is 10 * 5?", "What is 9 - 3?", "What is 8 / 2?"],
+    "ground_truth": ["4", "50", "6", "4"],   # optional
 })
 pq.write_table(table, "data.parquet")
 ```
-
-## Example (JSONL)
 
 ```jsonl
 {"system_prompt": "You are a helpful calculator.", "user_prompt": "What is 2 + 2?", "ground_truth": "4"}
 {"system_prompt": "You are a helpful calculator.", "user_prompt": "What is 10 * 5?", "ground_truth": "50"}
 ```
-
-## Example (CSV)
 
 ```csv
 system_prompt,user_prompt,ground_truth
@@ -47,35 +55,13 @@ You are a helpful calculator.,What is 2 + 2?,4
 You are a helpful calculator.,What is 10 * 5?,50
 ```
 
-> Fields with commas or newlines must be quoted per [RFC 4180](https://tools.ietf.org/html/rfc4180). Prefer Parquet or JSONL for rich text.
+> At least `MIN_ROW_COUNT` (4) rows are required. Quote CSV fields containing commas or newlines per [RFC 4180](https://tools.ietf.org/html/rfc4180); prefer Parquet or JSONL for rich text.
 
-## Additional columns
+## Note: rubric eval input is different
 
-Any other columns are kept on the normalized row dict. Downstream code (workflows, graders, or platform metadata) can read them from that structure.
-
-## Uploading datasets
-
-Upload a local dataset file with:
-
-```bash
-osmosis dataset upload data.jsonl
-```
-
-Add `--yes` (or `-y`) to skip the interactive confirmation prompt, which is
-useful in JSON/plain output modes and CI jobs.
-
-Dataset names are derived from the file name without its extension. If a dataset
-with the same name already exists, the upload fails instead of auto-renaming the
-new dataset. To replace the existing dataset, pass `--overwrite`:
-
-```bash
-osmosis dataset upload data.jsonl --overwrite
-```
-
-Overwrite creates a new dataset record and soft-deletes the old one. The platform
-may reject overwrites while the existing dataset is still uploading, still
-processing, or used by an active training run.
+`osmosis eval rubric` does **not** use this columnar contract. It reads a messages-based JSONL file ([../osmosis_ai/eval/rubric/dataset.py](../osmosis_ai/eval/rubric/dataset.py)); see [eval.md](./eval.md).
 
 ## See also
 
-- [Eval](./eval.md)
+- [eval.md](./eval.md) — `evaluate_rubric` API and config validation
+- [docs.osmosis.ai/platform/datasets](https://docs.osmosis.ai/platform/datasets) — upload + management

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -1,97 +1,95 @@
 # Eval
 
-An evaluation run submits against a platform dataset using the same workspace, rollout, entrypoint, dataset, and optional `commit_sha` semantics as `osmosis train submit`. The platform clones the repository identified by the workspace directory's `origin` remote and executes the rollout server-side, so push your changes and confirm Git Sync before submitting.
+> Product/end-user eval-run usage (results UI, metrics, config field reference) lives at [docs.osmosis.ai](https://docs.osmosis.ai/platform/evaluation-runs). This page is the **code-anchored** contract for `osmosis eval submit`: the TOML the SDK validates locally, the SDK-vs-backend validation split, and the submit flow. `osmosis eval rubric` (offline LLM-as-judge) is covered briefly at the end.
 
-Evaluation configs must live under `configs/eval/` inside a structured Osmosis workspace directory.
+## `osmosis eval submit` (cloud eval runs)
 
-## TOML configuration
+Reads an evaluation config TOML, validates its **structure** locally, and POSTs it to the platform over the same git-sync flow as `osmosis train submit`. The two commands share one implementation — only the literal strings, the config loader, and the API call differ.
 
-### Required fields
+- Command shell: [../osmosis_ai/cli/commands/eval.py](../osmosis_ai/cli/commands/eval.py) (`eval_submit`)
+- Handler + submit spec: [../osmosis_ai/platform/cli/eval.py](../osmosis_ai/platform/cli/eval.py) (`submit`, `_EVAL_SUBMIT_SPEC`)
+- Config loader: [../osmosis_ai/platform/cli/eval_config.py](../osmosis_ai/platform/cli/eval_config.py)
+- Shared submit flow: [../osmosis_ai/platform/cli/shared_submit.py](../osmosis_ai/platform/cli/shared_submit.py) (`run_cloud_submit`)
+- Shared config primitives: [../osmosis_ai/platform/cli/shared_config.py](../osmosis_ai/platform/cli/shared_config.py)
 
-**`[experiment]`**
+```bash
+osmosis eval submit configs/eval/<name>.toml        # interactive confirmation
+osmosis eval submit configs/eval/<name>.toml --yes  # skip the prompt
+```
 
-| Key | Description |
-|-----|-------------|
-| `rollout` | Directory name under `rollouts/`. |
-| `entrypoint` | Python file relative to the rollout directory. |
-| `model_path` | LiteLLM-style model name for the evaluation policy model, such as `openai/gpt-5-mini`. |
-| `dataset` | Platform dataset name from `osmosis dataset list`. |
+The config path must resolve under `configs/eval/` inside the current git workspace directory.
 
-### Optional fields and sections
-
-Evaluation submit configs also support optional `[experiment].commit_sha`, `[evaluation]`, and `[env]`. They must include `[secrets]`; default OpenAI eval configs should include `OPENAI_API_KEY`, and `required = []` is only for evaluations that need no secret refs. The SDK validates only shallow TOML shape, required fields, recognized keys, and env-var names; backend validation owns provider, dataset, model, and evaluation parameter errors.
-
-| Key | Description |
-|-----|-------------|
-| `commit_sha` | Optional pinned commit. When omitted, the platform chooses source from the connected repository. Must be a hexadecimal SHA (7–40 chars); `submit` preflights it against origin and fails fast if the commit is not found on the connected repository. |
-
-**`[evaluation]`**
-
-| Key | Description |
-|-----|-------------|
-| `limit` | Optional row cap. |
-| `n` | Number of evaluation attempts per row. Total evaluations are `limit * n` (or `sampled_rows * n`). |
-| `batch_size` | Rows evaluated per batch. |
-| `pass_threshold` | Minimum passing score. |
-| `agent_workflow_timeout_s` | Agent workflow timeout per row. |
-| `grader_timeout_s` | Grader timeout per row. |
-
-**`[env]` / `[secrets]`**
-
-`[env]` contains literal env-var values. `[secrets]` must contain a `required` list of secret names (e.g. `required = ["OPENAI_API_KEY"]`); the platform resolves each to its encrypted value server-side and injects it as an env var of the same name. `[env]` keys must match `^[A-Z_][A-Z0-9_]*$`; secret names must match `^[A-Z][A-Z0-9_]*$`; `[env]` names must not start with `_OSMOSIS_`; and a name cannot appear in both `[env]` and `[secrets]`. Register secrets with `osmosis secret set`; personal scope is the default, and `--scope workspace` creates workspace-shared secrets.
-
-### Example `configs/eval/my-rollout.toml`
+### Config contract (what the SDK validates)
 
 ```toml
-[experiment]
-rollout = "my-rollout"
-entrypoint = "main.py"
-model_path = "openai/gpt-5-mini"      # LiteLLM-style model name
-dataset = "my-platform-dataset"
-# commit_sha =
+[experiment]                      # required
+rollout = "my_rollout"            # single-segment logical name -> rollouts/my_rollout/
+entrypoint = "agent.py"           # resolves under rollouts/my_rollout/
+model_path = "Qwen/Qwen3-8B"
+dataset = "my-dataset"
+# commit_sha = "abc1234"          # optional, 7-40 hex chars
 
-[evaluation]
-# Optional. Omit values to use platform defaults.
-# limit = 200
-# n = 1
-# batch_size = 1
-# pass_threshold = 1.0
-# agent_workflow_timeout_s = 450
-# grader_timeout_s = 150
+[evaluation]                      # optional; structure-only, values owned by backend
+n = 4
+limit = 100
 
-# [env]
-# LOG_LEVEL = "INFO"
+[env]                             # optional
+LOG_LEVEL = "info"
 
-[secrets]
-# Default OpenAI eval models need this platform secret.
-# Use [] only when this evaluation needs no secret refs.
+[secrets]                         # required for eval (use required = [] when none)
 required = ["OPENAI_API_KEY"]
 ```
 
-## Quick start
+| Section | Required | SDK enforces locally |
+|---------|----------|----------------------|
+| `[experiment]` | yes | `rollout`, `entrypoint`, `model_path`, `dataset` present; `commit_sha` (if set) is 7-40 hex chars; `rollout` is a single-segment name resolving under `rollouts/`; unknown keys rejected (`ExperimentSection`). |
+| `[evaluation]` | no | Structure only — known keys are `limit`, `n`, `batch_size`, `pass_threshold`, `agent_workflow_timeout_s`, `grader_timeout_s`; unknown keys rejected, **values forwarded unvalidated** (`_EvaluationSection`). |
+| `[advanced]` | no | Passthrough — extra keys allowed and forwarded for server-side validation (`AdvancedPassthroughSection`). |
+| `[env]` | no | Names match `ENV_VAR_NAME_RE` = `^[A-Z_][A-Z0-9_]*$`, must not start with `_OSMOSIS_` (reserved), values must be strings. |
+| `[secrets]` | yes (eval) | Only the `required` key (a list of strings); names match `SECRET_NAME_RE` = `^[A-Z][A-Z0-9_]*$`; unknown keys rejected. Training configs may omit the section; **eval configs must include it** — use `required = []` when no secrets are needed. |
 
-```bash
-osmosis dataset list
-git push                                       # ensure the platform sees your commit
-osmosis eval submit configs/eval/my-rollout.toml
-osmosis eval info <eval-run-name-or-id>
-osmosis eval info <eval-run-name-or-id> -o ./eval-metrics.json
+A name cannot appear in both `[env]` and `[secrets]`.
+
+### SDK vs backend validation
+
+The SDK validates **structure only**; the backend owns value-level semantics. So the SDK does **not** check provider/model validity, dataset existence and naming, or evaluation parameter ranges (`n`, `limit`, `pass_threshold`, timeouts) — those errors surface from the platform at submit time, not from the SDK. This is deliberate: the SDK does not track backend schema evolution.
+
+### Submit flow (what happens locally before the POST)
+
+`run_cloud_submit` ([shared_submit.py](../osmosis_ai/platform/cli/shared_submit.py)) runs in order:
+
+1. Resolve the git/workspace-directory context and validate the workspace contract.
+2. Resolve the config path and ensure it lives under `configs/eval/`.
+3. Load + validate the TOML (`load_eval_submit_config`).
+4. Validate `rollout`/`entrypoint` resolve under `rollouts/<rollout>/`, then validate the rollout backend.
+5. Preflight a pinned `commit_sha` (fail fast on a confirmed-bad SHA before the platform clones the repo).
+6. Render the confirmation summary; if `[secrets]` are referenced, fetch workspace + personal scopes and **fail fast** on missing names with an `osmosis secret set <name>` hint.
+7. Confirm (skipped with `--yes`), then POST via `client.submit_evaluation_run`. A missing-secret `404` is enriched with the same add-secret hint.
+
+The result is an `OperationResult` whose next-steps point at `osmosis eval info <name>`, `osmosis eval list`, and the platform URL.
+
+### Companion commands
+
+All operate on the current git workspace directory ([../osmosis_ai/platform/cli/eval.py](../osmosis_ai/platform/cli/eval.py)):
+
+- `osmosis eval list [--all] [--limit N]` — list runs for the workspace.
+- `osmosis eval info <name|id> [-o path]` — run detail, results, and metrics (writes a metrics JSON in rich mode).
+- `osmosis eval logs <name|id> [--cursor …]` — recent run logs, oldest first.
+- `osmosis eval stop <name|id> [--yes]` — stop a run.
+
+See [docs.osmosis.ai/cli/config-files](https://docs.osmosis.ai/cli/config-files) for the full config field reference.
+
+## `osmosis eval rubric` (offline LLM-as-judge)
+
+Standalone, no-workspace scoring of a candidate output against a rubric via a hosted LLM judge (LiteLLM). It needs no platform auth and runs no rollout. The CLI command is `osmosis eval rubric`; the same logic is importable as `evaluate_rubric`:
+
+```python
+from osmosis_ai import evaluate_rubric, RubricResult  # lazy-loaded top-level exports
 ```
 
-## Rubric (LLM-as-judge)
-
-`osmosis eval rubric` is a local utility for scoring an existing JSONL conversation file with an LLM judge. It does not require a workspace directory or platform authentication, and it does not run a rollout.
-
-```bash
-osmosis eval rubric -d conversations.jsonl \
-  --rubric "Evaluate the assistant's helpfulness..." \
-  --model openai/gpt-5-mini
-```
-
-See the [CLI reference](./cli.md#osmosis-eval-rubric) for the full flag list.
+`evaluate_rubric` is an async function returning a `RubricResult` (`score: float`, `explanation: str`) with the score clamped to `[score_min, score_max]`. For the full signature, provider inference, API-key resolution, and error types, see the engine and types directly: [../osmosis_ai/eval/rubric/engine.py](../osmosis_ai/eval/rubric/engine.py), [../osmosis_ai/eval/rubric/types.py](../osmosis_ai/eval/rubric/types.py). For the CLI flag list, see the [command reference](https://docs.osmosis.ai/cli/command-reference).
 
 ## See also
 
-- [Dataset format](./datasets.md)
-- [CLI reference](./cli.md)
-- [Troubleshooting](./troubleshooting.md)
+- [datasets.md](./datasets.md) — dataset row contract
+- [rollout-sdk.md](./rollout-sdk.md) — the workflow + grader API graded during eval runs

--- a/docs/rollout-sdk.md
+++ b/docs/rollout-sdk.md
@@ -1,0 +1,161 @@
+# Rollout SDK
+
+> The library API you implement against. Anchored to [../osmosis_ai/rollout/__init__.py](../osmosis_ai/rollout/__init__.py). For how rollouts run end to end see [architecture.md](./architecture.md); for usage and the `osmosis rollout` CLI see [docs.osmosis.ai](https://docs.osmosis.ai/cli/rollout/overview).
+
+A rollout has two halves you provide: an `AgentWorkflow` (the agent loop) and a `Grader` (turns the trajectory into rewards). The SDK runs them behind an execution backend and the FastAPI server.
+
+## Public surface
+
+Everything below is re-exported from `osmosis_ai.rollout` unless noted.
+
+| Symbol | Source | Purpose |
+|--------|--------|---------|
+| `AgentWorkflow` | [agent_workflow.py](../osmosis_ai/rollout/agent_workflow.py) | ABC you subclass; implement `async run(ctx)` |
+| `Grader` | [grader.py](../osmosis_ai/rollout/grader.py) | ABC you subclass; implement `async grade(ctx)` |
+| `AgentWorkflowContext`, `HarborAgentWorkflowContext`, `GraderContext`, `RolloutContext`, `get_rollout_context` | [context.py](../osmosis_ai/rollout/context.py) | Execution context passed to `run` / `grade` |
+| `AgentWorkflowConfig`, `GraderConfig`, `ConcurrencyConfig` | [types/config.py](../osmosis_ai/rollout/types/config.py) | Pydantic config models |
+| `RolloutSample`, `RolloutStatus`, `RolloutErrorCategory`, `MultiTurnMode` | [types/sample.py](../osmosis_ai/rollout/types/sample.py) | Sample + status types |
+| `create_rollout_server`, `ControllerAuth` | [server/](../osmosis_ai/rollout/server/) | FastAPI factory + bearer auth |
+| `ExecutionBackend`, `LocalBackend` | [backend/](../osmosis_ai/rollout/backend/) | Execution backends |
+| `OsmosisStrandsAgent`, `OsmosisRolloutModel` | [integrations/agents/strands.py](../osmosis_ai/rollout/integrations/agents/strands.py) | Strands integration |
+
+## AgentWorkflow
+
+```python
+class AgentWorkflow[TConfig: AgentWorkflowConfig](ABC):
+    def __init__(self, config: TConfig | None = None): ...
+    @abstractmethod
+    async def run(self, ctx: AgentWorkflowContext[TConfig]) -> Any: ...
+```
+
+[../osmosis_ai/rollout/agent_workflow.py](../osmosis_ai/rollout/agent_workflow.py)
+
+- `run` is **async** (enforced by [validator.py](../osmosis_ai/rollout/validator.py)).
+- `ctx.prompt` is the initial message list; `ctx.config` is your typed config.
+- The return value is not the trajectory. Samples are collected from the active `RolloutContext` (see [Samples](#samples)); the integrations register sources for you.
+
+## Grader
+
+```python
+class Grader(ABC):
+    def __init__(self, config: GraderConfig | None = None): ...
+    @abstractmethod
+    async def grade(self, ctx: GraderContext) -> Any: ...
+```
+
+[../osmosis_ai/rollout/grader.py](../osmosis_ai/rollout/grader.py)
+
+- `ctx.get_samples()` returns the collected `dict[str, RolloutSample]` (**sync**).
+- Attach rewards with `ctx.set_sample_reward(sample_id, reward)` — it raises `ValueError` for an unknown `sample_id` ([context.py](../osmosis_ai/rollout/context.py)).
+- `ctx.label` carries the dataset row's label (the ground-truth string).
+
+## Contexts
+
+[../osmosis_ai/rollout/context.py](../osmosis_ai/rollout/context.py)
+
+- `AgentWorkflowContext` — `prompt: list[dict]`, `config`.
+- `HarborAgentWorkflowContext` — adds `environment` (Harbor `BaseEnvironment`) for `environment.exec()`, `environment.upload_file()`, etc. under `HarborBackend`.
+- `GraderContext` — `label`, `samples`, plus `get_samples()` / `set_sample_reward()`. (It also has a `project_path` field, but no backend currently populates it — it is always `None`.)
+- `RolloutContext` — ambient per-rollout context (chat completions URL, API key, rollout id). It is a context manager; the server enters it around execution. Local backends pass connection info directly; container runners read it from `OSMOSIS_CHAT_COMPLETIONS_URL` / `OSMOSIS_API_KEY` / `OSMOSIS_ROLLOUT_ID`. Fetch the current one with `get_rollout_context()`.
+
+### Samples
+
+The workflow does not return samples; instead a `SampleSource` is registered on the **ambient** `RolloutContext` (fetched with `get_rollout_context()`, not the `ctx` passed to `run`) and called lazily at collection time:
+
+```python
+from osmosis_ai.rollout import get_rollout_context
+
+rollout_ctx = get_rollout_context()                  # the active RolloutContext
+rollout_ctx.register_sample_source(name, source)     # name must be unique per rollout
+samples = await rollout_ctx.get_samples()            # async -> {name: RolloutSample}
+```
+
+`OsmosisStrandsAgent` registers a source automatically (keyed by the agent `name`/`agent_id`), so most workflows never call `register_sample_source` directly.
+
+`RolloutSample` ([types/sample.py](../osmosis_ai/rollout/types/sample.py)) fields: `id`, `messages`, `label`, `reward`, `remove_sample`, `metrics`, `extra_fields`.
+
+## Configs
+
+[../osmosis_ai/rollout/types/config.py](../osmosis_ai/rollout/types/config.py)
+
+```python
+class ConcurrencyConfig(BaseModel):
+    max_concurrent: int | None = None   # ge=1; None = backend default / no limit
+
+class AgentWorkflowConfig(BaseConfig):   # also GraderConfig
+    name: str
+    description: str | None = None
+    concurrency: ConcurrencyConfig = ConcurrencyConfig()
+```
+
+- `BaseConfig` sets `extra="allow"` and `validate_assignment=True`, so you can add your own fields (model paths, tool flags) and read them off `self.config` in `run` / `grade`.
+- `name` becomes the resolved agent name (1–256 chars; see `validate_backend`).
+- `concurrency.max_concurrent` caps in-flight executions — raise/lower it to avoid saturating an MCP-based rollout server (see [troubleshooting.md](./troubleshooting.md)).
+
+## Server and backends
+
+`LocalBackend.__init__` is keyword-only and takes `workflow` / `grader` (a class or a dotted import string), plus optional `workflow_config` / `grader_config` ([backend/local/backend.py](../osmosis_ai/rollout/backend/local/backend.py)):
+
+```python
+from osmosis_ai.rollout import create_rollout_server, LocalBackend
+
+backend = LocalBackend(
+    workflow=MyWorkflow, workflow_config=MyConfig(name="my-rollout"),
+    grader=MyGrader, grader_config=GraderConfig(name="my-grader"),
+)
+app = create_rollout_server(backend=backend)   # FastAPI: POST /rollout, GET /health
+```
+
+- `create_rollout_server` ([server/app.py](../osmosis_ai/rollout/server/app.py)) wires the protocol: it runs the backend in a background task and posts the completion + grader callbacks.
+- `ControllerAuth` ([server/auth.py](../osmosis_ai/rollout/server/auth.py)) supplies the bearer headers for callbacks.
+- `ExecutionBackend` ([backend/base.py](../osmosis_ai/rollout/backend/base.py)) is the ABC; pick one:
+  - `LocalBackend` ([backend/local/](../osmosis_ai/rollout/backend/local/)) — runs workflow + grader in-process. Re-exported from `osmosis_ai.rollout`. Used by the scaffold and eval.
+  - `HarborBackend` ([backend/harbor/backend.py](../osmosis_ai/rollout/backend/harbor/backend.py)) — runs the agent inside a Harbor container; pairs with `HarborAgentWorkflowContext`. It is **not** re-exported (import `from osmosis_ai.rollout.backend.harbor.backend import HarborBackend`) and requires the external `harbor` dependency.
+
+### Running a server
+
+There is no `osmosis rollout serve` command. Scaffold a server with `osmosis rollout init <name>`, which writes `rollouts/<name>/main.py` wiring `LocalBackend` + `create_rollout_server` + `uvicorn` ([../osmosis_ai/templates/_scaffolds/rollout/main.py.tpl](../osmosis_ai/templates/_scaffolds/rollout/main.py.tpl)), then run it with `python main.py` (it listens on `_OSMOSIS_ROLLOUT_PORT`, default 8000).
+
+## Integrations
+
+[../osmosis_ai/rollout/integrations/agents/](../osmosis_ai/rollout/integrations/agents/)
+
+- **Strands** — `OsmosisStrandsAgent` / `OsmosisRolloutModel` are re-exported from `osmosis_ai.rollout`. `OsmosisStrandsAgent` is a drop-in for `strands.Agent`: it swaps in the rollout model from the active `RolloutContext` and auto-registers a sample source.
+- **OpenAI Agents** — `OsmosisAgent` is a drop-in for `agents.Agent`, but it is **only** importable from the submodule, not re-exported by `osmosis_ai.rollout` or the integrations `__init__`:
+
+  ```python
+  from osmosis_ai.rollout.integrations.agents.openai_agents import OsmosisAgent
+  ```
+
+## Minimal example
+
+```python
+from typing import Any
+from osmosis_ai.rollout import (
+    AgentWorkflow, AgentWorkflowConfig, AgentWorkflowContext,
+    Grader, GraderConfig, GraderContext, OsmosisStrandsAgent, OsmosisRolloutModel,
+)
+
+class MyConfig(AgentWorkflowConfig):
+    pass
+
+class MyWorkflow(AgentWorkflow[MyConfig]):
+    async def run(self, ctx: AgentWorkflowContext[MyConfig]) -> Any:
+        # OsmosisRolloutModel is a placeholder; at sample time it binds to the
+        # controller's model via the active RolloutContext (no model id needed here).
+        agent = OsmosisStrandsAgent(name="solver", model=OsmosisRolloutModel())
+        await agent.invoke_async(ctx.prompt[-1]["content"])
+
+class MyGrader(Grader):
+    async def grade(self, ctx: GraderContext) -> Any:
+        for sample_id, sample in ctx.get_samples().items():
+            reward = 1.0 if str(ctx.label) in str(sample.messages[-1]) else 0.0
+            ctx.set_sample_reward(sample_id, reward)
+```
+
+For complete, runnable rollouts (local Strands, local OpenAI Agents, Harbor) see the [Osmosis-AI/workspace-template](https://github.com/Osmosis-AI/workspace-template) `rollouts/` directory.
+
+## See also
+
+- [architecture.md](./architecture.md) — protocol + execution model
+- [troubleshooting.md](./troubleshooting.md) — timeouts, event-loop blocking, concurrency

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,101 +1,18 @@
-# Troubleshooting
+# Troubleshooting (engineering)
 
-Common errors when using the Osmosis SDK CLI.
+> Engineering-level failure modes when building rollouts and running evals. Install, login, and workspace-setup basics live at [docs.osmosis.ai](https://docs.osmosis.ai). One entry fact: the SDK requires **Python 3.12+** and the server extra (`pip install osmosis-ai[server]`) to run a rollout server (scaffold one with `osmosis rollout init`, then `python main.py`).
 
-## Installation
+## Rollout timeouts
 
-### Missing optional dependencies
+The controller sends per-rollout `agent_timeout_sec` / `grader_timeout_sec` in the `RolloutInitRequest` ([../osmosis_ai/rollout/types/protocol.py](../osmosis_ai/rollout/types/protocol.py)). The Harbor backend enforces them per execution via `override_timeout_sec` ([../osmosis_ai/rollout/backend/harbor/backend.py](../osmosis_ai/rollout/backend/harbor/backend.py)); the in-process `LocalBackend` does **not** impose these per-rollout timeouts itself — it only maps a raised `TimeoutError` to `RolloutErrorCategory.TIMEOUT` ([../osmosis_ai/rollout/types/sample.py](../osmosis_ai/rollout/types/sample.py)).
 
-| Error | Install |
-|-------|---------|
-| `No module named 'fastapi'` / `uvicorn` | `pip install osmosis-ai[server]` |
-| `No module named 'pyarrow'` | `pip install pyarrow` or `pip install osmosis-ai[server]` |
-| `No module named 'rich'` | `pip install osmosis-ai[server]` |
-| `No module named 'litellm'` | Should ship with core; reinstall `osmosis-ai` |
+### All rollouts time out / zero reward across the board
 
-```bash
-pip install osmosis-ai[full]
-pip install osmosis-ai[dev]   # + pytest, ruff, etc.
-```
+If a training run completes with `rollout/raw_reward = 0` and `rollout/response_len/mean = 0`, every rollout timed out before producing output — usually the inference engine was overwhelmed by too many concurrent requests.
 
-### Python version
+**Cause:** a high `rollout_batch_size`. With `rollout_batch_size = 64` and `n_samples_per_prompt = 8`, the controller fires `64 × 8 = 512` concurrent calls at the rollout server, saturating the SGLang engine so every rollout exceeds its timeout.
 
-Requires **Python 3.12+**. Check with `python --version`.
-
-## Authentication
-
-Credentials path: `~/.config/osmosis/credentials.json`.
-
-### `osmosis auth login` fails
-
-1. Ensure outbound HTTPS to the platform is allowed.
-2. Retry with `osmosis auth login --force`.
-
-### Token expiration
-
-```
-Not logged in. Run 'osmosis auth login' first.
-```
-
-Run `osmosis auth login` again before using platform-scoped commands from a
-workspace directory.
-
-## Workspace Directory Flow
-
-Create or open a workspace in the Osmosis Platform, clone the repository created there,
-then run CLI commands from that workspace directory.
-
-```bash
-git clone <repo-url>
-cd <repo>
-osmosis auth login
-osmosis doctor
-osmosis template apply multiply              # or add your rollout under rollouts/
-cp configs/training/default.toml configs/training/<run>.toml
-$EDITOR configs/training/<run>.toml          # set rollout, dataset, and model_path
-git add rollouts configs data
-git commit -m "configure training run"
-git push
-osmosis train submit configs/training/<run>.toml
-```
-
-Platform-scoped commands derive scope from the workspace directory's `origin` remote and
-send `X-Osmosis-Git: namespace/repo_name`. The CLI does not store or send a
-workspace ID for commands scoped by the workspace directory.
-
-### Wrong workspace directory
-
-Confirm that the workspace directory's `origin` remote matches the repository created for
-the intended Osmosis Platform workspace. If it does not, clone the correct
-repository and rerun the command from that workspace directory.
-
-## Rubric (`osmosis eval rubric`)
-
-### Missing API key
-
-Set the provider-specific environment variable (e.g. `OPENAI_API_KEY`) or pass `--api-key`.
-
-### Provider errors
-
-Check quota, model name, and network. Increase `--timeout` if calls are slow.
-
-## Dataset errors
-
-### Dataset validation fails
-
-Unsupported extension or malformed file. Supported: `.parquet`, `.jsonl`, `.csv`.
-
-Every row needs non-empty string `ground_truth`, `user_prompt`, and `system_prompt`. See [Dataset format](./datasets.md).
-
-## Training run rollout failures
-
-### All rollouts timeout / zero reward across the board
-
-If a training run completes with `rollout/raw_reward = 0` and `rollout/response_len/mean = 0`, every rollout timed out before producing output. This usually means the LLM inference engine was overwhelmed with too many concurrent requests.
-
-**Cause:** A high configured `rollout_batch_size` can create too many concurrent LLM calls. For example, `rollout_batch_size = 64` with `n_samples_per_prompt = 8` sends 512 concurrent calls to the rollout server, which can saturate the SGLang engine and cause every rollout to exceed `agent_workflow_timeout_s`.
-
-**Fix:** Reduce `rollout_batch_size` in your training config:
+**Fix:** lower `rollout_batch_size` (a `[training]` field owned by the backend):
 
 ```toml
 [training]
@@ -103,43 +20,59 @@ n_samples_per_prompt = 8
 rollout_batch_size = 8    # 8 x 8 = 64 concurrent calls instead of 512
 ```
 
-If rollouts are still timing out with a smaller batch size (e.g. because your agent takes many turns), increase the timeout:
+If rollouts still time out with a smaller batch (e.g. a long multi-turn agent), raise the timeout:
 
 ```toml
 [training]
 agent_workflow_timeout_s = 900   # 15 minutes instead of the default 7.5
 ```
 
-### Some rollouts timeout (a few rows show zero reward / no output)
+### A few rollouts time out intermittently
 
-A small number of samples failing intermittently (2–5 rows out of 500+) indicates a resource contention issue on the rollout server rather than a total overload.
+2–5 failing rows out of 500+ points at resource contention on the rollout server, not a total overload. Two common causes:
 
-Common causes:
-- **Event loop blocking**: synchronous calls inside an `async` rollout workflow (e.g. `mcp.list_tools_sync()`) freeze the uvicorn event loop. New HTTP requests from our trainer cannot get a 200 OK within the 30 s httpx connect timeout. Fix: wrap blocking calls in `asyncio.get_running_loop().run_in_executor(None, ...)`.
-- **Subprocess exhaustion**: too many concurrent MCP subprocesses saturating OS limits. Set `ConcurrencyConfig(max_concurrent=64)` in your `AgentWorkflowConfig`.
+- **Event-loop blocking** — a synchronous call inside an `async` workflow (e.g. `mcp.list_tools_sync()`) freezes the uvicorn event loop, so new HTTP requests can't get a `200 OK` within the trainer's connect timeout. Wrap blocking work off the loop:
 
-## Training submission preflight
+  ```python
+  import asyncio
+  tools = await asyncio.get_running_loop().run_in_executor(None, mcp.list_tools_sync)
+  ```
 
-### Preflight failures
+- **Subprocess exhaustion** — too many concurrent MCP subprocesses saturating OS limits. Cap in-flight executions via `ConcurrencyConfig` ([../osmosis_ai/rollout/types/config.py](../osmosis_ai/rollout/types/config.py)):
 
-Submit an evaluation run before a training run:
+  ```python
+  MyWorkflowConfig(name="my-rollout", concurrency=ConcurrencyConfig(max_concurrent=64))
+  ```
 
-```bash
-osmosis eval submit configs/eval/<run>.toml
-```
+  A backend may also advertise a ceiling via `ExecutionBackend.max_concurrency`.
 
-Then submit the training run config:
+## Backend validation (submit preflight)
 
-```bash
-osmosis train submit configs/training/<run>.toml
-```
+Cloud `osmosis eval submit` / `osmosis train submit` run a backend preflight (`validate_rollout_backend` → `validate_backend`, [../osmosis_ai/rollout/validator.py](../osmosis_ai/rollout/validator.py)) before uploading. Frequent failures and their codes:
 
-Training run submission performs its own preflight checks before launching the
-managed run. Fix reported rollout, config, dataset, or repository scope issues before
-submitting again.
+| Code | Meaning |
+|------|---------|
+| `INVALID_WORKFLOW_CLASS` / `INVALID_GRADER_CLASS` | Not a concrete subclass of `AgentWorkflow` / `Grader` |
+| `WORKFLOW_RUN_NOT_ASYNC` / `GRADER_GRADE_NOT_ASYNC` | `run` / `grade` is not `async def` |
+| `WORKFLOW_INIT_FAILED` / `GRADER_INIT_FAILED` | Constructor raised when called as `cls(config)` |
+| `INVALID_AGENT_NAME` | Resolved name not 1–256 chars |
+| `MISSING_GRADER` | `grader_cls` is required for local validation |
+
+All applicable errors are aggregated into one `ValidationResult` — fix them together.
+
+## Dataset validation
+
+Local validation requires the columns `system_prompt` and `user_prompt` (exact, case-sensitive), at least 4 rows, and a `.csv` / `.jsonl` / `.parquet` extension. `ground_truth` is optional. See [datasets.md](./datasets.md) for the full contract; a "missing required columns" error means the header/keys don't match exactly.
+
+## Rubric (`osmosis eval rubric` / `evaluate_rubric`)
+
+- `MissingAPIKeyError` — set the provider env var (e.g. `OPENAI_API_KEY`) or pass `api_key` / `--api-key`.
+- `ModelNotFoundError` — wrong model identifier or no account access.
+- `ProviderRequestError` — quota, rate limit, network, or a non-JSON model response; raise the `timeout` for slow providers.
+
+See [eval.md](./eval.md) for the API and error hierarchy.
 
 ## See also
 
-- [CLI reference](./cli.md)
-- [Dataset format](./datasets.md)
-- [Eval](./eval.md)
+- [architecture.md](./architecture.md) — execution model and the protocol
+- [rollout-sdk.md](./rollout-sdk.md) — workflow/grader/config API

--- a/tests/unit/docs/test_doc_links.py
+++ b/tests/unit/docs/test_doc_links.py
@@ -1,0 +1,125 @@
+"""Guard the "code-anchored" docs contract.
+
+The developer docs under ``docs/`` link to package source with relative paths
+(e.g. ``../osmosis_ai/rollout/server/app.py``) and to each other (``./cli.md``).
+Nothing else enforces that those targets still exist, so a renamed or moved file
+silently rots the docs. This test fails when any relative link in repo markdown
+points at a path that no longer exists, forcing the doc to be fixed in the same
+PR as the code change.
+
+Scope: file/directory existence only. External URLs (``https://``, ``mailto:``)
+and in-file heading anchors (``#section``) are intentionally out of scope —
+heading-anchor slugging is too fragile to check reliably, and external links
+can't be verified offline.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Directory names that never contain documentation we author/control.
+_EXCLUDED_DIR_PARTS = frozenset(
+    {
+        ".git",
+        ".venv",
+        "venv",
+        "node_modules",
+        "build",
+        "dist",
+        "__pycache__",
+        ".ruff_cache",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".tox",
+        "htmlcov",
+        # Local-only working artifacts (gitignored), not published docs.
+        "superpowers",
+    }
+)
+
+# [label](target ...) — capture target up to whitespace or the closing paren,
+# tolerating an optional <...> wrapper. A trailing `"title"` is dropped because
+# the capture stops at the first whitespace.
+_LINK_RE = re.compile(r"\[[^\]]*\]\(\s*<?([^)>\s]+)")
+
+# Inline code spans can hold bracket/paren noise that mimics a link; drop them.
+_INLINE_CODE_RE = re.compile(r"`[^`]*`")
+
+# Scheme-prefixed (http:, mailto:, …) or protocol-relative (//host) targets.
+_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]*:")
+
+
+def _is_external(target: str) -> bool:
+    return bool(_SCHEME_RE.match(target)) or target.startswith("//")
+
+
+def _iter_local_link_targets(text: str) -> list[tuple[int, str]]:
+    """Return (lineno, target) for local markdown links, skipping code blocks."""
+    results: list[tuple[int, str]] = []
+    in_fence = False
+    fence_marker = ""
+    for lineno, raw_line in enumerate(text.splitlines(), start=1):
+        stripped = raw_line.lstrip()
+        if in_fence:
+            if stripped.startswith(fence_marker):
+                in_fence = False
+            continue
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = True
+            fence_marker = stripped[:3]
+            continue
+        line = _INLINE_CODE_RE.sub("", raw_line)
+        for match in _LINK_RE.finditer(line):
+            target = match.group(1)
+            if _is_external(target) or target.startswith("#"):
+                continue
+            results.append((lineno, target))
+    return results
+
+
+def _discover_markdown_files() -> list[Path]:
+    files: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(_REPO_ROOT):
+        dirnames[:] = [
+            d
+            for d in dirnames
+            if d not in _EXCLUDED_DIR_PARTS and not d.endswith(".egg-info")
+        ]
+        for name in filenames:
+            if name.endswith(".md"):
+                files.append(Path(dirpath) / name)
+    return sorted(files)
+
+
+_MARKDOWN_FILES = _discover_markdown_files()
+
+
+def test_scanner_is_not_vacuous() -> None:
+    """Fail loudly if discovery/parsing silently matches nothing (regex rot)."""
+    rels = {p.relative_to(_REPO_ROOT).as_posix() for p in _MARKDOWN_FILES}
+    assert "docs/architecture.md" in rels
+    assert "README.md" in rels
+
+    arch = _REPO_ROOT / "docs" / "architecture.md"
+    targets = [t for _, t in _iter_local_link_targets(arch.read_text("utf-8"))]
+    # architecture.md anchors to package source via ../osmosis_ai/... paths.
+    assert any(t.startswith("../osmosis_ai/") for t in targets)
+
+
+def test_local_markdown_links_resolve() -> None:
+    broken: list[str] = []
+    for md_file in _MARKDOWN_FILES:
+        rel = md_file.relative_to(_REPO_ROOT).as_posix()
+        for lineno, target in _iter_local_link_targets(md_file.read_text("utf-8")):
+            path_part = target.split("#", 1)[0].split("?", 1)[0]
+            if not path_part:  # was a pure anchor/query after stripping
+                continue
+            resolved = (md_file.parent / path_part).resolve()
+            if not resolved.exists():
+                broken.append(f"{rel}:{lineno} -> {target}")
+
+    assert not broken, "Broken relative links in markdown:\n" + "\n".join(broken)


### PR DESCRIPTION
## What

- Slim `README.md` down to an install snippet plus a docs links section that points at docs.osmosis.ai instead of duplicating CLI/workspace content.
- Restructure `docs/` into a code-anchored developer reference: rewrite `docs/README.md` with a "who reads what" map, add `docs/architecture.md` and `docs/rollout-sdk.md`, and heavily trim `docs/cli.md`.
- Refresh `docs/datasets.md`, `docs/eval.md`, and `docs/troubleshooting.md` to match current code.
- Add `tests/unit/docs/test_doc_links.py` to guard that every relative markdown link in the repo resolves to an existing path.
- Drop the `reward` module from the PR-title format in `.github/PULL_REQUEST_TEMPLATE.md`, `.github/workflows/check-pr-title.yml`, and `CONTRIBUTING.md`.
- Add `/AGENTS.md` to `.gitignore`.

## Why

Product concepts and end-user CLI usage already live at docs.osmosis.ai, so the repo README and `docs/` had drifted into duplicated, stale copies. This reframes `docs/` as the code-anchored developer reference (code wins when a doc disagrees) and keeps the README pointed at the canonical source. The new link-resolution test prevents doc rot by failing CI whenever a renamed or moved file breaks a relative link.

## How to Test

- `uv run pytest tests/unit/docs/test_doc_links.py`
- `uv run ruff check . && uv run ruff format --check .`
- `uv run pyright osmosis_ai/`
- `uv run pytest`

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restructures developer docs into a code-anchored reference and slims the README to point to docs.osmosis.ai. Adds a unit test that fails CI on broken relative markdown links to prevent doc rot.

- New Features
  - Added `docs/architecture.md` and `docs/rollout-sdk.md` as the core developer reference.
  - Added `tests/unit/docs/test_doc_links.py` to ensure all relative markdown links resolve.

- Refactors
  - Reduced `README.md` to an install snippet and links; rewrote `docs/README.md` with a “who reads what” map; trimmed `docs/cli.md` to contributor internals and refreshed `datasets`, `eval`, and `troubleshooting`.
  - Removed `reward` from the PR title modules in `.github/PULL_REQUEST_TEMPLATE.md`, `check-pr-title.yml`, and `CONTRIBUTING.md`; updated the feature request template option to “Graders & rewards”.
  - Added `/AGENTS.md` to `.gitignore`.

<sup>Written for commit 092122209f5e77c08c1f537ba1361a04e6f2ddfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

