### PR TITLE
[misc] chore: add mcp and click security floors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,17 @@ dependencies = [
     # so they can still float up with their parents.
     "aiohttp>=3.14.1",
     "cryptography>=48.0.1",
+    # mcp arrives transitively via strands-agents and openai-agents. The SDK
+    # itself never imports it, but >=1.28.1 is the floor that clears the
+    # server-transport advisories (GHSA-hvrp-rf83-w775, GHSA-jpw9-pfvf-9f58,
+    # GHSA-vj7q-gjh5-988w) for consumers that do build MCP servers on top.
+    "mcp>=1.28.1",
+    # External click arrives via litellm/pyiceberg/uvicorn. >=8.3.3 drops the
+    # shell=True in click.edit()/pager (CVE-2026-7246). NOTE: this is purely a
+    # floor — CLI code must still never import click, since Typer vendors its
+    # own copy (see osmosis_ai/cli/_click_compat.py); the vendored copy was
+    # never affected.
+    "click>=8.3.3",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -367,14 +367,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -1398,7 +1398,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1416,9 +1416,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]
@@ -2008,11 +2008,13 @@ name = "osmosis-ai"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "click" },
     { name = "cryptography" },
     { name = "harbor", extra = ["daytona"] },
     { name = "httpx" },
     { name = "keyring" },
     { name = "litellm" },
+    { name = "mcp" },
     { name = "openai-agents", extra = ["litellm"] },
     { name = "orjson" },
     { name = "pydantic" },
@@ -2056,12 +2058,14 @@ server = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.1" },
+    { name = "click", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.100.0,<1.0.0" },
     { name = "harbor", extras = ["daytona"], specifier = ">=0.15.0,<0.17.0" },
     { name = "httpx", specifier = ">=0.25.0,<1.0.0" },
     { name = "keyring", specifier = ">=25.0.0" },
     { name = "litellm", specifier = ">=1.84.0,<2.0.0" },
+    { name = "mcp", specifier = ">=1.28.1" },
     { name = "openai-agents", extras = ["litellm"], specifier = ">=0.18.1,<0.19" },
     { name = "orjson", specifier = ">=3.11.6,<4.0" },
     { name = "osmosis-ai", extras = ["platform"], marker = "extra == 'server'" },


### PR DESCRIPTION
## What

- Add `mcp>=1.28.1` to `pyproject.toml` dependencies, alongside the existing `aiohttp`/`cryptography` security floors.
- Add `click>=8.3.3` to the same block.
- Regenerate `uv.lock`: `mcp` 1.26.0 -> 1.28.1, `click` 8.3.1 -> 8.4.2. No other packages moved.

## Why

`mcp` had three open high-severity Dependabot alerts (#106, #107, #108) covering GHSA-hvrp-rf83-w775, GHSA-jpw9-pfvf-9f58, and GHSA-vj7q-gjh5-988w. All three are MCP server-transport issues; 1.28.1 is the lowest version that clears all of them. It arrives transitively via `strands-agents` and `openai-agents`, and both parents allow `mcp<2`, so the floor does not constrain them.

`click` was not flagged by Dependabot. It surfaced from an independent OSV.dev scan of the full lock file as CVE-2026-7246 — command injection via `shell=True` in `click.edit()` and the pager path, fixed in 8.3.3. The corresponding `GHSA-47fr-3ffg-hgmw` is not present in GitHub's advisory database, which is why Dependabot never fired; the record comes from the PySec/Red Hat feeds instead. External `click` reaches us through `litellm`, `pyiceberg`, and `uvicorn`, all of which allow `click<9.0`.

Neither package is imported anywhere in `osmosis_ai/`, so there is no live exposure in this repo. Notably, the CLI is unaffected by the click CVE on both sides: Typer 0.26+ vendors its own Click copy, and that vendored copy contains no `edit()`/`Editor` and no `shell=True` at all. These are lower-bound floors rather than lock-only bumps because `osmosis-ai` is a library — downstream consumers resolve their own dependency trees, so a lock-only change would silence the alerts without protecting anyone installing the package.

The `click` floor deliberately does not change the standing rule that CLI code must never import the external `click` package; that guidance in `osmosis_ai/cli/_click_compat.py` still holds, and the added comment says so.

## How to Test

- `uv sync --extra dev && uv run pytest` — 1736 passed.
- `uv run pyright osmosis_ai/` — 0 errors.
- `uv run ruff check . && uv run ruff format --check .` — both pass.
- `uv run osmosis --help` — CLI renders correctly under click 8.4.2 (a minor-line bump from 8.3.x).
- `uv run python -c "import strands, agents"` — the two packages that actually consume `mcp` import cleanly on 1.28.1.
- Full-tree vulnerability scan returns clean: `uv run python -c "import json,re,urllib.request; txt=open('uv.lock').read(); pkgs={re.search(r'^name = \"(.+?)\"',b,re.M).group(1): re.search(r'^version = \"(.+?)\"',b,re.M).group(1) for b in txt.split('[[package]]')[1:] if re.search(r'^name = \"(.+?)\"',b,re.M) and re.search(r'^version = \"(.+?)\"',b,re.M)}; q=[{'package':{'name':k,'ecosystem':'PyPI'},'version':v} for k,v in pkgs.items()]; res=json.load(urllib.request.urlopen(urllib.request.Request('https://api.osv.dev/v1/querybatch',data=json.dumps({'queries':q}).encode(),headers={'Content-Type':'application/json'}))); print([(n,pkgs[n],vv['id']) for n,r in zip(pkgs,res['results']) for vv in r.get('vulns',[])] or 'CLEAN')"`

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add security floors for `mcp>=1.28.1` and `click>=8.3.3` to block vulnerable versions in downstream installs. Regenerated `uv.lock` (mcp 1.26.0 → 1.28.1, click 8.3.1 → 8.4.2); no runtime code changes.

- **Dependencies**
  - Added lower bounds in `pyproject.toml` alongside `aiohttp`/`cryptography`.
  - Clears `mcp` transport advisories (GHSA-hvrp-rf83-w775, GHSA-jpw9-pfvf-9f58, GHSA-vj7q-gjh5-988w) and `click` CVE-2026-7246 (OSV-only); parents allow these ranges (`mcp<2`, `click<9`).
  - SDK doesn’t import these; CLI uses Typer’s vendored Click—do not import external `click`.

<sup>Written for commit 8136e8959beb3f08f91240ae3303e52579633e0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

