### PR TITLE
[rollout] feat: add `dev server logs` command with live streaming

### DIFF
--- a/osmosis_ai/cli/commands/dev/server.py
+++ b/osmosis_ai/cli/commands/dev/server.py
@@ -4,7 +4,11 @@ from typing import Any
 
 import typer
 
-from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
+from osmosis_ai.platform.constants import (
+    DEFAULT_PAGE_SIZE,
+    MAX_LOG_PAGE_SIZE,
+    MAX_PAGE_SIZE,
+)
 
 app: typer.Typer = typer.Typer(
     help="Manage a remote rollout server.", no_args_is_help=True
@@ -35,6 +39,30 @@ def down(
     from osmosis_ai.platform.cli.dev_server import down as _down
 
     return _down(server_id)
+
+
+@app.command("logs")
+def logs(
+    server_id: str = typer.Argument(..., help="The rollout server id from `up`."),
+    follow: bool = typer.Option(
+        None,
+        "-f",
+        "--follow",
+        help="Stream new logs as they arrive (default in rich mode).",
+    ),
+    tail: int = typer.Option(
+        100,
+        "--tail",
+        "-n",
+        min=1,
+        max=MAX_LOG_PAGE_SIZE,
+        help="Number of recent log lines to show.",
+    ),
+) -> Any:
+    """Show logs for a remote rollout server."""
+    from osmosis_ai.platform.cli.dev_server import logs as _logs
+
+    return _logs(server_id, follow=follow, tail=tail)
 
 
 @app.command("list")

--- a/osmosis_ai/platform/api/client.py
+++ b/osmosis_ai/platform/api/client.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote, urlencode
 
-from osmosis_ai.platform.auth.platform_client import platform_request
+from osmosis_ai.platform.auth.platform_client import platform_request, platform_stream
 from osmosis_ai.platform.constants import DEFAULT_PAGE_SIZE
 
 from .models import (
@@ -14,6 +15,7 @@ from .models import (
     EnvironmentSecretInfo,
     EvalRunMetrics,
     EvaluationRunDetail,
+    LogEntry,
     LogsPage,
     LoraModelDetail,
     LoraModelSummary,
@@ -712,6 +714,52 @@ class OsmosisClient:
             credentials=credentials,
             git_identity=git_identity,
         )
+
+    def get_dev_rollout_server_logs(
+        self,
+        server_id: str,
+        *,
+        limit: int = DEFAULT_PAGE_SIZE,
+        cursor: str | None = None,
+        direction: str = "older",
+        credentials: Credentials | None = None,
+        git_identity: str,
+    ) -> LogsPage:
+        """Fetch one page of dev rollout server logs.
+
+        Without ``cursor``, ``direction="older"`` returns the most recent page;
+        ``direction="newer"`` pages forward for live follow.
+        """
+        return self._get_logs(
+            f"/api/cli/dev-rollout-server/{_safe_path(server_id)}",
+            limit=limit,
+            cursor=cursor,
+            direction=direction,
+            credentials=credentials,
+            git_identity=git_identity,
+        )
+
+    def stream_dev_rollout_server_logs(
+        self,
+        server_id: str,
+        *,
+        tail: int = DEFAULT_PAGE_SIZE,
+        credentials: Credentials | None = None,
+        git_identity: str,
+    ) -> Iterator[LogEntry]:
+        """Stream a dev rollout server's logs live via Server-Sent Events.
+
+        The server sends the most recent ``tail`` lines first, then pushes new
+        lines as they arrive. The iterator ends when the stream closes (e.g. the
+        server is torn down).
+        """
+        qs = urlencode({"tail": tail})
+        for data in platform_stream(
+            f"/api/cli/dev-rollout-server/{_safe_path(server_id)}/logs/stream?{qs}",
+            credentials=credentials,
+            git_identity=git_identity,
+        ):
+            yield LogEntry.from_dict(data)
 
     def list_dev_rollout_servers(
         self,

--- a/osmosis_ai/platform/auth/platform_client.py
+++ b/osmosis_ai/platform/auth/platform_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING, Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
@@ -578,3 +579,98 @@ def platform_request(
         raise PlatformAPIError(f"Connection error: {e.reason}") from e
     except json.JSONDecodeError as e:
         raise PlatformAPIError("Invalid JSON response from platform") from e
+
+
+def iter_sse_data(lines: Iterable[str]) -> Iterator[dict[str, Any]]:
+    """Parse a Server-Sent Events stream into JSON ``data`` payloads.
+
+    Yields one dict per event (terminated by a blank line). Comment lines
+    (``:`` heartbeats) and non-``data`` fields are ignored; a ``data`` payload
+    that is not valid JSON is skipped. A trailing event without a closing blank
+    line is flushed when the stream ends.
+    """
+    buffer: list[str] = []
+
+    def _flush() -> Iterator[dict[str, Any]]:
+        if not buffer:
+            return
+        payload = "\n".join(buffer)
+        buffer.clear()
+        with contextlib.suppress(json.JSONDecodeError, ValueError):
+            parsed = json.loads(payload)
+            if isinstance(parsed, dict):
+                yield parsed
+
+    for raw in lines:
+        line = raw.rstrip("\n").rstrip("\r")
+        if line == "":
+            yield from _flush()
+            continue
+        if line.startswith(":"):
+            continue
+        if line.startswith("data:"):
+            buffer.append(line[len("data:") :].lstrip())
+    yield from _flush()
+
+
+def platform_stream(
+    endpoint: str,
+    *,
+    timeout: float = 65.0,
+    credentials: Credentials | None = None,
+    git_identity: str | None = None,
+    require_git_repo: bool = True,
+) -> Iterator[dict[str, Any]]:
+    """Open an authenticated Server-Sent Events stream and yield its events.
+
+    Mirrors :func:`platform_request`'s auth/header handling but keeps the
+    connection open, yielding each event's parsed JSON payload as it arrives.
+    ``timeout`` is the per-read socket timeout; it must exceed the server's
+    heartbeat interval so an idle-but-alive stream is not torn down.
+    """
+    if credentials is None:
+        credentials = load_credentials()
+    if credentials is None:
+        raise CLIError(MSG_NOT_LOGGED_IN)
+    using_env_token = _credentials_match_env_token(credentials)
+
+    url = f"{_platform_url()}{endpoint}"
+    req_headers = cli_request_headers(token=credentials.access_token)
+    req_headers["Accept"] = "text/event-stream"
+    if require_git_repo:
+        if not git_identity:
+            raise PlatformAPIError(
+                "Git-scoped platform requests require an explicit git_identity.",
+                error_code="GIT_SCOPE_HEADER_REQUIRED",
+            )
+        req_headers["X-Osmosis-Git"] = git_identity
+
+    request = Request(url, headers=req_headers, method="GET")
+
+    try:
+        response = urlopen(request, timeout=timeout)
+    except HTTPError as e:
+        if e.code == 401:
+            error_code = _read_error_body(e).get("code")
+            if not isinstance(error_code, str):
+                error_code = None
+            if not using_env_token:
+                reset_session()
+            raise AuthenticationExpiredError(
+                _auth_error_message(error_code, using_env_token=using_env_token),
+                code=error_code,
+            ) from e
+        if e.code == 426:
+            message, version_signal = upgrade_required_message(_read_error_body(e))
+            raise UpgradeRequiredError(
+                message, e.code, error_code="UPGRADE_REQUIRED", details=version_signal
+            ) from e
+        raise PlatformAPIError(f"API error: HTTP {e.code}.", e.code) from e
+    except URLError as e:
+        raise PlatformAPIError(f"Connection error: {e.reason}") from e
+
+    with response:
+        surface_response_version_signal(response)
+        yield from iter_sse_data(
+            line.decode("utf-8", errors="replace") for line in response
+        )

--- a/osmosis_ai/platform/auth/platform_client.py
+++ b/osmosis_ai/platform/auth/platform_client.py
@@ -6,7 +6,7 @@ import contextlib
 import json
 import os
 from collections.abc import Iterable, Iterator
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
@@ -406,6 +406,114 @@ def revoke_cli_token(credentials: Credentials) -> bool:
         return False
 
 
+def _raise_for_http_error(
+    e: HTTPError,
+    *,
+    using_env_token: bool,
+    git_identity: str | None,
+    cleanup_on_401: bool = True,
+) -> NoReturn:
+    """Translate a platform ``HTTPError`` into the appropriate SDK exception.
+
+    Centralizes auth (401), upgrade (426), repo-scope, and subscription/billing
+    mappings, plus the structured ``code``/``field``/``details`` extraction, so
+    streaming and non-streaming requests surface platform error codes
+    identically. Always raises.
+    """
+    if e.code == 401:
+        error_body = _read_error_body(e)
+        error_code = error_body.get("code")
+        if not isinstance(error_code, str):
+            error_code = None
+        if cleanup_on_401 and not using_env_token:
+            reset_session()
+        raise AuthenticationExpiredError(
+            _auth_error_message(error_code, using_env_token=using_env_token),
+            code=error_code,
+        ) from e
+
+    if e.code == 426:
+        error_body = _read_error_body(e)
+        message, version_signal = upgrade_required_message(error_body)
+        raise UpgradeRequiredError(
+            message,
+            e.code,
+            error_code="UPGRADE_REQUIRED",
+            details=version_signal or error_body or None,
+        ) from e
+
+    # Best-effort capture of structured error message from response body
+    detail = ""
+    error_body: dict[str, Any] = {}
+    error_code: str | None = None
+    field: str | None = None
+    platform_message: str | None = None
+    try:
+        raw = e.read()
+        text = raw.decode("utf-8", errors="replace").strip() if raw else ""
+        if text:
+            with contextlib.suppress(json.JSONDecodeError, ValueError):
+                parsed = json.loads(text)
+                # Only treat as error_body if it's actually a dict
+                if isinstance(parsed, dict):
+                    error_body = parsed
+                    if isinstance(error_body.get("code"), str):
+                        error_code = error_body["code"]
+                    if isinstance(error_body.get("field"), str):
+                        field = error_body["field"]
+            # Prefer structured error/message field over raw body
+            error_msg = error_body.get("error") or error_body.get("message")
+            if error_msg and isinstance(error_msg, str):
+                issues_detail = _format_response_issues(error_body)
+                platform_message = f"{error_msg}{issues_detail or ''}"
+            elif text:
+                if len(text) > 200:
+                    text = text[:200] + "...(truncated)"
+                detail = f" Response: {text}"
+    except Exception:
+        pass
+
+    if error_code in _REPO_SCOPE_ERROR_MESSAGES:
+        raise PlatformAPIError(
+            _repo_scope_error_message(error_code, git_identity),
+            e.code,
+            error_code=error_code,
+            field=field,
+            details=error_body or None,
+        ) from e
+
+    if e.code == 403 and error_code in {
+        "SUBSCRIPTION_REQUIRED",
+        "BILLING_REQUIRED",
+    }:
+        error_msg = error_body.get("error") or error_body.get("message")
+        raise SubscriptionRequiredError(
+            error_msg if isinstance(error_msg, str) else None,
+            error_code=error_code,
+            field=field,
+            details=error_body or None,
+        ) from e
+
+    # Detect subscription-required responses (403 with subscription message)
+    if e.code == 403 and isinstance(error_body, dict):
+        error_msg = error_body.get("error", "")
+        if isinstance(error_msg, str) and "subscription" in error_msg.lower():
+            raise SubscriptionRequiredError(
+                error_msg,
+                error_code=error_code,
+                field=field,
+                details=error_body or None,
+            ) from e
+
+    raise PlatformAPIError(
+        platform_message or f"API error: HTTP {e.code}.{detail}",
+        e.code,
+        error_code=error_code,
+        field=field,
+        details=error_body or None,
+    ) from e
+
+
 def platform_request(
     endpoint: str,
     method: str = "GET",
@@ -483,98 +591,12 @@ def platform_request(
             result: dict[str, Any] = json.loads(raw.decode())
             return result
     except HTTPError as e:
-        if e.code == 401:
-            error_body = _read_error_body(e)
-            error_code = error_body.get("code")
-            if not isinstance(error_code, str):
-                error_code = None
-            if cleanup_on_401 and not using_env_token:
-                reset_session()
-            raise AuthenticationExpiredError(
-                _auth_error_message(error_code, using_env_token=using_env_token),
-                code=error_code,
-            ) from e
-
-        if e.code == 426:
-            error_body = _read_error_body(e)
-            message, version_signal = upgrade_required_message(error_body)
-            raise UpgradeRequiredError(
-                message,
-                e.code,
-                error_code="UPGRADE_REQUIRED",
-                details=version_signal or error_body or None,
-            ) from e
-
-        # Best-effort capture of structured error message from response body
-        detail = ""
-        error_body: dict[str, Any] = {}
-        error_code: str | None = None
-        field: str | None = None
-        platform_message: str | None = None
-        try:
-            raw = e.read()
-            text = raw.decode("utf-8", errors="replace").strip() if raw else ""
-            if text:
-                with contextlib.suppress(json.JSONDecodeError, ValueError):
-                    parsed = json.loads(text)
-                    # Only treat as error_body if it's actually a dict
-                    if isinstance(parsed, dict):
-                        error_body = parsed
-                        if isinstance(error_body.get("code"), str):
-                            error_code = error_body["code"]
-                        if isinstance(error_body.get("field"), str):
-                            field = error_body["field"]
-                # Prefer structured error/message field over raw body
-                error_msg = error_body.get("error") or error_body.get("message")
-                if error_msg and isinstance(error_msg, str):
-                    issues_detail = _format_response_issues(error_body)
-                    platform_message = f"{error_msg}{issues_detail or ''}"
-                elif text:
-                    if len(text) > 200:
-                        text = text[:200] + "...(truncated)"
-                    detail = f" Response: {text}"
-        except Exception:
-            pass
-
-        if error_code in _REPO_SCOPE_ERROR_MESSAGES:
-            raise PlatformAPIError(
-                _repo_scope_error_message(error_code, git_identity),
-                e.code,
-                error_code=error_code,
-                field=field,
-                details=error_body or None,
-            ) from e
-
-        if e.code == 403 and error_code in {
-            "SUBSCRIPTION_REQUIRED",
-            "BILLING_REQUIRED",
-        }:
-            error_msg = error_body.get("error") or error_body.get("message")
-            raise SubscriptionRequiredError(
-                error_msg if isinstance(error_msg, str) else None,
-                error_code=error_code,
-                field=field,
-                details=error_body or None,
-            ) from e
-
-        # Detect subscription-required responses (403 with subscription message)
-        if e.code == 403 and isinstance(error_body, dict):
-            error_msg = error_body.get("error", "")
-            if isinstance(error_msg, str) and "subscription" in error_msg.lower():
-                raise SubscriptionRequiredError(
-                    error_msg,
-                    error_code=error_code,
-                    field=field,
-                    details=error_body or None,
-                ) from e
-
-        raise PlatformAPIError(
-            platform_message or f"API error: HTTP {e.code}.{detail}",
-            e.code,
-            error_code=error_code,
-            field=field,
-            details=error_body or None,
-        ) from e
+        _raise_for_http_error(
+            e,
+            using_env_token=using_env_token,
+            git_identity=git_identity,
+            cleanup_on_401=cleanup_on_401,
+        )
     except URLError as e:
         raise PlatformAPIError(f"Connection error: {e.reason}") from e
     except json.JSONDecodeError as e:
@@ -650,22 +672,11 @@ def platform_stream(
     try:
         response = urlopen(request, timeout=timeout)
     except HTTPError as e:
-        if e.code == 401:
-            error_code = _read_error_body(e).get("code")
-            if not isinstance(error_code, str):
-                error_code = None
-            if not using_env_token:
-                reset_session()
-            raise AuthenticationExpiredError(
-                _auth_error_message(error_code, using_env_token=using_env_token),
-                code=error_code,
-            ) from e
-        if e.code == 426:
-            message, version_signal = upgrade_required_message(_read_error_body(e))
-            raise UpgradeRequiredError(
-                message, e.code, error_code="UPGRADE_REQUIRED", details=version_signal
-            ) from e
-        raise PlatformAPIError(f"API error: HTTP {e.code}.", e.code) from e
+        _raise_for_http_error(
+            e,
+            using_env_token=using_env_token,
+            git_identity=git_identity,
+        )
     except URLError as e:
         raise PlatformAPIError(f"Connection error: {e.reason}") from e
 

--- a/osmosis_ai/platform/cli/dev_server.py
+++ b/osmosis_ai/platform/cli/dev_server.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
+import json
+import sys
 from pathlib import Path
 from typing import Any
 
+import typer
+
+from osmosis_ai.cli.console import console
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.cli.output import get_output_context, serialize_dev_rollout_server
+from osmosis_ai.cli.output.context import OutputFormat
 from osmosis_ai.cli.output.display import format_local_date
 from osmosis_ai.cli.output.result import ListColumn, ListResult, OperationResult
 from osmosis_ai.cli.prompts import require_confirmation
 from osmosis_ai.platform.api.client import OsmosisClient
+from osmosis_ai.platform.api.models import LogEntry
 from osmosis_ai.platform.cli.utils import paginated_fetch, validate_list_options
 from osmosis_ai.platform.cli.workspace_directory_context import (
     resolve_git_workspace_directory_context,
@@ -128,3 +135,66 @@ def list_servers(*, limit: int, all_: bool) -> ListResult:
             ListColumn(key="status", label="Status", no_wrap=True, ratio=1),
         ],
     )
+
+
+def _emit_entries(entries: list[LogEntry], fmt: OutputFormat) -> None:
+    if not entries:
+        return
+    if fmt is OutputFormat.json:
+        for entry in entries:
+            sys.stdout.write(
+                json.dumps({"timestamp": entry.timestamp, "message": entry.message})
+                + "\n"
+            )
+        sys.stdout.flush()
+        return
+    if fmt is OutputFormat.plain:
+        for entry in entries:
+            sys.stdout.write(f"{entry.timestamp}\t{entry.message}\n")
+        sys.stdout.flush()
+        return
+
+    for entry in entries:
+        console.print(
+            f"{entry.timestamp}  {entry.message}", markup=False, highlight=False
+        )
+
+
+def logs(server_id: str, *, follow: bool | None, tail: int) -> None:
+    """Show logs for a remote rollout server.
+
+    In rich mode logs stream live (attach); with ``--json``/``--plain`` the last
+    ``tail`` lines are printed and the command exits unless ``follow`` is forced.
+    """
+    ctx = resolve_git_workspace_directory_context()
+    output = get_output_context()
+    fmt = output.format
+    effective_follow = follow if follow is not None else (fmt is OutputFormat.rich)
+
+    client = OsmosisClient()
+
+    if effective_follow:
+        # The stream sends the last `tail` lines first, then pushes new ones.
+        try:
+            for entry in client.stream_dev_rollout_server_logs(
+                server_id,
+                tail=tail,
+                credentials=ctx.credentials,
+                git_identity=ctx.git_identity,
+            ):
+                _emit_entries([entry], fmt)
+        except KeyboardInterrupt:
+            if fmt is OutputFormat.rich:
+                console.print(f"\nDetached from {server_id}.", style="dim")
+    else:
+        page = client.get_dev_rollout_server_logs(
+            server_id,
+            limit=tail,
+            direction="older",
+            credentials=ctx.credentials,
+            git_identity=ctx.git_identity,
+        )
+        _emit_entries(page.logs, fmt)
+
+    output.output_emitted = True
+    raise typer.Exit(0)

--- a/tests/unit/auth/test_platform_client.py
+++ b/tests/unit/auth/test_platform_client.py
@@ -23,6 +23,7 @@ from osmosis_ai.platform.auth.platform_client import (
     SubscriptionRequiredError,
     UpgradeRequiredError,
     platform_request,
+    platform_stream,
     revoke_cli_token,
 )
 
@@ -52,6 +53,23 @@ def _make_http_response(data: dict[str, Any]) -> MagicMock:
     mock_resp.read.return_value = body
     mock_resp.status = 200
     mock_resp.headers = {}  # real dict: .get() returns None, no spurious warning
+    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+def _make_stream_response(
+    lines: list[bytes], headers: dict[str, str] | None = None
+) -> MagicMock:
+    """Create a mock urlopen() return value that streams ``lines`` of bytes.
+
+    Behaves like the real response object consumed by ``platform_stream``: it is
+    a context manager, exposes ``.headers``, and iterates over byte-encoded SSE
+    lines.
+    """
+    mock_resp = MagicMock()
+    mock_resp.headers = headers if headers is not None else {}
+    mock_resp.__iter__ = MagicMock(return_value=iter(lines))
     mock_resp.__enter__ = MagicMock(return_value=mock_resp)
     mock_resp.__exit__ = MagicMock(return_value=False)
     return mock_resp
@@ -398,6 +416,24 @@ class TestPlatformRequest:
 
         assert result == {}
         mock_resp.read.assert_not_called()
+
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_empty_body_returns_empty_dict(self, mock_urlopen: MagicMock) -> None:
+        """Verify a 200 response with an empty body yields an empty dict."""
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.headers = {}
+        mock_resp.read.return_value = b""
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+        creds = _make_credentials()
+
+        result = platform_request(
+            "/api/test", credentials=creds, git_identity="git_test"
+        )
+
+        assert result == {}
 
     @patch("osmosis_ai.platform.auth.platform_client.console")
     @patch("osmosis_ai.platform.auth.platform_client.urlopen")
@@ -1190,3 +1226,130 @@ class TestRevokeCLIToken:
         assert "Failed to revoke CLI token server-side" in message
         assert "HTTP 500" in message
         assert mock_warn.call_args.kwargs.get("code") == "TOKEN_REVOKE_FAILED"
+
+
+# =============================================================================
+# platform_stream Tests
+# =============================================================================
+
+
+class TestPlatformStream:
+    """Tests for the authenticated SSE streaming helper."""
+
+    @patch("osmosis_ai.platform.auth.platform_client.load_credentials")
+    def test_raises_when_no_credentials_found(self, mock_load: MagicMock) -> None:
+        mock_load.return_value = None
+
+        with pytest.raises(CLIError):
+            list(platform_stream("/api/stream", require_git_repo=False))
+
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    @patch("osmosis_ai.platform.auth.platform_client.load_credentials")
+    def test_uses_loaded_credentials_when_none_provided(
+        self, mock_load: MagicMock, mock_urlopen: MagicMock
+    ) -> None:
+        mock_load.return_value = _make_credentials()
+        mock_urlopen.return_value = _make_stream_response([])
+
+        list(platform_stream("/api/stream", require_git_repo=False))
+
+        mock_load.assert_called_once()
+
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_yields_parsed_events(self, mock_urlopen: MagicMock) -> None:
+        mock_urlopen.return_value = _make_stream_response(
+            [
+                b'data: {"message": "a"}\n',
+                b"\n",
+                b'data: {"message": "b"}\n',
+                b"\n",
+            ]
+        )
+        creds = _make_credentials()
+
+        events = list(
+            platform_stream("/api/stream", credentials=creds, git_identity="git_1")
+        )
+
+        assert events == [{"message": "a"}, {"message": "b"}]
+
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_sets_streaming_and_git_headers(self, mock_urlopen: MagicMock) -> None:
+        mock_urlopen.return_value = _make_stream_response([])
+        creds = _make_credentials()
+
+        list(platform_stream("/api/stream", credentials=creds, git_identity="git_abc"))
+
+        request_obj = mock_urlopen.call_args[0][0]
+        assert request_obj.get_header("Accept") == "text/event-stream"
+        assert request_obj.get_header("X-osmosis-git") == "git_abc"
+        assert request_obj.get_method() == "GET"
+
+    def test_require_git_repo_true_requires_explicit_git_identity(self) -> None:
+        creds = _make_credentials()
+
+        with pytest.raises(PlatformAPIError, match="explicit git_identity") as exc_info:
+            list(platform_stream("/api/stream", credentials=creds))
+
+        assert exc_info.value.error_code == "GIT_SCOPE_HEADER_REQUIRED"
+
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_no_git_header_when_require_git_repo_false(
+        self, mock_urlopen: MagicMock
+    ) -> None:
+        mock_urlopen.return_value = _make_stream_response([])
+        creds = _make_credentials()
+
+        list(platform_stream("/api/stream", credentials=creds, require_git_repo=False))
+
+        request_obj = mock_urlopen.call_args[0][0]
+        header_names = {name.casefold() for name in request_obj.headers}
+        assert "x-osmosis-git" not in header_names
+
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_http_error_is_translated(self, mock_urlopen: MagicMock) -> None:
+        mock_urlopen.side_effect = _make_http_error(401)
+        creds = _make_credentials()
+
+        with pytest.raises(AuthenticationExpiredError):
+            list(
+                platform_stream(
+                    "/api/stream",
+                    credentials=creds,
+                    git_identity="git_1",
+                )
+            )
+
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_url_error_becomes_platform_api_error(
+        self, mock_urlopen: MagicMock
+    ) -> None:
+        mock_urlopen.side_effect = URLError("boom")
+        creds = _make_credentials()
+
+        with pytest.raises(PlatformAPIError, match="Connection error"):
+            list(
+                platform_stream(
+                    "/api/stream",
+                    credentials=creds,
+                    git_identity="git_1",
+                )
+            )
+
+    @patch("osmosis_ai.platform.auth.platform_client.surface_version_signal")
+    @patch("osmosis_ai.platform.auth.platform_client.urlopen")
+    def test_surfaces_version_signal_from_response_headers(
+        self, mock_urlopen: MagicMock, mock_surface: MagicMock
+    ) -> None:
+        mock_urlopen.return_value = _make_stream_response(
+            [],
+            headers={
+                "X-Osmosis-Version-Status": "deprecated",
+                "X-Osmosis-Version-Message": "please upgrade",
+            },
+        )
+        creds = _make_credentials()
+
+        list(platform_stream("/api/stream", credentials=creds, git_identity="git_1"))
+
+        mock_surface.assert_called_once_with("deprecated", "please upgrade")

--- a/tests/unit/auth/test_sse_stream.py
+++ b/tests/unit/auth/test_sse_stream.py
@@ -1,0 +1,44 @@
+"""Tests for SSE parsing in osmosis_ai.platform.auth.platform_client."""
+
+from __future__ import annotations
+
+from osmosis_ai.platform.auth.platform_client import iter_sse_data
+
+
+class TestIterSSEData:
+    def test_yields_one_dict_per_event(self) -> None:
+        lines = [
+            'data: {"timestamp": "t1", "message": "a"}\n',
+            "\n",
+            'data: {"timestamp": "t2", "message": "b"}\n',
+            "\n",
+        ]
+        assert list(iter_sse_data(lines)) == [
+            {"timestamp": "t1", "message": "a"},
+            {"timestamp": "t2", "message": "b"},
+        ]
+
+    def test_skips_comment_heartbeats(self) -> None:
+        lines = [
+            ": keepalive\n",
+            'data: {"message": "x"}\n',
+            "\n",
+            ": keepalive\n",
+        ]
+        assert list(iter_sse_data(lines)) == [{"message": "x"}]
+
+    def test_concatenates_multiline_data(self) -> None:
+        lines = ["data: {\n", 'data: "message": "y"}\n', "\n"]
+        assert list(iter_sse_data(lines)) == [{"message": "y"}]
+
+    def test_ignores_non_data_fields(self) -> None:
+        lines = ["event: log\n", "id: 5\n", 'data: {"message": "z"}\n', "\n"]
+        assert list(iter_sse_data(lines)) == [{"message": "z"}]
+
+    def test_flushes_trailing_event_without_blank_line(self) -> None:
+        lines = ['data: {"message": "last"}\n']
+        assert list(iter_sse_data(lines)) == [{"message": "last"}]
+
+    def test_skips_non_json_data(self) -> None:
+        lines = ["data: not-json\n", "\n", 'data: {"message": "ok"}\n', "\n"]
+        assert list(iter_sse_data(lines)) == [{"message": "ok"}]

--- a/tests/unit/cli/test_dev_server_commands.py
+++ b/tests/unit/cli/test_dev_server_commands.py
@@ -533,3 +533,202 @@ class TestDevServerList:
         assert isinstance(result, ListResult)
         assert result.total_count == 0
         assert result.items == []
+
+
+class TestDevServerLogs:
+    """Tests for osmosis_ai.platform.cli.dev_server.logs."""
+
+    @staticmethod
+    def _page(messages, next_cursor=None):
+        from osmosis_ai.platform.api.models import LogsPage
+
+        return LogsPage.from_dict(
+            {
+                "logs": [
+                    {"timestamp": f"t{i}", "message": m} for i, m in enumerate(messages)
+                ],
+                "next_cursor": next_cursor,
+            }
+        )
+
+    def _install(self, monkeypatch, fake_client):
+        monkeypatch.setattr(
+            dev_server_module,
+            "resolve_git_workspace_directory_context",
+            lambda: _fake_ctx(),
+        )
+        monkeypatch.setattr(api_client_module, "OsmosisClient", fake_client)
+        monkeypatch.setattr(dev_server_module, "OsmosisClient", fake_client)
+
+    def test_json_oneshot_emits_ndjson(self, monkeypatch, capsys) -> None:
+        import json
+
+        import typer
+
+        from osmosis_ai.cli.output.context import OutputFormat, override_output_context
+
+        outer = self
+
+        class FakeClient:
+            def get_dev_rollout_server_logs(
+                self,
+                server_id,
+                *,
+                limit,
+                cursor=None,
+                direction="older",
+                credentials=None,
+                git_identity,
+            ):
+                assert direction == "older"
+                assert limit == 100
+                return outer._page(["a", "b"], next_cursor="c1")
+
+        self._install(monkeypatch, FakeClient)
+
+        with override_output_context(format=OutputFormat.json) as out:
+            with pytest.raises(typer.Exit) as exc:
+                dev_server_module.logs("srv-1", follow=None, tail=100)
+            assert exc.value.exit_code == 0
+            assert out.output_emitted is True
+
+        captured = capsys.readouterr().out
+        lines = [ln for ln in captured.splitlines() if ln.strip()]
+        assert json.loads(lines[0]) == {"timestamp": "t0", "message": "a"}
+        assert json.loads(lines[1]) == {"timestamp": "t1", "message": "b"}
+        assert "schema_version" not in captured
+
+    def test_plain_oneshot_emits_tab_lines(self, monkeypatch, capsys) -> None:
+        import typer
+
+        from osmosis_ai.cli.output.context import OutputFormat, override_output_context
+
+        outer = self
+
+        class FakeClient:
+            def get_dev_rollout_server_logs(
+                self, server_id, *, direction="older", **kw
+            ):
+                assert direction == "older"
+                return outer._page(["hello"], next_cursor=None)
+
+        self._install(monkeypatch, FakeClient)
+
+        with override_output_context(format=OutputFormat.plain):
+            with pytest.raises(typer.Exit):
+                dev_server_module.logs("srv-1", follow=None, tail=100)
+
+        captured = capsys.readouterr().out
+        assert captured.splitlines()[0] == "t0\thello"
+
+    def test_oneshot_does_not_follow(self, monkeypatch) -> None:
+        """json/plain with follow unset makes exactly one (older) fetch."""
+        import typer
+
+        from osmosis_ai.cli.output.context import OutputFormat, override_output_context
+
+        outer = self
+        calls = []
+
+        class FakeClient:
+            def get_dev_rollout_server_logs(
+                self, server_id, *, direction="older", cursor=None, **kw
+            ):
+                calls.append((direction, cursor))
+                return outer._page(["a"], next_cursor="c1")
+
+        self._install(monkeypatch, FakeClient)
+
+        with override_output_context(format=OutputFormat.json):
+            with pytest.raises(typer.Exit):
+                dev_server_module.logs("srv-1", follow=None, tail=100)
+
+        assert calls == [("older", None)]
+
+    @staticmethod
+    def _entries(messages):
+        from osmosis_ai.platform.api.models import LogEntry
+
+        return [
+            LogEntry.from_dict({"timestamp": f"t{i}", "message": m})
+            for i, m in enumerate(messages)
+        ]
+
+    def _stream_client(self, messages, *, raise_ki=False, calls=None):
+        outer = self
+
+        class FakeClient:
+            def stream_dev_rollout_server_logs(
+                self, server_id, *, tail, credentials=None, git_identity
+            ):
+                if calls is not None:
+                    calls.append(("stream", tail))
+                yield from outer._entries(messages)
+                if raise_ki:
+                    raise KeyboardInterrupt
+
+            def get_dev_rollout_server_logs(self, *a, **kw):
+                raise AssertionError("follow must not use the paged GET")
+
+        return FakeClient
+
+    def test_plain_follow_streams_lines(self, monkeypatch, capsys) -> None:
+        import typer
+
+        from osmosis_ai.cli.output.context import OutputFormat, override_output_context
+
+        self._install(monkeypatch, self._stream_client(["a1", "b1"]))
+
+        with override_output_context(format=OutputFormat.plain):
+            with pytest.raises(typer.Exit) as exc:
+                dev_server_module.logs("srv-1", follow=True, tail=100)
+            assert exc.value.exit_code == 0
+
+        captured = capsys.readouterr().out
+        messages = [ln.split("\t", 1)[1] for ln in captured.splitlines() if "\t" in ln]
+        assert messages == ["a1", "b1"]
+
+    def test_json_follow_streams_ndjson(self, monkeypatch, capsys) -> None:
+        import json
+
+        import typer
+
+        from osmosis_ai.cli.output.context import OutputFormat, override_output_context
+
+        self._install(monkeypatch, self._stream_client(["a1"]))
+
+        with override_output_context(format=OutputFormat.json):
+            with pytest.raises(typer.Exit):
+                dev_server_module.logs("srv-1", follow=True, tail=100)
+
+        captured = capsys.readouterr().out
+        lines = [ln for ln in captured.splitlines() if ln.strip()]
+        assert json.loads(lines[0]) == {"timestamp": "t0", "message": "a1"}
+        assert "schema_version" not in captured
+
+    def test_rich_follows_by_default(self, monkeypatch) -> None:
+        """rich with follow unset streams (uses the SSE stream, not the paged GET)."""
+        import typer
+
+        from osmosis_ai.cli.output.context import OutputFormat, override_output_context
+
+        calls = []
+        self._install(monkeypatch, self._stream_client(["a1"], calls=calls))
+
+        with override_output_context(format=OutputFormat.rich, interactive=False):
+            with pytest.raises(typer.Exit):
+                dev_server_module.logs("srv-1", follow=None, tail=100)
+
+        assert calls == [("stream", 100)]
+
+    def test_follow_keyboardinterrupt_detaches_cleanly(self, monkeypatch) -> None:
+        import typer
+
+        from osmosis_ai.cli.output.context import OutputFormat, override_output_context
+
+        self._install(monkeypatch, self._stream_client(["a1"], raise_ki=True))
+
+        with override_output_context(format=OutputFormat.plain):
+            with pytest.raises(typer.Exit) as exc:
+                dev_server_module.logs("srv-1", follow=True, tail=100)
+            assert exc.value.exit_code == 0

--- a/tests/unit/platform/api/test_client.py
+++ b/tests/unit/platform/api/test_client.py
@@ -1161,3 +1161,96 @@ class TestDevRolloutServer:
         assert mock_request.call_args.kwargs["git_identity"] == "git_test"
         assert "method" not in mock_request.call_args.kwargs
         assert "data" not in mock_request.call_args.kwargs
+
+
+class TestGetDevRolloutServerLogs:
+    """Tests for OsmosisClient.get_dev_rollout_server_logs."""
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_returns_parsed_logs_with_default_query(
+        self, mock_request: MagicMock
+    ) -> None:
+        mock_request.return_value = {
+            "logs": [
+                {"timestamp": "2026-06-25T00:00:00Z", "message": "boot"},
+                {"timestamp": "2026-06-25T00:00:01Z", "message": "ready"},
+            ],
+            "next_cursor": "tok-1",
+        }
+
+        result = OsmosisClient().get_dev_rollout_server_logs(
+            "srv-1", git_identity="git_test"
+        )
+
+        assert mock_request.call_args[0][0] == (
+            "/api/cli/dev-rollout-server/srv-1/logs?limit=50&direction=older"
+        )
+        assert mock_request.call_args.kwargs["git_identity"] == "git_test"
+        assert [log.message for log in result.logs] == ["boot", "ready"]
+        assert result.next_cursor == "tok-1"
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_includes_cursor_and_direction_when_provided(
+        self, mock_request: MagicMock
+    ) -> None:
+        mock_request.return_value = {"logs": [], "next_cursor": None}
+
+        OsmosisClient().get_dev_rollout_server_logs(
+            "srv-1",
+            limit=10,
+            cursor="abc|def",
+            direction="newer",
+            git_identity="git_test",
+        )
+
+        assert mock_request.call_args[0][0] == (
+            "/api/cli/dev-rollout-server/srv-1/logs"
+            "?limit=10&direction=newer&cursor=abc%7Cdef"
+        )
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_encodes_server_id(self, mock_request: MagicMock) -> None:
+        mock_request.return_value = {"logs": [], "next_cursor": None}
+
+        OsmosisClient().get_dev_rollout_server_logs("a/b", git_identity="git_test")
+
+        path = mock_request.call_args[0][0]
+        assert path.startswith("/api/cli/dev-rollout-server/a%2Fb/logs?")
+
+
+class TestStreamDevRolloutServerLogs:
+    """Tests for OsmosisClient.stream_dev_rollout_server_logs."""
+
+    @patch("osmosis_ai.platform.api.client.platform_stream")
+    def test_yields_log_entries_from_stream(self, mock_stream: MagicMock) -> None:
+        mock_stream.return_value = iter(
+            [
+                {"timestamp": "t1", "message": "a"},
+                {"timestamp": "t2", "message": "b"},
+            ]
+        )
+
+        entries = list(
+            OsmosisClient().stream_dev_rollout_server_logs(
+                "srv-1", tail=100, git_identity="git_test"
+            )
+        )
+
+        endpoint = mock_stream.call_args[0][0]
+        assert endpoint == "/api/cli/dev-rollout-server/srv-1/logs/stream?tail=100"
+        assert mock_stream.call_args.kwargs["git_identity"] == "git_test"
+        assert [(e.timestamp, e.message) for e in entries] == [("t1", "a"), ("t2", "b")]
+
+    @patch("osmosis_ai.platform.api.client.platform_stream")
+    def test_encodes_server_id(self, mock_stream: MagicMock) -> None:
+        mock_stream.return_value = iter([])
+
+        list(
+            OsmosisClient().stream_dev_rollout_server_logs(
+                "a/b", git_identity="git_test"
+            )
+        )
+
+        assert mock_stream.call_args[0][0].startswith(
+            "/api/cli/dev-rollout-server/a%2Fb/logs/stream?"
+        )


### PR DESCRIPTION
## What

Adds a new `dev server logs` subcommand to view logs from a remote rollout server.

- One-shot mode prints the most recent `--tail` (`-n`) lines and exits.
- Follow mode (`-f`/`--follow`) streams new log lines live as they arrive, and detaches cleanly on Ctrl-C. This is the default in rich/interactive output.
- Works across all output formats: rich (human-readable), `--plain` (tab-separated `timestamp<TAB>message`), and `--json` (newline-delimited JSON, one object per line).

Under the hood this adds two client methods for fetching a page of logs and for opening a live log stream, along with a small reusable helper for consuming Server-Sent Events on authenticated platform requests.

## Why

Users running a remote rollout server need a way to inspect what it is doing without leaving the CLI, both for quick checks (tail the last N lines) and for watching activity in real time while iterating. The streaming/JSON modes also make the logs easy to pipe into other tooling.

## How to Test

1. Start a remote rollout server with `osmosis dev server up`.
2. Run `osmosis dev server logs <server_id>` to stream logs live; press Ctrl-C to detach.
3. Run `osmosis dev server logs <server_id> --tail 50` to print the last 50 lines and exit.
4. Try `--plain` and `--json` to confirm the tab-separated and newline-delimited JSON outputs.

Automated coverage:

```bash
pytest tests/unit/cli/test_dev_server_commands.py tests/unit/platform/api/test_client.py tests/unit/auth/test_sse_stream.py
```

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `dev server logs` command to stream or tail logs from a remote rollout server. Also introduces authenticated SSE streaming and shared HTTP error handling for more reliable, consistent behavior.

- **New Features**
  - `osmosis dev server logs <server_id>`: tail with `--tail/-n` (max capped), follow with `-f/--follow` (default in rich), clean detach on Ctrl-C.
  - Output: rich, `--plain` (timestamp<TAB>message), `--json` (NDJSON). JSON/plain print one-shot unless `--follow` is set.
  - API client: `get_dev_rollout_server_logs` (paged) and `stream_dev_rollout_server_logs` (SSE).
  - Auth SSE helpers: `platform_stream` and `iter_sse_data` to open and parse authenticated event streams.

- **Refactors**
  - Centralized HTTP error handling via `_raise_for_http_error` used by both `platform_request` and `platform_stream` for consistent 401/426, repo-scope, and subscription/billing errors.

<sup>Written for commit 02b0b388b2172e7086d6a51ad492e87266eba020. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

