### PR TITLE
[cli][rollout] feat: support branch-based source selection

### DIFF
--- a/osmosis_ai/cli/commands/rollout.py
+++ b/osmosis_ai/cli/commands/rollout.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import typer
 
@@ -56,8 +56,12 @@ def list_rollouts(
         help="Maximum number of rollouts to show.",
     ),
     all_: bool = typer.Option(False, "--all", help="Show all rollouts."),
+    branch: Annotated[
+        str | None,
+        typer.Option("--branch", help="List rollouts synced from this branch."),
+    ] = None,
 ) -> Any:
     """List rollouts for the current workspace directory."""
     from osmosis_ai.platform.cli.rollout import list_rollouts as _list_rollouts
 
-    return _list_rollouts(limit=limit, all_=all_)
+    return _list_rollouts(limit=limit, all_=all_, branch=branch)

--- a/osmosis_ai/platform/api/client.py
+++ b/osmosis_ai/platform/api/client.py
@@ -410,10 +410,14 @@ class OsmosisClient:
         limit: int = DEFAULT_PAGE_SIZE,
         offset: int = 0,
         *,
+        branch: str | None = None,
         credentials: Credentials | None = None,
         git_identity: str,
     ) -> PaginatedRollouts:
-        qs = urlencode({"limit": limit, "offset": offset})
+        params: dict[str, str | int] = {"limit": limit, "offset": offset}
+        if branch:
+            params["branch"] = branch
+        qs = urlencode(params)
         data = platform_request(
             f"/api/cli/rollouts?{qs}",
             credentials=credentials,

--- a/osmosis_ai/platform/api/models.py
+++ b/osmosis_ai/platform/api/models.py
@@ -248,6 +248,7 @@ class TrainingRunDetail(TrainingRun):
     notes: str | None = None
     config: dict[str, Any] | None = None
     entrypoint: str | None = None
+    branch: str | None = None
     commit_sha: str | None = None
     env_config: dict[str, Any] | None = None
     resolved_secret_scopes: dict[str, Any] | None = None
@@ -291,6 +292,7 @@ class TrainingRunDetail(TrainingRun):
             entrypoint=data.get("entrypoint")
             if isinstance(data.get("entrypoint"), str)
             else None,
+            branch=data.get("branch") if isinstance(data.get("branch"), str) else None,
             commit_sha=data.get("commit_sha")
             if isinstance(data.get("commit_sha"), str)
             else None,
@@ -1028,6 +1030,7 @@ class EvaluationRunDetail(EvaluationRun):
     config: dict[str, Any] | None = None
     results: dict[str, Any] | None = None
     entrypoint: str | None = None
+    branch: str | None = None
     commit_sha: str | None = None
     env_config: dict[str, Any] | None = None
     resolved_secret_scopes: dict[str, Any] | None = None
@@ -1060,6 +1063,7 @@ class EvaluationRunDetail(EvaluationRun):
             entrypoint=data.get("entrypoint")
             if isinstance(data.get("entrypoint"), str)
             else None,
+            branch=data.get("branch") if isinstance(data.get("branch"), str) else None,
             commit_sha=data.get("commit_sha")
             if isinstance(data.get("commit_sha"), str)
             else None,

--- a/osmosis_ai/platform/cli/eval.py
+++ b/osmosis_ai/platform/cli/eval.py
@@ -532,6 +532,8 @@ def info(name_or_id: str, *, output: str | None) -> DetailResult:
     config = _format_eval_config(detail.config)
     if config:
         config_rows.append(("Config", config))
+    if detail.branch:
+        config_rows.append(("Branch", detail.branch))
     if detail.commit_sha:
         config_rows.append(("Commit", detail.commit_sha[:7]))
     secret_scopes = format_secret_scopes(detail.resolved_secret_scopes)
@@ -636,6 +638,7 @@ def info(name_or_id: str, *, output: str | None) -> DetailResult:
             "rollout": detail.rollout,
             "entrypoint": detail.entrypoint,
             "commit_sha": detail.commit_sha,
+            "branch": detail.branch,
             "env_config": detail.env_config,
             "resolved_secret_scopes": detail.resolved_secret_scopes,
             "dataset_df_stats": detail.dataset_df_stats,

--- a/osmosis_ai/platform/cli/rollout.py
+++ b/osmosis_ai/platform/cli/rollout.py
@@ -22,7 +22,7 @@ from osmosis_ai.platform.cli.utils import (
 from osmosis_ai.platform.cli.workspace_directory_context import git_result_context
 
 
-def list_rollouts(*, limit: int, all_: bool) -> ListResult:
+def list_rollouts(*, limit: int, all_: bool, branch: str | None = None) -> ListResult:
     """List rollouts for the current workspace directory."""
     effective_limit, fetch_all = validate_list_options(limit=limit, all_=all_)
 
@@ -32,14 +32,19 @@ def list_rollouts(*, limit: int, all_: bool) -> ListResult:
 
     output = get_output_context()
     client = OsmosisClient()
+
+    def fetch_page(limit_value: int, offset_value: int):
+        return client.list_rollouts(
+            limit=limit_value,
+            offset=offset_value,
+            credentials=credentials,
+            git_identity=git_identity,
+            **({"branch": branch} if branch else {}),
+        )
+
     with output.status("Fetching rollouts..."):
         rollouts, total_count, has_more, next_offset = paginated_fetch(
-            lambda lim, off: client.list_rollouts(
-                limit=lim,
-                offset=off,
-                credentials=credentials,
-                git_identity=git_identity,
-            ),
+            fetch_page,
             items_attr="rollouts",
             limit=effective_limit,
             fetch_all=fetch_all,
@@ -53,7 +58,10 @@ def list_rollouts(*, limit: int, all_: bool) -> ListResult:
         total_count=total_count,
         has_more=has_more,
         next_offset=next_offset,
-        extra=git_result_context(context),
+        extra={
+            **git_result_context(context),
+            **({"branch": branch} if branch else {}),
+        },
         columns=[
             ListColumn(
                 key="name",

--- a/osmosis_ai/platform/cli/shared_config.py
+++ b/osmosis_ai/platform/cli/shared_config.py
@@ -359,8 +359,8 @@ class ExperimentSection(BaseModel):
     @field_validator("branch")
     @classmethod
     def _validate_branch(cls, value: str | None) -> str | None:
-        if value == "":
-            raise ValueError("must not be empty")
+        if value is not None and not value.strip():
+            raise ValueError("must not be empty or whitespace")
         return value
 
     @field_validator("commit_sha")

--- a/osmosis_ai/platform/cli/shared_config.py
+++ b/osmosis_ai/platform/cli/shared_config.py
@@ -5,9 +5,16 @@ from __future__ import annotations
 import re
 import tomllib
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Self
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 from pydantic_core import ErrorDetails
 
 from osmosis_ai.cli.errors import CLIError
@@ -346,6 +353,7 @@ class ExperimentSection(BaseModel):
     entrypoint: str
     model_path: str
     dataset: str
+    branch: str | None = None
     commit_sha: str | None = None
 
     @field_validator("commit_sha")
@@ -359,6 +367,12 @@ class ExperimentSection(BaseModel):
                 f"e.g. a full 40-character SHA; got {value!r}"
             )
         return value
+
+    @model_validator(mode="after")
+    def _validate_source_reference(self) -> Self:
+        if self.branch is not None and self.commit_sha is not None:
+            raise ValueError("Provide either branch or commit_sha, not both")
+        return self
 
 
 _EXPERIMENT_REQUIRED_KEYS: tuple[str, ...] = (
@@ -406,6 +420,10 @@ class BaseSubmitConfig(BaseModel):
     @property
     def experiment_commit_sha(self) -> str | None:
         return self.experiment.commit_sha
+
+    @property
+    def experiment_branch(self) -> str | None:
+        return self.experiment.branch
 
     @property
     def experiment_config(self) -> dict[str, Any]:
@@ -506,6 +524,7 @@ def build_submit_summary_rows(
     entrypoint: str,
     model: str,
     dataset: str,
+    branch: str | None,
     commit_sha: str | None,
 ) -> list[tuple[str, str]]:
     """Build the confirmation-table rows shared by ``train`` and ``eval`` submit."""
@@ -515,6 +534,8 @@ def build_submit_summary_rows(
         ("Model", model),
         ("Dataset", dataset),
     ]
+    if branch:
+        rows.append(("Branch", branch))
     if commit_sha:
         rows.append(("Commit", commit_sha))
     return rows

--- a/osmosis_ai/platform/cli/shared_config.py
+++ b/osmosis_ai/platform/cli/shared_config.py
@@ -356,6 +356,13 @@ class ExperimentSection(BaseModel):
     branch: str | None = None
     commit_sha: str | None = None
 
+    @field_validator("branch")
+    @classmethod
+    def _validate_branch(cls, value: str | None) -> str | None:
+        if value == "":
+            raise ValueError("must not be empty")
+        return value
+
     @field_validator("commit_sha")
     @classmethod
     def _validate_commit_sha(cls, value: str | None) -> str | None:

--- a/osmosis_ai/platform/cli/shared_config.py
+++ b/osmosis_ai/platform/cli/shared_config.py
@@ -359,8 +359,8 @@ class ExperimentSection(BaseModel):
     @field_validator("branch")
     @classmethod
     def _validate_branch(cls, value: str | None) -> str | None:
-        if value is not None and not value.strip():
-            raise ValueError("must not be empty or whitespace")
+        if value is not None and (not value or any(char.isspace() for char in value)):
+            raise ValueError("must not be empty or contain whitespace")
         return value
 
     @field_validator("commit_sha")

--- a/osmosis_ai/platform/cli/shared_submit.py
+++ b/osmosis_ai/platform/cli/shared_submit.py
@@ -231,6 +231,7 @@ def run_cloud_submit[ConfigT: BaseSubmitConfig](
         entrypoint=config.experiment_entrypoint,
         model=config.experiment_model_path,
         dataset=config.experiment_dataset,
+        branch=config.experiment_branch,
         commit_sha=config.experiment_commit_sha,
     )
 
@@ -285,6 +286,7 @@ def run_cloud_submit[ConfigT: BaseSubmitConfig](
 
     notes, warnings = print_remote_fetch_notice(
         workspace_directory,
+        branch=config.experiment_branch,
         pinned_commit_sha=config.experiment_commit_sha,
         extra_warnings=commit_preflight_warnings,
     )
@@ -329,6 +331,7 @@ def run_cloud_submit[ConfigT: BaseSubmitConfig](
                 "entrypoint": config.experiment_entrypoint,
                 "model": config.experiment_model_path,
                 "dataset": config.experiment_dataset,
+                "branch": config.experiment_branch,
                 "commit_sha": config.experiment_commit_sha,
             },
         },

--- a/osmosis_ai/platform/cli/train.py
+++ b/osmosis_ai/platform/cli/train.py
@@ -297,6 +297,8 @@ def info(name: str, *, output: str | None) -> DetailResult:
     train_config = _format_train_config(run.config)
     if train_config:
         config_rows.append(("Config", train_config))
+    if run.branch:
+        config_rows.append(("Branch", run.branch))
     if run.commit_sha:
         config_rows.append(("Commit", run.commit_sha[:7]))
     secret_scopes = format_secret_scopes(run.resolved_secret_scopes)

--- a/osmosis_ai/platform/cli/utils.py
+++ b/osmosis_ai/platform/cli/utils.py
@@ -478,6 +478,7 @@ def validate_list_options(
 def print_remote_fetch_notice(
     workspace_directory: Path,
     *,
+    branch: str | None,
     pinned_commit_sha: str | None,
     extra_warnings: list[str] | None = None,
 ) -> tuple[list[str], list[str]]:
@@ -531,6 +532,11 @@ def print_remote_fetch_notice(
             "Platform-connected repository."
         )
         notes.append("Make sure that commit is pushed to origin.")
+    elif branch:
+        notes.append(
+            f"Osmosis will fetch branch {branch} from the Platform-connected repository."
+        )
+        notes.append("Make sure your code changes are committed and pushed.")
     else:
         notes.append("Osmosis will fetch code from the Platform-connected repository.")
         if state is not None and state.branch and state.head_sha:
@@ -553,6 +559,12 @@ def print_remote_fetch_notice(
                 "from the Platform-connected repository."
             )
             body_lines.append("Make sure that commit is pushed to origin.")
+        elif branch:
+            body_lines.append(
+                f"Osmosis will fetch branch [bold]{console.escape(branch)}[/bold] "
+                "from the Platform-connected repository."
+            )
+            body_lines.append("Make sure your code changes are committed and pushed.")
         else:
             body_lines.append(
                 "Osmosis will fetch code from the Platform-connected repository."

--- a/osmosis_ai/templates/_scaffolds/rollout/eval.toml.tpl
+++ b/osmosis_ai/templates/_scaffolds/rollout/eval.toml.tpl
@@ -6,6 +6,7 @@ rollout = "<your-rollout>"            # Rollout name
 entrypoint = "main.py"                # Entrypoint file name
 model_path = "openai/gpt-5-mini"      # LiteLLM-style model name
 dataset = "<your-dataset-name>"       # Platform dataset name
+# branch = "my-feature"              # Pin to a branch (mutually exclusive with commit_sha)
 # commit_sha =                        # Pin to a specific commit
 
 [evaluation]

--- a/osmosis_ai/templates/_scaffolds/rollout/training.toml.tpl
+++ b/osmosis_ai/templates/_scaffolds/rollout/training.toml.tpl
@@ -13,6 +13,7 @@ rollout = "<your-rollout>"  # Rollout name (directory under rollouts/)
 entrypoint = "main.py"  # Entrypoint file name
 model_path = "<your-model-path>"  # Must be a supported model (see above)
 dataset = "<your-dataset-name>"  # Platform dataset name from `osmosis dataset list`
+# branch = "my-feature"              # Pin to a branch (mutually exclusive with commit_sha)
 # commit_sha =                        # Pin to a specific commit (default: latest on default branch)
 
 [training]

--- a/tests/unit/cli/test_train_commands.py
+++ b/tests/unit/cli/test_train_commands.py
@@ -1181,6 +1181,7 @@ rollout_batch_size = 64
             "entrypoint": "main.py",
             "model": "Qwen/Qwen3.6-35B-A3B",
             "dataset": "abc-123",
+            "branch": None,
             "commit_sha": None,
         }
 

--- a/tests/unit/platform/api/test_client.py
+++ b/tests/unit/platform/api/test_client.py
@@ -189,6 +189,29 @@ class TestListDatasets:
         assert "workspace_id" not in mock_request.call_args.kwargs
 
 
+class TestListRollouts:
+    """Tests for OsmosisClient.list_rollouts query parameters."""
+
+    @patch("osmosis_ai.platform.api.client.platform_request")
+    def test_list_rollouts_includes_urlencoded_branch(
+        self, mock_request: MagicMock
+    ) -> None:
+        mock_request.return_value = {"rollouts": [], "total_count": 0}
+
+        OsmosisClient().list_rollouts(
+            limit=10,
+            offset=20,
+            branch="feature/my-work",
+            git_identity="git_123",
+        )
+
+        mock_request.assert_called_once_with(
+            "/api/cli/rollouts?limit=10&offset=20&branch=feature%2Fmy-work",
+            credentials=None,
+            git_identity="git_123",
+        )
+
+
 class TestGitIdentityPassthrough:
     """Tests representative repo-scoped methods pass git_identity."""
 

--- a/tests/unit/platform/api/test_models.py
+++ b/tests/unit/platform/api/test_models.py
@@ -291,6 +291,7 @@ class TestTrainingRunDetail:
                 "model": {"id": "model_1", "name": "Qwen/Qwen3"},
                 "dataset": {"id": "dataset_1", "name": "train.jsonl"},
                 "rollout": {"id": "rollout_1", "name": "math-rollout"},
+                "branch": "my-feature",
             }
         )
 
@@ -301,6 +302,7 @@ class TestTrainingRunDetail:
         assert run.dataset_name == "train.jsonl"
         assert run.rollout_id == "rollout_1"
         assert run.rollout_name == "math-rollout"
+        assert run.branch == "my-feature"
         assert run.examples_processed_count == 42
 
 
@@ -722,6 +724,7 @@ class TestEvaluationRunModels:
                 "dataset": {"id": "dataset_1"},
                 "rollout": {"id": "rollout_1"},
                 "entrypoint": "main.py",
+                "branch": "my-feature",
                 "commit_sha": "abcdef1234567890",
                 "env_config": {"PROMPT_MODE": "strict"},
                 "resolved_secret_scopes": {"OPENAI_API_KEY": "workspace"},
@@ -740,6 +743,7 @@ class TestEvaluationRunModels:
         assert detail.dataset == {"id": "dataset_1"}
         assert detail.rollout == {"id": "rollout_1"}
         assert detail.entrypoint == "main.py"
+        assert detail.branch == "my-feature"
         assert detail.commit_sha == "abcdef1234567890"
         assert detail.env_config == {"PROMPT_MODE": "strict"}
         assert detail.resolved_secret_scopes == {"OPENAI_API_KEY": "workspace"}

--- a/tests/unit/platform/cli/test_eval_config.py
+++ b/tests/unit/platform/cli/test_eval_config.py
@@ -114,23 +114,26 @@ required = []
     assert config.experiment_config["branch"] == "my-feature"
 
 
-def test_load_eval_submit_config_rejects_empty_branch(tmp_path: Path) -> None:
+@pytest.mark.parametrize("branch", ["", "   "])
+def test_load_eval_submit_config_rejects_blank_branch(
+    tmp_path: Path, branch: str
+) -> None:
     path = _write_config(
         tmp_path / "eval.toml",
-        """
+        f"""
 [experiment]
 rollout = "calculator"
 entrypoint = "main.py"
 model_path = "openai/gpt-5-mini"
 dataset = "multiply"
-branch = ""
+branch = "{branch}"
 
 [secrets]
 required = []
 """,
     )
 
-    with pytest.raises(CLIError, match="must not be empty"):
+    with pytest.raises(CLIError, match="must not be empty or whitespace"):
         load_eval_submit_config(path)
 
 

--- a/tests/unit/platform/cli/test_eval_config.py
+++ b/tests/unit/platform/cli/test_eval_config.py
@@ -114,6 +114,26 @@ required = []
     assert config.experiment_config["branch"] == "my-feature"
 
 
+def test_load_eval_submit_config_rejects_empty_branch(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path / "eval.toml",
+        """
+[experiment]
+rollout = "calculator"
+entrypoint = "main.py"
+model_path = "openai/gpt-5-mini"
+dataset = "multiply"
+branch = ""
+
+[secrets]
+required = []
+""",
+    )
+
+    with pytest.raises(CLIError, match="must not be empty"):
+        load_eval_submit_config(path)
+
+
 def test_load_eval_submit_config_rejects_branch_and_commit_sha(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/platform/cli/test_eval_config.py
+++ b/tests/unit/platform/cli/test_eval_config.py
@@ -93,6 +93,50 @@ required = []
     assert config.experiment_commit_sha == full_sha
 
 
+def test_load_eval_submit_config_accepts_branch(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path / "eval.toml",
+        """
+[experiment]
+rollout = "calculator"
+entrypoint = "main.py"
+model_path = "openai/gpt-5-mini"
+dataset = "multiply"
+branch = "my-feature"
+
+[secrets]
+required = []
+""",
+    )
+
+    config = load_eval_submit_config(path)
+    assert config.experiment_branch == "my-feature"
+    assert config.experiment_config["branch"] == "my-feature"
+
+
+def test_load_eval_submit_config_rejects_branch_and_commit_sha(
+    tmp_path: Path,
+) -> None:
+    path = _write_config(
+        tmp_path / "eval.toml",
+        """
+[experiment]
+rollout = "calculator"
+entrypoint = "main.py"
+model_path = "openai/gpt-5-mini"
+dataset = "multiply"
+branch = "my-feature"
+commit_sha = "deadbeef"
+
+[secrets]
+required = []
+""",
+    )
+
+    with pytest.raises(CLIError, match="Provide either branch or commit_sha, not both"):
+        load_eval_submit_config(path)
+
+
 @pytest.mark.parametrize(
     "bad_sha",
     [

--- a/tests/unit/platform/cli/test_eval_config.py
+++ b/tests/unit/platform/cli/test_eval_config.py
@@ -114,8 +114,8 @@ required = []
     assert config.experiment_config["branch"] == "my-feature"
 
 
-@pytest.mark.parametrize("branch", ["", "   "])
-def test_load_eval_submit_config_rejects_blank_branch(
+@pytest.mark.parametrize("branch", ["", "   ", " main", "main ", "feature branch"])
+def test_load_eval_submit_config_rejects_empty_or_whitespace_branch(
     tmp_path: Path, branch: str
 ) -> None:
     path = _write_config(
@@ -133,7 +133,7 @@ required = []
 """,
     )
 
-    with pytest.raises(CLIError, match="must not be empty or whitespace"):
+    with pytest.raises(CLIError, match="must not be empty or contain whitespace"):
         load_eval_submit_config(path)
 
 

--- a/tests/unit/platform/cli/test_eval_submit.py
+++ b/tests/unit/platform/cli/test_eval_submit.py
@@ -209,6 +209,7 @@ def test_eval_submit_passes_new_schema_to_evaluation_run_api(
         "entrypoint": "main.py",
         "model": "openai/gpt-5-mini",
         "dataset": "multiply",
+        "branch": None,
         "commit_sha": "deadbeef",
     }
 

--- a/tests/unit/platform/cli/test_submit_summary.py
+++ b/tests/unit/platform/cli/test_submit_summary.py
@@ -15,6 +15,7 @@ def _rows(**kwargs) -> dict[str, str]:
         "entrypoint": "e.py",
         "model": "m",
         "dataset": "d",
+        "branch": None,
         "commit_sha": None,
     }
     defaults.update(kwargs)
@@ -32,6 +33,18 @@ def test_summary_rows_includes_core_fields() -> None:
 def test_summary_rows_includes_commit_sha() -> None:
     rows = _rows(commit_sha="abc123")
     assert rows["Commit"] == "abc123"
+
+
+def test_summary_rows_includes_branch_before_commit() -> None:
+    rows = build_submit_summary_rows(
+        rollout="r",
+        entrypoint="e.py",
+        model="m",
+        dataset="d",
+        branch="my-feature",
+        commit_sha="abc123",
+    )
+    assert rows[-2:] == [("Branch", "my-feature"), ("Commit", "abc123")]
 
 
 # --- build_env_table_rows ---

--- a/tests/unit/platform/cli/test_training_config.py
+++ b/tests/unit/platform/cli/test_training_config.py
@@ -100,6 +100,44 @@ commit_sha = "not-a-sha"
     assert "hexadecimal Git commit SHA" in message
 
 
+def test_load_config_accepts_branch(tmp_path: Path) -> None:
+    path = tmp_path / "train.toml"
+    path.write_text(
+        """
+[experiment]
+rollout = "r"
+entrypoint = "main.py"
+model_path = "m"
+dataset = "d"
+branch = "my-feature"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    config = load_train_submit_config(path)
+    assert config.experiment_branch == "my-feature"
+    assert config.experiment_config["branch"] == "my-feature"
+
+
+def test_load_config_rejects_branch_and_commit_sha(tmp_path: Path) -> None:
+    path = tmp_path / "train.toml"
+    path.write_text(
+        """
+[experiment]
+rollout = "r"
+entrypoint = "main.py"
+model_path = "m"
+dataset = "d"
+branch = "my-feature"
+commit_sha = "deadbeef"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CLIError, match="Provide either branch or commit_sha, not both"):
+        load_train_submit_config(path)
+
+
 def test_load_minimal_config(tmp_path: Path) -> None:
     path = tmp_path / "minimal.toml"
     path.write_text(


### PR DESCRIPTION
## What

- Add optional `branch` source selection to training and evaluation submit configs, while rejecting configs that specify both `branch` and `commit_sha`.
- Forward the selected branch in submission payloads and surface branch metadata in train/eval details, confirmation summaries, and remote-fetch notices.
- Add `osmosis rollout list --branch` support and pass the branch filter to the rollouts API.
- Update rollout scaffold templates and unit tests for branch configuration, API model parsing, submission payloads, and summary output.

## Why

Users need a convenient way to run cloud training and evaluation jobs from an active development branch without resolving and updating `commit_sha` after every change. Keeping `branch` and `commit_sha` mutually exclusive preserves an unambiguous source reference, while branch-filtered rollout listing makes it easier to find rollouts synced from that branch.

## How to Test

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright osmosis_ai/`
- `uv run pytest`
- `uv run osmosis rollout list --help`

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds branch-based source selection for training/evaluation submissions and rollout listing. You can pin a branch instead of a commit; invalid combinations and branches that are empty or contain whitespace are rejected. Branch flows through payloads, info/details, summaries, rollout filters, and fetch notices.

- New Features
  - Add `branch` to experiment config; validate mutual exclusivity with `commit_sha` and reject empty/whitespace.
  - Include branch in submission payloads, train/eval info (tables and eval JSON), and submit confirmation tables.
  - Update remote-fetch notice to explain branch-based fetching.
  - Support `osmosis rollout list --branch`; forward URL-encoded filter to the API and include branch in list context.
  - API: client accepts `branch` query; models parse `branch` in Training/Evaluation detail; scaffold templates updated; tests cover validation, filtering, payloads, models, and summaries.

<sup>Written for commit b5b285a734a313dbb5e6bfe8029700f529f555d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

