### PR TITLE
feat: nest completion webhook under [experiment]

### DIFF
--- a/osmosis_ai/platform/api/client.py
+++ b/osmosis_ai/platform/api/client.py
@@ -250,6 +250,8 @@ class OsmosisClient:
         ``env_config`` is a literal env-var-name to value map applied to the
         rollout container. ``secrets`` is a list of ``environment_secret`` names;
         their values are resolved server-side and never travel through the CLI.
+        An optional completion webhook (fired when the run reaches a terminal
+        state) rides inside ``experiment_config`` under ``completion_webhook``.
         """
         data: dict[str, Any] = {
             "experiment_config": experiment_config,

--- a/osmosis_ai/platform/cli/shared_config.py
+++ b/osmosis_ai/platform/cli/shared_config.py
@@ -371,15 +371,13 @@ class CompletionWebhookSection(BaseModel):
         return value
 
     @model_validator(mode="after")
-    def _require_url_when_configured(self) -> CompletionWebhookSection:
-        has_other = bool(
-            self.headers
-            or self.query_params
-            or self.timeout_seconds is not None
-            or self.retries is not None
-        )
-        if has_other and not self.url:
-            raise ValueError("requires 'url' when other fields are set")
+    def _require_url(self) -> CompletionWebhookSection:
+        # The section only exists when the [experiment.completion_webhook] table
+        # is present, so an empty table (no url) is a mistake — not "no webhook".
+        # Requiring url here stops an empty table from serializing to a bodyless
+        # webhook config that the platform would reject.
+        if not self.url:
+            raise ValueError("requires 'url'")
         return self
 
 

--- a/osmosis_ai/platform/cli/shared_config.py
+++ b/osmosis_ai/platform/cli/shared_config.py
@@ -7,7 +7,14 @@ import tomllib
 from pathlib import Path
 from typing import Any, ClassVar
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 from pydantic_core import ErrorDetails
 
 from osmosis_ai.cli.errors import CLIError
@@ -337,6 +344,45 @@ def validate_secret_names(
         )
 
 
+class CompletionWebhookSection(BaseModel):
+    """``[experiment.completion_webhook]`` table — optional GET webhook fired
+    when the run reaches a terminal state.
+
+    The whole subtable may be omitted. When present, ``url`` is required and
+    must be an ``https://`` URL. Value-level SSRF checks are authoritative on
+    the backend; the SDK only enforces structure + scheme for fast feedback.
+    """
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    url: str | None = None
+    headers: dict[str, str] = Field(default_factory=dict)
+    query_params: dict[str, str] = Field(default_factory=dict)
+    timeout_seconds: float | None = None
+    retries: int | None = None
+
+    @field_validator("url")
+    @classmethod
+    def _validate_url(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        if not value.startswith("https://"):
+            raise ValueError("must be an https:// URL")
+        return value
+
+    @model_validator(mode="after")
+    def _require_url_when_configured(self) -> CompletionWebhookSection:
+        has_other = bool(
+            self.headers
+            or self.query_params
+            or self.timeout_seconds is not None
+            or self.retries is not None
+        )
+        if has_other and not self.url:
+            raise ValueError("requires 'url' when other fields are set")
+        return self
+
+
 class ExperimentSection(BaseModel):
     """``[experiment]`` table — shared between train and eval submit configs."""
 
@@ -347,6 +393,7 @@ class ExperimentSection(BaseModel):
     model_path: str
     dataset: str
     commit_sha: str | None = None
+    completion_webhook: CompletionWebhookSection | None = None
 
     @field_validator("commit_sha")
     @classmethod
@@ -574,6 +621,7 @@ __all__ = [
     "AdvancedPassthroughSection",
     "BackendValidatedParamSection",
     "BaseSubmitConfig",
+    "CompletionWebhookSection",
     "ExperimentSection",
     "build_env_table_rows",
     "build_secret_table_rows",

--- a/osmosis_ai/platform/cli/shared_submit.py
+++ b/osmosis_ai/platform/cli/shared_submit.py
@@ -283,6 +283,16 @@ def run_cloud_submit[ConfigT: BaseSubmitConfig](
         )
         full_summary.extend((f"secret.{name}", scope) for name, scope in secret_rows)
 
+    completion_webhook = config.experiment.completion_webhook
+    if completion_webhook is not None and completion_webhook.url:
+        console.table(
+            [("URL", console.escape(completion_webhook.url))],
+            title="Completion Webhook (GET)",
+        )
+        full_summary.append(
+            ("experiment.completion_webhook.url", completion_webhook.url)
+        )
+
     notes, warnings = print_remote_fetch_notice(
         workspace_directory,
         pinned_commit_sha=config.experiment_commit_sha,

--- a/osmosis_ai/templates/_scaffolds/rollout/training.toml.tpl
+++ b/osmosis_ai/templates/_scaffolds/rollout/training.toml.tpl
@@ -15,6 +15,17 @@ model_path = "<your-model-path>"  # Must be a supported model (see above)
 dataset = "<your-dataset-name>"  # Platform dataset name from `osmosis dataset list`
 # commit_sha =                        # Pin to a specific commit (default: latest on default branch)
 
+# Completion webhook (optional). When set, the platform issues a single
+# best-effort GET to `url` once the run reaches a terminal state, appending
+# `?training_run_id=...&status=...` (status is finished / failed / stopped).
+# The URL must be https:// on port 443 and must not point to a private or
+# internal host.
+#
+# [experiment.completion_webhook]
+# url = "https://example.com/osmosis/training-complete"
+# headers = { "Authorization" = "Bearer <token>" }   # your endpoint's auth
+# query_params = { "source" = "osmosis" }            # extra static params
+
 [training]
 # Optional. Omit values to use platform defaults.
 # Uncomment a field only when you want to override platform behavior.

--- a/osmosis_ai/templates/_scaffolds/rollout/training.toml.tpl
+++ b/osmosis_ai/templates/_scaffolds/rollout/training.toml.tpl
@@ -15,16 +15,13 @@ model_path = "<your-model-path>"  # Must be a supported model (see above)
 dataset = "<your-dataset-name>"  # Platform dataset name from `osmosis dataset list`
 # commit_sha =                        # Pin to a specific commit (default: latest on default branch)
 
-# Completion webhook (optional). When set, the platform issues a single
-# best-effort GET to `url` once the run reaches a terminal state, appending
-# `?training_run_id=...&status=...` (status is finished / failed / stopped).
-# The URL must be https:// on port 443 and must not point to a private or
-# internal host.
+# Optional webhook: a GET fired when the run finishes, with
+# ?training_run_id=...&status=... appended. Must be an https:// URL.
 #
 # [experiment.completion_webhook]
-# url = "https://example.com/osmosis/training-complete"
-# headers = { "Authorization" = "Bearer <token>" }   # your endpoint's auth
-# query_params = { "source" = "osmosis" }            # extra static params
+# url = "https://example.com/training-complete"
+# headers = { "Authorization" = "Bearer <token>" }
+# query_params = { "source" = "osmosis" }
 
 [training]
 # Optional. Omit values to use platform defaults.

--- a/tests/unit/platform/cli/test_submit_wiring.py
+++ b/tests/unit/platform/cli/test_submit_wiring.py
@@ -10,17 +10,19 @@ from osmosis_ai.platform.cli.eval_config import EvalSubmitConfig
 from osmosis_ai.platform.cli.training_config import TrainSubmitConfig
 
 
-def _train_config(secrets: list[str]) -> TrainSubmitConfig:
+def _train_config(
+    secrets: list[str], *, webhook: dict | None = None
+) -> TrainSubmitConfig:
+    experiment: dict = {
+        "rollout": "r",
+        "entrypoint": "rollouts/main.py",
+        "model_path": "m",
+        "dataset": "d",
+    }
+    if webhook is not None:
+        experiment["completion_webhook"] = webhook
     return TrainSubmitConfig.model_validate(
-        {
-            "experiment": {
-                "rollout": "r",
-                "entrypoint": "rollouts/main.py",
-                "model_path": "m",
-                "dataset": "d",
-            },
-            "secrets": secrets,
-        }
+        {"experiment": experiment, "secrets": secrets}
     )
 
 
@@ -54,6 +56,31 @@ def test_submit_training_passes_none_when_empty() -> None:
         client, _train_config([]), credentials=None, git_identity="g"
     )
     assert client.submit_training_run.call_args.kwargs["secrets"] is None
+
+
+def test_submit_training_forwards_completion_webhook() -> None:
+    client = MagicMock()
+    train_mod._submit_training(
+        client,
+        _train_config([], webhook={"url": "https://example.com/hook"}),
+        credentials=None,
+        git_identity="g",
+    )
+    experiment_config = client.submit_training_run.call_args.kwargs["experiment_config"]
+    assert experiment_config["completion_webhook"] == {
+        "url": "https://example.com/hook",
+        "headers": {},
+        "query_params": {},
+    }
+
+
+def test_submit_training_passes_none_webhook_when_absent() -> None:
+    client = MagicMock()
+    train_mod._submit_training(
+        client, _train_config([]), credentials=None, git_identity="g"
+    )
+    experiment_config = client.submit_training_run.call_args.kwargs["experiment_config"]
+    assert "completion_webhook" not in experiment_config
 
 
 def test_submit_eval_forwards_secrets_list() -> None:

--- a/tests/unit/platform/cli/test_training_config.py
+++ b/tests/unit/platform/cli/test_training_config.py
@@ -507,6 +507,18 @@ def test_webhook_requires_url_when_other_fields_set(tmp_path: Path) -> None:
     assert "requires 'url'" in str(exc_info.value)
 
 
+def test_webhook_empty_section_requires_url(tmp_path: Path) -> None:
+    path = tmp_path / "webhook_empty.toml"
+    path.write_text(
+        _config_with_webhook("[experiment.completion_webhook]"),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CLIError) as exc_info:
+        load_train_submit_config(path)
+    assert "requires 'url'" in str(exc_info.value)
+
+
 def test_webhook_rejects_unknown_keys(tmp_path: Path) -> None:
     path = tmp_path / "webhook_extra.toml"
     path.write_text(

--- a/tests/unit/platform/cli/test_training_config.py
+++ b/tests/unit/platform/cli/test_training_config.py
@@ -404,6 +404,128 @@ dataset = "d"
 
 
 # ---------------------------------------------------------------------------
+# Completion webhook section
+# ---------------------------------------------------------------------------
+
+
+def _config_with_webhook(webhook_block: str) -> str:
+    return f"""
+[experiment]
+rollout = "r"
+entrypoint = "e.py"
+model_path = "m"
+dataset = "d"
+
+{webhook_block}
+""".strip()
+
+
+def test_webhook_absent_yields_none(tmp_path: Path) -> None:
+    path = tmp_path / "no_webhook.toml"
+    path.write_text(
+        """
+[experiment]
+rollout = "r"
+entrypoint = "e.py"
+model_path = "m"
+dataset = "d"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    cfg = load_train_submit_config(path)
+    assert cfg.experiment.completion_webhook is None
+    assert "completion_webhook" not in cfg.experiment_config
+
+
+def test_webhook_full_config(tmp_path: Path) -> None:
+    path = tmp_path / "webhook.toml"
+    path.write_text(
+        _config_with_webhook(
+            "[experiment.completion_webhook]\n"
+            'url = "https://example.com/hook"\n'
+            'headers = { "Authorization" = "Bearer x" }\n'
+            'query_params = { "source" = "osmosis" }\n'
+            "timeout_seconds = 10\n"
+            "retries = 2"
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = load_train_submit_config(path)
+    assert cfg.experiment_config["completion_webhook"] == {
+        "url": "https://example.com/hook",
+        "headers": {"Authorization": "Bearer x"},
+        "query_params": {"source": "osmosis"},
+        "timeout_seconds": 10,
+        "retries": 2,
+    }
+
+
+def test_webhook_url_only(tmp_path: Path) -> None:
+    path = tmp_path / "webhook_url.toml"
+    path.write_text(
+        _config_with_webhook(
+            '[experiment.completion_webhook]\nurl = "https://example.com/hook"'
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = load_train_submit_config(path)
+    assert cfg.experiment_config["completion_webhook"] == {
+        "url": "https://example.com/hook",
+        "headers": {},
+        "query_params": {},
+    }
+
+
+def test_webhook_rejects_non_https(tmp_path: Path) -> None:
+    path = tmp_path / "webhook_http.toml"
+    path.write_text(
+        _config_with_webhook(
+            '[experiment.completion_webhook]\nurl = "http://example.com/hook"'
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CLIError) as exc_info:
+        load_train_submit_config(path)
+    assert "https://" in str(exc_info.value)
+
+
+def test_webhook_requires_url_when_other_fields_set(tmp_path: Path) -> None:
+    path = tmp_path / "webhook_no_url.toml"
+    path.write_text(
+        _config_with_webhook(
+            '[experiment.completion_webhook]\nheaders = { "X" = "y" }'
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CLIError) as exc_info:
+        load_train_submit_config(path)
+    assert "requires 'url'" in str(exc_info.value)
+
+
+def test_webhook_rejects_unknown_keys(tmp_path: Path) -> None:
+    path = tmp_path / "webhook_extra.toml"
+    path.write_text(
+        _config_with_webhook(
+            "[experiment.completion_webhook]\n"
+            'url = "https://example.com/hook"\n'
+            'method = "POST"'
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CLIError) as exc_info:
+        load_train_submit_config(path)
+    assert "experiment.completion_webhook.method: Unrecognized key" in str(
+        exc_info.value
+    )
+
+
+# ---------------------------------------------------------------------------
 # Context path validation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Moves the training **completion webhook** from a standalone top-level `[webhook]` TOML section to **`[experiment.completion_webhook]`**, sending it inside `experiment_config` to match the platform API contract (the platform no longer accepts a top-level `completion_webhook`).

## Changes
- Add `CompletionWebhookSection` to the shared experiment model (`shared_config.py`) with an optional `completion_webhook` field on `ExperimentSection`; keeps the https-scheme and "url required when other fields set" fast checks (server-side SSRF validation remains authoritative).
- Drop the standalone `[webhook]` section and `completion_webhook_config` from `training_config.py`; `train.py`/`training_config.py` revert to their previous shape.
- `api/client.submit_training_run`: remove the top-level `completion_webhook` request field (now carried inside `experiment_config`).
- `shared_submit.py`: read the webhook from `config.experiment.completion_webhook` for the confirmation summary.
- Update the `training.toml.tpl` scaffold to document `[experiment.completion_webhook]`.

## Test plan
- [x] `ruff check` + `ruff format` clean (pre-commit).
- [x] `pytest tests/unit/platform` — 564 passed.
- [x] Real CLI → deployed staging API: bad webhook → `400` validation; valid webhook → passes schema, fails only at nonexistent dataset.

Companion to osmosis-monolith#852.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the training completion webhook to `[experiment.completion_webhook]` and removed the top-level `[webhook]`. The CLI now validates and sends it inside `experiment_config` and shows it in the submit summary.

- **Migration**
  - Update `training.toml`: replace `[webhook]` with `[experiment.completion_webhook]`; `url` is required whenever the table exists and must be `https://`; optional `headers`, `query_params`, `timeout_seconds`, `retries` remain supported. Omit the table to disable the webhook.
  - No code changes needed; `submit_training_run` no longer accepts a top-level `completion_webhook`.

<sup>Written for commit 65df5585be6c131c7e67b79ef7a951b844d340b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

