### PR TITLE
[cli] feat: add `dev server` CLI commands 

### DIFF
--- a/osmosis_ai/cli/commands/dev/__init__.py
+++ b/osmosis_ai/cli/commands/dev/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import typer
+
+from osmosis_ai.cli.commands.dev.server import app as server_app
+
+app: typer.Typer = typer.Typer(help="Internal developer tooling.", no_args_is_help=True)
+app.add_typer(server_app, name="server")

--- a/osmosis_ai/cli/commands/dev/server.py
+++ b/osmosis_ai/cli/commands/dev/server.py
@@ -5,7 +5,7 @@ from typing import Any
 import typer
 
 app: typer.Typer = typer.Typer(
-    help="Manage a remote dev rollout server.", no_args_is_help=True
+    help="Manage a remote rollout server.", no_args_is_help=True
 )
 
 

--- a/osmosis_ai/cli/commands/dev/server.py
+++ b/osmosis_ai/cli/commands/dev/server.py
@@ -17,11 +17,12 @@ def up(
     ttl_hours: int = typer.Option(
         24, "--ttl-hours", min=1, help="Hours before auto-teardown."
     ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
 ) -> Any:
     """Provision a remote rollout server for the current rollout folder."""
     from osmosis_ai.platform.cli.dev_server import up as _up
 
-    return _up(ttl_hours=None if no_ttl else ttl_hours)
+    return _up(ttl_hours=None if no_ttl else ttl_hours, yes=yes)
 
 
 @app.command("down")
@@ -32,3 +33,11 @@ def down(
     from osmosis_ai.platform.cli.dev_server import down as _down
 
     return _down(server_id)
+
+
+@app.command("list")
+def list_servers() -> Any:
+    """List active rollout servers for the current workspace."""
+    from osmosis_ai.platform.cli.dev_server import list_servers as _list
+
+    return _list()

--- a/osmosis_ai/cli/commands/dev/server.py
+++ b/osmosis_ai/cli/commands/dev/server.py
@@ -4,6 +4,8 @@ from typing import Any
 
 import typer
 
+from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
+
 app: typer.Typer = typer.Typer(
     help="Manage a remote rollout server.", no_args_is_help=True
 )
@@ -36,8 +38,17 @@ def down(
 
 
 @app.command("list")
-def list_servers() -> Any:
+def list_servers(
+    limit: int = typer.Option(
+        DEFAULT_PAGE_SIZE,
+        "--limit",
+        min=1,
+        max=MAX_PAGE_SIZE,
+        help="Maximum number of rollout servers to show.",
+    ),
+    all_: bool = typer.Option(False, "--all", help="Show all rollout servers."),
+) -> Any:
     """List active rollout servers for the current workspace."""
     from osmosis_ai.platform.cli.dev_server import list_servers as _list
 
-    return _list()
+    return _list(limit=limit, all_=all_)

--- a/osmosis_ai/cli/commands/dev/server.py
+++ b/osmosis_ai/cli/commands/dev/server.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+app: typer.Typer = typer.Typer(
+    help="Manage a remote dev rollout server.", no_args_is_help=True
+)
+
+
+@app.command("up")
+def up(
+    no_ttl: bool = typer.Option(
+        False, "--no-ttl", help="Disable the 24h auto-teardown."
+    ),
+    ttl_hours: int = typer.Option(
+        24, "--ttl-hours", min=1, help="Hours before auto-teardown."
+    ),
+) -> Any:
+    """Provision a remote rollout server for the current rollout folder."""
+    from osmosis_ai.platform.cli.dev_server import up as _up
+
+    return _up(ttl_hours=None if no_ttl else ttl_hours)
+
+
+@app.command("down")
+def down(
+    server_id: str = typer.Argument(..., help="The rollout server id from `up`."),
+) -> Any:
+    """Tear down a remote rollout server."""
+    from osmosis_ai.platform.cli.dev_server import down as _down
+
+    return _down(server_id)

--- a/osmosis_ai/cli/main.py
+++ b/osmosis_ai/cli/main.py
@@ -195,6 +195,10 @@ def _register_commands() -> None:
     app.add_typer(rollout_app, name="rollout", rich_help_panel=_WORKFLOW)
     app.add_typer(template_app, name="template", rich_help_panel=_WORKFLOW)
 
+    from osmosis_ai.cli.commands.dev import app as dev_app
+
+    app.add_typer(dev_app, name="dev", rich_help_panel=_WORKFLOW)
+
     app.add_typer(auth_app, name="auth", rich_help_panel=_PLATFORM)
     app.add_typer(secret_app, name="secret", rich_help_panel=_PLATFORM)
 

--- a/osmosis_ai/cli/main.py
+++ b/osmosis_ai/cli/main.py
@@ -197,7 +197,7 @@ def _register_commands() -> None:
 
     from osmosis_ai.cli.commands.dev import app as dev_app
 
-    app.add_typer(dev_app, name="dev", rich_help_panel=_WORKFLOW)
+    app.add_typer(dev_app, name="dev", hidden=True)
 
     app.add_typer(auth_app, name="auth", rich_help_panel=_PLATFORM)
     app.add_typer(secret_app, name="secret", rich_help_panel=_PLATFORM)

--- a/osmosis_ai/cli/output/__init__.py
+++ b/osmosis_ai/cli/output/__init__.py
@@ -31,6 +31,7 @@ from .result import (
 from .serializers import (
     serialize_checkpoint,
     serialize_dataset,
+    serialize_dev_rollout_server,
     serialize_environment_secret,
     serialize_eval_run,
     serialize_lora_model,
@@ -65,6 +66,7 @@ __all__ = [
     "resolve_format_selectors",
     "serialize_checkpoint",
     "serialize_dataset",
+    "serialize_dev_rollout_server",
     "serialize_environment_secret",
     "serialize_eval_run",
     "serialize_lora_model",

--- a/osmosis_ai/cli/output/serializers.py
+++ b/osmosis_ai/cli/output/serializers.py
@@ -7,6 +7,7 @@ from typing import Any
 from osmosis_ai.platform.api.models import (
     BaseModelInfo,
     DatasetFile,
+    DevRolloutServerInfo,
     EnvironmentSecretInfo,
     EvaluationRun,
     LoraCheckpointInfo,
@@ -120,6 +121,18 @@ def serialize_rollout(rollout: RolloutInfo) -> dict[str, Any]:
         "repo_full_name": rollout.repo_full_name,
         "last_synced_commit_sha": rollout.last_synced_commit_sha,
         "created_at": rollout.created_at,
+    }
+
+
+def serialize_dev_rollout_server(server: DevRolloutServerInfo) -> dict[str, Any]:
+    """Serialize a dev rollout server for the public JSON contract."""
+    return {
+        "id": server.id,
+        "name": server.name,
+        "url": server.url,
+        "status": server.status,
+        "expires_at": server.expires_at,
+        "started_at": server.started_at,
     }
 
 

--- a/osmosis_ai/platform/api/client.py
+++ b/osmosis_ai/platform/api/client.py
@@ -669,3 +669,45 @@ class OsmosisClient:
             credentials=credentials,
             git_identity=git_identity,
         )
+
+    # ── Dev Rollout Servers ───────────────────────────────────────
+
+    def provision_dev_rollout_server(
+        self,
+        *,
+        rollout_name: str,
+        commit_sha: str,
+        repository_path: str,
+        entrypoint: str,
+        ttl_hours: int | None,
+        credentials: Credentials | None = None,
+        git_identity: str,
+    ) -> dict[str, Any]:
+        return platform_request(
+            "/api/cli/dev-rollout-server",
+            method="POST",
+            data={
+                "rollout_name": rollout_name,
+                "commit_sha": commit_sha,
+                "repository_path": repository_path,
+                "entrypoint": entrypoint,
+                "ttl_hours": ttl_hours,
+            },
+            credentials=credentials,
+            git_identity=git_identity,
+        )
+
+    def teardown_dev_rollout_server(
+        self,
+        server_id: str,
+        *,
+        credentials: Credentials | None = None,
+        git_identity: str,
+    ) -> dict[str, Any]:
+        return platform_request(
+            f"/api/cli/dev-rollout-server/{_safe_path(server_id)}",
+            method="DELETE",
+            data={},
+            credentials=credentials,
+            git_identity=git_identity,
+        )

--- a/osmosis_ai/platform/api/client.py
+++ b/osmosis_ai/platform/api/client.py
@@ -19,6 +19,7 @@ from .models import (
     LoraModelSummary,
     PaginatedBaseModels,
     PaginatedDatasets,
+    PaginatedDevRolloutServers,
     PaginatedEnvironmentSecrets,
     PaginatedEvaluationRuns,
     PaginatedLoraModels,
@@ -714,12 +715,16 @@ class OsmosisClient:
 
     def list_dev_rollout_servers(
         self,
+        limit: int = DEFAULT_PAGE_SIZE,
+        offset: int = 0,
         *,
         credentials: Credentials | None = None,
         git_identity: str,
-    ) -> dict[str, Any]:
-        return platform_request(
-            "/api/cli/dev-rollout-server",
+    ) -> PaginatedDevRolloutServers:
+        qs = urlencode({"limit": limit, "offset": offset})
+        data = platform_request(
+            f"/api/cli/dev-rollout-server?{qs}",
             credentials=credentials,
             git_identity=git_identity,
         )
+        return PaginatedDevRolloutServers.from_dict(data)

--- a/osmosis_ai/platform/api/client.py
+++ b/osmosis_ai/platform/api/client.py
@@ -711,3 +711,15 @@ class OsmosisClient:
             credentials=credentials,
             git_identity=git_identity,
         )
+
+    def list_dev_rollout_servers(
+        self,
+        *,
+        credentials: Credentials | None = None,
+        git_identity: str,
+    ) -> dict[str, Any]:
+        return platform_request(
+            "/api/cli/dev-rollout-server",
+            credentials=credentials,
+            git_identity=git_identity,
+        )

--- a/osmosis_ai/platform/api/models.py
+++ b/osmosis_ai/platform/api/models.py
@@ -885,6 +885,51 @@ class PaginatedRollouts:
         )
 
 
+@dataclass
+class DevRolloutServerInfo:
+    """A dev rollout server record."""
+
+    id: str
+    name: str
+    url: str
+    status: str
+    expires_at: str | None = None
+    started_at: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DevRolloutServerInfo:
+        return cls(
+            id=data["id"],
+            name=data.get("name", ""),
+            url=data.get("url", ""),
+            status=data.get("status", ""),
+            expires_at=data.get("expires_at"),
+            started_at=data.get("started_at"),
+        )
+
+
+@dataclass
+class PaginatedDevRolloutServers:
+    """Paginated list of dev rollout servers."""
+
+    dev_rollout_servers: list[DevRolloutServerInfo]
+    total_count: int
+    has_more: bool
+    next_offset: int | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PaginatedDevRolloutServers:
+        return cls(
+            dev_rollout_servers=[
+                DevRolloutServerInfo.from_dict(s)
+                for s in data.get("dev_rollout_servers", [])
+            ],
+            total_count=data.get("total_count", 0),
+            has_more=data.get("has_more", False),
+            next_offset=data.get("next_offset"),
+        )
+
+
 # ── LoRA checkpoints (for `osmosis train info`) ──────────────────
 
 

--- a/osmosis_ai/platform/cli/dev_server.py
+++ b/osmosis_ai/platform/cli/dev_server.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.cli.output import get_output_context, serialize_dev_rollout_server
+from osmosis_ai.cli.output.display import format_local_date
 from osmosis_ai.cli.output.result import ListColumn, ListResult, OperationResult
 from osmosis_ai.cli.prompts import require_confirmation
 from osmosis_ai.platform.api.client import OsmosisClient
@@ -63,7 +64,7 @@ def up(*, ttl_hours: int | None, yes: bool = False) -> OperationResult:
         operation="dev.server.up",
         status="success",
         resource=result,
-        message=f"Rollout server: {result['url']}",
+        message=f"Rollout server provisioning at {result['url']} — it may take a few minutes to become ready; check with 'osmosis dev server list'.",
     )
 
 
@@ -110,6 +111,15 @@ def list_servers(*, limit: int, all_: bool) -> ListResult:
         total_count=total_count,
         has_more=has_more,
         next_offset=next_offset,
+        display_items=[
+            {
+                **item,
+                "expires_at": format_local_date(item["expires_at"])
+                if item["expires_at"]
+                else "No expiration",
+            }
+            for item in items
+        ],
         columns=[
             ListColumn(key="id", label="ID", ratio=2, overflow="fold"),
             ListColumn(key="name", label="Rollout", ratio=2, overflow="fold"),

--- a/osmosis_ai/platform/cli/dev_server.py
+++ b/osmosis_ai/platform/cli/dev_server.py
@@ -4,9 +4,11 @@ from pathlib import Path
 from typing import Any
 
 from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.cli.output import get_output_context, serialize_dev_rollout_server
 from osmosis_ai.cli.output.result import ListColumn, ListResult, OperationResult
 from osmosis_ai.cli.prompts import require_confirmation
 from osmosis_ai.platform.api.client import OsmosisClient
+from osmosis_ai.platform.cli.utils import paginated_fetch, validate_list_options
 from osmosis_ai.platform.cli.workspace_directory_context import (
     resolve_git_workspace_directory_context,
 )
@@ -81,23 +83,36 @@ def down(server_id: str) -> OperationResult:
     )
 
 
-def list_servers() -> ListResult:
+def list_servers(*, limit: int, all_: bool) -> ListResult:
+    effective_limit, fetch_all = validate_list_options(limit=limit, all_=all_)
+
     ctx = resolve_git_workspace_directory_context()
+    output = get_output_context()
     client = OsmosisClient()
-    result: dict[str, Any] = client.list_dev_rollout_servers(
-        credentials=ctx.credentials,
-        git_identity=ctx.git_identity,
-    )
-    servers: list[dict[str, Any]] = result.get("servers", [])
+    with output.status("Fetching rollout servers..."):
+        servers, total_count, has_more, next_offset = paginated_fetch(
+            lambda lim, off: client.list_dev_rollout_servers(
+                limit=lim,
+                offset=off,
+                credentials=ctx.credentials,
+                git_identity=ctx.git_identity,
+            ),
+            items_attr="dev_rollout_servers",
+            limit=effective_limit,
+            fetch_all=fetch_all,
+        )
+
+    items = [serialize_dev_rollout_server(server) for server in servers]
+
     return ListResult(
         title="Dev Rollout Servers",
-        items=servers,
-        total_count=len(servers),
-        has_more=False,
-        next_offset=None,
+        items=items,
+        total_count=total_count,
+        has_more=has_more,
+        next_offset=next_offset,
         columns=[
-            ListColumn(key="rollout_id", label="ID", ratio=2, overflow="fold"),
-            ListColumn(key="rollout_name", label="Rollout", ratio=2, overflow="fold"),
+            ListColumn(key="id", label="ID", ratio=2, overflow="fold"),
+            ListColumn(key="name", label="Rollout", ratio=2, overflow="fold"),
             ListColumn(key="url", label="URL", ratio=4, overflow="fold"),
             ListColumn(key="expires_at", label="Expires At", no_wrap=True, ratio=2),
             ListColumn(key="status", label="Status", no_wrap=True, ratio=1),

--- a/osmosis_ai/platform/cli/dev_server.py
+++ b/osmosis_ai/platform/cli/dev_server.py
@@ -18,8 +18,12 @@ from osmosis_ai.platform.cli.workspace_repo import (
 
 
 def up(*, ttl_hours: int | None, yes: bool = False) -> OperationResult:
-    ctx = resolve_git_workspace_directory_context()
     cwd = Path.cwd()
+    if not (cwd / "main.py").is_file():
+        raise CLIError(
+            "Run from a rollout folder containing main.py.", code="INVALID_USAGE"
+        )
+    ctx = resolve_git_workspace_directory_context()
     state = summarize_local_git_state(cwd)
     if state is None or not state.head_sha:
         raise CLIError("Not in a git repo with a commit.", code="VALIDATION")
@@ -45,10 +49,6 @@ def up(*, ttl_hours: int | None, yes: bool = False) -> OperationResult:
     root = git_worktree_top_level(cwd) or cwd
     repository_path = str(cwd.relative_to(root))
     rollout_name = cwd.name
-    if not (cwd / "main.py").is_file():
-        raise CLIError(
-            "Run from a rollout folder containing main.py.", code="INVALID_USAGE"
-        )
     client = OsmosisClient()
     result: dict[str, Any] = client.provision_dev_rollout_server(
         rollout_name=rollout_name,

--- a/osmosis_ai/platform/cli/dev_server.py
+++ b/osmosis_ai/platform/cli/dev_server.py
@@ -12,7 +12,6 @@ from osmosis_ai.platform.cli.workspace_directory_context import (
 )
 from osmosis_ai.platform.cli.workspace_repo import (
     check_pinned_commit,
-    git_worktree_top_level,
     summarize_local_git_state,
 )
 
@@ -24,12 +23,12 @@ def up(*, ttl_hours: int | None, yes: bool = False) -> OperationResult:
             "Run from a rollout folder containing main.py.", code="INVALID_USAGE"
         )
     ctx = resolve_git_workspace_directory_context()
-    state = summarize_local_git_state(cwd)
+    state = summarize_local_git_state(ctx.workspace_directory)
     if state is None or not state.head_sha:
         raise CLIError("Not in a git repo with a commit.", code="VALIDATION")
 
     preflight = check_pinned_commit(
-        workspace_directory=cwd,
+        workspace_directory=ctx.workspace_directory,
         git_identity=ctx.git_identity,
         commit_sha=state.head_sha,
     )
@@ -46,8 +45,7 @@ def up(*, ttl_hours: int | None, yes: bool = False) -> OperationResult:
             ],
         )
 
-    root = git_worktree_top_level(cwd) or cwd
-    repository_path = str(cwd.relative_to(root))
+    repository_path = str(cwd.resolve().relative_to(ctx.workspace_directory))
     rollout_name = cwd.name
     client = OsmosisClient()
     result: dict[str, Any] = client.provision_dev_rollout_server(

--- a/osmosis_ai/platform/cli/dev_server.py
+++ b/osmosis_ai/platform/cli/dev_server.py
@@ -4,28 +4,44 @@ from pathlib import Path
 from typing import Any
 
 from osmosis_ai.cli.errors import CLIError
-from osmosis_ai.cli.output.result import OperationResult
+from osmosis_ai.cli.output.result import ListColumn, ListResult, OperationResult
+from osmosis_ai.cli.prompts import require_confirmation
 from osmosis_ai.platform.api.client import OsmosisClient
 from osmosis_ai.platform.cli.workspace_directory_context import (
     resolve_git_workspace_directory_context,
 )
 from osmosis_ai.platform.cli.workspace_repo import (
+    check_pinned_commit,
     git_worktree_top_level,
     summarize_local_git_state,
 )
 
 
-def up(*, ttl_hours: int | None) -> OperationResult:
+def up(*, ttl_hours: int | None, yes: bool = False) -> OperationResult:
     ctx = resolve_git_workspace_directory_context()
     cwd = Path.cwd()
     state = summarize_local_git_state(cwd)
     if state is None or not state.head_sha:
         raise CLIError("Not in a git repo with a commit.", code="VALIDATION")
+
+    preflight = check_pinned_commit(
+        workspace_directory=cwd,
+        git_identity=ctx.git_identity,
+        commit_sha=state.head_sha,
+    )
+    if preflight.error:
+        raise CLIError(preflight.error, code="VALIDATION")
+
     if state.is_dirty:
-        raise CLIError(
-            "Commit and push your changes first (working tree is dirty).",
-            code="VALIDATION",
+        require_confirmation(
+            f"The remote server will run committed HEAD ({state.head_sha[:7]}), not your uncommitted changes. Continue?",
+            yes=yes,
+            default=False,
+            warnings=[
+                f"Working tree is dirty — uncommitted edits won't be on the server (runs commit {state.head_sha[:7]})."
+            ],
         )
+
     root = git_worktree_top_level(cwd) or cwd
     repository_path = str(cwd.relative_to(root))
     rollout_name = cwd.name
@@ -64,4 +80,28 @@ def down(server_id: str) -> OperationResult:
         status="success",
         resource=result,
         message=f"Stopped {server_id}",
+    )
+
+
+def list_servers() -> ListResult:
+    ctx = resolve_git_workspace_directory_context()
+    client = OsmosisClient()
+    result: dict[str, Any] = client.list_dev_rollout_servers(
+        credentials=ctx.credentials,
+        git_identity=ctx.git_identity,
+    )
+    servers: list[dict[str, Any]] = result.get("servers", [])
+    return ListResult(
+        title="Dev Rollout Servers",
+        items=servers,
+        total_count=len(servers),
+        has_more=False,
+        next_offset=None,
+        columns=[
+            ListColumn(key="rollout_id", label="ID", ratio=2, overflow="fold"),
+            ListColumn(key="rollout_name", label="Rollout", ratio=2, overflow="fold"),
+            ListColumn(key="url", label="URL", ratio=4, overflow="fold"),
+            ListColumn(key="expires_at", label="Expires At", no_wrap=True, ratio=2),
+            ListColumn(key="status", label="Status", no_wrap=True, ratio=1),
+        ],
     )

--- a/osmosis_ai/platform/cli/dev_server.py
+++ b/osmosis_ai/platform/cli/dev_server.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.cli.output.result import OperationResult
+from osmosis_ai.platform.api.client import OsmosisClient
+from osmosis_ai.platform.cli.workspace_directory_context import (
+    resolve_git_workspace_directory_context,
+)
+from osmosis_ai.platform.cli.workspace_repo import (
+    git_worktree_top_level,
+    summarize_local_git_state,
+)
+
+
+def up(*, ttl_hours: int | None) -> OperationResult:
+    ctx = resolve_git_workspace_directory_context()
+    cwd = Path.cwd()
+    state = summarize_local_git_state(cwd)
+    if state is None or not state.head_sha:
+        raise CLIError("Not in a git repo with a commit.", code="VALIDATION")
+    if state.is_dirty:
+        raise CLIError(
+            "Commit and push your changes first (working tree is dirty).",
+            code="VALIDATION",
+        )
+    root = git_worktree_top_level(cwd) or cwd
+    repository_path = str(cwd.relative_to(root))
+    rollout_name = cwd.name
+    if not (cwd / "main.py").is_file():
+        raise CLIError(
+            "Run from a rollout folder containing main.py.", code="INVALID_USAGE"
+        )
+    client = OsmosisClient()
+    result: dict[str, Any] = client.provision_dev_rollout_server(
+        rollout_name=rollout_name,
+        commit_sha=state.head_sha,
+        repository_path=repository_path,
+        entrypoint="main.py",
+        ttl_hours=ttl_hours,
+        credentials=ctx.credentials,
+        git_identity=ctx.git_identity,
+    )
+    return OperationResult(
+        operation="dev.server.up",
+        status="success",
+        resource=result,
+        message=f"Rollout server: {result['url']}",
+    )
+
+
+def down(server_id: str) -> OperationResult:
+    ctx = resolve_git_workspace_directory_context()
+    client = OsmosisClient()
+    result: dict[str, Any] = client.teardown_dev_rollout_server(
+        server_id,
+        credentials=ctx.credentials,
+        git_identity=ctx.git_identity,
+    )
+    return OperationResult(
+        operation="dev.server.down",
+        status="success",
+        resource=result,
+        message=f"Stopped {server_id}",
+    )

--- a/tests/unit/cli/test_command_groups.py
+++ b/tests/unit/cli/test_command_groups.py
@@ -28,7 +28,6 @@ REMOVED_ROOT_COMMANDS = [
 
 PRESERVED_ROOT_COMMANDS = [
     "auth",
-    "dev",
     "doctor",
     "dataset",
     "train",
@@ -37,6 +36,11 @@ PRESERVED_ROOT_COMMANDS = [
     "template",
     "eval",
     "upgrade",
+]
+
+# Commands registered but intentionally hidden from --help output.
+HIDDEN_ROOT_COMMANDS = [
+    "dev",
 ]
 
 
@@ -104,7 +108,11 @@ def _root_command_names() -> set[str]:
 
 
 def _root_help_command_names(output: str) -> set[str]:
-    expected_command_names = set(REMOVED_ROOT_COMMANDS) | set(PRESERVED_ROOT_COMMANDS)
+    expected_command_names = (
+        set(REMOVED_ROOT_COMMANDS)
+        | set(PRESERVED_ROOT_COMMANDS)
+        | set(HIDDEN_ROOT_COMMANDS)
+    )
     command_names = set()
     for line in output.splitlines():
         cleaned = ANSI_ESCAPE.sub("", line).strip()
@@ -183,6 +191,9 @@ def test_root_command_registry_does_not_include_removed_groups_or_aliases():
     for command in PRESERVED_ROOT_COMMANDS:
         assert command in root_commands
 
+    for command in HIDDEN_ROOT_COMMANDS:
+        assert command in root_commands
+
 
 def test_root_help_surface_does_not_list_removed_groups_or_aliases(capfd):
     rc = main(["--plain", "--help"])
@@ -195,6 +206,9 @@ def test_root_help_surface_does_not_list_removed_groups_or_aliases(capfd):
 
     for command in PRESERVED_ROOT_COMMANDS:
         assert command in root_help_commands
+
+    for command in HIDDEN_ROOT_COMMANDS:
+        assert command not in root_help_commands
 
 
 def test_eval_help_lists_info_not_status(capfd):

--- a/tests/unit/cli/test_command_groups.py
+++ b/tests/unit/cli/test_command_groups.py
@@ -28,6 +28,7 @@ REMOVED_ROOT_COMMANDS = [
 
 PRESERVED_ROOT_COMMANDS = [
     "auth",
+    "dev",
     "doctor",
     "dataset",
     "train",

--- a/tests/unit/cli/test_dev_server_commands.py
+++ b/tests/unit/cli/test_dev_server_commands.py
@@ -1,0 +1,209 @@
+"""Tests for osmosis_ai.platform.cli.dev_server (dev server up/down)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import osmosis_ai.platform.api.client as api_client_module
+import osmosis_ai.platform.cli.dev_server as dev_server_module
+from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.cli.output import OperationResult
+
+GIT_IDENTITY = "acme/rollouts"
+FAKE_CREDENTIALS = object()
+FAKE_SERVER = {
+    "id": "r1",
+    "url": "https://r1.rollout-staging.gulp.dev",
+    "expires_at": None,
+}
+FAKE_HEAD_SHA = "abc123def456abc123def456abc123def456abc1"
+
+
+def _fake_ctx():
+    return type(
+        "FakeCtx",
+        (),
+        {"credentials": FAKE_CREDENTIALS, "git_identity": GIT_IDENTITY},
+    )()
+
+
+def _fake_git_state(*, is_dirty=False, head_sha=FAKE_HEAD_SHA):
+    return type(
+        "FakeGitState",
+        (),
+        {"head_sha": head_sha, "is_dirty": is_dirty},
+    )()
+
+
+class TestDevServerUp:
+    def test_up_happy_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        rollout_dir = tmp_path / "rollouts" / "multiply"
+        rollout_dir.mkdir(parents=True)
+        (rollout_dir / "main.py").write_text("# main", encoding="utf-8")
+
+        monkeypatch.setattr(
+            dev_server_module,
+            "resolve_git_workspace_directory_context",
+            lambda: _fake_ctx(),
+        )
+        monkeypatch.setattr(
+            dev_server_module,
+            "summarize_local_git_state",
+            lambda cwd: _fake_git_state(),
+        )
+        monkeypatch.setattr(
+            dev_server_module, "git_worktree_top_level", lambda cwd: tmp_path
+        )
+        monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: rollout_dir))
+
+        captured: dict = {}
+
+        class FakeClient:
+            def provision_dev_rollout_server(
+                self,
+                *,
+                rollout_name,
+                commit_sha,
+                repository_path,
+                entrypoint,
+                ttl_hours,
+                credentials=None,
+                git_identity,
+            ):
+                captured["rollout_name"] = rollout_name
+                captured["commit_sha"] = commit_sha
+                captured["repository_path"] = repository_path
+                captured["ttl_hours"] = ttl_hours
+                assert credentials is FAKE_CREDENTIALS
+                assert git_identity == GIT_IDENTITY
+                return FAKE_SERVER
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(dev_server_module, "OsmosisClient", FakeClient)
+
+        result = dev_server_module.up(ttl_hours=24)
+
+        assert isinstance(result, OperationResult)
+        assert result.resource is not None
+        assert result.resource["url"] == FAKE_SERVER["url"]
+        assert captured["rollout_name"] == "multiply"
+        assert captured["commit_sha"] == FAKE_HEAD_SHA
+        assert captured["repository_path"] == "rollouts/multiply"
+        assert captured["ttl_hours"] == 24
+
+    def test_up_no_ttl_passes_none(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        rollout_dir = tmp_path / "rollouts" / "multiply"
+        rollout_dir.mkdir(parents=True)
+        (rollout_dir / "main.py").write_text("# main", encoding="utf-8")
+
+        monkeypatch.setattr(
+            dev_server_module,
+            "resolve_git_workspace_directory_context",
+            lambda: _fake_ctx(),
+        )
+        monkeypatch.setattr(
+            dev_server_module,
+            "summarize_local_git_state",
+            lambda cwd: _fake_git_state(),
+        )
+        monkeypatch.setattr(
+            dev_server_module, "git_worktree_top_level", lambda cwd: tmp_path
+        )
+        monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: rollout_dir))
+
+        captured: dict = {}
+
+        class FakeClient:
+            def provision_dev_rollout_server(self, *, ttl_hours, **kwargs):
+                captured["ttl_hours"] = ttl_hours
+                return FAKE_SERVER
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(dev_server_module, "OsmosisClient", FakeClient)
+
+        result = dev_server_module.up(ttl_hours=None)
+
+        assert isinstance(result, OperationResult)
+        assert captured["ttl_hours"] is None
+
+    def test_up_dirty_working_tree_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        rollout_dir = tmp_path / "rollouts" / "multiply"
+        rollout_dir.mkdir(parents=True)
+        (rollout_dir / "main.py").write_text("# main", encoding="utf-8")
+
+        monkeypatch.setattr(
+            dev_server_module,
+            "resolve_git_workspace_directory_context",
+            lambda: _fake_ctx(),
+        )
+        monkeypatch.setattr(
+            dev_server_module,
+            "summarize_local_git_state",
+            lambda cwd: _fake_git_state(is_dirty=True),
+        )
+        monkeypatch.setattr(
+            dev_server_module, "git_worktree_top_level", lambda cwd: tmp_path
+        )
+        monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: rollout_dir))
+
+        with pytest.raises(CLIError, match="dirty"):
+            dev_server_module.up(ttl_hours=24)
+
+    def test_up_missing_main_py_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        rollout_dir = tmp_path / "rollouts" / "multiply"
+        rollout_dir.mkdir(parents=True)
+
+        monkeypatch.setattr(
+            dev_server_module,
+            "resolve_git_workspace_directory_context",
+            lambda: _fake_ctx(),
+        )
+        monkeypatch.setattr(
+            dev_server_module,
+            "summarize_local_git_state",
+            lambda cwd: _fake_git_state(),
+        )
+        monkeypatch.setattr(
+            dev_server_module, "git_worktree_top_level", lambda cwd: tmp_path
+        )
+        monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: rollout_dir))
+
+        with pytest.raises(CLIError, match=r"main\.py"):
+            dev_server_module.up(ttl_hours=24)
+
+
+class TestDevServerDown:
+    def test_down_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            dev_server_module,
+            "resolve_git_workspace_directory_context",
+            lambda: _fake_ctx(),
+        )
+
+        class FakeClient:
+            def teardown_dev_rollout_server(
+                self, server_id, *, credentials=None, git_identity
+            ):
+                assert server_id == "r1"
+                assert credentials is FAKE_CREDENTIALS
+                assert git_identity == GIT_IDENTITY
+                return {"id": "r1", "status": "stopped"}
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(dev_server_module, "OsmosisClient", FakeClient)
+
+        result = dev_server_module.down("r1")
+
+        assert isinstance(result, OperationResult)
+        assert result.resource is not None
+        assert result.resource["status"] == "stopped"

--- a/tests/unit/cli/test_dev_server_commands.py
+++ b/tests/unit/cli/test_dev_server_commands.py
@@ -10,6 +10,8 @@ import osmosis_ai.platform.api.client as api_client_module
 import osmosis_ai.platform.cli.dev_server as dev_server_module
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.cli.output import ListResult, OperationResult
+from osmosis_ai.platform.api.models import PaginatedDevRolloutServers
+from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE
 
 GIT_IDENTITY = "acme/rollouts"
 FAKE_CREDENTIALS = object()
@@ -367,30 +369,40 @@ class TestDevServerList:
 
         fake_servers = [
             {
-                "rollout_id": "r1",
-                "rollout_name": "multiply",
+                "id": "r1",
+                "name": "multiply",
                 "url": "https://r1.rollout-staging.gulp.dev",
                 "expires_at": None,
+                "started_at": None,
                 "status": "running",
             }
         ]
 
         class FakeClient:
-            def list_dev_rollout_servers(self, *, credentials=None, git_identity):
+            def list_dev_rollout_servers(
+                self, limit, offset, *, credentials=None, git_identity
+            ):
                 assert credentials is FAKE_CREDENTIALS
                 assert git_identity == GIT_IDENTITY
-                return {"servers": fake_servers}
+                return PaginatedDevRolloutServers.from_dict(
+                    {
+                        "dev_rollout_servers": fake_servers,
+                        "total_count": 1,
+                        "has_more": False,
+                        "next_offset": None,
+                    }
+                )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
         monkeypatch.setattr(dev_server_module, "OsmosisClient", FakeClient)
 
-        result = dev_server_module.list_servers()
+        result = dev_server_module.list_servers(limit=DEFAULT_PAGE_SIZE, all_=False)
 
         assert isinstance(result, ListResult)
         assert result.total_count == 1
         assert len(result.items) == 1
-        assert result.items[0]["rollout_id"] == "r1"
-        assert result.items[0]["rollout_name"] == "multiply"
+        assert result.items[0]["id"] == "r1"
+        assert result.items[0]["name"] == "multiply"
         assert result.items[0]["status"] == "running"
 
     def test_list_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -402,13 +414,22 @@ class TestDevServerList:
         )
 
         class FakeClient:
-            def list_dev_rollout_servers(self, *, credentials=None, git_identity):
-                return {"servers": []}
+            def list_dev_rollout_servers(
+                self, limit, offset, *, credentials=None, git_identity
+            ):
+                return PaginatedDevRolloutServers.from_dict(
+                    {
+                        "dev_rollout_servers": [],
+                        "total_count": 0,
+                        "has_more": False,
+                        "next_offset": None,
+                    }
+                )
 
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
         monkeypatch.setattr(dev_server_module, "OsmosisClient", FakeClient)
 
-        result = dev_server_module.list_servers()
+        result = dev_server_module.list_servers(limit=DEFAULT_PAGE_SIZE, all_=False)
 
         assert isinstance(result, ListResult)
         assert result.total_count == 0

--- a/tests/unit/cli/test_dev_server_commands.py
+++ b/tests/unit/cli/test_dev_server_commands.py
@@ -21,11 +21,15 @@ FAKE_SERVER = {
 FAKE_HEAD_SHA = "abc123def456abc123def456abc123def456abc1"
 
 
-def _fake_ctx():
+def _fake_ctx(workspace_directory: Path | None = None):
     return type(
         "FakeCtx",
         (),
-        {"credentials": FAKE_CREDENTIALS, "git_identity": GIT_IDENTITY},
+        {
+            "credentials": FAKE_CREDENTIALS,
+            "git_identity": GIT_IDENTITY,
+            "workspace_directory": workspace_directory,
+        },
     )()
 
 
@@ -57,15 +61,12 @@ class TestDevServerUp:
         monkeypatch.setattr(
             dev_server_module,
             "resolve_git_workspace_directory_context",
-            lambda: _fake_ctx(),
+            lambda: _fake_ctx(workspace_directory=tmp_path),
         )
         monkeypatch.setattr(
             dev_server_module,
             "summarize_local_git_state",
             lambda cwd: _fake_git_state(),
-        )
-        monkeypatch.setattr(
-            dev_server_module, "git_worktree_top_level", lambda cwd: tmp_path
         )
         monkeypatch.setattr(
             dev_server_module,
@@ -119,15 +120,12 @@ class TestDevServerUp:
         monkeypatch.setattr(
             dev_server_module,
             "resolve_git_workspace_directory_context",
-            lambda: _fake_ctx(),
+            lambda: _fake_ctx(workspace_directory=tmp_path),
         )
         monkeypatch.setattr(
             dev_server_module,
             "summarize_local_git_state",
             lambda cwd: _fake_git_state(),
-        )
-        monkeypatch.setattr(
-            dev_server_module, "git_worktree_top_level", lambda cwd: tmp_path
         )
         monkeypatch.setattr(
             dev_server_module,
@@ -162,15 +160,12 @@ class TestDevServerUp:
         monkeypatch.setattr(
             dev_server_module,
             "resolve_git_workspace_directory_context",
-            lambda: _fake_ctx(),
+            lambda: _fake_ctx(workspace_directory=tmp_path),
         )
         monkeypatch.setattr(
             dev_server_module,
             "summarize_local_git_state",
             lambda cwd: _fake_git_state(is_dirty=True),
-        )
-        monkeypatch.setattr(
-            dev_server_module, "git_worktree_top_level", lambda cwd: tmp_path
         )
         monkeypatch.setattr(
             dev_server_module,
@@ -208,15 +203,12 @@ class TestDevServerUp:
         monkeypatch.setattr(
             dev_server_module,
             "resolve_git_workspace_directory_context",
-            lambda: _fake_ctx(),
+            lambda: _fake_ctx(workspace_directory=tmp_path),
         )
         monkeypatch.setattr(
             dev_server_module,
             "summarize_local_git_state",
             lambda cwd: _fake_git_state(is_dirty=True),
-        )
-        monkeypatch.setattr(
-            dev_server_module, "git_worktree_top_level", lambda cwd: tmp_path
         )
         monkeypatch.setattr(
             dev_server_module,
@@ -259,15 +251,12 @@ class TestDevServerUp:
         monkeypatch.setattr(
             dev_server_module,
             "resolve_git_workspace_directory_context",
-            lambda: _fake_ctx(),
+            lambda: _fake_ctx(workspace_directory=tmp_path),
         )
         monkeypatch.setattr(
             dev_server_module,
             "summarize_local_git_state",
             lambda cwd: _fake_git_state(),
-        )
-        monkeypatch.setattr(
-            dev_server_module, "git_worktree_top_level", lambda cwd: tmp_path
         )
         monkeypatch.setattr(
             dev_server_module,
@@ -290,15 +279,12 @@ class TestDevServerUp:
         monkeypatch.setattr(
             dev_server_module,
             "resolve_git_workspace_directory_context",
-            lambda: _fake_ctx(),
+            lambda: _fake_ctx(workspace_directory=tmp_path),
         )
         monkeypatch.setattr(
             dev_server_module,
             "summarize_local_git_state",
             lambda cwd: _fake_git_state(),
-        )
-        monkeypatch.setattr(
-            dev_server_module, "git_worktree_top_level", lambda cwd: tmp_path
         )
         monkeypatch.setattr(
             dev_server_module,
@@ -320,15 +306,12 @@ class TestDevServerUp:
         monkeypatch.setattr(
             dev_server_module,
             "resolve_git_workspace_directory_context",
-            lambda: _fake_ctx(),
+            lambda: _fake_ctx(workspace_directory=tmp_path),
         )
         monkeypatch.setattr(
             dev_server_module,
             "summarize_local_git_state",
             lambda cwd: _fake_git_state(is_dirty=True),
-        )
-        monkeypatch.setattr(
-            dev_server_module, "git_worktree_top_level", lambda cwd: tmp_path
         )
         monkeypatch.setattr(
             dev_server_module,

--- a/tests/unit/cli/test_dev_server_commands.py
+++ b/tests/unit/cli/test_dev_server_commands.py
@@ -10,6 +10,7 @@ import osmosis_ai.platform.api.client as api_client_module
 import osmosis_ai.platform.cli.dev_server as dev_server_module
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.cli.output import ListResult, OperationResult
+from osmosis_ai.cli.output.display import format_local_date
 from osmosis_ai.platform.api.models import PaginatedDevRolloutServers
 from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE
 
@@ -457,10 +458,10 @@ class TestDevServerList:
         assert result.display_items[0]["expires_at"] == "No expiration"
         assert result.display_items[0]["id"] == "r2"
 
-    def test_list_display_items_preserves_non_empty_expires_at(
+    def test_list_display_items_formats_non_empty_expires_at(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """display_items leaves a real expires_at timestamp as-is."""
+        """display_items renders a real expires_at as a local date string."""
         monkeypatch.setattr(
             dev_server_module,
             "resolve_git_workspace_directory_context",
@@ -499,7 +500,9 @@ class TestDevServerList:
         assert isinstance(result, ListResult)
         assert result.items[0]["expires_at"] == "2026-06-25T12:00:00Z"
         assert result.display_items is not None
-        assert result.display_items[0]["expires_at"] == "2026-06-25T12:00:00Z"
+        assert result.display_items[0]["expires_at"] == format_local_date(
+            "2026-06-25T12:00:00Z"
+        )
 
     def test_list_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """list_servers() returns a ListResult with zero items when API returns empty."""

--- a/tests/unit/cli/test_dev_server_commands.py
+++ b/tests/unit/cli/test_dev_server_commands.py
@@ -310,6 +310,41 @@ class TestDevServerUp:
         with pytest.raises(CLIError, match=r"main\.py"):
             dev_server_module.up(ttl_hours=24, yes=False)
 
+    def test_up_missing_main_py_takes_priority_over_dirty(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Missing main.py errors before the dirty-tree confirmation is reached."""
+        rollout_dir = tmp_path / "rollouts" / "multiply"
+        rollout_dir.mkdir(parents=True)  # no main.py
+
+        monkeypatch.setattr(
+            dev_server_module,
+            "resolve_git_workspace_directory_context",
+            lambda: _fake_ctx(),
+        )
+        monkeypatch.setattr(
+            dev_server_module,
+            "summarize_local_git_state",
+            lambda cwd: _fake_git_state(is_dirty=True),
+        )
+        monkeypatch.setattr(
+            dev_server_module, "git_worktree_top_level", lambda cwd: tmp_path
+        )
+        monkeypatch.setattr(
+            dev_server_module,
+            "check_pinned_commit",
+            lambda **kwargs: _fake_pinned_check(),
+        )
+        monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: rollout_dir))
+
+        def _fail_if_called(*args, **kwargs):
+            raise AssertionError("require_confirmation should not be reached")
+
+        monkeypatch.setattr(dev_server_module, "require_confirmation", _fail_if_called)
+
+        with pytest.raises(CLIError, match=r"main\.py"):
+            dev_server_module.up(ttl_hours=24, yes=False)
+
 
 class TestDevServerDown:
     def test_down_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/cli/test_dev_server_commands.py
+++ b/tests/unit/cli/test_dev_server_commands.py
@@ -1,4 +1,4 @@
-"""Tests for osmosis_ai.platform.cli.dev_server (dev server up/down)."""
+"""Tests for osmosis_ai.platform.cli.dev_server (dev server up/down/list)."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ import pytest
 import osmosis_ai.platform.api.client as api_client_module
 import osmosis_ai.platform.cli.dev_server as dev_server_module
 from osmosis_ai.cli.errors import CLIError
-from osmosis_ai.cli.output import OperationResult
+from osmosis_ai.cli.output import ListResult, OperationResult
 
 GIT_IDENTITY = "acme/rollouts"
 FAKE_CREDENTIALS = object()
@@ -37,6 +37,15 @@ def _fake_git_state(*, is_dirty=False, head_sha=FAKE_HEAD_SHA):
     )()
 
 
+def _fake_pinned_check(*, error=None, warnings=()):
+    """Return a fake PinnedCommitCheck-like object."""
+    return type(
+        "FakePinnedCommitCheck",
+        (),
+        {"error": error, "warnings": warnings},
+    )()
+
+
 class TestDevServerUp:
     def test_up_happy_path(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -57,6 +66,11 @@ class TestDevServerUp:
         )
         monkeypatch.setattr(
             dev_server_module, "git_worktree_top_level", lambda cwd: tmp_path
+        )
+        monkeypatch.setattr(
+            dev_server_module,
+            "check_pinned_commit",
+            lambda **kwargs: _fake_pinned_check(),
         )
         monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: rollout_dir))
 
@@ -85,7 +99,7 @@ class TestDevServerUp:
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
         monkeypatch.setattr(dev_server_module, "OsmosisClient", FakeClient)
 
-        result = dev_server_module.up(ttl_hours=24)
+        result = dev_server_module.up(ttl_hours=24, yes=False)
 
         assert isinstance(result, OperationResult)
         assert result.resource is not None
@@ -115,6 +129,11 @@ class TestDevServerUp:
         monkeypatch.setattr(
             dev_server_module, "git_worktree_top_level", lambda cwd: tmp_path
         )
+        monkeypatch.setattr(
+            dev_server_module,
+            "check_pinned_commit",
+            lambda **kwargs: _fake_pinned_check(),
+        )
         monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: rollout_dir))
 
         captured: dict = {}
@@ -127,14 +146,15 @@ class TestDevServerUp:
         monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
         monkeypatch.setattr(dev_server_module, "OsmosisClient", FakeClient)
 
-        result = dev_server_module.up(ttl_hours=None)
+        result = dev_server_module.up(ttl_hours=None, yes=False)
 
         assert isinstance(result, OperationResult)
         assert captured["ttl_hours"] is None
 
-    def test_up_dirty_working_tree_raises(
+    def test_up_dirty_tree_with_yes_proceeds(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
+        """Dirty tree + --yes → no prompt, client is called."""
         rollout_dir = tmp_path / "rollouts" / "multiply"
         rollout_dir.mkdir(parents=True)
         (rollout_dir / "main.py").write_text("# main", encoding="utf-8")
@@ -152,10 +172,114 @@ class TestDevServerUp:
         monkeypatch.setattr(
             dev_server_module, "git_worktree_top_level", lambda cwd: tmp_path
         )
+        monkeypatch.setattr(
+            dev_server_module,
+            "check_pinned_commit",
+            lambda **kwargs: _fake_pinned_check(),
+        )
         monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: rollout_dir))
 
-        with pytest.raises(CLIError, match="dirty"):
-            dev_server_module.up(ttl_hours=24)
+        # require_confirmation with yes=True is a no-op, so no need to mock it
+        client_called = {}
+
+        class FakeClient:
+            def provision_dev_rollout_server(self, **kwargs):
+                client_called["called"] = True
+                return FAKE_SERVER
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(dev_server_module, "OsmosisClient", FakeClient)
+
+        result = dev_server_module.up(ttl_hours=24, yes=True)
+
+        assert isinstance(result, OperationResult)
+        assert client_called.get("called") is True
+
+    def test_up_dirty_tree_declined_aborts(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Dirty tree + no --yes + confirmation declined → aborts (no client call)."""
+        import typer
+
+        rollout_dir = tmp_path / "rollouts" / "multiply"
+        rollout_dir.mkdir(parents=True)
+        (rollout_dir / "main.py").write_text("# main", encoding="utf-8")
+
+        monkeypatch.setattr(
+            dev_server_module,
+            "resolve_git_workspace_directory_context",
+            lambda: _fake_ctx(),
+        )
+        monkeypatch.setattr(
+            dev_server_module,
+            "summarize_local_git_state",
+            lambda cwd: _fake_git_state(is_dirty=True),
+        )
+        monkeypatch.setattr(
+            dev_server_module, "git_worktree_top_level", lambda cwd: tmp_path
+        )
+        monkeypatch.setattr(
+            dev_server_module,
+            "check_pinned_commit",
+            lambda **kwargs: _fake_pinned_check(),
+        )
+        monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: rollout_dir))
+
+        # Mock require_confirmation to raise Exit(0) simulating decline
+        def _mock_require_confirmation(*args, **kwargs):
+            raise typer.Exit(0)
+
+        monkeypatch.setattr(
+            dev_server_module, "require_confirmation", _mock_require_confirmation
+        )
+
+        client_called = {}
+
+        class FakeClient:
+            def provision_dev_rollout_server(self, **kwargs):
+                client_called["called"] = True
+                return FAKE_SERVER
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(dev_server_module, "OsmosisClient", FakeClient)
+
+        with pytest.raises(typer.Exit):
+            dev_server_module.up(ttl_hours=24, yes=False)
+
+        assert not client_called.get("called")
+
+    def test_up_commit_not_pushed_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Commit not found on remote → CLIError (hard error)."""
+        rollout_dir = tmp_path / "rollouts" / "multiply"
+        rollout_dir.mkdir(parents=True)
+        (rollout_dir / "main.py").write_text("# main", encoding="utf-8")
+
+        monkeypatch.setattr(
+            dev_server_module,
+            "resolve_git_workspace_directory_context",
+            lambda: _fake_ctx(),
+        )
+        monkeypatch.setattr(
+            dev_server_module,
+            "summarize_local_git_state",
+            lambda cwd: _fake_git_state(),
+        )
+        monkeypatch.setattr(
+            dev_server_module, "git_worktree_top_level", lambda cwd: tmp_path
+        )
+        monkeypatch.setattr(
+            dev_server_module,
+            "check_pinned_commit",
+            lambda **kwargs: _fake_pinned_check(
+                error=f"Pinned commit {FAKE_HEAD_SHA} exists locally but was not found on origin"
+            ),
+        )
+        monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: rollout_dir))
+
+        with pytest.raises(CLIError, match="not found on origin"):
+            dev_server_module.up(ttl_hours=24, yes=False)
 
     def test_up_missing_main_py_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -176,10 +300,15 @@ class TestDevServerUp:
         monkeypatch.setattr(
             dev_server_module, "git_worktree_top_level", lambda cwd: tmp_path
         )
+        monkeypatch.setattr(
+            dev_server_module,
+            "check_pinned_commit",
+            lambda **kwargs: _fake_pinned_check(),
+        )
         monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: rollout_dir))
 
         with pytest.raises(CLIError, match=r"main\.py"):
-            dev_server_module.up(ttl_hours=24)
+            dev_server_module.up(ttl_hours=24, yes=False)
 
 
 class TestDevServerDown:
@@ -207,3 +336,62 @@ class TestDevServerDown:
         assert isinstance(result, OperationResult)
         assert result.resource is not None
         assert result.resource["status"] == "stopped"
+
+
+class TestDevServerList:
+    def test_list_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """list_servers() returns a ListResult with the server rows from the API."""
+        monkeypatch.setattr(
+            dev_server_module,
+            "resolve_git_workspace_directory_context",
+            lambda: _fake_ctx(),
+        )
+
+        fake_servers = [
+            {
+                "rollout_id": "r1",
+                "rollout_name": "multiply",
+                "url": "https://r1.rollout-staging.gulp.dev",
+                "expires_at": None,
+                "status": "running",
+            }
+        ]
+
+        class FakeClient:
+            def list_dev_rollout_servers(self, *, credentials=None, git_identity):
+                assert credentials is FAKE_CREDENTIALS
+                assert git_identity == GIT_IDENTITY
+                return {"servers": fake_servers}
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(dev_server_module, "OsmosisClient", FakeClient)
+
+        result = dev_server_module.list_servers()
+
+        assert isinstance(result, ListResult)
+        assert result.total_count == 1
+        assert len(result.items) == 1
+        assert result.items[0]["rollout_id"] == "r1"
+        assert result.items[0]["rollout_name"] == "multiply"
+        assert result.items[0]["status"] == "running"
+
+    def test_list_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """list_servers() returns a ListResult with zero items when API returns empty."""
+        monkeypatch.setattr(
+            dev_server_module,
+            "resolve_git_workspace_directory_context",
+            lambda: _fake_ctx(),
+        )
+
+        class FakeClient:
+            def list_dev_rollout_servers(self, *, credentials=None, git_identity):
+                return {"servers": []}
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(dev_server_module, "OsmosisClient", FakeClient)
+
+        result = dev_server_module.list_servers()
+
+        assert isinstance(result, ListResult)
+        assert result.total_count == 0
+        assert result.items == []

--- a/tests/unit/cli/test_dev_server_commands.py
+++ b/tests/unit/cli/test_dev_server_commands.py
@@ -111,6 +111,10 @@ class TestDevServerUp:
         assert captured["commit_sha"] == FAKE_HEAD_SHA
         assert captured["repository_path"] == "rollouts/multiply"
         assert captured["ttl_hours"] == 24
+        assert result.message is not None
+        assert "provisioning" in result.message
+        assert FAKE_SERVER["url"] in result.message
+        assert "osmosis dev server list" in result.message
 
     def test_up_no_ttl_passes_none(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -404,6 +408,98 @@ class TestDevServerList:
         assert result.items[0]["id"] == "r1"
         assert result.items[0]["name"] == "multiply"
         assert result.items[0]["status"] == "running"
+        assert result.items[0]["expires_at"] is None
+        assert result.display_items is not None
+        assert result.display_items[0]["expires_at"] == "No expiration"
+
+    def test_list_display_items_no_expiration(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """display_items shows 'No expiration' for None expires_at; items keeps original."""
+        monkeypatch.setattr(
+            dev_server_module,
+            "resolve_git_workspace_directory_context",
+            lambda: _fake_ctx(),
+        )
+
+        fake_servers = [
+            {
+                "id": "r2",
+                "name": "my-rollout",
+                "url": "https://r2.rollout-staging.gulp.dev",
+                "expires_at": None,
+                "started_at": None,
+                "status": "running",
+            }
+        ]
+
+        class FakeClient:
+            def list_dev_rollout_servers(
+                self, limit, offset, *, credentials=None, git_identity
+            ):
+                return PaginatedDevRolloutServers.from_dict(
+                    {
+                        "dev_rollout_servers": fake_servers,
+                        "total_count": 1,
+                        "has_more": False,
+                        "next_offset": None,
+                    }
+                )
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(dev_server_module, "OsmosisClient", FakeClient)
+
+        result = dev_server_module.list_servers(limit=DEFAULT_PAGE_SIZE, all_=False)
+
+        assert isinstance(result, ListResult)
+        assert result.items[0]["expires_at"] is None
+        assert result.display_items is not None
+        assert result.display_items[0]["expires_at"] == "No expiration"
+        assert result.display_items[0]["id"] == "r2"
+
+    def test_list_display_items_preserves_non_empty_expires_at(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """display_items leaves a real expires_at timestamp as-is."""
+        monkeypatch.setattr(
+            dev_server_module,
+            "resolve_git_workspace_directory_context",
+            lambda: _fake_ctx(),
+        )
+
+        fake_servers = [
+            {
+                "id": "r3",
+                "name": "timed-rollout",
+                "url": "https://r3.rollout-staging.gulp.dev",
+                "expires_at": "2026-06-25T12:00:00Z",
+                "started_at": None,
+                "status": "running",
+            }
+        ]
+
+        class FakeClient:
+            def list_dev_rollout_servers(
+                self, limit, offset, *, credentials=None, git_identity
+            ):
+                return PaginatedDevRolloutServers.from_dict(
+                    {
+                        "dev_rollout_servers": fake_servers,
+                        "total_count": 1,
+                        "has_more": False,
+                        "next_offset": None,
+                    }
+                )
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(dev_server_module, "OsmosisClient", FakeClient)
+
+        result = dev_server_module.list_servers(limit=DEFAULT_PAGE_SIZE, all_=False)
+
+        assert isinstance(result, ListResult)
+        assert result.items[0]["expires_at"] == "2026-06-25T12:00:00Z"
+        assert result.display_items is not None
+        assert result.display_items[0]["expires_at"] == "2026-06-25T12:00:00Z"
 
     def test_list_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """list_servers() returns a ListResult with zero items when API returns empty."""

--- a/tests/unit/platform/api/test_client.py
+++ b/tests/unit/platform/api/test_client.py
@@ -1055,3 +1055,87 @@ class TestGetEvalRunMetrics:
         assert result.reward_stats.mean == 0.72
         assert result.pass_at_k[0].k == 1
         assert mock_request.call_args[0][0] == "/api/cli/eval-runs/a%2Fb/metrics"
+
+
+class TestDevRolloutServer:
+    """Tests for OsmosisClient dev rollout server methods."""
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_provision_posts_correct_payload(self, mock_request: MagicMock) -> None:
+        mock_request.return_value = {"server_id": "srv-1", "status": "provisioning"}
+        credentials = object()
+
+        result = OsmosisClient().provision_dev_rollout_server(
+            rollout_name="my-rollout",
+            commit_sha="abc123",
+            repository_path="/repo",
+            entrypoint="rollout.py",
+            ttl_hours=4,
+            credentials=credentials,
+            git_identity="git_test",
+        )
+
+        assert result == {"server_id": "srv-1", "status": "provisioning"}
+        assert mock_request.call_args[0][0] == "/api/cli/dev-rollout-server"
+        assert mock_request.call_args.kwargs["method"] == "POST"
+        assert mock_request.call_args.kwargs["data"] == {
+            "rollout_name": "my-rollout",
+            "commit_sha": "abc123",
+            "repository_path": "/repo",
+            "entrypoint": "rollout.py",
+            "ttl_hours": 4,
+        }
+        assert mock_request.call_args.kwargs["credentials"] is credentials
+        assert mock_request.call_args.kwargs["git_identity"] == "git_test"
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_provision_accepts_none_ttl_hours(self, mock_request: MagicMock) -> None:
+        mock_request.return_value = {"server_id": "srv-2", "status": "provisioning"}
+
+        OsmosisClient().provision_dev_rollout_server(
+            rollout_name="r",
+            commit_sha="sha",
+            repository_path="/p",
+            entrypoint="e.py",
+            ttl_hours=None,
+            git_identity="git_test",
+        )
+
+        assert mock_request.call_args.kwargs["data"]["ttl_hours"] is None
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_teardown_sends_delete_and_encodes_id(
+        self, mock_request: MagicMock
+    ) -> None:
+        mock_request.return_value = {"server_id": "a/b", "status": "terminating"}
+        credentials = object()
+
+        result = OsmosisClient().teardown_dev_rollout_server(
+            "a/b",
+            credentials=credentials,
+            git_identity="git_test",
+        )
+
+        assert result == {"server_id": "a/b", "status": "terminating"}
+        assert mock_request.call_args[0][0] == "/api/cli/dev-rollout-server/a%2Fb"
+        assert mock_request.call_args.kwargs["method"] == "DELETE"
+        assert mock_request.call_args.kwargs["data"] == {}
+        assert mock_request.call_args.kwargs["credentials"] is credentials
+        assert mock_request.call_args.kwargs["git_identity"] == "git_test"
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_list_dev_rollout_servers_sends_get(self, mock_request: MagicMock) -> None:
+        mock_request.return_value = {"servers": [], "total_count": 0}
+        credentials = object()
+
+        result = OsmosisClient().list_dev_rollout_servers(
+            credentials=credentials,
+            git_identity="git_test",
+        )
+
+        assert result == {"servers": [], "total_count": 0}
+        assert mock_request.call_args[0][0] == "/api/cli/dev-rollout-server"
+        assert mock_request.call_args.kwargs["credentials"] is credentials
+        assert mock_request.call_args.kwargs["git_identity"] == "git_test"
+        assert "method" not in mock_request.call_args.kwargs
+        assert "data" not in mock_request.call_args.kwargs

--- a/tests/unit/platform/api/test_client.py
+++ b/tests/unit/platform/api/test_client.py
@@ -1125,7 +1125,21 @@ class TestDevRolloutServer:
 
     @patch("osmosis_ai.platform.api.client.platform_request")
     def test_list_dev_rollout_servers_sends_get(self, mock_request: MagicMock) -> None:
-        mock_request.return_value = {"servers": [], "total_count": 0}
+        mock_request.return_value = {
+            "dev_rollout_servers": [
+                {
+                    "id": "r1",
+                    "name": "multiply",
+                    "url": "https://r1.example.dev",
+                    "status": "running",
+                    "expires_at": None,
+                    "started_at": None,
+                }
+            ],
+            "total_count": 1,
+            "has_more": False,
+            "next_offset": None,
+        }
         credentials = object()
 
         result = OsmosisClient().list_dev_rollout_servers(
@@ -1133,8 +1147,16 @@ class TestDevRolloutServer:
             git_identity="git_test",
         )
 
-        assert result == {"servers": [], "total_count": 0}
-        assert mock_request.call_args[0][0] == "/api/cli/dev-rollout-server"
+        assert result.total_count == 1
+        assert result.has_more is False
+        assert result.next_offset is None
+        assert len(result.dev_rollout_servers) == 1
+        assert result.dev_rollout_servers[0].id == "r1"
+        assert result.dev_rollout_servers[0].name == "multiply"
+        assert (
+            mock_request.call_args[0][0]
+            == "/api/cli/dev-rollout-server?limit=50&offset=0"
+        )
         assert mock_request.call_args.kwargs["credentials"] is credentials
         assert mock_request.call_args.kwargs["git_identity"] == "git_test"
         assert "method" not in mock_request.call_args.kwargs


### PR DESCRIPTION
## What

Adds a new `osmosis dev server` command group for provisioning, listing, and tearing down remote rollout servers from a local rollout folder:

- `dev server up` — provisions a remote rollout server pinned to the committed `HEAD` of the current rollout folder. Supports `--ttl-hours` (default 24h), `--no-ttl` to disable auto-teardown, and `--yes/-y` to skip the dirty-working-tree confirmation.
- `dev server down <server_id>` — tears down a server by id.
- `dev server list` — lists active rollout servers for the workspace.

Backing this, three methods are added to `OsmosisClient` (`provision_dev_rollout_server`, `teardown_dev_rollout_server`, `list_dev_rollout_servers`) that call the `/api/cli/dev-rollout-server` platform endpoints. The `dev` group is registered in the CLI but marked `hidden=True` so it does not appear in `--help`.

Safety behavior on `up`:

- Requires being in a git repo with a commit and a rollout folder containing `main.py`.
- Preflights that the pinned commit exists on `origin`; errors if it hasn't been pushed.
- Warns and confirms when the working tree is dirty, since the server runs the committed `HEAD` rather than local uncommitted changes.

## Why

Enables an internal developer workflow to spin up remote rollout servers against a specific committed revision for testing and iteration, without exposing the tooling in the public CLI surface.

## How to Test

- `pytest tests/unit/cli/test_dev_server_commands.py` — covers `up` (TTL passthrough, dirty-tree confirm/decline, unpushed-commit error, missing `main.py`), `down`, and `list` (populated and empty).
- `pytest tests/unit/cli/test_command_groups.py` — verifies `dev` is registered but hidden from `--help`.
- Manual: from a rollout folder containing `main.py`, run `osmosis dev server up`, then `osmosis dev server list`, then `osmosis dev server down <server_id>`.

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hidden `osmosis dev server` CLI to provision, list, and tear down remote rollout servers pinned to the current rollout’s committed HEAD for internal testing. Validates the rollout folder, resolves git state from the workspace root, prints a clear provisioning hint, and shows "No expiration" for no‑TTL servers.

- **New Features**
  - Commands: `dev server up`, `dev server down <server_id>`, `dev server list`.
  - `up`: pins to `HEAD`; supports `--ttl-hours` (default 24h), `--no-ttl`, `--yes/-y`; prints a provisioning hint with the server URL.
  - `list`: paginated with `--limit` and `--all`; displays "No expiration" when TTL is disabled.
  - Safety: requires a git repo and `main.py`, verifies `HEAD` exists on `origin`, confirms when the working tree is dirty.
  - Client: added `provision_dev_rollout_server`, `teardown_dev_rollout_server`, `list_dev_rollout_servers` calling `/api/cli/dev-rollout-server`; `dev` group is registered but hidden from `--help`.

- **Bug Fixes**
  - `up`: check for `main.py` before dirty/pushed checks.
  - `up`: resolve git state from the workspace root (not CWD).

<sup>Written for commit cebd95e4bd3c57067e529c94d253c35215fbf9e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

