### PR TITLE
[rollout] fix: support OpenAI 2.45 usage details

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -154,7 +154,14 @@ jobs:
         run: |
           uv venv --python 3.12 /tmp/osmosis-wheel-smoke
           uv pip install --python /tmp/osmosis-wheel-smoke/bin/python dist/*.whl
-          /tmp/osmosis-wheel-smoke/bin/python -c "import osmosis_ai; print(osmosis_ai.__version__)"
+          /tmp/osmosis-wheel-smoke/bin/python - <<'PY'
+          import osmosis_ai
+          from agents.usage import Usage
+          from osmosis_ai.rollout.integrations.agents.openai_agents import OsmosisLitellmModel
+
+          assert Usage().input_tokens_details.cached_tokens == 0
+          print(osmosis_ai.__version__, OsmosisLitellmModel.__name__)
+          PY
           /tmp/osmosis-wheel-smoke/bin/osmosis --version
 
       - name: Upload dist artifact

--- a/osmosis_ai/rollout/integrations/agents/openai_agents.py
+++ b/osmosis_ai/rollout/integrations/agents/openai_agents.py
@@ -11,10 +11,6 @@ from agents.memory.session import SessionABC
 from agents.model_settings import ModelSettings
 from agents.models.chatcmpl_converter import Converter
 from agents.usage import Usage
-from openai.types.responses.response_usage import (
-    InputTokensDetails,
-    OutputTokensDetails,
-)
 
 from osmosis_ai.rollout.context import SampleSource, get_rollout_context
 from osmosis_ai.rollout.types import RolloutSample
@@ -221,14 +217,8 @@ class OsmosisLitellmModel(LitellmModel):
                         input_tokens=final.usage.input_tokens,
                         output_tokens=final.usage.output_tokens,
                         total_tokens=final.usage.total_tokens,
-                        input_tokens_details=(
-                            final.usage.input_tokens_details
-                            or InputTokensDetails(cached_tokens=0)
-                        ),
-                        output_tokens_details=(
-                            final.usage.output_tokens_details
-                            or OutputTokensDetails(reasoning_tokens=0)
-                        ),
+                        input_tokens_details=final.usage.input_tokens_details,
+                        output_tokens_details=final.usage.output_tokens_details,
                     )
         return ModelResponse(output=output_items, usage=usage, response_id=None)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ dependencies = [
     "httpx>=0.25.0,<1.0.0",
     "pydantic>=2.0.0,<3.0.0",
     "strands-agents[litellm]>=1.29.0",
-    "openai-agents[litellm]>=0.14,<0.18",
+    # >=0.18.1 supports OpenAI Python 2.45's cache_write_tokens usage field.
+    "openai-agents[litellm]>=0.18.1,<0.19",
     # Secure credential storage (system keychain)
     "keyring>=25.0.0",
     # Interactive CLI prompts

--- a/tests/unit/rollout/integrations/test_openai_agents.py
+++ b/tests/unit/rollout/integrations/test_openai_agents.py
@@ -182,6 +182,11 @@ class TestOpenAIAgentsIntegration:
         assert response.usage.input_tokens == 3
         assert response.usage.output_tokens == 5
         assert response.usage.total_tokens == 8
+        assert response.usage.input_tokens_details.cached_tokens == 0
+        assert (
+            getattr(response.usage.input_tokens_details, "cache_write_tokens", 0) == 0
+        )
+        assert response.usage.output_tokens_details.reasoning_tokens == 0
 
     async def test_upstream_runner_run_records_session_sample(
         self, rollout_context, monkeypatch

--- a/uv.lock
+++ b/uv.lock
@@ -1774,7 +1774,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.44.0"
+version = "2.45.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1786,14 +1786,14 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/f5/7c7cb955305cb41f7f3c5fd7e0e38bf6bbf2658468863d4b7b868a5cb8df/openai-2.44.0.tar.gz", hash = "sha256:68a5a5ffad82b8ff7d451c437529fb64f7c3b8123aaf0c021966a882d9e3947d", size = 988753, upload-time = "2026-06-24T20:56:02.293Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/60/d4219875289b11d2c2f7da93c36283da224a2e55865ed865ab64e0ce9217/openai-2.45.0.tar.gz", hash = "sha256:10d34ca9c5643bce775852fddbfc172505cb1d4de1ccd101696c3ecff358765d", size = 1109653, upload-time = "2026-07-09T18:02:44.091Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/f4/561ed79fd94876160018a5e75254cfcb9b0e62d4dded9dcb20072e86d623/openai-2.44.0-py3-none-any.whl", hash = "sha256:0a2a3ab2e29aeda368700f662ff9ba0f9df17ba4c54577a64e08b8115a3cc0ad", size = 1366216, upload-time = "2026-06-24T20:55:58.882Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b0/2291689e3ec4723fbf5bbf3b54afcd7b160f9ddc98ca7aedfd0132af5677/openai-2.45.0-py3-none-any.whl", hash = "sha256:5df105f5f8c9b711fcb9d06d2d3888cebc82506db216484c14a4e53cdf651777", size = 1629470, upload-time = "2026-07-09T18:02:42.21Z" },
 ]
 
 [[package]]
 name = "openai-agents"
-version = "0.17.7"
+version = "0.18.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffelib" },
@@ -1804,9 +1804,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/b2/235cbfdefe86623fc77f65fc1d016686372f61d4a1bf3fc66151de2eb847/openai_agents-0.17.7.tar.gz", hash = "sha256:ca76e7f882c9d8f06e3dfb8064cc33bcb5a5f34a29816cb9af863f395964ff0c", size = 5485068, upload-time = "2026-06-24T05:15:33.705Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/0c/52e9aeff5549b225d5666a0eb84a8a22b4c47db08b6f44dbd45876fcfba3/openai_agents-0.18.2.tar.gz", hash = "sha256:9f418bb563eddff1e01f245ae8a4964b7649396f444b569b4113d105e41ca1d3", size = 5546139, upload-time = "2026-07-11T01:08:18.537Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/2e/2e96ca6928951fe1d16744c22dc1355eda1dd5b0dd920ca1d3ab602929f8/openai_agents-0.17.7-py3-none-any.whl", hash = "sha256:51b5ae43756eea37032e430f95979ba3999af6b1ade397df6c0ffeaf1939646a", size = 856074, upload-time = "2026-06-24T05:15:31.741Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/23/b5b6b80a3e36f021ca2a8c4637684f0d722d646b19d3616768a68802c302/openai_agents-0.18.2-py3-none-any.whl", hash = "sha256:c7aea341b256a90b87b17b7e444bab29a12655864a2f0094f65561223d867185", size = 874310, upload-time = "2026-07-11T01:08:16.851Z" },
 ]
 
 [package.optional-dependencies]
@@ -2062,7 +2062,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.25.0,<1.0.0" },
     { name = "keyring", specifier = ">=25.0.0" },
     { name = "litellm", specifier = ">=1.84.0,<2.0.0" },
-    { name = "openai-agents", extras = ["litellm"], specifier = ">=0.14,<0.18" },
+    { name = "openai-agents", extras = ["litellm"], specifier = ">=0.18.1,<0.19" },
     { name = "orjson", specifier = ">=3.11.6,<4.0" },
     { name = "osmosis-ai", extras = ["platform"], marker = "extra == 'server'" },
     { name = "osmosis-ai", extras = ["server"], marker = "extra == 'dev'" },


### PR DESCRIPTION
## What

- Raise the `openai-agents[litellm]` lower bound to 0.18.1 and refresh the lockfile for OpenAI Python 2.45 compatibility.
- Delegate missing token-detail normalization to the updated Agents SDK and cover null usage details in the rollout integration test.
- Expand the built-wheel smoke test so fresh dependency resolution exercises `agents.usage.Usage` and the Osmosis OpenAI Agents integration.

## Why

A staging eval fresh-installed `openai==2.45.0` with `openai-agents==0.17.8`. The older Agents SDK constructed `InputTokensDetails` without the newly required `cache_write_tokens` field, so every rollout failed with a Pydantic validation error before the model call. Version 0.18.1 adds the compatibility normalization needed for OpenAI Python 2.45 while retaining support for providers that omit token-detail objects.

## How to Test

- `uv lock --check`
- `uv run --locked --extra dev ruff check .`
- `uv run --locked --extra dev ruff format --check .`
- `uv run --locked --extra dev pyright osmosis_ai/`
- `uv run --locked --extra dev pytest -q`
- Build the wheel and install it into a clean Python 3.12 virtual environment; import `Usage` and `OsmosisLitellmModel`.

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix rollout compatibility with `openai` 2.45 by updating `openai-agents` and relying on the SDK to normalize the new usage detail fields. Prevents Pydantic validation errors when `cache_write_tokens` or token details are missing.

- **Bug Fixes**
  - Delegate input/output token-detail normalization to the updated Agents SDK and remove local defaults.
  - Add tests for null usage details and expand the wheel smoke test to exercise `agents.usage.Usage` and `OsmosisLitellmModel`.

- **Dependencies**
  - Bump `openai-agents[litellm]` to >=0.18.1,<0.19 and refresh the lockfile to `openai` 2.45.0.

<sup>Written for commit 513048d954806de8ffdab5aa1263f6f4cd3f0b56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

