### PR TITLE
[rollout] fix: verify artifacts dir is writable with retries on mounted storage`

### DIFF
--- a/docs/rollout-sdk.md
+++ b/docs/rollout-sdk.md
@@ -81,7 +81,7 @@ samples = await rollout_ctx.get_samples()            # async -> {name: RolloutSa
 
 Artifacts are files produced by a rollout — logs, traces, generated outputs, screenshots, or other large/binary data that does not belong in the sample.
 
-There is one rule: write files under `ctx.artifacts_dir` (available on both `AgentWorkflowContext` and `GraderContext`). It is `Path | None` — guard before use. In Harbor-backed rollouts it is the sandbox's `/logs/artifacts/`; `LocalBackend` provides an isolated per-rollout directory. If a file is produced elsewhere, copy it in (`shutil.copy2(path, ctx.artifacts_dir / "name")`).
+There is one rule: write files under `ctx.artifacts_dir` (available on both `AgentWorkflowContext` and `GraderContext`). It is `Path | None`, so check `if ctx.artifacts_dir:` before using it. In Harbor-backed rollouts it is the sandbox's `/logs/artifacts/`; `LocalBackend` provides an isolated per-rollout directory. If a file is produced elsewhere, copy it in once you've confirmed the dir exists (`if ctx.artifacts_dir: shutil.copy2(path, ctx.artifacts_dir / "name")`).
 
 ```python
 import json
@@ -95,7 +95,9 @@ async def grade(self, ctx: GraderContext) -> Any:
         ctx.set_sample_reward(sample_id, 1.0)
 ```
 
-After each rollout the artifacts land on the host under `~/.osmosis/<rollout_id>/artifacts/`. `LocalBackend` writes the files you produced at its root; Harbor mirrors its collected-trial layout, so the `/logs/artifacts/` convention dir lands at `.../artifacts/logs/artifacts/<file>` alongside any paths you declare in the task's `artifacts` config. Artifact handling never affects rewards or rollout status.
+After each rollout the artifacts land on the host under `~/.osmosis/<rollout_id>/artifacts/`. `LocalBackend` writes your files at that root. Harbor mirrors its collected-trial layout, so the `/logs/artifacts/` convention dir lands at `.../artifacts/logs/artifacts/<file>`, next to any paths you declare in the task's `artifacts` config.
+
+The backend's directory setup and collection is best-effort and never affects rewards or rollout status. Writes you make in `run` or `grade` run as normal code. An unguarded write that raises will fail that workflow or grader, so always check `if ctx.artifacts_dir:` before writing to it.
 
 ## Configs
 

--- a/docs/rollout-sdk.md
+++ b/docs/rollout-sdk.md
@@ -81,7 +81,7 @@ samples = await rollout_ctx.get_samples()            # async -> {name: RolloutSa
 
 Artifacts are files produced by a rollout — logs, traces, generated outputs, screenshots, or other large/binary data that does not belong in the sample.
 
-There is one rule: write files under `ctx.artifacts_dir` (available on both `AgentWorkflowContext` and `GraderContext`). It normally exists before your code runs, but is `Path | None` — it can be `None` when the host directory could not be created — so guard before use. In Harbor-backed rollouts it is the sandbox's `/logs/artifacts/`; `LocalBackend` provides an isolated per-rollout directory. If a file is produced elsewhere, copy it in (`shutil.copy2(path, ctx.artifacts_dir / "name")`).
+There is one rule: write files under `ctx.artifacts_dir` (available on both `AgentWorkflowContext` and `GraderContext`). It is `Path | None` — guard before use. In Harbor-backed rollouts it is the sandbox's `/logs/artifacts/`; `LocalBackend` provides an isolated per-rollout directory. If a file is produced elsewhere, copy it in (`shutil.copy2(path, ctx.artifacts_dir / "name")`).
 
 ```python
 import json
@@ -95,7 +95,7 @@ async def grade(self, ctx: GraderContext) -> Any:
         ctx.set_sample_reward(sample_id, 1.0)
 ```
 
-After each rollout the artifacts land on the host under `~/.osmosis/<rollout_id>/artifacts/`, mirroring Harbor's collected-trial layout (user files sit at `.../artifacts/logs/artifacts/<file>`). Artifact handling is best-effort and never affects rewards or rollout status.
+After each rollout the artifacts land on the host under `~/.osmosis/<rollout_id>/artifacts/`. `LocalBackend` writes the files you produced at its root; Harbor mirrors its collected-trial layout, so the `/logs/artifacts/` convention dir lands at `.../artifacts/logs/artifacts/<file>` alongside any paths you declare in the task's `artifacts` config. Artifact handling never affects rewards or rollout status.
 
 ## Configs
 

--- a/osmosis_ai/rollout/backend/local/backend.py
+++ b/osmosis_ai/rollout/backend/local/backend.py
@@ -23,7 +23,7 @@ from osmosis_ai.rollout.types import (
 )
 from osmosis_ai.rollout.utils.concurrency import ConcurrencyLimiter
 from osmosis_ai.rollout.utils.file_artifacts import (
-    HARBOR_COLLECTED_ARTIFACTS_SUBPATH,
+    create_rollout_artifacts_dir,
     default_artifact_root,
 )
 from osmosis_ai.rollout.utils.imports import resolve_object
@@ -96,32 +96,15 @@ class LocalBackend(ExecutionBackend):
             else:
                 await on_grader_complete(ExecutionResult(status=RolloutStatus.FAILURE))
 
-    def _make_artifacts_dir(self, rollout_id: str) -> Path | None:
-        """Idempotently create the rollout's artifacts dir; ``None`` on failure."""
-        artifacts_dir = (
-            self.artifact_root
-            / rollout_id
-            / "artifacts"
-            / HARBOR_COLLECTED_ARTIFACTS_SUBPATH
-        )
-        try:
-            artifacts_dir.mkdir(parents=True, exist_ok=True)
-        except OSError:
-            logger.warning(
-                "Failed to create artifacts dir for rollout %s (best-effort)",
-                rollout_id,
-                exc_info=True,
-            )
-            return None
-        return artifacts_dir
-
     async def run_workflow(self, request: ExecutionRequest) -> ExecutionResult:
         config = copy.deepcopy(self.workflow_config)
         ctx = AgentWorkflowContext(
             prompt=request.prompt,
             config=config,
             metadata=request.metadata,
-            artifacts_dir=self._make_artifacts_dir(request.id),
+            artifacts_dir=await create_rollout_artifacts_dir(
+                self.artifact_root, request.id
+            ),
         )
 
         rollout_ctx = get_rollout_context()
@@ -155,7 +138,9 @@ class LocalBackend(ExecutionBackend):
             label=request.label,
             samples=result.samples,
             metadata=request.metadata,
-            artifacts_dir=self._make_artifacts_dir(request.id),
+            artifacts_dir=await create_rollout_artifacts_dir(
+                self.artifact_root, request.id
+            ),
         )
         try:
             grader = self.grader_cls(self.grader_config)

--- a/osmosis_ai/rollout/utils/file_artifacts.py
+++ b/osmosis_ai/rollout/utils/file_artifacts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from pathlib import Path
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -25,6 +26,20 @@ def default_artifact_root() -> Path:
     ``trajectory.json`` — which the platform persists to durable storage.
     """
     return Path.home() / ".osmosis"
+
+
+def _is_single_path_segment(name: str) -> bool:
+    """True when ``name`` is a plain path component, not a traversal or root escape.
+
+    ``rollout_id`` comes from the untrusted rollout request, so values like
+    ``../other`` or ``/tmp/other`` must not be joined onto the artifact root or
+    they'd let a rollout write outside its own directory.
+    """
+    if not name or name in (".", ".."):
+        return False
+    if os.sep in name or (os.altsep and os.altsep in name):
+        return False
+    return Path(name).name == name
 
 
 def _ensure_artifacts_dir(rollout_dir: Path) -> Path:
@@ -50,20 +65,28 @@ async def create_rollout_artifacts_dir(
     The check file is written outside ``artifacts/`` so it doesn't appear among
     the rollout's artifacts.
     """
+    if not _is_single_path_segment(rollout_id):
+        logger.warning(
+            "Refusing artifacts dir for rollout %r: id is not a single path "
+            "segment (best-effort)",
+            rollout_id,
+        )
+        return None
     rollout_dir = root / rollout_id
     total = attempts if attempts is not None else CREATE_ATTEMPTS
+    last_error: OSError | None = None
     for attempt in range(total):
         try:
             # Filesystem I/O may block; run it off the event loop.
             return await asyncio.to_thread(_ensure_artifacts_dir, rollout_dir)
-        except OSError:
-            if attempt == total - 1:
-                logger.warning(
-                    "Artifacts dir unusable for rollout %s under %s (best-effort)",
-                    rollout_id,
-                    root,
-                    exc_info=True,
-                )
-                return None
-            await asyncio.sleep(CREATE_BACKOFF_SECONDS * (2**attempt))
+        except OSError as error:
+            last_error = error
+            if attempt < total - 1:
+                await asyncio.sleep(CREATE_BACKOFF_SECONDS * (2**attempt))
+    logger.warning(
+        "Artifacts dir unusable for rollout %s under %s (best-effort)",
+        rollout_id,
+        root,
+        exc_info=last_error,
+    )
     return None

--- a/osmosis_ai/rollout/utils/file_artifacts.py
+++ b/osmosis_ai/rollout/utils/file_artifacts.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from pathlib import Path
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 # Harbor's auto-collected convention directory inside the sandbox.
 HARBOR_ARTIFACTS_DIR = Path("/logs/artifacts")
 
-# Host subpath where Harbor lands it; LocalBackend reuses it to match.
-HARBOR_COLLECTED_ARTIFACTS_SUBPATH = HARBOR_ARTIFACTS_DIR.relative_to("/")
+CREATE_ATTEMPTS = 3
+CREATE_BACKOFF_SECONDS = 0.5  # doubled per retry
+
+_HEALTH_CHECK_FILENAME = ".osmosis-health-check"
 
 
 def default_artifact_root() -> Path:
@@ -19,3 +25,45 @@ def default_artifact_root() -> Path:
     ``trajectory.json`` — which the platform persists to durable storage.
     """
     return Path.home() / ".osmosis"
+
+
+def _ensure_artifacts_dir(rollout_dir: Path) -> Path:
+    artifacts_dir = rollout_dir / "artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    # Create a marker to confirm the dir is writable; only once per rollout, so
+    # a later call can't fail on a store that rejects overwrites.
+    health_check = rollout_dir / _HEALTH_CHECK_FILENAME
+    if not health_check.exists():
+        health_check.write_bytes(b"osmosis-health-check")
+    return artifacts_dir
+
+
+async def create_rollout_artifacts_dir(
+    root: Path, rollout_id: str, *, attempts: int | None = None
+) -> Path | None:
+    """Create and verify the rollout's artifacts dir; ``None`` when unusable.
+
+    ``mkdir`` alone can succeed without proving the directory is writable, so the
+    first call writes a check file to confirm it before user code relies on the
+    dir. Retries ride out transient errors while the dir becomes available.
+
+    The check file is written outside ``artifacts/`` so it doesn't appear among
+    the rollout's artifacts.
+    """
+    rollout_dir = root / rollout_id
+    total = attempts if attempts is not None else CREATE_ATTEMPTS
+    for attempt in range(total):
+        try:
+            # Filesystem I/O may block; run it off the event loop.
+            return await asyncio.to_thread(_ensure_artifacts_dir, rollout_dir)
+        except OSError:
+            if attempt == total - 1:
+                logger.warning(
+                    "Artifacts dir unusable for rollout %s under %s (best-effort)",
+                    rollout_id,
+                    root,
+                    exc_info=True,
+                )
+                return None
+            await asyncio.sleep(CREATE_BACKOFF_SECONDS * (2**attempt))
+    return None

--- a/tests/unit/rollout/test_file_artifacts.py
+++ b/tests/unit/rollout/test_file_artifacts.py
@@ -1,0 +1,79 @@
+"""Tests for osmosis_ai.rollout.utils.file_artifacts."""
+
+from pathlib import Path
+
+import pytest
+
+from osmosis_ai.rollout.utils import file_artifacts
+from osmosis_ai.rollout.utils.file_artifacts import create_rollout_artifacts_dir
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff(monkeypatch):
+    monkeypatch.setattr(file_artifacts, "CREATE_BACKOFF_SECONDS", 0)
+
+
+class TestCreateRolloutArtifactsDir:
+    async def test_creates_and_returns_harbor_shaped_dir(self, tmp_path):
+        result = await create_rollout_artifacts_dir(tmp_path, "r1")
+
+        assert result == tmp_path / "r1" / "artifacts"
+        assert result.is_dir()
+        # Marker lives outside artifacts/, so the collected dir starts empty.
+        assert list(result.iterdir()) == []
+        assert (tmp_path / "r1" / ".osmosis-health-check").is_file()
+
+    async def test_retries_past_transient_mkdir_failure(self, tmp_path, monkeypatch):
+        original_mkdir = Path.mkdir
+        calls = {"n": 0}
+
+        def flaky_mkdir(self, *args, **kwargs):
+            calls["n"] += 1
+            # Only the first top-level call fails; pathlib re-enters mkdir
+            # recursively for parents, so raw counts don't map to attempts.
+            if calls["n"] == 1:
+                raise OSError("mount not ready")
+            return original_mkdir(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "mkdir", flaky_mkdir)
+
+        result = await create_rollout_artifacts_dir(tmp_path, "r1")
+
+        assert result is not None and result.is_dir()
+
+    async def test_second_call_skips_write_when_marker_exists(
+        self, tmp_path, monkeypatch
+    ):
+        # Workflow + grader probe the same rollout_id; on a no-overwrite mount a
+        # second write to the same marker key would fail, so it must be skipped.
+        first = await create_rollout_artifacts_dir(tmp_path, "r1")
+        assert first is not None
+
+        def no_overwrite(self, *args, **kwargs):
+            raise OSError("overwrite not permitted")
+
+        monkeypatch.setattr(Path, "write_bytes", no_overwrite)
+
+        second = await create_rollout_artifacts_dir(tmp_path, "r1")
+
+        assert second == first
+
+    async def test_returns_none_when_dir_is_not_writable(self, tmp_path, monkeypatch):
+        def unwritable(self, *args, **kwargs):
+            raise OSError("read-only file system")
+
+        monkeypatch.setattr(Path, "write_bytes", unwritable)
+
+        result = await create_rollout_artifacts_dir(tmp_path, "r1")
+
+        assert result is None
+
+    async def test_returns_none_when_mkdir_always_fails(self, tmp_path, monkeypatch):
+        def boom(self, *args, **kwargs):
+            raise OSError("read-only file system")
+
+        monkeypatch.setattr(Path, "mkdir", boom)
+
+        result = await create_rollout_artifacts_dir(tmp_path, "r1")
+
+        assert result is None

--- a/tests/unit/rollout/test_file_artifacts.py
+++ b/tests/unit/rollout/test_file_artifacts.py
@@ -77,3 +77,16 @@ class TestCreateRolloutArtifactsDir:
         result = await create_rollout_artifacts_dir(tmp_path, "r1")
 
         assert result is None
+
+    @pytest.mark.parametrize(
+        "rollout_id",
+        ["../other", "a/b", "/tmp/other", "..", ".", ""],
+    )
+    async def test_rejects_ids_that_escape_root(
+        self, tmp_path, monkeypatch, rollout_id
+    ):
+        # An untrusted rollout id must never place artifacts outside the root.
+        result = await create_rollout_artifacts_dir(tmp_path, rollout_id)
+
+        assert result is None
+        assert list(tmp_path.iterdir()) == []

--- a/tests/unit/rollout/test_local_backend.py
+++ b/tests/unit/rollout/test_local_backend.py
@@ -145,14 +145,17 @@ class TestLocalBackend:
         await backend.execute(request, AsyncMock(), AsyncMock())
 
         root = tmp_path / ".osmosis"
-        rollout_dir = root / "r1" / "artifacts" / "logs" / "artifacts"
-        assert (rollout_dir / "trace.txt").read_text() == "trace"
-        assert (rollout_dir / "grade_debug.json").read_text() == "{}"
+        artifacts_dir = root / "r1" / "artifacts"
+        assert (artifacts_dir / "trace.txt").read_text() == "trace"
+        assert (artifacts_dir / "grade_debug.json").read_text() == "{}"
 
     async def test_rollout_degrades_when_artifacts_dir_unavailable(
         self, tmp_path, monkeypatch
     ):
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(
+            "osmosis_ai.rollout.utils.file_artifacts.CREATE_BACKOFF_SECONDS", 0
+        )
 
         def _boom(self, *_args, **_kwargs):
             raise OSError("read-only filesystem")


### PR DESCRIPTION
## What

Hardens creation of the per-rollout artifacts directory in `LocalBackend`. The inline `_make_artifacts_dir` helper is replaced by a shared async `create_rollout_artifacts_dir` in `osmosis_ai/rollout/utils/file_artifacts.py` that:

- Writes a per-rollout `.osmosis-health-check` file after `mkdir` to force a real write, so we prove the directory is actually usable rather than trusting a `mkdir` that may succeed without the directory being writable.
- Retries up to 3 times with exponential backoff (0.5s, doubling) to ride out filesystem startup races.
- Returns `None` when the directory is unusable, preserving the existing best-effort contract.

The health-check file is written outside `artifacts/` (so it isn't collected) and keyed by `rollout_id` (concurrent rollouts may share the same backing store).

Also updates `docs/rollout-sdk.md` to reflect the guarded `Path | None` behavior.

## Why

For some backing filesystems, `mkdir` can succeed even when the directory is not yet ready or is read-only. The previous logic trusted that `mkdir` alone meant the directory was writable, which could hand user code a `Path` that later failed on write. Forcing a real write plus retries makes the check reflect actual usability and tolerates startup races.

## How to Test

- `pytest tests/unit/rollout/test_file_artifacts.py tests/unit/rollout/test_local_backend.py`
- New tests cover: dir creation with the marker outside `artifacts/`, retry past a transient `mkdir` failure, and `None` returned when the dir is not writable or `mkdir` always fails.

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included
