### PR TITLE
[cli][eval] feat: add evaluation run output downloads

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ The package (`osmosis_ai/`) is organized into top-level domains. See [architectu
 - [datasets.md](./datasets.md) — the dataset row contract enforced by the SDK validator.
 - [troubleshooting.md](./troubleshooting.md) — engineering issues (rollout timeouts, event-loop blocking, concurrency tuning).
 - [cli.md](./cli.md) — CLI internals for contributors (command shells, lazy imports, JSON envelopes).
+- [run-downloads.md](./run-downloads.md) — eval download command, platform route contract, fixed local layout, resume, confirmation, and retry behavior.
 
 ## See also
 

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -73,11 +73,14 @@ The result is an `OperationResult` whose next-steps point at `osmosis eval info 
 All operate on the current git workspace directory ([../osmosis_ai/platform/cli/eval.py](../osmosis_ai/platform/cli/eval.py)):
 
 - `osmosis eval list [--all] [--limit N]` — list runs for the workspace.
-- `osmosis eval info <name|id> [-o path]` — run detail, results, and metrics (writes a metrics JSON in rich mode).
+- `osmosis eval info <name|id> [-o root]` — run detail, results, and metrics (writes `<root>/metrics.json` in rich mode; default `.osmosis/evals/<name>/metrics.json`).
 - `osmosis eval logs <name|id> [--cursor …]` — recent run logs, oldest first.
+- `osmosis eval download <name|id> [--type metrics,trajectories|artifacts|logs|all] [--rows 3,7,10-20] [-o root] [--overwrite] [--yes]` — download run outputs into the fixed run-scoped layout. The default is `metrics,trajectories`; `--type` replaces that selection. Matching local sizes resume for free, and transfers over 100 MiB require confirmation unless `--yes` is supplied.
 - `osmosis eval stop <name|id> [--yes]` — stop a run.
 
 See [docs.osmosis.ai/cli/config-files](https://docs.osmosis.ai/cli/config-files) for the full config field reference.
+
+Migration notice: rich-mode metrics exports no longer write new files under `.osmosis/metrics/`. Existing legacy files are left untouched; new eval exports use `.osmosis/evals/<name>/metrics.json`.
 
 ## `osmosis eval rubric` (offline LLM-as-judge)
 

--- a/docs/run-downloads.md
+++ b/docs/run-downloads.md
@@ -1,9 +1,6 @@
 # Evaluation run output download contract
 
-The eval download implementation lives in
-[`platform/cli/run_download.py`](../osmosis_ai/platform/cli/run_download.py).
-Its Typer shell remains thin and lives in
-[`cli/commands/eval.py`](../osmosis_ai/cli/commands/eval.py).
+The eval download implementation lives in [`platform/cli/run_download.py`](../osmosis_ai/platform/cli/run_download.py). Its Typer shell remains thin and lives in [`cli/commands/eval.py`](../osmosis_ai/cli/commands/eval.py).
 
 ## Commands
 
@@ -16,9 +13,7 @@ osmosis eval download NAME_OR_ID
   -y, --yes
 ```
 
-`--type` replaces the default selection and defaults to
-`metrics,trajectories`. A row selection includes every run for each selected
-row.
+`--type` replaces the default selection and defaults to `metrics,trajectories`. A row selection includes every run for each selected row.
 
 ## Platform routes
 
@@ -29,10 +24,7 @@ GET  /api/cli/eval-runs/[id]/samples/manifest?types=&rows=
 POST /api/cli/eval-runs/[id]/samples/download-urls
 ```
 
-The manifest returns `{files: [{rolloutId?, path, size}], totals}`. `path` is
-the final path relative to the local run root. URL requests contain at most 500
-`{rolloutId, path}` items. The platform derives full S3 keys server-side and
-returns 15-minute presigned GET URLs; the SDK never accepts raw object keys.
+The manifest returns `{files: [{rolloutId?, path, size}], totals}`. `path` is the final path relative to the local run root. URL requests contain at most 500 `{rolloutId, path}` items. The platform derives full S3 keys server-side and returns 15-minute presigned GET URLs; the SDK never accepts raw object keys.
 
 ## Fixed local layout
 
@@ -47,30 +39,17 @@ returns 15-minute presigned GET URLs; the SDK never accepts raw object keys.
 └── metrics/                       # legacy eval exports; never deleted
 ```
 
-`--output` relocates the run root; filenames and subdirectories below it do not
-change. Rich-mode `eval info` uses the same resolver and writes the same
-run-scoped `metrics.json` path. Names that require filesystem sanitization gain
-a stable run-ID suffix so distinct runs never share a local directory. Training
-download and training metrics-path migration are intentionally out of scope
-until the platform routes are ready; `train info` keeps its existing export
-behavior for now.
+`--output` relocates the run root; filenames and subdirectories below it do not change. Rich-mode `eval info` uses the same resolver and writes the same run-scoped `metrics.json` path. Names that require filesystem sanitization gain a stable run-ID suffix so distinct runs never share a local directory. Training download and training metrics-path migration are intentionally out of scope until the platform routes are ready; `train info` keeps its existing export behavior for now.
 
 ## Transfer behavior
 
 - Files with a matching local size are skipped unless `--overwrite` is set.
 - Remaining transfers over 100 MiB require confirmation; `--yes` skips it.
 - Presigned URLs are requested batch-by-batch, with at most 500 files per call.
-- Eight files download concurrently into sibling `*.partial` files, then move
-  atomically into place after the manifest size is verified.
-- Each file is retried up to three times with exponential backoff. Failures do
-  not stop other files; the command reports every failed path and exits partial
-  so re-running retries only missing or mismatched files.
-- Manifest paths outside the fixed layout and reserved `manifest.json` entries
-  are rejected defensively. The platform remains responsible for authoritative
-  path validation and scoped S3 listing.
+- Eight files download concurrently into sibling `*.partial` files, then move atomically into place after the manifest size is verified.
+- Each file is retried up to three times with exponential backoff. Failures do not stop other files; the command reports every failed path and exits partial so re-running retries only missing or mismatched files.
+- Manifest paths outside the fixed layout and reserved `manifest.json` entries are rejected defensively. The platform remains responsible for authoritative path validation and scoped S3 listing.
 
 ## Metrics export migration
 
-New rich-mode eval info exports use `.osmosis/evals/<name>/metrics.json`.
-Existing `.osmosis/metrics/` files are left untouched. The CLI emits a
-one-release migration notice after saving.
+New rich-mode eval info exports use `.osmosis/evals/<name>/metrics.json`. Existing `.osmosis/metrics/` files are left untouched. The CLI emits a one-release migration notice after saving.

--- a/docs/run-downloads.md
+++ b/docs/run-downloads.md
@@ -1,0 +1,76 @@
+# Evaluation run output download contract
+
+The eval download implementation lives in
+[`platform/cli/run_download.py`](../osmosis_ai/platform/cli/run_download.py).
+Its Typer shell remains thin and lives in
+[`cli/commands/eval.py`](../osmosis_ai/cli/commands/eval.py).
+
+## Commands
+
+```text
+osmosis eval download NAME_OR_ID
+  --type metrics,trajectories|artifacts|logs|all
+  --rows 3,7,10-20
+  -o, --output ROOT
+  --overwrite
+  -y, --yes
+```
+
+`--type` replaces the default selection and defaults to
+`metrics,trajectories`. A row selection includes every run for each selected
+row.
+
+## Platform routes
+
+After resolving a run name or ID, the SDK uses two eval routes:
+
+```text
+GET  /api/cli/eval-runs/[id]/samples/manifest?types=&rows=
+POST /api/cli/eval-runs/[id]/samples/download-urls
+```
+
+The manifest returns `{files: [{rolloutId?, path, size}], totals}`. `path` is
+the final path relative to the local run root. URL requests contain at most 500
+`{rolloutId, path}` items. The platform derives full S3 keys server-side and
+returns 15-minute presigned GET URLs; the SDK never accepts raw object keys.
+
+## Fixed local layout
+
+```text
+.osmosis/
+├── evals/<run-name>/
+│   ├── metrics.json
+│   ├── summary.jsonl
+│   ├── trajectories/row_3_run_0.json
+│   ├── artifacts/row_3_run_0/logs/agent.log
+│   └── logs.txt
+└── metrics/                       # legacy eval exports; never deleted
+```
+
+`--output` relocates the run root; filenames and subdirectories below it do not
+change. Rich-mode `eval info` uses the same resolver and writes the same
+run-scoped `metrics.json` path. Names that require filesystem sanitization gain
+a stable run-ID suffix so distinct runs never share a local directory. Training
+download and training metrics-path migration are intentionally out of scope
+until the platform routes are ready; `train info` keeps its existing export
+behavior for now.
+
+## Transfer behavior
+
+- Files with a matching local size are skipped unless `--overwrite` is set.
+- Remaining transfers over 100 MiB require confirmation; `--yes` skips it.
+- Presigned URLs are requested batch-by-batch, with at most 500 files per call.
+- Eight files download concurrently into sibling `*.partial` files, then move
+  atomically into place after the manifest size is verified.
+- Each file is retried up to three times with exponential backoff. Failures do
+  not stop other files; the command reports every failed path and exits partial
+  so re-running retries only missing or mismatched files.
+- Manifest paths outside the fixed layout and reserved `manifest.json` entries
+  are rejected defensively. The platform remains responsible for authoritative
+  path validation and scoped S3 listing.
+
+## Metrics export migration
+
+New rich-mode eval info exports use `.osmosis/evals/<name>/metrics.json`.
+Existing `.osmosis/metrics/` files are left untouched. The CLI emits a
+one-release migration notice after saving.

--- a/docs/run-downloads.md
+++ b/docs/run-downloads.md
@@ -29,10 +29,7 @@ GET  /api/cli/eval-runs/[id]/samples/manifest?types=&rows=
 POST /api/cli/eval-runs/[id]/samples/download-urls
 ```
 
-The manifest returns `{files: [{rolloutId?, path, size}], totals}`. `path` is
-the final path relative to the local run root. URL requests contain at most 500
-`{rolloutId, path}` items. The platform derives full S3 keys server-side and
-returns 15-minute presigned GET URLs; the SDK never accepts raw object keys.
+The manifest returns `{files: [{token?, path, size}], totals}`. `path` is the final path relative to the local run root, and `token` is an opaque server handle (a rollout id or an export snapshot token). URL requests contain at most 500 `{token, path}` items. The platform derives full S3 keys server-side and returns 15-minute presigned GET URLs; the SDK never accepts raw object keys.
 
 ## Fixed local layout
 

--- a/osmosis_ai/cli/commands/eval.py
+++ b/osmosis_ai/cli/commands/eval.py
@@ -14,7 +14,10 @@ from osmosis_ai.platform.constants import (
 )
 
 app: typer.Typer = typer.Typer(
-    help="Manage evaluation runs (submit, list, info, stop) and LLM-as-judge rubric scoring.",
+    help=(
+        "Manage evaluation runs (submit, list, info, download, stop) and"
+        " LLM-as-judge rubric scoring."
+    ),
     no_args_is_help=True,
 )
 
@@ -135,17 +138,60 @@ def eval_info(
         None,
         "--output",
         "-o",
-        help=(
-            "Output path for metrics JSON. Non-.json extensions are replaced with"
-            " .json; a trailing '/' or existing directory generates a default"
-            " filename inside it. (default in rich mode: .osmosis/metrics/)"
-        ),
+        help="Run output root (default in rich mode: .osmosis/evals/<name>/).",
     ),
 ) -> Any:
     """Show evaluation run details, results, and metrics."""
     from osmosis_ai.platform.cli.eval import info as _info
 
     return _info(name_or_id, output=output)
+
+
+@app.command("download")
+def eval_download(
+    name_or_id: str = typer.Argument(..., help="Evaluation run name or ID."),
+    output: str | None = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Run output root (default: .osmosis/evals/<name>/).",
+    ),
+    types: str = typer.Option(
+        "metrics,trajectories",
+        "--type",
+        help=(
+            "Comma-separated selector: metrics, trajectories, artifacts, logs, all. "
+            "Replaces the default selection."
+        ),
+    ),
+    rows: str | None = typer.Option(
+        None,
+        "--rows",
+        help='Rows for trajectories/artifacts, for example "3,7,10-20".',
+    ),
+    overwrite: bool = typer.Option(
+        False,
+        "--overwrite",
+        help="Re-download files that already exist locally.",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip size confirmation.",
+    ),
+) -> Any:
+    """Download evaluation metrics, trajectories, artifacts, or logs."""
+    from osmosis_ai.platform.cli.eval import download as _download
+
+    return _download(
+        name_or_id,
+        output=output,
+        types=types,
+        rows=rows,
+        overwrite=overwrite,
+        yes=yes,
+    )
 
 
 @app.command("stop")

--- a/osmosis_ai/cli/metrics_export.py
+++ b/osmosis_ai/cli/metrics_export.py
@@ -16,6 +16,21 @@ from osmosis_ai.platform.api.models import (
     TrainingRunMetrics,
 )
 
+METRICS_EXPORT_MIGRATION_NOTICE = (
+    "Eval metrics exports now use run-scoped "
+    ".osmosis/evals/<name>/metrics.json paths; existing .osmosis/metrics files "
+    "are left untouched."
+)
+
+_WINDOWS_RESERVED_FILENAMES = {
+    "aux",
+    "con",
+    "nul",
+    "prn",
+    *(f"com{index}" for index in range(1, 10)),
+    *(f"lpt{index}" for index in range(1, 10)),
+}
+
 
 def safe_name(name: str) -> str:
     """Sanitise a run name for use as a filename component."""
@@ -66,6 +81,69 @@ def resolve_default_metrics_output(
     metrics_dir = workspace_directory / ".osmosis" / "metrics"
     metrics_dir.mkdir(parents=True, exist_ok=True)
     return metrics_dir / default_metrics_filename(run_name, run_id)
+
+
+def resolve_eval_output_dir(
+    run_name: str | None,
+    run_id: str,
+    *,
+    workspace_directory: Path,
+    output: str | None = None,
+    create: bool = True,
+) -> Path:
+    """Resolve the fixed eval-scoped output root used by ``info`` and download.
+
+    ``output`` relocates the run root itself; the layout below it is fixed.
+    Without an explicit root, evals live under ``.osmosis/evals/<name>``.
+    Unnamed runs fall back to their full ID so separate runs never share the
+    unnamed directory.
+    """
+    if output is not None:
+        root = parse_cli_path(output, expand_user=True).path
+    else:
+        safe_run_name = safe_name(run_name).strip("_") if run_name else ""
+        needs_disambiguation = bool(
+            safe_run_name
+            and run_name
+            and (
+                safe_run_name != run_name
+                or safe_run_name != safe_run_name.casefold()
+                or safe_run_name.casefold() in _WINDOWS_RESERVED_FILENAMES
+            )
+        )
+        if needs_disambiguation:
+            safe_run_id = safe_name(run_id).strip("_") or "run"
+            suffix = f"--{safe_run_id}"
+            safe_run_name = f"{safe_run_name[: 255 - len(suffix)]}{suffix}"
+        root = workspace_directory / ".osmosis" / "evals" / (safe_run_name or run_id)
+
+    try:
+        if root.exists() and not root.is_dir():
+            raise CLIError(f"Output path is not a directory: {root}")
+        if create:
+            root.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise CLIError(f"Cannot create output directory: {exc}") from exc
+    return root
+
+
+def resolve_eval_metrics_output(
+    run_name: str | None,
+    run_id: str,
+    *,
+    workspace_directory: Path,
+    output: str | None = None,
+) -> Path:
+    """Resolve the canonical ``metrics.json`` path inside a run output root."""
+    return (
+        resolve_eval_output_dir(
+            run_name,
+            run_id,
+            workspace_directory=workspace_directory,
+            output=output,
+        )
+        / "metrics.json"
+    )
 
 
 def _ref_name(ref: dict[str, Any] | None) -> str | None:

--- a/osmosis_ai/platform/api/client.py
+++ b/osmosis_ai/platform/api/client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote, urlencode
 
@@ -27,6 +27,9 @@ from .models import (
     PaginatedLoraModels,
     PaginatedRollouts,
     PaginatedTrainingRuns,
+    RunDownloadFile,
+    RunDownloadManifest,
+    RunDownloadURLBatch,
     SubmitRunResult,
     TrainingRunCheckpoints,
     TrainingRunDetail,
@@ -73,6 +76,46 @@ class OsmosisClient:
             git_identity=git_identity,
         )
         return LogsPage.from_dict(data)
+
+    def _get_run_download_manifest(
+        self,
+        resource_path: str,
+        *,
+        types: Sequence[str],
+        rows: str | None = None,
+        credentials: Credentials | None = None,
+        git_identity: str,
+    ) -> RunDownloadManifest:
+        params: dict[str, str] = {"types": ",".join(types)}
+        if rows is not None:
+            params["rows"] = rows
+        data = platform_request(
+            f"{resource_path}/samples/manifest?{urlencode(params)}",
+            credentials=credentials,
+            git_identity=git_identity,
+        )
+        return RunDownloadManifest.from_dict(data)
+
+    def _get_run_download_urls(
+        self,
+        resource_path: str,
+        *,
+        items: Sequence[RunDownloadFile],
+        credentials: Credentials | None = None,
+        git_identity: str,
+    ) -> RunDownloadURLBatch:
+        if not 1 <= len(items) <= 500:
+            raise ValueError(
+                "Download URL batches must contain between 1 and 500 items"
+            )
+        data = platform_request(
+            f"{resource_path}/samples/download-urls",
+            method="POST",
+            data={"items": [item.to_request_item() for item in items]},
+            credentials=credentials,
+            git_identity=git_identity,
+        )
+        return RunDownloadURLBatch.from_dict(data)
 
     # ── Datasets ─────────────────────────────────────────────────────
 
@@ -653,6 +696,38 @@ class OsmosisClient:
             limit=limit,
             cursor=cursor,
             direction=direction,
+            credentials=credentials,
+            git_identity=git_identity,
+        )
+
+    def get_eval_run_download_manifest(
+        self,
+        eval_run_id: str,
+        *,
+        types: Sequence[str],
+        rows: str | None = None,
+        credentials: Credentials | None = None,
+        git_identity: str,
+    ) -> RunDownloadManifest:
+        return self._get_run_download_manifest(
+            f"/api/cli/eval-runs/{_safe_path(eval_run_id)}",
+            types=types,
+            rows=rows,
+            credentials=credentials,
+            git_identity=git_identity,
+        )
+
+    def get_eval_run_download_urls(
+        self,
+        eval_run_id: str,
+        *,
+        items: Sequence[RunDownloadFile],
+        credentials: Credentials | None = None,
+        git_identity: str,
+    ) -> RunDownloadURLBatch:
+        return self._get_run_download_urls(
+            f"/api/cli/eval-runs/{_safe_path(eval_run_id)}",
+            items=items,
             credentials=credentials,
             git_identity=git_identity,
         )

--- a/osmosis_ai/platform/api/download.py
+++ b/osmosis_ai/platform/api/download.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import os
 import tempfile
 from collections.abc import Iterator
 from email.message import Message
@@ -17,6 +18,15 @@ DOWNLOAD_TIMEOUT = 600.0
 DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 MAX_DOWNLOAD_REDIRECTS = 20
 _REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
+
+
+class DownloadHTTPError(RuntimeError):
+    """Non-success response while fetching a presigned download URL."""
+
+    def __init__(self, status_code: int, detail: str = "") -> None:
+        self.status_code = status_code
+        suffix = f" {detail}" if detail else ""
+        super().__init__(f"HTTP {status_code}.{suffix}")
 
 
 def _safe_download_filename(filename: str | None) -> str | None:
@@ -100,6 +110,54 @@ def _stream_download_response(
             response.read()
 
 
+def download_file_to(
+    url: str,
+    destination: Path,
+    *,
+    expected_size: int | None = None,
+) -> int:
+    """Download a presigned URL to an exact path and return bytes written.
+
+    Creates missing parent directories, streams through a sibling ``.partial`` file,
+    and atomically replaces ``destination``. Unlike :func:`download_file`
+    there is no per-file progress bar and existing files are replaced —
+    callers own skip/overwrite policy and aggregate progress reporting.
+    """
+    timeout = httpx.Timeout(DOWNLOAD_TIMEOUT, connect=30.0)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with _stream_download_response(url, timeout) as response:
+        if not 200 <= response.status_code < 300:
+            body = response.read().decode("utf-8", errors="replace")[:500]
+            raise DownloadHTTPError(response.status_code, body)
+
+        partial_path = destination.with_name(f"{destination.name}.partial")
+        bytes_downloaded = 0
+        try:
+            if partial_path.is_symlink():
+                raise RuntimeError(
+                    f"Partial download path is a symlink: {partial_path}"
+                )
+            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+            flags |= getattr(os, "O_NOFOLLOW", 0)
+            fd = os.open(partial_path, flags, 0o600)
+            with os.fdopen(fd, "wb") as tmp_file:
+                for chunk in response.iter_bytes(DOWNLOAD_CHUNK_SIZE):
+                    if not chunk:
+                        continue
+                    tmp_file.write(chunk)
+                    bytes_downloaded += len(chunk)
+            if expected_size is not None and bytes_downloaded != expected_size:
+                raise RuntimeError(
+                    f"Downloaded size mismatch: expected {expected_size}, "
+                    f"received {bytes_downloaded}"
+                )
+            partial_path.replace(destination)
+        except Exception:
+            partial_path.unlink(missing_ok=True)
+            raise
+    return bytes_downloaded
+
+
 def download_file(
     url: str,
     *,
@@ -115,8 +173,7 @@ def download_file(
     with _stream_download_response(url, timeout) as response:
         if not 200 <= response.status_code < 300:
             body = response.read().decode("utf-8", errors="replace")[:500]
-            detail = f" {body}" if body else ""
-            raise RuntimeError(f"HTTP {response.status_code}.{detail}")
+            raise DownloadHTTPError(response.status_code, body)
 
         header_filename = _filename_from_content_disposition(
             response.headers.get("content-disposition")

--- a/osmosis_ai/platform/api/download.py
+++ b/osmosis_ai/platform/api/download.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import contextlib
-import os
 import tempfile
 from collections.abc import Iterator
 from email.message import Message
@@ -118,8 +117,8 @@ def download_file_to(
 ) -> int:
     """Download a presigned URL to an exact path and return bytes written.
 
-    Creates missing parent directories, streams through a sibling ``.partial`` file,
-    and atomically replaces ``destination``. Unlike :func:`download_file`
+    Creates missing parent directories, streams through a unique sibling temporary
+    file, and atomically replaces ``destination``. Unlike :func:`download_file`
     there is no per-file progress bar and existing files are replaced —
     callers own skip/overwrite policy and aggregate progress reporting.
     """
@@ -130,17 +129,17 @@ def download_file_to(
             body = response.read().decode("utf-8", errors="replace")[:500]
             raise DownloadHTTPError(response.status_code, body)
 
-        partial_path = destination.with_name(f"{destination.name}.partial")
+        tmp_path: Path | None = None
         bytes_downloaded = 0
         try:
-            if partial_path.is_symlink():
-                raise RuntimeError(
-                    f"Partial download path is a symlink: {partial_path}"
-                )
-            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-            flags |= getattr(os, "O_NOFOLLOW", 0)
-            fd = os.open(partial_path, flags, 0o600)
-            with os.fdopen(fd, "wb") as tmp_file:
+            with tempfile.NamedTemporaryFile(
+                "wb",
+                delete=False,
+                dir=destination.parent,
+                prefix=f".{destination.name}.",
+                suffix=".partial",
+            ) as tmp_file:
+                tmp_path = Path(tmp_file.name)
                 for chunk in response.iter_bytes(DOWNLOAD_CHUNK_SIZE):
                     if not chunk:
                         continue
@@ -151,9 +150,10 @@ def download_file_to(
                     f"Downloaded size mismatch: expected {expected_size}, "
                     f"received {bytes_downloaded}"
                 )
-            partial_path.replace(destination)
+            tmp_path.replace(destination)
         except Exception:
-            partial_path.unlink(missing_ok=True)
+            if tmp_path is not None:
+                tmp_path.unlink(missing_ok=True)
             raise
     return bytes_downloaded
 

--- a/osmosis_ai/platform/api/models.py
+++ b/osmosis_ai/platform/api/models.py
@@ -1093,3 +1093,106 @@ class PaginatedEvaluationRuns:
             has_more=data.get("has_more", False),
             next_offset=data.get("next_offset"),
         )
+
+
+@dataclass(frozen=True)
+class RunDownloadFile:
+    """One run-scoped file returned by a samples manifest endpoint.
+
+    ``path`` is the fixed local path relative to the run output root. The
+    optional ``rollout_id`` is echoed back with ``path`` when requesting a
+    presigned URL; the server remains solely responsible for deriving S3 keys.
+    """
+
+    path: str
+    size: int
+    rollout_id: str | None = None
+
+    @property
+    def identity(self) -> tuple[str | None, str]:
+        return self.rollout_id, self.path
+
+    def to_request_item(self) -> dict[str, Any]:
+        item: dict[str, Any] = {"path": self.path}
+        if self.rollout_id is not None:
+            item["rolloutId"] = self.rollout_id
+        return item
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunDownloadFile:
+        path = data.get("path")
+        size = data.get("size")
+        rollout_id = data.get("rolloutId", data.get("rollout_id"))
+        if not isinstance(path, str) or not path:
+            raise ValueError("Download manifest file path must be a non-empty string")
+        if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+            raise ValueError(f"Download manifest size is invalid for {path!r}")
+        if rollout_id is not None and not isinstance(rollout_id, str):
+            raise ValueError(f"Download manifest rolloutId is invalid for {path!r}")
+        return cls(path=path, size=size, rollout_id=rollout_id)
+
+
+@dataclass(frozen=True)
+class RunDownloadManifest:
+    """Complete file manifest for an evaluation run download."""
+
+    files: list[RunDownloadFile]
+    totals: dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunDownloadManifest:
+        raw_files = data.get("files", [])
+        if not isinstance(raw_files, list):
+            raise ValueError("Download manifest files must be a list")
+        totals = data.get("totals", {})
+        return cls(
+            files=[RunDownloadFile.from_dict(item) for item in raw_files],
+            totals=totals if isinstance(totals, dict) else {},
+        )
+
+
+@dataclass(frozen=True)
+class RunDownloadURL:
+    """Presigned URL for one manifest item."""
+
+    path: str
+    url: str
+    rollout_id: str | None = None
+
+    @property
+    def identity(self) -> tuple[str | None, str]:
+        return self.rollout_id, self.path
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunDownloadURL:
+        path = data.get("path")
+        url = data.get("url") or data.get("presignedUrl") or data.get("presigned_url")
+        rollout_id = data.get("rolloutId", data.get("rollout_id"))
+        if not isinstance(path, str) or not path:
+            raise ValueError("Download URL path must be a non-empty string")
+        if not isinstance(url, str) or not url:
+            raise ValueError(f"Download URL is missing for {path!r}")
+        if rollout_id is not None and not isinstance(rollout_id, str):
+            raise ValueError(f"Download URL rolloutId is invalid for {path!r}")
+        return cls(path=path, url=url, rollout_id=rollout_id)
+
+
+@dataclass(frozen=True)
+class RunDownloadURLBatch:
+    """Presigned URLs returned for one bounded manifest batch."""
+
+    items: list[RunDownloadURL]
+    expires_in: int | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunDownloadURLBatch:
+        raw_items = data.get("items")
+        if raw_items is None:
+            raw_items = data.get("files", data.get("urls", []))
+        if not isinstance(raw_items, list):
+            raise ValueError("Download URL response items must be a list")
+        expires_in = data.get("expires_in", data.get("expiresIn"))
+        return cls(
+            items=[RunDownloadURL.from_dict(item) for item in raw_items],
+            expires_in=expires_in if isinstance(expires_in, int) else None,
+        )

--- a/osmosis_ai/platform/api/models.py
+++ b/osmosis_ai/platform/api/models.py
@@ -1100,36 +1100,37 @@ class RunDownloadFile:
     """One run-scoped file returned by a samples manifest endpoint.
 
     ``path`` is the fixed local path relative to the run output root. The
-    optional ``rollout_id`` is echoed back with ``path`` when requesting a
-    presigned URL; the server remains solely responsible for deriving S3 keys.
+    optional ``token`` is an opaque server handle (a rollout id or an export
+    snapshot token) echoed back with ``path`` when requesting a presigned
+    URL; the server remains solely responsible for deriving S3 keys.
     """
 
     path: str
     size: int
-    rollout_id: str | None = None
+    token: str | None = None
 
     @property
     def identity(self) -> tuple[str | None, str]:
-        return self.rollout_id, self.path
+        return self.token, self.path
 
     def to_request_item(self) -> dict[str, Any]:
         item: dict[str, Any] = {"path": self.path}
-        if self.rollout_id is not None:
-            item["rolloutId"] = self.rollout_id
+        if self.token is not None:
+            item["token"] = self.token
         return item
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RunDownloadFile:
         path = data.get("path")
         size = data.get("size")
-        rollout_id = data.get("rolloutId", data.get("rollout_id"))
+        token = data.get("token")
         if not isinstance(path, str) or not path:
             raise ValueError("Download manifest file path must be a non-empty string")
         if isinstance(size, bool) or not isinstance(size, int) or size < 0:
             raise ValueError(f"Download manifest size is invalid for {path!r}")
-        if rollout_id is not None and not isinstance(rollout_id, str):
-            raise ValueError(f"Download manifest rolloutId is invalid for {path!r}")
-        return cls(path=path, size=size, rollout_id=rollout_id)
+        if token is not None and not isinstance(token, str):
+            raise ValueError(f"Download manifest token is invalid for {path!r}")
+        return cls(path=path, size=size, token=token)
 
 
 @dataclass(frozen=True)
@@ -1157,24 +1158,24 @@ class RunDownloadURL:
 
     path: str
     url: str
-    rollout_id: str | None = None
+    token: str | None = None
 
     @property
     def identity(self) -> tuple[str | None, str]:
-        return self.rollout_id, self.path
+        return self.token, self.path
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RunDownloadURL:
         path = data.get("path")
         url = data.get("url") or data.get("presignedUrl") or data.get("presigned_url")
-        rollout_id = data.get("rolloutId", data.get("rollout_id"))
+        token = data.get("token")
         if not isinstance(path, str) or not path:
             raise ValueError("Download URL path must be a non-empty string")
         if not isinstance(url, str) or not url:
             raise ValueError(f"Download URL is missing for {path!r}")
-        if rollout_id is not None and not isinstance(rollout_id, str):
-            raise ValueError(f"Download URL rolloutId is invalid for {path!r}")
-        return cls(path=path, url=url, rollout_id=rollout_id)
+        if token is not None and not isinstance(token, str):
+            raise ValueError(f"Download URL token is invalid for {path!r}")
+        return cls(path=path, url=url, token=token)
 
 
 @dataclass(frozen=True)
@@ -1191,7 +1192,7 @@ class RunDownloadURLBatch:
             raw_items = data.get("files", data.get("urls", []))
         if not isinstance(raw_items, list):
             raise ValueError("Download URL response items must be a list")
-        expires_in = data.get("expires_in", data.get("expiresIn"))
+        expires_in = data.get("expires_in")
         return cls(
             items=[RunDownloadURL.from_dict(item) for item in raw_items],
             expires_in=expires_in if isinstance(expires_in, int) else None,

--- a/osmosis_ai/platform/cli/eval.py
+++ b/osmosis_ai/platform/cli/eval.py
@@ -688,6 +688,9 @@ def download(
             git_identity=git_identity,
         )
 
+    if detail.status in EVAL_RUN_STATUSES_PENDING:
+        raise CLIError("Outputs are not yet available for pending evaluation runs.")
+
     try:
         return run_download(
             run_id=detail.id,

--- a/osmosis_ai/platform/cli/eval.py
+++ b/osmosis_ai/platform/cli/eval.py
@@ -1,8 +1,7 @@
-"""Handler for `osmosis eval` remote subcommands (submit/list/info/stop)."""
+"""Handler for `osmosis eval` remote subcommands (submit/list/info/download/stop)."""
 
 from __future__ import annotations
 
-import json
 import math
 from datetime import UTC, datetime
 from pathlib import Path
@@ -11,9 +10,9 @@ from typing import Any
 from osmosis_ai.cli.console import console
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.cli.metrics_export import (
+    METRICS_EXPORT_MIGRATION_NOTICE,
     build_eval_export_dict,
-    resolve_default_metrics_output,
-    resolve_metrics_output_path,
+    resolve_eval_metrics_output,
 )
 from osmosis_ai.cli.output import (
     DetailResult,
@@ -591,21 +590,35 @@ def info(name_or_id: str, *, output: str | None) -> DetailResult:
         should_write_file = output is not None or output_ctx.format is OutputFormat.rich
         if should_write_file:
             try:
-                out_path = (
-                    resolve_metrics_output_path(output, detail.name, detail.id)
-                    if output
-                    else resolve_default_metrics_output(
-                        detail.name,
-                        detail.id,
-                        workspace_directory=context.workspace_directory,
-                    )
+                from osmosis_ai.platform.cli.run_download import download_manifest_file
+
+                out_path = resolve_eval_metrics_output(
+                    detail.name,
+                    detail.id,
+                    workspace_directory=context.workspace_directory,
+                    output=output,
                 )
-                out_path.write_text(
-                    json.dumps(export, indent=2, ensure_ascii=False) + "\n"
+                manifest = client.get_eval_run_download_manifest(
+                    detail.id,
+                    types=["metrics"],
+                    credentials=credentials,
+                    git_identity=context.git_identity,
+                )
+                download_manifest_file(
+                    manifest=manifest,
+                    path="metrics.json",
+                    destination=out_path,
+                    url_loader=lambda items: client.get_eval_run_download_urls(
+                        detail.id,
+                        items=items,
+                        credentials=credentials,
+                        git_identity=context.git_identity,
+                    ),
                 )
                 output_path = str(out_path)
                 display_hints.append(f"Saved metrics to {output_path}")
-            except (CLIError, OSError) as exc:
+                display_hints.append(METRICS_EXPORT_MIGRATION_NOTICE)
+            except (CLIError, OSError, PlatformAPIError) as exc:
                 save_warning = f"Could not save metrics: {exc}"
                 display_hints.append(save_warning)
     elif metrics_error is not None:
@@ -637,6 +650,79 @@ def info(name_or_id: str, *, output: str | None) -> DetailResult:
         sections=sections,
         display_hints=display_hints,
     )
+
+
+# ── eval download ───────────────────────────────────────────────────
+
+
+def download(
+    name_or_id: str,
+    *,
+    output: str | None,
+    types: str = "metrics,trajectories",
+    rows: str | None = None,
+    overwrite: bool = False,
+    yes: bool = False,
+) -> OperationResult:
+    """Download selected eval run outputs through the manifest contract."""
+    from osmosis_ai.platform.cli.run_download import (
+        EVAL_DOWNLOAD_TYPES,
+        parse_download_types,
+        run_download,
+        validate_rows,
+    )
+
+    selected_types = parse_download_types(types, allowed=EVAL_DOWNLOAD_TYPES)
+    selected_rows = validate_rows(rows)
+
+    context = require_git_workspace_directory_context()
+    credentials = context.credentials
+    git_identity = context.git_identity
+
+    client = OsmosisClient()
+    output_ctx = get_output_context()
+    with output_ctx.status("Fetching evaluation run..."):
+        detail = client.get_eval_run(
+            name_or_id,
+            credentials=credentials,
+            git_identity=git_identity,
+        )
+
+    try:
+        return run_download(
+            run_id=detail.id,
+            run_name=detail.name,
+            run_status=detail.status,
+            selected_types=selected_types,
+            output=output,
+            overwrite=overwrite,
+            yes=yes,
+            workspace_directory=context.workspace_directory,
+            result_context=git_result_context(context),
+            manifest_loader=lambda requested_types: (
+                client.get_eval_run_download_manifest(
+                    detail.id,
+                    types=requested_types,
+                    rows=selected_rows,
+                    credentials=credentials,
+                    git_identity=git_identity,
+                )
+            ),
+            url_loader=lambda items: client.get_eval_run_download_urls(
+                detail.id,
+                items=items,
+                credentials=credentials,
+                git_identity=git_identity,
+            ),
+            selection={"rows": selected_rows},
+        )
+    except PlatformAPIError as exc:
+        if exc.status_code == 404:
+            raise CLIError(
+                "Eval run download route was not found. The run may have been deleted "
+                "or the platform may not support run downloads yet."
+            ) from exc
+        raise
 
 
 def stop(name_or_id: str, *, yes: bool) -> OperationResult:

--- a/osmosis_ai/platform/cli/run_download.py
+++ b/osmosis_ai/platform/cli/run_download.py
@@ -1,0 +1,499 @@
+"""Manifest-to-disk download engine for evaluation runs."""
+
+from __future__ import annotations
+
+import re
+import time
+from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from osmosis_ai.cli.console import console
+from osmosis_ai.cli.errors import CLIError
+from osmosis_ai.cli.metrics_export import resolve_eval_output_dir
+from osmosis_ai.cli.output import OperationResult, get_output_context
+from osmosis_ai.cli.prompts import require_confirmation
+from osmosis_ai.platform.api.download import DownloadHTTPError, download_file_to
+from osmosis_ai.platform.api.models import (
+    RunDownloadFile,
+    RunDownloadManifest,
+    RunDownloadURLBatch,
+)
+from osmosis_ai.platform.api.upload import make_progress_bar
+from osmosis_ai.platform.auth.platform_client import (
+    AuthenticationExpiredError,
+    PlatformAPIError,
+)
+from osmosis_ai.platform.cli.utils import format_size
+
+DOWNLOAD_CONFIRM_THRESHOLD_BYTES = 100 * 1024 * 1024
+DOWNLOAD_URL_BATCH_SIZE = 500
+DOWNLOAD_CONCURRENCY = 8
+DOWNLOAD_MAX_ATTEMPTS = 3
+DOWNLOAD_RETRY_BASE_SECONDS = 0.5
+
+EVAL_DOWNLOAD_TYPES = ("metrics", "trajectories", "artifacts", "logs")
+
+ManifestLoader = Callable[[Sequence[str]], RunDownloadManifest]
+URLLoader = Callable[[Sequence[RunDownloadFile]], RunDownloadURLBatch]
+
+_ROWS_RE = re.compile(r"\d+(?:-\d+)?(?:,\d+(?:-\d+)?)*")
+_URL_RE = re.compile(r"https?://\S+")
+_RESERVED_ARTIFACT_MANIFEST_RE = re.compile(r"artifacts/row_\d+_run_\d+/manifest\.json")
+
+
+@dataclass(frozen=True)
+class _PreparedFile:
+    manifest: RunDownloadFile
+    destination: Path
+    category: str
+
+
+@dataclass(frozen=True)
+class _TransferResult:
+    file: _PreparedFile
+    bytes_written: int = 0
+    error: str | None = None
+
+
+def _safe_error_message(error: BaseException) -> str:
+    """Keep presigned URLs and their credentials out of result envelopes."""
+    return _URL_RE.sub("<redacted URL>", str(error))
+
+
+def parse_download_types(value: str, *, allowed: Sequence[str]) -> tuple[str, ...]:
+    """Parse a comma-separated selector, expanding the standalone ``all``."""
+    requested = [part.strip().lower() for part in value.split(",")]
+    if not requested or any(not part for part in requested):
+        raise CLIError("--type must be a comma-separated list of output types.")
+    if "all" in requested:
+        if len(requested) != 1:
+            raise CLIError("--type all cannot be combined with other output types.")
+        return tuple(allowed)
+
+    unknown = sorted(set(requested) - set(allowed))
+    if unknown:
+        raise CLIError(
+            f"Unknown --type value(s): {', '.join(unknown)}. "
+            f"Choose from: {', '.join(allowed)}, all."
+        )
+    return tuple(dict.fromkeys(requested))
+
+
+def validate_rows(value: str | None) -> str | None:
+    """Validate ``3,7,10-20`` row-selection syntax without expanding it."""
+    if value is None:
+        return None
+    normalized = value.strip()
+    if not normalized or _ROWS_RE.fullmatch(normalized) is None:
+        raise CLIError('--rows must use syntax like "3,7,10-20".')
+    for part in normalized.split(","):
+        if "-" not in part:
+            continue
+        start, end = (int(item) for item in part.split("-", 1))
+        if start > end:
+            raise CLIError(f"Invalid --rows range {part!r}: start exceeds end.")
+    return normalized
+
+
+def _path_category(path: str) -> str | None:
+    if path == "metrics.json":
+        return "metrics"
+    if path == "logs.txt":
+        return "logs"
+    if path == "summary.jsonl" or path.startswith("trajectories/"):
+        return "trajectories"
+    if path.startswith("artifacts/"):
+        return "artifacts"
+    return None
+
+
+def _safe_relative_path(
+    path: str,
+    *,
+    selected_types: set[str],
+) -> tuple[Path, str] | None:
+    if not path or path.startswith("/") or "\\" in path:
+        return None
+    parts = path.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        return None
+    if _RESERVED_ARTIFACT_MANIFEST_RE.fullmatch(path) is not None:
+        return None
+    category = _path_category(path)
+    if category is None or category not in selected_types:
+        return None
+    return Path(*parts), category
+
+
+def _prepare_files(
+    manifest: RunDownloadManifest,
+    *,
+    output_dir: Path,
+    selected_types: Sequence[str],
+) -> tuple[list[_PreparedFile], list[dict[str, str]]]:
+    prepared: list[_PreparedFile] = []
+    rejected: list[dict[str, str]] = []
+    local_paths: set[Path] = set()
+    selected = set(selected_types)
+    resolved_root = output_dir.resolve(strict=False)
+    for item in manifest.files:
+        safe = _safe_relative_path(item.path, selected_types=selected)
+        if safe is None:
+            rejected.append(
+                {
+                    "path": item.path,
+                    "error": "Manifest path is outside the fixed run layout.",
+                }
+            )
+            continue
+        relative, category = safe
+        if relative in local_paths:
+            rejected.append(
+                {"path": item.path, "error": "Manifest contains a duplicate path."}
+            )
+            continue
+        destination = output_dir / relative
+        if not destination.resolve(strict=False).is_relative_to(resolved_root):
+            rejected.append(
+                {
+                    "path": item.path,
+                    "error": "Manifest path crosses a local symlink outside the run root.",
+                }
+            )
+            continue
+        local_paths.add(relative)
+        prepared.append(
+            _PreparedFile(
+                manifest=item,
+                destination=destination,
+                category=category,
+            )
+        )
+    return prepared, rejected
+
+
+def _breakdown(files: Sequence[_PreparedFile]) -> dict[str, dict[str, int]]:
+    result: dict[str, dict[str, int]] = {}
+    for item in files:
+        bucket = result.setdefault(item.category, {"files": 0, "bytes": 0})
+        bucket["files"] += 1
+        bucket["bytes"] += item.manifest.size
+    return result
+
+
+def _request_urls_with_retry(
+    loader: URLLoader,
+    files: Sequence[RunDownloadFile],
+) -> tuple[RunDownloadURLBatch | None, str | None]:
+    error: Exception | None = None
+    for attempt in range(DOWNLOAD_MAX_ATTEMPTS):
+        try:
+            return loader(files), None
+        except AuthenticationExpiredError:
+            raise
+        except PlatformAPIError as exc:
+            if (
+                exc.status_code is not None
+                and 400 <= exc.status_code < 500
+                and exc.status_code != 429
+            ):
+                raise
+            error = exc
+        except Exception as exc:  # every failed batch is reported, not fatal
+            error = exc
+        if attempt + 1 < DOWNLOAD_MAX_ATTEMPTS:
+            time.sleep(DOWNLOAD_RETRY_BASE_SECONDS * (2**attempt))
+    return (
+        None,
+        _safe_error_message(error)
+        if error is not None
+        else "Could not request download URLs.",
+    )
+
+
+def _find_url(
+    batch: RunDownloadURLBatch,
+    file: RunDownloadFile,
+) -> str | None:
+    for item in batch.items:
+        if item.identity == file.identity:
+            return item.url
+    path_matches = [item.url for item in batch.items if item.path == file.path]
+    return path_matches[0] if len(path_matches) == 1 else None
+
+
+def _download_with_retry(
+    item: _PreparedFile,
+    url: str,
+    *,
+    url_loader: URLLoader,
+) -> _TransferResult:
+    current_url = url
+    error: Exception | None = None
+    for attempt in range(DOWNLOAD_MAX_ATTEMPTS):
+        try:
+            written = download_file_to(
+                current_url,
+                item.destination,
+                expected_size=item.manifest.size,
+            )
+            return _TransferResult(file=item, bytes_written=written)
+        except Exception as exc:  # per-file failures do not stop other files
+            error = exc
+            if attempt + 1 >= DOWNLOAD_MAX_ATTEMPTS:
+                break
+            if isinstance(exc, DownloadHTTPError) and exc.status_code == 403:
+                refreshed, refresh_error = _request_urls_with_retry(
+                    url_loader, [item.manifest]
+                )
+                if refreshed is None:
+                    error = RuntimeError(refresh_error or "Could not refresh URL")
+                    break
+                refreshed_url = _find_url(refreshed, item.manifest)
+                if refreshed_url is None:
+                    error = RuntimeError("Refreshed response omitted this file")
+                    break
+                current_url = refreshed_url
+            time.sleep(DOWNLOAD_RETRY_BASE_SECONDS * (2**attempt))
+    return _TransferResult(
+        file=item,
+        error=_safe_error_message(error) if error is not None else "Download failed.",
+    )
+
+
+def download_manifest_file(
+    *,
+    manifest: RunDownloadManifest,
+    path: str,
+    destination: Path,
+    url_loader: URLLoader,
+) -> int:
+    """Download one uniquely named manifest file through the shared retry path."""
+    matches = [item for item in manifest.files if item.path == path]
+    if len(matches) != 1:
+        raise CLIError(f"Download manifest did not contain exactly one {path!r} file.")
+
+    item = _PreparedFile(
+        manifest=matches[0],
+        destination=destination,
+        category=_path_category(path) or "unknown",
+    )
+    url_batch, batch_error = _request_urls_with_retry(url_loader, [item.manifest])
+    if url_batch is None:
+        raise CLIError(batch_error or f"Could not request a download URL for {path!r}.")
+    url = _find_url(url_batch, item.manifest)
+    if url is None:
+        raise CLIError(f"Download URL response omitted {path!r}.")
+
+    result = _download_with_retry(item, url, url_loader=url_loader)
+    if result.error is not None:
+        raise CLIError(f"Could not download {path!r}: {result.error}")
+    return result.bytes_written
+
+
+def _chunks[T](items: Sequence[T], size: int) -> Sequence[Sequence[T]]:
+    return [items[index : index + size] for index in range(0, len(items), size)]
+
+
+def run_download(
+    *,
+    run_id: str,
+    run_name: str | None,
+    run_status: str,
+    selected_types: Sequence[str],
+    output: str | None,
+    overwrite: bool,
+    yes: bool,
+    workspace_directory: Path,
+    result_context: dict[str, Any],
+    manifest_loader: ManifestLoader,
+    url_loader: URLLoader,
+    selection: dict[str, Any] | None = None,
+) -> OperationResult:
+    """Plan, confirm, and execute one eval download using the route contract."""
+    output_dir = resolve_eval_output_dir(
+        run_name,
+        run_id,
+        workspace_directory=workspace_directory,
+        output=output,
+        create=False,
+    )
+    output_ctx = get_output_context()
+    with output_ctx.status("Fetching download manifest..."):
+        manifest = manifest_loader(selected_types)
+
+    prepared, rejected = _prepare_files(
+        manifest,
+        output_dir=output_dir,
+        selected_types=selected_types,
+    )
+    if not prepared:
+        if rejected:
+            raise CLIError(
+                "The download manifest contained no usable run-scoped paths."
+            )
+        raise CLIError("No downloadable files matched the requested selection.")
+
+    pending: list[_PreparedFile] = []
+    skipped = 0
+    for item in prepared:
+        try:
+            up_to_date = (
+                not overwrite
+                and item.destination.is_file()
+                and item.destination.stat().st_size == item.manifest.size
+            )
+        except OSError:
+            up_to_date = False
+        if up_to_date:
+            skipped += 1
+        else:
+            pending.append(item)
+
+    total_bytes = sum(item.manifest.size for item in prepared)
+    pending_bytes = sum(item.manifest.size for item in pending)
+    breakdown = _breakdown(prepared)
+    console.print(
+        f"Download plan: {len(pending):,} files, {format_size(pending_bytes)} "
+        f"({skipped:,} already up to date)",
+        markup=False,
+    )
+    console.print(f"Destination: {output_dir}", markup=False, style="dim")
+
+    if pending_bytes > DOWNLOAD_CONFIRM_THRESHOLD_BYTES:
+        require_confirmation(
+            "Download these run outputs?",
+            yes=yes,
+            default=False,
+            summary=[
+                ("Files", f"{len(pending):,}"),
+                ("Download size", format_size(pending_bytes)),
+                ("Destination", str(output_dir)),
+            ],
+            notes=[f"Selected types: {', '.join(selected_types)}"],
+        )
+
+    resolve_eval_output_dir(
+        run_name,
+        run_id,
+        workspace_directory=workspace_directory,
+        output=output,
+    )
+
+    downloaded = 0
+    bytes_downloaded = 0
+    failures = list(rejected)
+    if pending:
+        progress_total = max(pending_bytes, 1)
+        progress_ctx, progress_cb = make_progress_bar(
+            progress_total, description="Downloading"
+        )
+        processed_bytes = 0
+        with progress_ctx:
+            for batch in _chunks(pending, DOWNLOAD_URL_BATCH_SIZE):
+                url_batch, batch_error = _request_urls_with_retry(
+                    url_loader, [item.manifest for item in batch]
+                )
+                if url_batch is None:
+                    for item in batch:
+                        failures.append(
+                            {
+                                "path": item.manifest.path,
+                                "error": batch_error
+                                or "Could not request download URL.",
+                            }
+                        )
+                        processed_bytes += item.manifest.size
+                        progress_cb(
+                            min(processed_bytes, progress_total), progress_total
+                        )
+                    continue
+
+                ready: list[tuple[_PreparedFile, str]] = []
+                for item in batch:
+                    url = _find_url(url_batch, item.manifest)
+                    if url is None:
+                        failures.append(
+                            {
+                                "path": item.manifest.path,
+                                "error": "Download URL response omitted this file.",
+                            }
+                        )
+                        processed_bytes += item.manifest.size
+                        progress_cb(
+                            min(processed_bytes, progress_total), progress_total
+                        )
+                    else:
+                        ready.append((item, url))
+
+                with ThreadPoolExecutor(max_workers=DOWNLOAD_CONCURRENCY) as executor:
+                    futures = [
+                        executor.submit(
+                            _download_with_retry,
+                            item,
+                            url,
+                            url_loader=url_loader,
+                        )
+                        for item, url in ready
+                    ]
+                    for future in as_completed(futures):
+                        result = future.result()
+                        processed_bytes += result.file.manifest.size
+                        progress_cb(
+                            min(processed_bytes, progress_total), progress_total
+                        )
+                        if result.error is not None:
+                            failures.append(
+                                {
+                                    "path": result.file.manifest.path,
+                                    "error": result.error,
+                                }
+                            )
+                        else:
+                            downloaded += 1
+                            bytes_downloaded += result.bytes_written
+            progress_cb(progress_total, progress_total)
+
+    partial = bool(failures)
+    message = (
+        f"Downloaded {downloaded:,} files ({format_size(bytes_downloaded)}) "
+        f"to {output_dir}"
+    )
+    if skipped:
+        message += f" ({skipped:,} already up to date)"
+    if partial:
+        message += f" ({len(failures):,} failed; re-run to retry)"
+
+    resource: dict[str, Any] = {
+        "eval_run": {"id": run_id, "name": run_name},
+        "status": run_status,
+        "selected_types": list(selected_types),
+        "files_downloaded": downloaded,
+        "files_skipped": skipped,
+        "files_failed": failures,
+        "bytes_downloaded": bytes_downloaded,
+        "total_files": len(prepared),
+        "total_bytes": total_bytes,
+        "breakdown": breakdown,
+        "manifest_totals": manifest.totals,
+        "output_path": str(output_dir),
+        **result_context,
+    }
+    if selection:
+        resource.update(selection)
+
+    return OperationResult(
+        operation="eval.download",
+        status="partial" if partial else "success",
+        resource=resource,
+        message=message,
+        display_next_steps=(
+            [f"Failed: {item['path']} — {item['error']}" for item in failures]
+            if failures
+            else []
+        ),
+        exit_code=1 if partial else 0,
+    )

--- a/osmosis_ai/platform/cli/run_download.py
+++ b/osmosis_ai/platform/cli/run_download.py
@@ -40,7 +40,7 @@ ManifestLoader = Callable[[Sequence[str]], RunDownloadManifest]
 URLLoader = Callable[[Sequence[RunDownloadFile]], RunDownloadURLBatch]
 
 _ROWS_RE = re.compile(r"\d+(?:-\d+)?(?:,\d+(?:-\d+)?)*")
-_URL_RE = re.compile(r"https?://\S+")
+_URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
 _RESERVED_ARTIFACT_MANIFEST_RE = re.compile(r"artifacts/row_\d+_run_\d+/manifest\.json")
 
 

--- a/tests/unit/cli/test_eval_download.py
+++ b/tests/unit/cli/test_eval_download.py
@@ -327,6 +327,22 @@ def test_invalid_selectors_fail_before_manifest(
     assert fake_client.manifest_calls == []
 
 
+def test_pending_run_fails_before_manifest(monkeypatch, tmp_path, capsys):
+    _stub_git_context(monkeypatch, tmp_path)
+    fake_client = _make_fake_client(status="pending")
+    monkeypatch.setattr(eval_module, "OsmosisClient", fake_client)
+
+    exit_code = cli.main(["--json", "eval", "download", "my-run"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert (
+        "Outputs are not yet available for pending evaluation runs."
+        in json.loads(captured.err)["error"]["message"]
+    )
+    assert fake_client.manifest_calls == []
+
+
 def test_resume_skips_matching_sizes_and_overwrite_forces_download(
     monkeypatch, tmp_path, capsys
 ):

--- a/tests/unit/cli/test_eval_download.py
+++ b/tests/unit/cli/test_eval_download.py
@@ -527,6 +527,12 @@ def test_per_file_retries_continue_and_report_only_permanent_failures(
     assert attempts[metrics_url] == 3
 
 
+def test_error_message_redacts_mixed_case_presigned_url() -> None:
+    error = RuntimeError("failed HTTPS://example.com/file?token=secret")
+
+    assert run_download_module._safe_error_message(error) == "failed <redacted URL>"
+
+
 def test_expired_presigned_url_refreshes_by_typed_status(monkeypatch, tmp_path, capsys):
     _stub_git_context(monkeypatch, tmp_path)
     fake_client = _make_fake_client()

--- a/tests/unit/cli/test_eval_download.py
+++ b/tests/unit/cli/test_eval_download.py
@@ -1,0 +1,571 @@
+"""Tests for the run-output download CLI contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import osmosis_ai.cli.main as cli
+import osmosis_ai.platform.cli.eval as eval_module
+import osmosis_ai.platform.cli.run_download as run_download_module
+from osmosis_ai.platform.api.download import DownloadHTTPError
+from osmosis_ai.platform.api.models import (
+    EvalRunMetrics,
+    EvalRunMetricsOverview,
+    EvaluationRunDetail,
+    RunDownloadFile,
+    RunDownloadManifest,
+    RunDownloadURL,
+    RunDownloadURLBatch,
+)
+from osmosis_ai.platform.auth import PlatformAPIError
+
+GIT_IDENTITY = "acme/rollouts"
+
+FILES = {
+    "metrics": [RunDownloadFile("metrics.json", 10)],
+    "trajectories": [
+        RunDownloadFile("summary.jsonl", 20),
+        RunDownloadFile("trajectories/row_3_run_0.json", 30, rollout_id="rollout-3-0"),
+    ],
+    "artifacts": [
+        RunDownloadFile(
+            "artifacts/row_3_run_0/logs/agent.log",
+            40,
+            rollout_id="rollout-3-0",
+        )
+    ],
+    "logs": [RunDownloadFile("logs.txt", 50)],
+}
+
+
+def _stub_git_context(monkeypatch: pytest.MonkeyPatch, workspace: Path) -> object:
+    credentials = object()
+    context = SimpleNamespace(
+        workspace_directory=workspace,
+        git_identity=GIT_IDENTITY,
+        repo_url="https://github.com/acme/rollouts.git",
+        credentials=credentials,
+    )
+    monkeypatch.setattr(
+        eval_module,
+        "require_git_workspace_directory_context",
+        lambda: context,
+    )
+    return credentials
+
+
+def _detail(status: str = "finished") -> EvaluationRunDetail:
+    return EvaluationRunDetail(
+        id="er_12345678",
+        name="my-run",
+        status=status,
+        created_at="2026-07-01T00:00:00Z",
+    )
+
+
+def _make_fake_client(
+    *,
+    status: str = "finished",
+    manifest_error: Exception | None = None,
+    manifest_files: list[RunDownloadFile] | None = None,
+):
+    manifest_calls: list[dict[str, object]] = []
+    url_calls: list[list[RunDownloadFile]] = []
+
+    class FakeClient:
+        def get_eval_run(self, name_or_id, *, git_identity, credentials=None):
+            assert name_or_id == "my-run"
+            assert git_identity == GIT_IDENTITY
+            return _detail(status)
+
+        def get_eval_run_download_manifest(
+            self,
+            run_id,
+            *,
+            types,
+            rows=None,
+            git_identity,
+            credentials=None,
+        ):
+            if manifest_error is not None:
+                raise manifest_error
+            assert run_id == "er_12345678"
+            manifest_calls.append({"types": tuple(types), "rows": rows})
+            files = (
+                manifest_files
+                if manifest_files is not None
+                else [item for kind in types for item in FILES[kind]]
+            )
+            return RunDownloadManifest(
+                files=files,
+                totals={"files": len(files), "bytes": sum(f.size for f in files)},
+            )
+
+        def get_eval_run_download_urls(
+            self,
+            run_id,
+            *,
+            items,
+            git_identity,
+            credentials=None,
+        ):
+            assert run_id == "er_12345678"
+            url_calls.append(list(items))
+            return RunDownloadURLBatch(
+                items=[
+                    RunDownloadURL(
+                        path=item.path,
+                        rollout_id=item.rollout_id,
+                        url=f"https://example.com/{item.path}?size={item.size}",
+                    )
+                    for item in items
+                ],
+                expires_in=900,
+            )
+
+    FakeClient.manifest_calls = manifest_calls
+    FakeClient.url_calls = url_calls
+    return FakeClient
+
+
+def _stub_download(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    downloaded: list[str] = []
+
+    def fake_download_file_to(
+        url: str,
+        destination: Path,
+        *,
+        expected_size: int | None = None,
+    ) -> int:
+        size = expected_size if expected_size is not None else 1
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"x" * size)
+        downloaded.append(url)
+        return size
+
+    monkeypatch.setattr(run_download_module, "download_file_to", fake_download_file_to)
+    return downloaded
+
+
+def test_default_download_is_metrics_and_trajectories(monkeypatch, tmp_path, capsys):
+    _stub_git_context(monkeypatch, tmp_path)
+    fake_client = _make_fake_client()
+    monkeypatch.setattr(eval_module, "OsmosisClient", fake_client)
+    _stub_download(monkeypatch)
+
+    exit_code = cli.main(["--json", "eval", "download", "my-run"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    resource = json.loads(captured.out)["resource"]
+    expected = tmp_path / ".osmosis" / "evals" / "my-run"
+    assert resource["selected_types"] == ["metrics", "trajectories"]
+    assert resource["output_path"] == str(expected)
+    assert fake_client.manifest_calls == [
+        {"types": ("metrics", "trajectories"), "rows": None}
+    ]
+    assert (expected / "metrics.json").is_file()
+    assert (expected / "summary.jsonl").is_file()
+    assert (expected / "trajectories" / "row_3_run_0.json").is_file()
+    assert not (expected / "artifacts").exists()
+
+
+def test_eval_info_uses_same_run_scoped_metrics_path(monkeypatch, tmp_path):
+    _stub_git_context(monkeypatch, tmp_path)
+    server_metrics = b'{"summary":{"pass_rate":1}}\n'
+
+    class InfoClient:
+        def get_eval_run(self, name_or_id, *, git_identity, credentials=None):
+            return _detail()
+
+        def get_eval_run_metrics(self, eval_run_id, *, git_identity, credentials=None):
+            return EvalRunMetrics(
+                eval_run_id=eval_run_id,
+                status="finished",
+                overview=EvalRunMetricsOverview(
+                    duration_ms=None,
+                    total_samples=1,
+                    completed_samples=1,
+                    graded=1,
+                    passed=1,
+                    failed=0,
+                    skipped=0,
+                    pass_rate=1.0,
+                    pass_threshold=0.5,
+                    tokens_used=10,
+                ),
+                reward_stats=None,
+                pass_at_k=[],
+            )
+
+        def get_eval_run_download_manifest(
+            self, eval_run_id, *, types, git_identity, credentials=None
+        ):
+            assert types == ["metrics"]
+            return RunDownloadManifest(
+                files=[
+                    RunDownloadFile(
+                        "metrics.json",
+                        len(server_metrics),
+                        rollout_id="export-token",
+                    )
+                ],
+                totals={"files": 1, "bytes": len(server_metrics)},
+            )
+
+        def get_eval_run_download_urls(
+            self, eval_run_id, *, items, git_identity, credentials=None
+        ):
+            return RunDownloadURLBatch(
+                items=[
+                    RunDownloadURL(
+                        path=items[0].path,
+                        rollout_id=items[0].rollout_id,
+                        url="https://example.com/metrics.json",
+                    )
+                ],
+                expires_in=900,
+            )
+
+    monkeypatch.setattr(eval_module, "OsmosisClient", InfoClient)
+
+    def download_server_metrics(url, destination, *, expected_size=None):
+        destination.write_bytes(server_metrics)
+        return len(server_metrics)
+
+    monkeypatch.setattr(
+        run_download_module, "download_file_to", download_server_metrics
+    )
+
+    result = eval_module.info("my-run", output=None)
+
+    expected = tmp_path / ".osmosis/evals/my-run/metrics.json"
+    assert result.data["output_path"] == str(expected)
+    assert expected.read_bytes() == server_metrics
+
+
+def test_type_selector_replaces_default_and_rows_are_forwarded(
+    monkeypatch, tmp_path, capsys
+):
+    _stub_git_context(monkeypatch, tmp_path)
+    fake_client = _make_fake_client()
+    monkeypatch.setattr(eval_module, "OsmosisClient", fake_client)
+    _stub_download(monkeypatch)
+    output = tmp_path / "custom-root"
+
+    exit_code = cli.main(
+        [
+            "--json",
+            "eval",
+            "download",
+            "my-run",
+            "--type",
+            "artifacts,logs",
+            "--rows",
+            "3,7,10-20",
+            "--output",
+            str(output),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    resource = json.loads(captured.out)["resource"]
+    assert resource["selected_types"] == ["artifacts", "logs"]
+    assert resource["rows"] == "3,7,10-20"
+    assert fake_client.manifest_calls == [
+        {"types": ("artifacts", "logs"), "rows": "3,7,10-20"}
+    ]
+    assert (output / "artifacts/row_3_run_0/logs/agent.log").is_file()
+    assert (output / "logs.txt").is_file()
+    assert not (output / "metrics.json").exists()
+
+
+def test_type_all_expands_all_eval_categories(monkeypatch, tmp_path, capsys):
+    _stub_git_context(monkeypatch, tmp_path)
+    fake_client = _make_fake_client()
+    monkeypatch.setattr(eval_module, "OsmosisClient", fake_client)
+    _stub_download(monkeypatch)
+
+    exit_code = cli.main(["--json", "eval", "download", "my-run", "--type", "all"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert json.loads(captured.out)["resource"]["selected_types"] == [
+        "metrics",
+        "trajectories",
+        "artifacts",
+        "logs",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("args", "message"),
+    [
+        (["--type", "unknown"], "Unknown --type"),
+        (["--type", "all,logs"], "cannot be combined"),
+        (["--rows", "10-3"], "start exceeds end"),
+        (["--rows", "3,,7"], "--rows must use syntax"),
+    ],
+)
+def test_invalid_selectors_fail_before_manifest(
+    monkeypatch, tmp_path, capsys, args, message
+):
+    _stub_git_context(monkeypatch, tmp_path)
+    fake_client = _make_fake_client()
+    monkeypatch.setattr(eval_module, "OsmosisClient", fake_client)
+
+    exit_code = cli.main(["--json", "eval", "download", "my-run", *args])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert message in json.loads(captured.err)["error"]["message"]
+    assert fake_client.manifest_calls == []
+
+
+def test_resume_skips_matching_sizes_and_overwrite_forces_download(
+    monkeypatch, tmp_path, capsys
+):
+    _stub_git_context(monkeypatch, tmp_path)
+    fake_client = _make_fake_client()
+    monkeypatch.setattr(eval_module, "OsmosisClient", fake_client)
+    downloaded = _stub_download(monkeypatch)
+    output = tmp_path / "run"
+    existing = output / "metrics.json"
+    existing.parent.mkdir(parents=True)
+    existing.write_bytes(b"x" * 10)
+
+    assert (
+        cli.main(
+            [
+                "--json",
+                "eval",
+                "download",
+                "my-run",
+                "--output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    first = json.loads(capsys.readouterr().out)["resource"]
+    assert first["files_skipped"] == 1
+    assert len(downloaded) == 2
+
+    assert (
+        cli.main(
+            [
+                "--json",
+                "eval",
+                "download",
+                "my-run",
+                "--output",
+                str(output),
+                "--overwrite",
+            ]
+        )
+        == 0
+    )
+    second = json.loads(capsys.readouterr().out)["resource"]
+    assert second["files_skipped"] == 0
+    assert len(downloaded) == 5
+
+
+def test_presigned_urls_are_requested_in_batches_of_at_most_500(
+    monkeypatch, tmp_path, capsys
+):
+    files = [
+        RunDownloadFile(f"trajectories/row_{row}_run_0.json", 1) for row in range(501)
+    ]
+    _stub_git_context(monkeypatch, tmp_path)
+    fake_client = _make_fake_client(manifest_files=files)
+    monkeypatch.setattr(eval_module, "OsmosisClient", fake_client)
+    _stub_download(monkeypatch)
+
+    exit_code = cli.main(
+        ["--json", "eval", "download", "my-run", "--type", "trajectories"]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert json.loads(captured.out)["resource"]["files_downloaded"] == 501
+    assert [len(batch) for batch in fake_client.url_calls] == [500, 1]
+
+
+def test_large_download_requires_yes_in_json(monkeypatch, tmp_path, capsys):
+    _stub_git_context(monkeypatch, tmp_path)
+    fake_client = _make_fake_client()
+    monkeypatch.setattr(eval_module, "OsmosisClient", fake_client)
+    _stub_download(monkeypatch)
+    monkeypatch.setattr(run_download_module, "DOWNLOAD_CONFIRM_THRESHOLD_BYTES", 1)
+
+    exit_code = cli.main(["--json", "eval", "download", "my-run"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    error = json.loads(captured.err)["error"]
+    assert error["code"] == "INTERACTIVE_REQUIRED"
+    assert fake_client.url_calls == []
+
+    assert cli.main(["--json", "eval", "download", "my-run", "--yes"]) == 0
+
+
+def test_invalid_manifest_paths_are_reported_and_reserved_manifest_is_skipped(
+    monkeypatch, tmp_path, capsys
+):
+    files = [
+        RunDownloadFile("metrics.json", 10),
+        RunDownloadFile("../evil.json", 10),
+        RunDownloadFile("artifacts/row_3_run_0/manifest.json", 10),
+    ]
+    _stub_git_context(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        eval_module, "OsmosisClient", _make_fake_client(manifest_files=files)
+    )
+    _stub_download(monkeypatch)
+
+    exit_code = cli.main(["--json", "eval", "download", "my-run"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    payload = json.loads(captured.out)
+    assert payload["status"] == "partial"
+    assert payload["resource"]["files_downloaded"] == 1
+    assert {item["path"] for item in payload["resource"]["files_failed"]} == {
+        "../evil.json",
+        "artifacts/row_3_run_0/manifest.json",
+    }
+    assert not (tmp_path / "evil.json").exists()
+
+
+def test_nested_artifact_manifest_is_downloadable(monkeypatch, tmp_path, capsys):
+    nested = "artifacts/row_3_run_0/logs/manifest.json"
+    files = [RunDownloadFile(nested, 10, rollout_id="rollout-3-0")]
+    _stub_git_context(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        eval_module, "OsmosisClient", _make_fake_client(manifest_files=files)
+    )
+    _stub_download(monkeypatch)
+
+    exit_code = cli.main(
+        ["--json", "eval", "download", "my-run", "--type", "artifacts"]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert json.loads(captured.out)["resource"]["files_downloaded"] == 1
+    assert (tmp_path / ".osmosis/evals/my-run" / nested).is_file()
+
+
+def test_manifest_cannot_cross_existing_symlink_outside_run_root(
+    monkeypatch, tmp_path, capsys
+):
+    output = tmp_path / "run"
+    outside = tmp_path / "outside"
+    output.mkdir()
+    outside.mkdir()
+    (output / "trajectories").symlink_to(outside, target_is_directory=True)
+    files = [RunDownloadFile("trajectories/row_3_run_0.json", 10)]
+    _stub_git_context(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        eval_module, "OsmosisClient", _make_fake_client(manifest_files=files)
+    )
+
+    exit_code = cli.main(
+        [
+            "--json",
+            "eval",
+            "download",
+            "my-run",
+            "--type",
+            "trajectories",
+            "--output",
+            str(output),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "no usable run-scoped paths" in json.loads(captured.err)["error"]["message"]
+    assert list(outside.iterdir()) == []
+
+
+def test_per_file_retries_continue_and_report_only_permanent_failures(
+    monkeypatch, tmp_path, capsys
+):
+    _stub_git_context(monkeypatch, tmp_path)
+    monkeypatch.setattr(eval_module, "OsmosisClient", _make_fake_client())
+    attempts: dict[str, int] = {}
+
+    def flaky_download(url, destination, *, expected_size=None):
+        attempts[url] = attempts.get(url, 0) + 1
+        if "metrics.json" in url and attempts[url] < 3:
+            raise RuntimeError("connection reset")
+        if "summary.jsonl" in url:
+            raise RuntimeError(f"still broken {url}")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"x" * expected_size)
+        return expected_size
+
+    monkeypatch.setattr(run_download_module, "download_file_to", flaky_download)
+    monkeypatch.setattr(run_download_module, "DOWNLOAD_RETRY_BASE_SECONDS", 0)
+
+    exit_code = cli.main(["--json", "eval", "download", "my-run"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    resource = json.loads(captured.out)["resource"]
+    assert resource["files_downloaded"] == 2
+    assert [item["path"] for item in resource["files_failed"]] == ["summary.jsonl"]
+    assert "example.com" not in resource["files_failed"][0]["error"]
+    assert "<redacted URL>" in resource["files_failed"][0]["error"]
+    metrics_url = next(url for url in attempts if "metrics.json" in url)
+    assert attempts[metrics_url] == 3
+
+
+def test_expired_presigned_url_refreshes_by_typed_status(monkeypatch, tmp_path, capsys):
+    _stub_git_context(monkeypatch, tmp_path)
+    fake_client = _make_fake_client()
+    monkeypatch.setattr(eval_module, "OsmosisClient", fake_client)
+    attempts = 0
+
+    def expired_once(url, destination, *, expected_size=None):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise DownloadHTTPError(403, "expired")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"x" * expected_size)
+        return expected_size
+
+    monkeypatch.setattr(run_download_module, "download_file_to", expired_once)
+    monkeypatch.setattr(run_download_module, "DOWNLOAD_RETRY_BASE_SECONDS", 0)
+
+    exit_code = cli.main(["--json", "eval", "download", "my-run", "--type", "metrics"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert json.loads(captured.out)["resource"]["files_downloaded"] == 1
+    assert attempts == 2
+    assert [len(batch) for batch in fake_client.url_calls] == [1, 1]
+
+
+def test_missing_manifest_route_has_upgrade_hint(monkeypatch, tmp_path, capsys):
+    _stub_git_context(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        eval_module,
+        "OsmosisClient",
+        _make_fake_client(manifest_error=PlatformAPIError("Not found", 404)),
+    )
+
+    exit_code = cli.main(["--json", "eval", "download", "my-run"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert (
+        "download route was not found" in json.loads(captured.err)["error"]["message"]
+    )

--- a/tests/unit/cli/test_eval_download.py
+++ b/tests/unit/cli/test_eval_download.py
@@ -29,13 +29,13 @@ FILES = {
     "metrics": [RunDownloadFile("metrics.json", 10)],
     "trajectories": [
         RunDownloadFile("summary.jsonl", 20),
-        RunDownloadFile("trajectories/row_3_run_0.json", 30, rollout_id="rollout-3-0"),
+        RunDownloadFile("trajectories/row_3_run_0.json", 30, token="rollout-3-0"),
     ],
     "artifacts": [
         RunDownloadFile(
             "artifacts/row_3_run_0/logs/agent.log",
             40,
-            rollout_id="rollout-3-0",
+            token="rollout-3-0",
         )
     ],
     "logs": [RunDownloadFile("logs.txt", 50)],
@@ -119,7 +119,7 @@ def _make_fake_client(
                 items=[
                     RunDownloadURL(
                         path=item.path,
-                        rollout_id=item.rollout_id,
+                        token=item.token,
                         url=f"https://example.com/{item.path}?size={item.size}",
                     )
                     for item in items
@@ -211,7 +211,7 @@ def test_eval_info_uses_same_run_scoped_metrics_path(monkeypatch, tmp_path):
                     RunDownloadFile(
                         "metrics.json",
                         len(server_metrics),
-                        rollout_id="export-token",
+                        token="export-token",
                     )
                 ],
                 totals={"files": 1, "bytes": len(server_metrics)},
@@ -224,7 +224,7 @@ def test_eval_info_uses_same_run_scoped_metrics_path(monkeypatch, tmp_path):
                 items=[
                     RunDownloadURL(
                         path=items[0].path,
-                        rollout_id=items[0].rollout_id,
+                        token=items[0].token,
                         url="https://example.com/metrics.json",
                     )
                 ],
@@ -444,7 +444,7 @@ def test_invalid_manifest_paths_are_reported_and_reserved_manifest_is_skipped(
 
 def test_nested_artifact_manifest_is_downloadable(monkeypatch, tmp_path, capsys):
     nested = "artifacts/row_3_run_0/logs/manifest.json"
-    files = [RunDownloadFile(nested, 10, rollout_id="rollout-3-0")]
+    files = [RunDownloadFile(nested, 10, token="rollout-3-0")]
     _stub_git_context(monkeypatch, tmp_path)
     monkeypatch.setattr(
         eval_module, "OsmosisClient", _make_fake_client(manifest_files=files)

--- a/tests/unit/cli/test_metrics_export.py
+++ b/tests/unit/cli/test_metrics_export.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from osmosis_ai.cli.metrics_export import build_eval_export_dict, build_export_dict
+from osmosis_ai.cli.metrics_export import (
+    build_eval_export_dict,
+    build_export_dict,
+    resolve_eval_metrics_output,
+    resolve_eval_output_dir,
+)
 from osmosis_ai.platform.api.models import (
     EvalPassAtKPoint,
     EvalRewardStats,
@@ -16,6 +21,78 @@ from osmosis_ai.platform.api.models import (
     TrainingRunMetrics,
     TrainingRunMetricsOverview,
 )
+
+
+def test_eval_scoped_metrics_path_is_fixed(tmp_path) -> None:
+    eval_path = resolve_eval_metrics_output(
+        "math/eval",
+        "eval-1",
+        workspace_directory=tmp_path,
+    )
+
+    assert eval_path == tmp_path / ".osmosis/evals/math_eval--eval-1/metrics.json"
+
+
+def test_output_relocates_run_root_without_changing_internal_layout(tmp_path) -> None:
+    output = tmp_path / "custom-root"
+
+    root = resolve_eval_output_dir(
+        "ignored-name",
+        "eval-1",
+        workspace_directory=tmp_path,
+        output=str(output),
+    )
+    metrics = resolve_eval_metrics_output(
+        "ignored-name",
+        "eval-1",
+        workspace_directory=tmp_path,
+        output=str(output),
+    )
+
+    assert root == output
+    assert metrics == output / "metrics.json"
+
+
+def test_sanitized_eval_names_use_run_id_to_avoid_directory_collisions(
+    tmp_path,
+) -> None:
+    first = resolve_eval_output_dir(
+        "a/b",
+        "eval-1",
+        workspace_directory=tmp_path,
+        create=False,
+    )
+    second = resolve_eval_output_dir(
+        "a?b",
+        "eval-2",
+        workspace_directory=tmp_path,
+        create=False,
+    )
+
+    assert first.name == "a_b--eval-1"
+    assert second.name == "a_b--eval-2"
+    assert first != second
+
+
+def test_case_variant_eval_names_do_not_collide_on_case_insensitive_filesystems(
+    tmp_path,
+) -> None:
+    lowercase = resolve_eval_output_dir(
+        "run",
+        "eval-1",
+        workspace_directory=tmp_path,
+        create=False,
+    )
+    uppercase = resolve_eval_output_dir(
+        "Run",
+        "eval-2",
+        workspace_directory=tmp_path,
+        create=False,
+    )
+
+    assert lowercase.name == "run"
+    assert uppercase.name == "Run--eval-2"
+    assert lowercase.name.casefold() != uppercase.name.casefold()
 
 
 class TestBuildExportDict:

--- a/tests/unit/cli/test_metrics_export.py
+++ b/tests/unit/cli/test_metrics_export.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import pytest
+
+from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.cli.metrics_export import (
     build_eval_export_dict,
     build_export_dict,
@@ -93,6 +96,31 @@ def test_case_variant_eval_names_do_not_collide_on_case_insensitive_filesystems(
     assert lowercase.name == "run"
     assert uppercase.name == "Run--eval-2"
     assert lowercase.name.casefold() != uppercase.name.casefold()
+
+
+def test_eval_output_dir_rejects_existing_non_directory_path(tmp_path) -> None:
+    occupied = tmp_path / "occupied"
+    occupied.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(CLIError, match="Output path is not a directory"):
+        resolve_eval_output_dir(
+            "run",
+            "eval-1",
+            workspace_directory=tmp_path,
+            output=str(occupied),
+        )
+
+
+def test_eval_output_dir_wraps_os_errors_when_creation_fails(tmp_path) -> None:
+    # `.osmosis` existing as a file makes mkdir(parents=True) raise an OSError.
+    (tmp_path / ".osmosis").write_text("blocker", encoding="utf-8")
+
+    with pytest.raises(CLIError, match="Cannot create output directory"):
+        resolve_eval_output_dir(
+            "run",
+            "eval-1",
+            workspace_directory=tmp_path,
+        )
 
 
 class TestBuildExportDict:

--- a/tests/unit/platform/api/test_client.py
+++ b/tests/unit/platform/api/test_client.py
@@ -780,6 +780,22 @@ class TestEvaluationRuns:
         assert batch.items[0].url == "https://example.com/signed"
         assert batch.expires_in == 900
 
+    @pytest.mark.parametrize("item_count", [0, 501])
+    def test_eval_run_download_urls_rejects_out_of_bounds_batches(
+        self, item_count: int
+    ) -> None:
+        from osmosis_ai.platform.api.models import RunDownloadFile
+
+        items = [
+            RunDownloadFile(f"trajectories/row_{index}_run_0.json", 1)
+            for index in range(item_count)
+        ]
+
+        with pytest.raises(ValueError, match="between 1 and 500 items"):
+            OsmosisClient().get_eval_run_download_urls(
+                "er-1", items=items, git_identity="git_test"
+            )
+
 
 class TestGetTrainingRunMetrics:
     """Tests for OsmosisClient.get_training_run_metrics."""

--- a/tests/unit/platform/api/test_client.py
+++ b/tests/unit/platform/api/test_client.py
@@ -717,7 +717,7 @@ class TestEvaluationRuns:
                 {
                     "path": "trajectories/row_3_run_0.json",
                     "size": 12,
-                    "rolloutId": "rollout-1",
+                    "token": "rollout-1",
                 }
             ],
             "totals": {"files": 1, "bytes": 12},
@@ -734,7 +734,7 @@ class TestEvaluationRuns:
             "/api/cli/eval-runs/a%2Fb/samples/manifest?"
             "types=metrics%2Ctrajectories&rows=3%2C7%2C10-20"
         )
-        assert manifest.files[0].rollout_id == "rollout-1"
+        assert manifest.files[0].token == "rollout-1"
         assert manifest.totals == {"files": 1, "bytes": 12}
 
     @patch("osmosis_ai.platform.api.client.platform_request")
@@ -745,11 +745,11 @@ class TestEvaluationRuns:
             "items": [
                 {
                     "path": "trajectories/row_3_run_0.json",
-                    "rolloutId": "rollout-1",
+                    "token": "rollout-1",
                     "url": "https://example.com/signed",
                 }
             ],
-            "expiresIn": 900,
+            "expires_in": 900,
         }
         from osmosis_ai.platform.api.models import RunDownloadFile
 
@@ -759,7 +759,7 @@ class TestEvaluationRuns:
                 RunDownloadFile(
                     "trajectories/row_3_run_0.json",
                     12,
-                    rollout_id="rollout-1",
+                    token="rollout-1",
                 )
             ],
             git_identity="git_test",
@@ -772,7 +772,7 @@ class TestEvaluationRuns:
         assert mock_request.call_args.kwargs["data"] == {
             "items": [
                 {
-                    "rolloutId": "rollout-1",
+                    "token": "rollout-1",
                     "path": "trajectories/row_3_run_0.json",
                 }
             ]

--- a/tests/unit/platform/api/test_client.py
+++ b/tests/unit/platform/api/test_client.py
@@ -710,6 +710,76 @@ class TestEvaluationRuns:
         assert mock_request.call_args.kwargs["method"] == "POST"
         assert mock_request.call_args.kwargs["data"] == {}
 
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_eval_run_download_manifest_contract(self, mock_request: MagicMock) -> None:
+        mock_request.return_value = {
+            "files": [
+                {
+                    "path": "trajectories/row_3_run_0.json",
+                    "size": 12,
+                    "rolloutId": "rollout-1",
+                }
+            ],
+            "totals": {"files": 1, "bytes": 12},
+        }
+
+        manifest = OsmosisClient().get_eval_run_download_manifest(
+            "a/b",
+            types=["metrics", "trajectories"],
+            rows="3,7,10-20",
+            git_identity="git_test",
+        )
+
+        assert mock_request.call_args[0][0] == (
+            "/api/cli/eval-runs/a%2Fb/samples/manifest?"
+            "types=metrics%2Ctrajectories&rows=3%2C7%2C10-20"
+        )
+        assert manifest.files[0].rollout_id == "rollout-1"
+        assert manifest.totals == {"files": 1, "bytes": 12}
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_eval_run_download_urls_post_bounded_items(
+        self, mock_request: MagicMock
+    ) -> None:
+        mock_request.return_value = {
+            "items": [
+                {
+                    "path": "trajectories/row_3_run_0.json",
+                    "rolloutId": "rollout-1",
+                    "url": "https://example.com/signed",
+                }
+            ],
+            "expiresIn": 900,
+        }
+        from osmosis_ai.platform.api.models import RunDownloadFile
+
+        batch = OsmosisClient().get_eval_run_download_urls(
+            "er-1",
+            items=[
+                RunDownloadFile(
+                    "trajectories/row_3_run_0.json",
+                    12,
+                    rollout_id="rollout-1",
+                )
+            ],
+            git_identity="git_test",
+        )
+
+        assert mock_request.call_args[0][0] == (
+            "/api/cli/eval-runs/er-1/samples/download-urls"
+        )
+        assert mock_request.call_args.kwargs["method"] == "POST"
+        assert mock_request.call_args.kwargs["data"] == {
+            "items": [
+                {
+                    "rolloutId": "rollout-1",
+                    "path": "trajectories/row_3_run_0.json",
+                }
+            ]
+        }
+        assert batch.items[0].url == "https://example.com/signed"
+        assert batch.expires_in == 900
+
 
 class TestGetTrainingRunMetrics:
     """Tests for OsmosisClient.get_training_run_metrics."""

--- a/tests/unit/platform/api/test_download.py
+++ b/tests/unit/platform/api/test_download.py
@@ -200,3 +200,111 @@ def test_download_file_reports_http_errors(monkeypatch, tmp_path) -> None:
             default_filename="data.jsonl",
             expected_size=10,
         )
+
+
+def test_download_file_to_creates_nested_directories(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        download_module.httpx,
+        "stream",
+        lambda *args, **kwargs: _FakeStreamResponse(chunks=[b"hello", b" world"]),
+    )
+    destination = tmp_path / "rollout_trials" / "abc" / "trajectory.json"
+
+    written = download_module.download_file_to(
+        "https://example.com/signed", destination
+    )
+
+    assert written == 11
+    assert destination.read_bytes() == b"hello world"
+
+
+def test_download_file_to_replaces_existing_file(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        download_module.httpx,
+        "stream",
+        lambda *args, **kwargs: _FakeStreamResponse(chunks=[b"new"]),
+    )
+    destination = tmp_path / "index.jsonl"
+    destination.write_bytes(b"old-content")
+
+    download_module.download_file_to("https://example.com/signed", destination)
+
+    assert destination.read_bytes() == b"new"
+
+
+def test_download_file_to_rejects_size_mismatch_before_atomic_replace(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setattr(
+        download_module.httpx,
+        "stream",
+        lambda *args, **kwargs: _FakeStreamResponse(chunks=[b"short"]),
+    )
+    destination = tmp_path / "metrics.json"
+    destination.write_bytes(b"old-content")
+
+    with pytest.raises(RuntimeError, match="Downloaded size mismatch"):
+        download_module.download_file_to(
+            "https://example.com/signed", destination, expected_size=10
+        )
+
+    assert destination.read_bytes() == b"old-content"
+    assert not (tmp_path / "metrics.json.partial").exists()
+
+
+def test_download_file_to_refuses_partial_symlink(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        download_module.httpx,
+        "stream",
+        lambda *args, **kwargs: _FakeStreamResponse(chunks=[b"data"]),
+    )
+    outside = tmp_path / "outside"
+    outside.write_bytes(b"safe")
+    destination = tmp_path / "metrics.json"
+    partial = tmp_path / "metrics.json.partial"
+    partial.symlink_to(outside)
+
+    with pytest.raises(RuntimeError, match="Partial download path is a symlink"):
+        download_module.download_file_to(
+            "https://example.com/signed", destination, expected_size=4
+        )
+
+    assert outside.read_bytes() == b"safe"
+    assert not destination.exists()
+
+
+def test_download_file_to_reports_http_errors(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        download_module.httpx,
+        "stream",
+        lambda *args, **kwargs: _FakeStreamResponse(status_code=403, body=b"expired"),
+    )
+    destination = tmp_path / "index.jsonl"
+
+    with pytest.raises(RuntimeError, match=r"HTTP 403.*expired"):
+        download_module.download_file_to("https://example.com/signed", destination)
+
+    assert not destination.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_download_file_to_cleans_up_temp_file_on_write_failure(
+    monkeypatch, tmp_path
+) -> None:
+    class _ExplodingResponse(_FakeStreamResponse):
+        def iter_bytes(self, _chunk_size: int):
+            yield b"partial"
+            raise RuntimeError("connection dropped")
+
+    monkeypatch.setattr(
+        download_module.httpx,
+        "stream",
+        lambda *args, **kwargs: _ExplodingResponse(),
+    )
+    destination = tmp_path / "index.jsonl"
+
+    with pytest.raises(RuntimeError, match="connection dropped"):
+        download_module.download_file_to("https://example.com/signed", destination)
+
+    assert not destination.exists()
+    assert list(tmp_path.iterdir()) == []

--- a/tests/unit/platform/api/test_download.py
+++ b/tests/unit/platform/api/test_download.py
@@ -218,6 +218,22 @@ def test_download_file_to_creates_nested_directories(monkeypatch, tmp_path) -> N
     assert destination.read_bytes() == b"hello world"
 
 
+def test_download_file_to_skips_empty_chunks(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        download_module.httpx,
+        "stream",
+        lambda *args, **kwargs: _FakeStreamResponse(chunks=[b"hello", b"", b" world"]),
+    )
+    destination = tmp_path / "trajectory.json"
+
+    written = download_module.download_file_to(
+        "https://example.com/signed", destination, expected_size=11
+    )
+
+    assert written == 11
+    assert destination.read_bytes() == b"hello world"
+
+
 def test_download_file_to_replaces_existing_file(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(
         download_module.httpx,

--- a/tests/unit/platform/api/test_download.py
+++ b/tests/unit/platform/api/test_download.py
@@ -252,7 +252,9 @@ def test_download_file_to_rejects_size_mismatch_before_atomic_replace(
     assert not (tmp_path / "metrics.json.partial").exists()
 
 
-def test_download_file_to_refuses_partial_symlink(monkeypatch, tmp_path) -> None:
+def test_download_file_to_does_not_follow_preexisting_partial_symlink(
+    monkeypatch, tmp_path
+) -> None:
     monkeypatch.setattr(
         download_module.httpx,
         "stream",
@@ -264,13 +266,39 @@ def test_download_file_to_refuses_partial_symlink(monkeypatch, tmp_path) -> None
     partial = tmp_path / "metrics.json.partial"
     partial.symlink_to(outside)
 
-    with pytest.raises(RuntimeError, match="Partial download path is a symlink"):
-        download_module.download_file_to(
-            "https://example.com/signed", destination, expected_size=4
-        )
+    download_module.download_file_to(
+        "https://example.com/signed", destination, expected_size=4
+    )
 
     assert outside.read_bytes() == b"safe"
-    assert not destination.exists()
+    assert destination.read_bytes() == b"data"
+    assert partial.is_symlink()
+
+
+def test_download_file_to_does_not_truncate_preexisting_partial_hard_link(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setattr(
+        download_module.httpx,
+        "stream",
+        lambda *args, **kwargs: _FakeStreamResponse(chunks=[b"data"]),
+    )
+    outside = tmp_path / "outside"
+    outside.write_bytes(b"safe")
+    destination = tmp_path / "metrics.json"
+    partial = tmp_path / "metrics.json.partial"
+    try:
+        partial.hardlink_to(outside)
+    except OSError:
+        pytest.skip("hard links are not supported")
+
+    download_module.download_file_to(
+        "https://example.com/signed", destination, expected_size=4
+    )
+
+    assert outside.read_bytes() == b"safe"
+    assert partial.read_bytes() == b"safe"
+    assert destination.read_bytes() == b"data"
 
 
 def test_download_file_to_reports_http_errors(monkeypatch, tmp_path) -> None:

--- a/tests/unit/platform/api/test_models.py
+++ b/tests/unit/platform/api/test_models.py
@@ -24,6 +24,10 @@ from osmosis_ai.platform.api.models import (
     MetricHistory,
     PaginatedEnvironmentSecrets,
     PaginatedEvaluationRuns,
+    RunDownloadFile,
+    RunDownloadManifest,
+    RunDownloadURL,
+    RunDownloadURLBatch,
     SubmitRunResult,
     TrainingRunDetail,
     TrainingRunMetrics,
@@ -834,6 +838,61 @@ class TestEvalRunMetrics:
         assert metrics.pass_at_k == []
         assert metrics.overview.duration_ms is None
         assert metrics.overview.total_samples is None
+
+
+class TestRunDownloadModels:
+    """Tests for the run download manifest and presigned URL models."""
+
+    def test_run_download_file_rejects_missing_path(self) -> None:
+        with pytest.raises(ValueError, match="path must be a non-empty string"):
+            RunDownloadFile.from_dict({"size": 10})
+
+    @pytest.mark.parametrize("size", [None, -1, True, "10"])
+    def test_run_download_file_rejects_invalid_size(self, size: object) -> None:
+        with pytest.raises(ValueError, match="size is invalid"):
+            RunDownloadFile.from_dict({"path": "metrics.json", "size": size})
+
+    def test_run_download_file_rejects_non_string_token(self) -> None:
+        with pytest.raises(ValueError, match="token is invalid"):
+            RunDownloadFile.from_dict(
+                {"path": "metrics.json", "size": 10, "token": 123}
+            )
+
+    def test_run_download_manifest_rejects_non_list_files(self) -> None:
+        with pytest.raises(ValueError, match="files must be a list"):
+            RunDownloadManifest.from_dict({"files": {"path": "metrics.json"}})
+
+    def test_run_download_url_rejects_missing_path(self) -> None:
+        with pytest.raises(ValueError, match="path must be a non-empty string"):
+            RunDownloadURL.from_dict({"url": "https://example.com/signed"})
+
+    def test_run_download_url_rejects_missing_url(self) -> None:
+        with pytest.raises(ValueError, match="URL is missing"):
+            RunDownloadURL.from_dict({"path": "metrics.json"})
+
+    def test_run_download_url_rejects_non_string_token(self) -> None:
+        with pytest.raises(ValueError, match="token is invalid"):
+            RunDownloadURL.from_dict(
+                {
+                    "path": "metrics.json",
+                    "url": "https://example.com/signed",
+                    "token": 123,
+                }
+            )
+
+    def test_run_download_url_batch_accepts_files_and_urls_fallback_keys(self) -> None:
+        item = {"path": "metrics.json", "url": "https://example.com/signed"}
+
+        from_files = RunDownloadURLBatch.from_dict({"files": [item]})
+        from_urls = RunDownloadURLBatch.from_dict({"urls": [item]})
+
+        assert from_files.items[0].path == "metrics.json"
+        assert from_urls.items[0].url == "https://example.com/signed"
+        assert from_files.expires_in is None
+
+    def test_run_download_url_batch_rejects_non_list_items(self) -> None:
+        with pytest.raises(ValueError, match="items must be a list"):
+            RunDownloadURLBatch.from_dict({"items": {"path": "metrics.json"}})
 
 
 class TestIsInternalUserFlag:


### PR DESCRIPTION
## What

- Add `osmosis eval download` with output-type and row selectors, fixed run-scoped layout, size-based resume, overwrite support, and large-download confirmation.
- Add manifest and presigned URL API models plus a shared transfer engine with bounded URL batches, eight concurrent downloads, atomic partial files, retries, and per-file failure reporting.
- Move rich-mode eval metrics exports to `.osmosis/evals/<name>/metrics.json` and route `eval info` through the same manifest-backed file as `eval download --type metrics`.
- Document the download contract, local layout, transfer behavior, and metrics export migration.

## Why

Users need to pull evaluation metrics, trajectories, artifacts, and logs to local disk without relying on the web UI. The manifest flow keeps object-key validation on the platform while downloading bytes directly from S3.

Migration note: `osmosis eval info -o` now treats its argument as the run output root rather than a metrics filename. Default rich-mode exports move from `.osmosis/metrics/<name>_<id>.json` to `.osmosis/evals/<name>/metrics.json`; existing legacy files are left untouched.

## How to Test

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright osmosis_ai/`
- `uv run pytest`
- `osmosis eval download <name-or-id> --type metrics,trajectories --rows 3,7,10-20`

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (1,716 tests)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `osmosis eval download` to pull run outputs (metrics, trajectories, artifacts, logs) into a fixed run-scoped layout with resume, overwrite, confirmation, and robust retries; `eval info` now saves `metrics.json` to the same layout via the manifest flow and shows a one-time migration notice.

- **New Features**
  - Command: `osmosis eval download <name|id> [--type metrics|trajectories|artifacts|logs|all] [--rows 3,7,10-20] [-o root] [--overwrite] [--yes]` (default `metrics,trajectories`).
  - Fixed layout under `.osmosis/evals/<name>/` (metrics.json, summary.jsonl, trajectories/, artifacts/, logs.txt). Run names are sanitized and may gain a stable `--<run-id>` suffix to avoid collisions and Windows-reserved names.
  - Transfer engine: up to 500-URL batches, eight concurrent downloads, atomic `*.partial` writes, size checks, retries with backoff, 403 URL refresh, progress bar, and redacted URLs in errors. Matching sizes are skipped unless `--overwrite`; downloads over 100 MiB require confirmation unless `--yes`.
  - Safety: early failure for pending runs, strict path enforcement with symlink guards, rollout-level artifact `manifest.json` is skipped, and a friendly hint if the platform lacks the download route (404).
  - Client/SDK: manifest and presigned URL models with strict validation; `download_file_to` for atomic, size-checked writes. Docs: `docs/run-downloads.md`.

- **Migration**
  - Metrics exports move from `.osmosis/metrics/` to `.osmosis/evals/<name>/metrics.json`; legacy files remain.
  - `osmosis eval info -o` now sets the run output root, not a metrics filename.

<sup>Written for commit 2e5f6e7bd737b21e0c43266b0163c72428e2c514. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

