### PR TITLE
[rollout] chore: upgrade harbor to 0.15.0 and migrate backend to current api

### DIFF
--- a/osmosis_ai/rollout/backend/harbor/agent_adapter.py
+++ b/osmosis_ai/rollout/backend/harbor/agent_adapter.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from harbor.agents.installed.base import BaseInstalledAgent
 from harbor.models.agent.context import AgentContext
+from harbor.models.trial.paths import EnvironmentPaths
 
 
 class OsmosisInstalledAgent(BaseInstalledAgent):
@@ -39,8 +40,9 @@ class OsmosisInstalledAgent(BaseInstalledAgent):
     async def run(self, instruction: Any, environment: Any, context: Any) -> None:
         prompt_path = self.logs_dir / "prompt.json"
         config_path = self.logs_dir / "rollout_config.json"
-        prompt_env_path = environment.env_paths.agent_dir / "prompt.json"
-        config_env_path = environment.env_paths.agent_dir / "rollout_config.json"
+        env_paths = EnvironmentPaths.for_os(environment.os)
+        prompt_env_path = env_paths.agent_dir / "prompt.json"
+        config_env_path = env_paths.agent_dir / "rollout_config.json"
 
         prompt_path.write_text(instruction)
 

--- a/osmosis_ai/rollout/backend/harbor/backend.py
+++ b/osmosis_ai/rollout/backend/harbor/backend.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 import toml
+from harbor.models.environment_type import EnvironmentType
 from harbor.models.trial.config import (
     AgentConfig as HarborAgentConfig,
 )
@@ -18,7 +19,6 @@ from harbor.models.trial.config import (
     EnvironmentConfig as HarborEnvironmentConfig,
 )
 from harbor.models.trial.config import (
-    EnvironmentType,
     TaskConfig,
     TrialConfig,
     VerifierConfig,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     # exceptions it raises bypass our top-level `click` error handling.
     "typer>=0.16.0,<0.26",
     "rich>=14.2.0",
-    "harbor[daytona]==0.6.1",
+    "harbor[daytona]>=0.15.0,<0.16.0",
     # Security floors for load-bearing transitive deps (CVE remediation):
     # aiohttp is exercised via litellm's async transport, and cryptography is
     # loaded via keyring's SecretService backend on Linux. Lower bounds only,

--- a/uv.lock
+++ b/uv.lock
@@ -564,16 +564,18 @@ wheels = [
 
 [[package]]
 name = "daytona"
-version = "0.160.0"
+version = "0.189.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
+    { name = "aiohttp" },
     { name = "daytona-api-client" },
     { name = "daytona-api-client-async" },
     { name = "daytona-toolbox-api-client" },
     { name = "daytona-toolbox-api-client-async" },
     { name = "deprecated" },
     { name = "httpx" },
+    { name = "httpx-ws" },
     { name = "obstore" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
@@ -584,16 +586,16 @@ dependencies = [
     { name = "python-multipart" },
     { name = "toml" },
     { name = "urllib3" },
-    { name = "websockets" },
+    { name = "wsproto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/39/ed38f65ed37509c495ca607eece228bf15dc2b9bc4a383d8b09885b3381e/daytona-0.160.0.tar.gz", hash = "sha256:7b5bef0f688d0e5b8a4ee34213f8c64e06af82391f5cd0deef8eb964caa19ff5", size = 128261, upload-time = "2026-04-02T14:51:34.292Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/5c/95a0a9db9dd4460025b3853c2153b2fc01bbd35d415b1ce692c23f09149e/daytona-0.189.0.tar.gz", hash = "sha256:1f5cef667bbc8396ca75d9289dac4c74592999498b8b038d7c52566c6ec43b0b", size = 146555, upload-time = "2026-06-19T11:36:49.208Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/76/a7c63e1676171b7ec4dc81757f4e527e28d5d8b509924cfa01cba3ade6ac/daytona-0.160.0-py3-none-any.whl", hash = "sha256:b594c061bb5a5a3fc42d4b7cff1a1d43c165221c40c0a9c3adadbfe9ece26d79", size = 158436, upload-time = "2026-04-02T14:51:32.509Z" },
+    { url = "https://files.pythonhosted.org/packages/34/3f/ffc54877884f71ffddec43b044cd6ee28e36410016c9889b5b5e581a364c/daytona-0.189.0-py3-none-any.whl", hash = "sha256:325681bcd68b5bde84cb7fc74be78d89a260f0e15abd5994b260f7c36ff9b74d", size = 177300, upload-time = "2026-06-19T11:36:47.739Z" },
 ]
 
 [[package]]
 name = "daytona-api-client"
-version = "0.160.0"
+version = "0.189.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -601,14 +603,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/be/30578b721658cb78c9037013763a012127f30613d173bb57d4a71b114f8b/daytona_api_client-0.160.0.tar.gz", hash = "sha256:21ed529b75633b7c383b9a191f0cd0695ff88752811f1b59a7df97cc99e4c030", size = 145942, upload-time = "2026-04-02T14:50:39.049Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/fb/1924083404d098e60fc218fb5ed49d069b9b2d62972ff16c5c8663eb9182/daytona_api_client-0.189.0.tar.gz", hash = "sha256:54c6ee0872735df59b5a0cbcbe2bb1033a4ee382de198d061a580663310a41a8", size = 147915, upload-time = "2026-06-19T11:35:58.47Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/73/2281a6976eae1ab0898d62b7c5ae41e26ed7396361995ca5e545d3c052a0/daytona_api_client-0.160.0-py3-none-any.whl", hash = "sha256:9253c7874b2d70d7706d612f9ec0ba681603b2cea2961504dd95511ced426889", size = 401067, upload-time = "2026-04-02T14:50:37.351Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/36/9a970def71ab4d4981e558b4d2607ccbdd63480753c9155daab4b25cdf9f/daytona_api_client-0.189.0-py3-none-any.whl", hash = "sha256:22bf811e90d2e1d4b65b0ce04713b3fdd969e6f8a14a567ac95fdd261fb05a54", size = 408239, upload-time = "2026-06-19T11:35:57.036Z" },
 ]
 
 [[package]]
 name = "daytona-api-client-async"
-version = "0.160.0"
+version = "0.189.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -616,16 +618,15 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "typing-extensions" },
-    { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/de/3bc36d71bf695868ded19582f0cb85506513bf92021cd4aef6de44705bb3/daytona_api_client_async-0.160.0.tar.gz", hash = "sha256:e1f5670565131e471047e353df26c10d308047da803ecd46ceef0790b24e7ee9", size = 146080, upload-time = "2026-04-02T14:50:41.268Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/12/c8f232921cd65baaf18980680ce5489cb339a869819e53c8d48aacaae2d4/daytona_api_client_async-0.189.0.tar.gz", hash = "sha256:11412a81a9c3b521b2b9d0204389683e1dcf80507cfacfa11edac47f665e3720", size = 148707, upload-time = "2026-06-19T11:35:59.525Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/63/c53fe053fc1bf5611de25139e18e823eafc4f21f713355b9f33e7ea59d96/daytona_api_client_async-0.160.0-py3-none-any.whl", hash = "sha256:21c7a5ade9f4262149d352a23fb340d8d4e0a04362abd100bf8f8469d6495496", size = 404115, upload-time = "2026-04-02T14:50:39.548Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/7c/83087e73e8fe13aa7238c5e68a6165b4b4975d6f5a176dc861fa3565d6b5/daytona_api_client_async-0.189.0-py3-none-any.whl", hash = "sha256:7dfa90b74f479958cf8fa5bb15103fd24e3d145c940466618f26313ea63d51bd", size = 411530, upload-time = "2026-06-19T11:35:57.603Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client"
-version = "0.160.0"
+version = "0.189.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -633,14 +634,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/a2/e5078ae13c819ad60d4dc3a922dc6de50d85e15c20447dd092cba5d5b393/daytona_toolbox_api_client-0.160.0.tar.gz", hash = "sha256:b6eedfc1041f2febd366d6c3fa456d2ad348fc90ae4792bbb4f95c76c314e6fb", size = 67476, upload-time = "2026-04-02T14:50:46.828Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/ba/c9ff115207db818fb0bc3a214a0017aeeffee3eb61c6c4e60afdd4816d16/daytona_toolbox_api_client-0.189.0.tar.gz", hash = "sha256:0d82a174e5eb9710d7e518bf1497adac11cc5784be77764cc7996e968d9477bc", size = 79765, upload-time = "2026-06-19T11:36:20.371Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/26/d2130042605dd00e0cc8ecc84836f9f3847a02faf2bff2a02efc19b77db8/daytona_toolbox_api_client-0.160.0-py3-none-any.whl", hash = "sha256:5b8b19fadd20e85a33b1b6aada88e21680952357640f33655518656ecc151006", size = 177514, upload-time = "2026-04-02T14:50:45.232Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c7/e7a5ba9c7a324099e1fb95c910554d3fb48e07a58e6cb6da594c8eb9471d/daytona_toolbox_api_client-0.189.0-py3-none-any.whl", hash = "sha256:ebf0a9a8b507d9ea37d715bfea14f015f21bb0b768b162e46e491e360fcad7ce", size = 220038, upload-time = "2026-06-19T11:36:19.13Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client-async"
-version = "0.160.0"
+version = "0.189.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -648,11 +649,10 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "typing-extensions" },
-    { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/4d/35ed6d3d62413b93d344b7d420465e066dd99656aea7bdc666879429853d/daytona_toolbox_api_client_async-0.160.0.tar.gz", hash = "sha256:9ea77af30deab3070d7fd29fc154958eca18d6c93b791add49dbc9ee66aedbfe", size = 64564, upload-time = "2026-04-02T14:51:02.547Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/ce/aa9f8a45fa22f77cfa166e163345e59bb57d6a77146590f21cd9c028c7cd/daytona_toolbox_api_client_async-0.189.0.tar.gz", hash = "sha256:82edec90d43d4301754c2312913ccde0039e851d9bc21f290e704816c1673a19", size = 73279, upload-time = "2026-06-19T11:36:00.399Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/5e/9854b5b6b4f4d3e02713ccbc3be172b046af2fa5c6d9496531e8042cad5b/daytona_toolbox_api_client_async-0.160.0-py3-none-any.whl", hash = "sha256:2f9410baf98f21be4fa39798e5884036e14aa5ba2cef5ba82b5f04cf20cfe597", size = 178900, upload-time = "2026-04-02T14:51:01.286Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/6a/a0eec48b4cc29b61fb0aae97346fa3c9de0c88651b5e81e8e8efd903f803/daytona_toolbox_api_client_async-0.189.0-py3-none-any.whl", hash = "sha256:635682004cfa6ca55f4b235cd56371122d5a01e4403653e38cc2e9021c4f6165", size = 218334, upload-time = "2026-06-19T11:35:57.262Z" },
 ]
 
 [[package]]
@@ -941,7 +941,7 @@ wheels = [
 
 [[package]]
 name = "harbor"
-version = "0.6.1"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "claude-agent-sdk" },
@@ -958,7 +958,6 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
-    { name = "ruff" },
     { name = "shortuuid" },
     { name = "supabase" },
     { name = "tenacity" },
@@ -966,9 +965,9 @@ dependencies = [
     { name = "typer" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/d0/6a191db74b63675e4e1746a2d28839567a82df62ad492a67a326efa5ac17/harbor-0.6.1.tar.gz", hash = "sha256:6418b584c3068c392b2d2bd3dc996629ad42524ea7a1260abcf5db94ae040ef0", size = 975530, upload-time = "2026-04-30T03:24:24.477Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/af/9927af345cd7d80e4346539e2340a1cd795861b12fb5d5ffc7b0788a7401/harbor-0.15.0.tar.gz", hash = "sha256:406b20ce520fc1ec12bc9b05396cc91756bb6379fb565a5bc2f2b6759e94cb12", size = 1287081, upload-time = "2026-06-19T22:48:17.474Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/ec/b8cb6a7979fc5aa4eb20b5cc39d9709ffc4c84bc4429c3afb400a571f9fb/harbor-0.6.1-py3-none-any.whl", hash = "sha256:9b77b7d413329c1c06af3decdecc38bdd6eb483796250473ee0225be35301cbb", size = 1106106, upload-time = "2026-04-30T03:24:26.339Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/6e860d3bdbb09c56296d4b57fcebc22f8eb014b06eb3810f9e0a8ab718f7/harbor-0.15.0-py3-none-any.whl", hash = "sha256:a6f7f703d9b008920f07751ae27f6c049afe908bee8199aa6bcc911f6c2aab1b", size = 1463875, upload-time = "2026-06-19T22:48:19.009Z" },
 ]
 
 [package.optional-dependencies]
@@ -1054,6 +1053,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "httpx-ws"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/cd/ca91a07ae446451f7476bf3fcc909e98cb942ff032ebfda0e3fe449aca7b/httpx_ws-0.9.0.tar.gz", hash = "sha256:797373326f70eec1ae96f6e43ae9f12002fd7d73aee139a4985eaab964338a08", size = 107105, upload-time = "2026-03-28T14:11:10.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/f8/a6bc80313a9e93c888fa10534dfce2ad76ff86911b6f485777ce6de6a073/httpx_ws-0.9.0-py3-none-any.whl", hash = "sha256:71640d2fb1bf9a225775015b33cd755cfd4c5f7e21c885192fe3adc4c387b248", size = 15759, upload-time = "2026-03-28T14:11:11.887Z" },
 ]
 
 [[package]]
@@ -2006,7 +2020,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.1" },
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.100.0,<1.0.0" },
-    { name = "harbor", extras = ["daytona"], specifier = "==0.6.1" },
+    { name = "harbor", extras = ["daytona"], specifier = ">=0.15.0,<0.16.0" },
     { name = "httpx", specifier = ">=0.25.0,<1.0.0" },
     { name = "keyring", specifier = ">=25.0.0" },
     { name = "litellm", specifier = ">=1.84.0,<2.0.0" },
@@ -3486,6 +3500,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
     { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

- Bump `harbor[daytona]` from `==0.6.1` to `>=0.15.0,<0.16.0` in `pyproject.toml` and regenerate `uv.lock` (resolves to harbor 0.15.0).
- Migrate `osmosis_ai/rollout/backend/harbor/agent_adapter.py` off the removed `BaseEnvironment.env_paths` to `EnvironmentPaths.for_os(environment.os)` (the one real API break across 0.6 -> 0.15).
- Import `EnvironmentType` from its canonical `harbor.models.environment_type` in `backend.py` instead of relying on the `harbor.models.trial.config` re-export.

## Why

harbor 0.6.1 was many minors behind; moving to 0.15 picks up the current library API and unblocks the planned native-harbor backend work. Across 0.6 -> 0.15 the only break our backend hits is the removal of `BaseEnvironment.env_paths` (harbor 0.14); everything else we use is unchanged: the `TrialQueue` hook flow (`TrialEvent`/`TrialHookEvent`, `add_hook`/`submit`), the trial config models (`AgentConfig`/`EnvironmentConfig`/`VerifierConfig`/`TaskConfig`/`TrialConfig`), `BaseInstalledAgent`, `AgentContext.metadata`, and `VerifierResult.rewards`. The 0.14 -> 0.15 delta is fully additive (new log-streaming hooks, extra enum values, extra factory agents) and needs no code change.

The range is capped at `<0.16.0` rather than left open because the SDK depends on harbor's internal APIs, which churn across minors (this very upgrade is the proof); the committed `uv.lock` keeps dev/CI pinned to an exact version while allowing downstream installs to take 0.15.x patches. No public SDK API or behavior changes; the existing `HarborBackend` is preserved (not deprecated).

## How to Test

- `uv run pytest` (full suite, 1702 passed)
- `uv run pytest tests/unit/rollout/test_harbor_backend.py`
- `uv run ruff check .` and `uv run ruff format --check .`
- `uv run pyright osmosis_ai/`

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `harbor[daytona]` to `>=0.15.0,<0.16.0` and migrate our Harbor backend to the current API. Preserves existing `HarborBackend` behavior and unblocks native Harbor work.

- **Dependencies**
  - Bump `harbor[daytona]` and regenerate `uv.lock`; cap at `<0.16.0` to avoid future minor API churn.

- **Migration**
  - Replace `environment.env_paths` with `EnvironmentPaths.for_os(environment.os)` in the agent adapter.
  - Import `EnvironmentType` from `harbor.models.environment_type` in the backend.

<sup>Written for commit 059377c9e395f080657a3eb47ff608d5d9d79ddd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

