### PR TITLE
[cli] fix: skip submit preflight when rollout deps aren't installed locally

### DIFF
--- a/osmosis_ai/eval/common/cli.py
+++ b/osmosis_ai/eval/common/cli.py
@@ -263,6 +263,8 @@ def load_workflow(
     """Load an AgentWorkflow class and its config.
 
     Returns (workflow_cls, workflow_config, entrypoint_module_name, error).
+    Raises ModuleNotFoundError when the rollout's dependencies aren't installed
+    in this environment (other load failures are returned as the error string).
     """
     if console and not quiet:
         console.print(f"Loading workflow: {entrypoint}")
@@ -273,6 +275,10 @@ def load_workflow(
             entrypoint=entrypoint,
             workspace_directory=workspace_directory,
         )
+    except ModuleNotFoundError:
+        # Deps aren't importable here; let the submit preflight skip and defer
+        # to the server, which installs from pyproject before validating.
+        raise
     except Exception as e:
         detail = str(e)
         if not isinstance(e, (CLIError, ImportError, ValueError, TypeError)):

--- a/osmosis_ai/platform/cli/dev_server.py
+++ b/osmosis_ai/platform/cli/dev_server.py
@@ -80,7 +80,7 @@ def down(server_id: str) -> OperationResult:
         operation="dev.server.down",
         status="success",
         resource=result,
-        message=f"Stopped {server_id}",
+        message=f"Stopping rollout server {server_id}",
     )
 
 

--- a/osmosis_ai/platform/cli/workspace_directory_contract.py
+++ b/osmosis_ai/platform/cli/workspace_directory_contract.py
@@ -132,13 +132,20 @@ def validate_rollout_backend(
     from osmosis_ai.eval.common.cli import _resolve_grader, load_workflow
     from osmosis_ai.rollout.validator import validate_backend
 
-    workflow_cls, workflow_config, entrypoint_module, workflow_error = load_workflow(
-        rollout=rollout,
-        entrypoint=entrypoint,
-        quiet=True,
-        console=None,
-        workspace_directory=workspace_directory,
-    )
+    try:
+        workflow_cls, workflow_config, entrypoint_module, workflow_error = (
+            load_workflow(
+                rollout=rollout,
+                entrypoint=entrypoint,
+                quiet=True,
+                console=None,
+                workspace_directory=workspace_directory,
+            )
+        )
+    except ModuleNotFoundError:
+        # Deps aren't installed locally, so we can't import the entrypoint here.
+        # Skip; the server validates after installing from pyproject.toml.
+        return
     if workflow_error or workflow_cls is None or entrypoint_module is None:
         raise CLIError(
             f"{command_label} preflight failed for `rollouts/{rollout}/{entrypoint}`.\n"

--- a/tests/unit/platform/cli/test_eval_submit_preflight.py
+++ b/tests/unit/platform/cli/test_eval_submit_preflight.py
@@ -1,0 +1,187 @@
+"""eval submit must not fail preflight when rollout deps aren't installed locally.
+
+Mirror of test_train_submit_preflight: train and eval share `run_cloud_submit`,
+so each covers the `validate_rollout_backend` seam from its own command's side.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import osmosis_ai.platform.api.client as api_client_module
+import osmosis_ai.platform.cli.eval as eval_module
+import osmosis_ai.platform.cli.shared_submit as shared_submit_module
+import osmosis_ai.platform.cli.utils as utils_module
+from osmosis_ai.cli.console import Console
+from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.cli.output import OperationResult
+from osmosis_ai.platform.api.models import SubmitRunResult
+from tests.unit.submit_preflight_helpers import disable_commit_preflight
+
+GIT_IDENTITY = "acme/rollouts"
+REPO_URL = "https://github.com/acme/rollouts.git"
+FAKE_CREDENTIALS = object()
+
+
+def _find_temp_workspace_directory(start: Path) -> Path | None:
+    current = start.resolve()
+    for candidate in (current, *current.parents):
+        if (
+            (candidate / ".osmosis").is_dir()
+            and (candidate / "configs" / "eval").is_dir()
+            and (candidate / "rollouts").is_dir()
+        ):
+            return candidate
+    return None
+
+
+def _make_workspace_directory(root: Path, *, main_py: str) -> Path:
+    subprocess.run(
+        ["git", "init", "-b", "main", str(root)], check=True, capture_output=True
+    )
+    for rel_path in (
+        ".osmosis",
+        "rollouts/calculator",
+        "configs/eval",
+        "configs/training",
+        "data",
+    ):
+        (root / rel_path).mkdir(parents=True, exist_ok=True)
+    (root / "rollouts" / "calculator" / "main.py").write_text(main_py, encoding="utf-8")
+    return root
+
+
+def _write_eval_config(path: Path) -> Path:
+    path.write_text(
+        (
+            "[experiment]\n"
+            'rollout = "calculator"\n'
+            'entrypoint = "main.py"\n'
+            'model_path = "openai/gpt-5-mini"\n'
+            'dataset = "multiply"\n\n'
+            "[evaluation]\n"
+            "n = 2\n\n"
+            "[secrets]\n"
+            'required = ["OPENAI_API_KEY"]\n'
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.fixture()
+def console_capture(monkeypatch: pytest.MonkeyPatch) -> StringIO:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, width=200)
+    monkeypatch.setattr(eval_module, "console", console)
+    monkeypatch.setattr(shared_submit_module, "console", console)
+    monkeypatch.setattr(utils_module, "console", console)
+    return output
+
+
+@pytest.fixture(autouse=True)
+def _mock_git_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _git_context() -> Any:
+        workspace_directory = _find_temp_workspace_directory(Path.cwd()) or Path(
+            "/repo"
+        )
+        return type(
+            "GitContext",
+            (),
+            {
+                "workspace_directory": workspace_directory.resolve(),
+                "git_identity": GIT_IDENTITY,
+                "repo_url": REPO_URL,
+                "credentials": FAKE_CREDENTIALS,
+            },
+        )()
+
+    monkeypatch.setattr(
+        shared_submit_module,
+        "require_git_workspace_directory_context",
+        _git_context,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _mock_workspace_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.workspace_repo.summarize_local_git_state",
+        lambda workspace_directory: type(
+            "State",
+            (),
+            {
+                "head_sha": "localhead",
+                "is_dirty": False,
+                "has_upstream": True,
+                "ahead": 0,
+                "branch": "main",
+            },
+        )(),
+    )
+    disable_commit_preflight(monkeypatch)
+
+
+def _fake_client_class(submitted: list[bool]) -> type:
+    class FakeClient:
+        def submit_evaluation_run(self, **kwargs: Any) -> SubmitRunResult:
+            submitted.append(True)
+            return SubmitRunResult(
+                id="eval-1",
+                name="eval-run",
+                status="pending",
+                created_at="2026-05-27T00:00:00Z",
+                platform_url="https://platform.osmosis.ai/evals/eval-1",
+            )
+
+    return FakeClient
+
+
+def test_eval_submit_skips_preflight_when_dependency_uninstalled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    console_capture: StringIO,
+) -> None:
+    workspace_directory = _make_workspace_directory(
+        tmp_path / "project", main_py="import a_package_that_is_not_installed_xyz\n"
+    )
+    config_path = _write_eval_config(
+        workspace_directory / "configs" / "eval" / "default.toml"
+    )
+    monkeypatch.chdir(workspace_directory)
+    submitted: list[bool] = []
+    fake = _fake_client_class(submitted)
+    monkeypatch.setattr(api_client_module, "OsmosisClient", fake)
+    monkeypatch.setattr(shared_submit_module, "OsmosisClient", fake)
+
+    result = eval_module.submit(config_path=config_path, yes=True)
+
+    assert isinstance(result, OperationResult)
+    assert submitted == [True]
+
+
+def test_eval_submit_preflight_still_fails_on_syntax_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    console_capture: StringIO,
+) -> None:
+    workspace_directory = _make_workspace_directory(
+        tmp_path / "project", main_py="def (oops\n"
+    )
+    config_path = _write_eval_config(
+        workspace_directory / "configs" / "eval" / "default.toml"
+    )
+    monkeypatch.chdir(workspace_directory)
+    submitted: list[bool] = []
+    fake = _fake_client_class(submitted)
+    monkeypatch.setattr(api_client_module, "OsmosisClient", fake)
+    monkeypatch.setattr(shared_submit_module, "OsmosisClient", fake)
+
+    with pytest.raises(CLIError):
+        eval_module.submit(config_path=config_path, yes=True)
+    assert submitted == []

--- a/tests/unit/platform/cli/test_train_submit_preflight.py
+++ b/tests/unit/platform/cli/test_train_submit_preflight.py
@@ -1,0 +1,186 @@
+"""train submit must not fail preflight when rollout deps aren't installed locally.
+
+Mirror of test_eval_submit_preflight: train and eval share `run_cloud_submit`,
+so each covers the `validate_rollout_backend` seam from its own command's side.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import osmosis_ai.platform.api.client as api_client_module
+import osmosis_ai.platform.cli.shared_submit as shared_submit_module
+import osmosis_ai.platform.cli.train as train_module
+import osmosis_ai.platform.cli.utils as utils_module
+from osmosis_ai.cli.console import Console
+from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.cli.output import OperationResult
+from osmosis_ai.platform.api.models import SubmitRunResult
+from tests.unit.submit_preflight_helpers import disable_commit_preflight
+
+GIT_IDENTITY = "acme/rollouts"
+REPO_URL = "https://github.com/acme/rollouts.git"
+FAKE_CREDENTIALS = object()
+
+
+def _find_temp_workspace_directory(start: Path) -> Path | None:
+    current = start.resolve()
+    for candidate in (current, *current.parents):
+        if (
+            (candidate / ".osmosis").is_dir()
+            and (candidate / "configs" / "training").is_dir()
+            and (candidate / "rollouts").is_dir()
+        ):
+            return candidate
+    return None
+
+
+def _make_workspace_directory(root: Path, *, main_py: str) -> Path:
+    subprocess.run(
+        ["git", "init", "-b", "main", str(root)], check=True, capture_output=True
+    )
+    for rel_path in (
+        ".osmosis",
+        "rollouts/calculator",
+        "configs/eval",
+        "configs/training",
+        "data",
+    ):
+        (root / rel_path).mkdir(parents=True, exist_ok=True)
+    (root / "rollouts" / "calculator" / "main.py").write_text(main_py, encoding="utf-8")
+    return root
+
+
+def _write_train_config(path: Path) -> Path:
+    path.write_text(
+        (
+            "[experiment]\n"
+            'rollout = "calculator"\n'
+            'entrypoint = "main.py"\n'
+            'model_path = "Qwen/Qwen3.6-35B-A3B"\n'
+            'dataset = "multiply"\n\n'
+            "[training]\n"
+            "lr = 1e-6\n"
+            "total_epochs = 2\n"
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.fixture()
+def console_capture(monkeypatch: pytest.MonkeyPatch) -> StringIO:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, width=200)
+    monkeypatch.setattr(train_module, "console", console)
+    monkeypatch.setattr(shared_submit_module, "console", console)
+    monkeypatch.setattr(utils_module, "console", console)
+    return output
+
+
+@pytest.fixture(autouse=True)
+def _mock_git_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _git_context() -> Any:
+        workspace_directory = _find_temp_workspace_directory(Path.cwd()) or Path(
+            "/repo"
+        )
+        return type(
+            "GitContext",
+            (),
+            {
+                "workspace_directory": workspace_directory.resolve(),
+                "git_identity": GIT_IDENTITY,
+                "repo_url": REPO_URL,
+                "credentials": FAKE_CREDENTIALS,
+            },
+        )()
+
+    monkeypatch.setattr(
+        shared_submit_module,
+        "require_git_workspace_directory_context",
+        _git_context,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _mock_workspace_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "osmosis_ai.platform.cli.workspace_repo.summarize_local_git_state",
+        lambda workspace_directory: type(
+            "State",
+            (),
+            {
+                "head_sha": "localhead",
+                "is_dirty": False,
+                "has_upstream": True,
+                "ahead": 0,
+                "branch": "main",
+            },
+        )(),
+    )
+    disable_commit_preflight(monkeypatch)
+
+
+def _fake_client_class(submitted: list[bool]) -> type:
+    class FakeClient:
+        def submit_training_run(self, **kwargs: Any) -> SubmitRunResult:
+            submitted.append(True)
+            return SubmitRunResult(
+                id="train-1",
+                name="train-run",
+                status="pending",
+                created_at="2026-05-27T00:00:00Z",
+                platform_url="https://platform.osmosis.ai/training/train-1",
+            )
+
+    return FakeClient
+
+
+def test_train_submit_skips_preflight_when_dependency_uninstalled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    console_capture: StringIO,
+) -> None:
+    workspace_directory = _make_workspace_directory(
+        tmp_path / "project", main_py="import a_package_that_is_not_installed_xyz\n"
+    )
+    config_path = _write_train_config(
+        workspace_directory / "configs" / "training" / "default.toml"
+    )
+    monkeypatch.chdir(workspace_directory)
+    submitted: list[bool] = []
+    fake = _fake_client_class(submitted)
+    monkeypatch.setattr(api_client_module, "OsmosisClient", fake)
+    monkeypatch.setattr(shared_submit_module, "OsmosisClient", fake)
+
+    result = train_module.submit(config_path=config_path, yes=True)
+
+    assert isinstance(result, OperationResult)
+    assert submitted == [True]
+
+
+def test_train_submit_preflight_still_fails_on_syntax_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    console_capture: StringIO,
+) -> None:
+    workspace_directory = _make_workspace_directory(
+        tmp_path / "project", main_py="def (oops\n"
+    )
+    config_path = _write_train_config(
+        workspace_directory / "configs" / "training" / "default.toml"
+    )
+    monkeypatch.chdir(workspace_directory)
+    submitted: list[bool] = []
+    fake = _fake_client_class(submitted)
+    monkeypatch.setattr(api_client_module, "OsmosisClient", fake)
+    monkeypatch.setattr(shared_submit_module, "OsmosisClient", fake)
+
+    with pytest.raises(CLIError):
+        train_module.submit(config_path=config_path, yes=True)
+    assert submitted == []


### PR DESCRIPTION
## What

Makes `train submit` and `eval submit` preflight tolerant of rollout dependencies that aren't installed in the local environment.

- `load_workflow` now re-raises `ModuleNotFoundError` instead of swallowing it into a generic error string, so callers can distinguish "deps missing locally" from real load failures.
- `validate_rollout_backend` catches `ModuleNotFoundError` and skips backend validation, deferring to the server (which installs from `pyproject.toml` before validating).
- Minor UX wording fix: dev server `down` now reports "Stopping rollout server {id}" instead of "Stopped {id}".
- Adds mirrored test suites for the train and eval submit preflight seam.

## Why

Submitting a run failed locally whenever a rollout imported a package that wasn't installed in the user's CLI environment, even though the server installs those dependencies from `pyproject.toml` before running. Genuine errors (e.g. syntax errors) should still fail fast. This lets users submit without having to install every rollout dependency locally, while preserving real preflight validation.

## How to Test

- Run the new tests: `pytest tests/unit/platform/cli/test_train_submit_preflight.py tests/unit/platform/cli/test_eval_submit_preflight.py`
- `test_*_submit_skips_preflight_when_dependency_uninstalled` verifies submit proceeds when the entrypoint imports a missing package.
- `test_*_submit_preflight_still_fails_on_syntax_error` verifies submit still raises `CLIError` on a real load failure.
- Manual: in a workspace whose rollout imports an uninstalled package, run `osmosis train submit` / `osmosis eval submit` and confirm it submits instead of erroring.

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip local preflight in `train submit` and `eval submit` when rollout dependencies aren’t installed, deferring validation to the server. Real load errors still fail fast.

- **Bug Fixes**
  - `load_workflow` now re-raises `ModuleNotFoundError` to signal missing local deps.
  - `validate_rollout_backend` catches `ModuleNotFoundError` and skips backend validation; server validates after installing from `pyproject.toml`.
  - Added mirrored train/eval preflight tests; tweaked dev server `down` message to say “Stopping rollout server {id}”.

<sup>Written for commit bbd686073775d7a8e413170f5b26392a18ed8d1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

