### PR TITLE
[rollout] fix: preserve grader-written file artifacts on Harbor

### DIFF
--- a/osmosis_ai/rollout/backend/harbor/backend.py
+++ b/osmosis_ai/rollout/backend/harbor/backend.py
@@ -38,7 +38,12 @@ from osmosis_ai.rollout.types import (
     RolloutSample,
     RolloutStatus,
 )
-from osmosis_ai.rollout.utils.file_artifacts import default_artifact_root
+from osmosis_ai.rollout.utils.file_artifacts import (
+    GRADER_ARTIFACTS_SNAPSHOT_DIRNAME,
+    HARBOR_ARTIFACTS_DIR,
+    copy_artifact_tree,
+    default_artifact_root,
+)
 from osmosis_ai.rollout.utils.imports import to_import_path
 from osmosis_ai.rollout.utils.rewards import validate_samples_have_rewards
 
@@ -470,12 +475,38 @@ class HarborBackend(ExecutionBackend):
             return False
         return True
 
+    def _merge_grader_artifacts(self, rollout_id: str) -> None:
+        """Merge the verifier-returned final snapshot into trial artifacts."""
+        trial_dir = self.trials_dir / f"{TRIAL_NAME_PREFIX}{rollout_id}"
+        source_dir = trial_dir / "verifier" / GRADER_ARTIFACTS_SNAPSHOT_DIRNAME
+        if not source_dir.is_dir():
+            return
+
+        # Harbor maps the /logs/artifacts convention directory beneath the trial's
+        # artifacts root as logs/artifacts.
+        destination_dir = (
+            trial_dir / "artifacts" / HARBOR_ARTIFACTS_DIR.relative_to("/")
+        )
+        try:
+            copy_artifact_tree(source_dir, destination_dir)
+        except Exception:
+            logger.warning(
+                "Failed to merge grader artifacts for rollout %s (best-effort)",
+                rollout_id,
+                exc_info=True,
+            )
+
     async def on_trial_end(self, event: TrialHookEvent) -> None:
         rollout_id = parse_rollout_id(event)
         pending = self.pending.pop(rollout_id, None)
         if not pending:
             logger.error("No pending trial found for rollout %s", rollout_id)
             return
+
+        # Harbor collects /logs/artifacts before verification. grader_runner stages
+        # the final tree in /logs/verifier, which Harbor returns after verification;
+        # merge that post-grader snapshot before relocating the trial artifacts.
+        self._merge_grader_artifacts(rollout_id)
 
         # Evacuate artifacts first; delete the source only if it succeeds.
         delete_trial = bool(

--- a/osmosis_ai/rollout/backend/harbor/backend.py
+++ b/osmosis_ai/rollout/backend/harbor/backend.py
@@ -452,21 +452,25 @@ class HarborBackend(ExecutionBackend):
         await pending.on_workflow_complete(result)
 
     def _relocate_trial_artifacts(self, rollout_id: str, *, move: bool) -> bool:
-        """Persist collected artifacts to the artifact root; ``move`` before
-        cleanup, else copy. Best-effort: returns ``False`` to keep the source."""
+        """Safely persist regular files to the artifact root.
+
+        When ``move`` is true, remove the source only after the copy succeeds.
+        Best-effort: returns ``False`` to keep the source on any failure.
+        """
         source_dir = self.trials_dir / f"{TRIAL_NAME_PREFIX}{rollout_id}" / "artifacts"
         if not source_dir.is_dir():
             return True
         dest_dir = self.artifact_root / rollout_id / "artifacts"
         try:
-            if dest_dir.exists():
-                shutil.rmtree(dest_dir)
-            dest_dir.parent.mkdir(parents=True, exist_ok=True)
+            copy_artifact_tree(
+                source_dir,
+                dest_dir,
+                destination_root=self.artifact_root,
+                replace_destination=True,
+            )
             if move:
-                shutil.move(source_dir, dest_dir)
-            else:
-                shutil.copytree(source_dir, dest_dir, symlinks=False)
-        except OSError:
+                shutil.rmtree(source_dir)
+        except Exception:
             logger.warning(
                 "Failed to relocate trial artifacts for rollout %s (best-effort)",
                 rollout_id,
@@ -488,7 +492,11 @@ class HarborBackend(ExecutionBackend):
             trial_dir / "artifacts" / HARBOR_ARTIFACTS_DIR.relative_to("/")
         )
         try:
-            copy_artifact_tree(source_dir, destination_dir)
+            copy_artifact_tree(
+                source_dir,
+                destination_dir,
+                destination_root=self.trials_dir,
+            )
         except Exception:
             logger.warning(
                 "Failed to merge grader artifacts for rollout %s (best-effort)",

--- a/osmosis_ai/rollout/backend/harbor/grader_runner.py
+++ b/osmosis_ai/rollout/backend/harbor/grader_runner.py
@@ -74,7 +74,11 @@ def stage_grader_artifacts(baseline: ArtifactFileState) -> None:
     """
     snapshot_dir = VERIFIER_LOGS_DIR / GRADER_ARTIFACTS_SNAPSHOT_DIRNAME
     try:
-        if snapshot_dir.is_symlink() or snapshot_dir.is_file():
+        if snapshot_dir.is_junction():
+            snapshot_dir.rmdir()
+        elif snapshot_dir.is_symlink() or (
+            snapshot_dir.exists() and not snapshot_dir.is_dir()
+        ):
             snapshot_dir.unlink()
         elif snapshot_dir.is_dir():
             shutil.rmtree(snapshot_dir)
@@ -83,6 +87,7 @@ def stage_grader_artifacts(baseline: ArtifactFileState) -> None:
         copied = copy_artifact_tree(
             HARBOR_ARTIFACTS_DIR,
             snapshot_dir,
+            destination_root=VERIFIER_LOGS_DIR,
             baseline=baseline,
         )
         if not copied:
@@ -114,20 +119,23 @@ def main() -> None:
         return
 
     samples = load_samples(args.samples)
-    grader_cls = resolve_object(config["grader"])
-    grader_config = (
-        resolve_object(config["grader_config"]) if "grader_config" in config else None
-    )
-
-    ctx = GraderContext(
-        label=label,
-        samples=samples,
-        metadata=metadata,
-        artifacts_dir=HARBOR_ARTIFACTS_DIR,
-    )
-    grader = grader_cls(grader_config)
     artifact_baseline = capture_artifact_baseline()
     try:
+        # Resolving user modules and constructing the grader are part of its
+        # lifecycle: either step may write diagnostics before failing.
+        grader_cls = resolve_object(config["grader"])
+        grader_config = (
+            resolve_object(config["grader_config"])
+            if "grader_config" in config
+            else None
+        )
+        ctx = GraderContext(
+            label=label,
+            samples=samples,
+            metadata=metadata,
+            artifacts_dir=HARBOR_ARTIFACTS_DIR,
+        )
+        grader = grader_cls(grader_config)
         asyncio.run(grader.grade(ctx))
     finally:
         # Harbor 0.16 collects /logs/artifacts before running the verifier. Its

--- a/osmosis_ai/rollout/backend/harbor/grader_runner.py
+++ b/osmosis_ai/rollout/backend/harbor/grader_runner.py
@@ -9,12 +9,20 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import shutil
+import sys
 from pathlib import Path
 from typing import Any
 
 from osmosis_ai.rollout.context import GraderContext
 from osmosis_ai.rollout.types import RolloutSample
-from osmosis_ai.rollout.utils.file_artifacts import HARBOR_ARTIFACTS_DIR
+from osmosis_ai.rollout.utils.file_artifacts import (
+    GRADER_ARTIFACTS_SNAPSHOT_DIRNAME,
+    HARBOR_ARTIFACTS_DIR,
+    ArtifactFileState,
+    artifact_tree_state,
+    copy_artifact_tree,
+)
 from osmosis_ai.rollout.utils.imports import resolve_object
 
 VERIFIER_LOGS_DIR = Path("/logs/verifier")
@@ -43,6 +51,45 @@ def load_samples(path: Path) -> dict[str, RolloutSample]:
 def write_rewards(rewards: dict[str, float | None]) -> None:
     VERIFIER_LOGS_DIR.mkdir(parents=True, exist_ok=True)
     (VERIFIER_LOGS_DIR / "reward.json").write_text(json.dumps(rewards))
+
+
+def capture_artifact_baseline() -> ArtifactFileState:
+    """Capture pre-grader files without making artifact I/O grading-critical."""
+    try:
+        return artifact_tree_state(HARBOR_ARTIFACTS_DIR)
+    except Exception as exc:
+        print(
+            f"Failed to inspect pre-grader artifacts (best-effort): {exc}",
+            file=sys.stderr,
+        )
+        return {}
+
+
+def stage_grader_artifacts(baseline: ArtifactFileState) -> None:
+    """Stage the post-grader artifact tree in Harbor's returned verifier logs.
+
+    A snapshot directory exists afterwards only when the grader changed files:
+    stale snapshots are removed first, and an empty copy result is dropped so
+    the host backend can treat the snapshot's presence as "there is an increment".
+    """
+    snapshot_dir = VERIFIER_LOGS_DIR / GRADER_ARTIFACTS_SNAPSHOT_DIRNAME
+    try:
+        if snapshot_dir.is_symlink() or snapshot_dir.is_file():
+            snapshot_dir.unlink()
+        elif snapshot_dir.is_dir():
+            shutil.rmtree(snapshot_dir)
+        if not HARBOR_ARTIFACTS_DIR.is_dir():
+            return
+        copied = copy_artifact_tree(
+            HARBOR_ARTIFACTS_DIR,
+            snapshot_dir,
+            baseline=baseline,
+        )
+        if not copied:
+            shutil.rmtree(snapshot_dir, ignore_errors=True)
+    except Exception as exc:
+        # File artifacts are best-effort and must never mask a grader result.
+        print(f"Failed to stage grader artifacts (best-effort): {exc}", file=sys.stderr)
 
 
 def main() -> None:
@@ -79,7 +126,15 @@ def main() -> None:
         artifacts_dir=HARBOR_ARTIFACTS_DIR,
     )
     grader = grader_cls(grader_config)
-    asyncio.run(grader.grade(ctx))
+    artifact_baseline = capture_artifact_baseline()
+    try:
+        asyncio.run(grader.grade(ctx))
+    finally:
+        # Harbor 0.16 collects /logs/artifacts before running the verifier. Its
+        # verifier directory, however, is returned after verification for both
+        # shared and separate environments. Snapshot here so grader-authored files
+        # survive until HarborBackend.on_trial_end can merge and relocate them.
+        stage_grader_artifacts(artifact_baseline)
 
     graded = ctx.get_samples()
     for sid, sample in graded.items():

--- a/osmosis_ai/rollout/utils/file_artifacts.py
+++ b/osmosis_ai/rollout/utils/file_artifacts.py
@@ -4,17 +4,107 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import shutil
 from pathlib import Path
 
 logger: logging.Logger = logging.getLogger(__name__)
 
 # Harbor's auto-collected convention directory inside the sandbox.
 HARBOR_ARTIFACTS_DIR = Path("/logs/artifacts")
+# Harbor always returns /logs/verifier after the verifier exits. The grader runner
+# stages its final artifacts tree under this reserved child so the host backend can
+# merge grader-authored files into Harbor's earlier, pre-verifier artifact snapshot.
+GRADER_ARTIFACTS_SNAPSHOT_DIRNAME = ".osmosis-artifacts"
 
 CREATE_ATTEMPTS = 3
 CREATE_BACKOFF_SECONDS = 0.5  # doubled per retry
 
 _HEALTH_CHECK_FILENAME = ".osmosis-health-check"
+
+type ArtifactFileState = dict[str, tuple[int, int, int]]
+
+
+def artifact_tree_state(source: Path) -> ArtifactFileState:
+    """Return cheap change-detection metadata for regular files in a tree."""
+    state: ArtifactFileState = {}
+
+    def _visit(directory: Path, relative_dir: Path) -> None:
+        if directory.is_symlink() or not directory.is_dir():
+            return
+        for entry in sorted(directory.iterdir(), key=lambda path: path.name):
+            if entry.is_symlink():
+                continue
+            relative_path = relative_dir / entry.name
+            if entry.is_dir():
+                _visit(entry, relative_path)
+            elif entry.is_file():
+                stat = entry.stat()
+                state[relative_path.as_posix()] = (
+                    stat.st_size,
+                    stat.st_mtime_ns,
+                    stat.st_ctime_ns,
+                )
+
+    _visit(source, Path())
+    return state
+
+
+def copy_artifact_tree(
+    source: Path,
+    destination: Path,
+    *,
+    baseline: ArtifactFileState | None = None,
+) -> int:
+    """Merge regular files from ``source`` into ``destination``.
+
+    Artifact trees cross trust and filesystem boundaries, so copy file contents
+    only: never follow or recreate symlinks, special files, or metadata. Existing
+    destination entries are replaced when their file/directory type changed. When
+    ``baseline`` is provided, unchanged files are skipped. The merge is additive:
+    files present only in ``destination`` are kept, so deletions in ``source``
+    never propagate. Returns the number of files copied.
+    """
+    if source.is_symlink() or not source.is_dir():
+        return 0
+
+    if destination.is_symlink() or (destination.exists() and not destination.is_dir()):
+        destination.unlink()
+    destination.mkdir(parents=True, exist_ok=True)
+
+    def _copy(directory: Path, target_dir: Path, relative_dir: Path) -> int:
+        copied = 0
+        for entry in sorted(directory.iterdir(), key=lambda path: path.name):
+            target = target_dir / entry.name
+            relative_path = relative_dir / entry.name
+            if entry.is_symlink():
+                logger.warning("Skipping symlink in artifact tree: %s", entry)
+                continue
+            if entry.is_dir():
+                if target.is_symlink() or (target.exists() and not target.is_dir()):
+                    target.unlink()
+                target.mkdir(parents=True, exist_ok=True)
+                copied += _copy(entry, target, relative_path)
+                continue
+            if entry.is_file():
+                stat = entry.stat()
+                current_state = (stat.st_size, stat.st_mtime_ns, stat.st_ctime_ns)
+                if (
+                    baseline is not None
+                    and baseline.get(relative_path.as_posix()) == current_state
+                ):
+                    continue
+                if target.is_symlink():
+                    target.unlink()
+                elif target.is_dir():
+                    shutil.rmtree(target)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(entry, target)
+                copied += 1
+                continue
+            logger.warning("Skipping special file in artifact tree: %s", entry)
+        return copied
+
+    return _copy(source, destination, Path())
 
 
 def default_artifact_root() -> Path:

--- a/osmosis_ai/rollout/utils/file_artifacts.py
+++ b/osmosis_ai/rollout/utils/file_artifacts.py
@@ -24,15 +24,28 @@ _HEALTH_CHECK_FILENAME = ".osmosis-health-check"
 type ArtifactFileState = dict[str, tuple[int, int, int]]
 
 
+def _is_link(path: Path) -> bool:
+    """Return whether a path can redirect traversal to another location."""
+    return path.is_symlink() or path.is_junction()
+
+
+def _remove_link(path: Path) -> None:
+    """Remove a symbolic link or Windows junction without touching its target."""
+    if path.is_junction():
+        path.rmdir()
+    else:
+        path.unlink()
+
+
 def artifact_tree_state(source: Path) -> ArtifactFileState:
     """Return cheap change-detection metadata for regular files in a tree."""
     state: ArtifactFileState = {}
 
     def _visit(directory: Path, relative_dir: Path) -> None:
-        if directory.is_symlink() or not directory.is_dir():
+        if _is_link(directory) or not directory.is_dir():
             return
         for entry in sorted(directory.iterdir(), key=lambda path: path.name):
-            if entry.is_symlink():
+            if _is_link(entry):
                 continue
             relative_path = relative_dir / entry.name
             if entry.is_dir():
@@ -53,7 +66,9 @@ def copy_artifact_tree(
     source: Path,
     destination: Path,
     *,
+    destination_root: Path,
     baseline: ArtifactFileState | None = None,
+    replace_destination: bool = False,
 ) -> int:
     """Merge regular files from ``source`` into ``destination``.
 
@@ -62,25 +77,66 @@ def copy_artifact_tree(
     destination entries are replaced when their file/directory type changed. When
     ``baseline`` is provided, unchanged files are skipped. The merge is additive:
     files present only in ``destination`` are kept, so deletions in ``source``
-    never propagate. Returns the number of files copied.
+    never propagate. Set ``replace_destination`` to clear the destination first.
+
+    ``destination_root`` is the trusted ancestor beneath which the destination
+    must live. Every descendant component leading to the destination is checked
+    without resolving symlinks, so an untrusted intermediate link cannot redirect
+    writes outside the intended tree. Returns the number of files copied.
     """
-    if source.is_symlink() or not source.is_dir():
+    if _is_link(source) or not source.is_dir():
         return 0
 
-    if destination.is_symlink() or (destination.exists() and not destination.is_dir()):
-        destination.unlink()
-    destination.mkdir(parents=True, exist_ok=True)
+    trusted_root = destination_root.absolute()
+    destination = destination.absolute()
+    try:
+        relative_destination = destination.relative_to(trusted_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"Artifact destination {destination} is outside trusted root {trusted_root}"
+        ) from exc
+    if not relative_destination.parts or ".." in relative_destination.parts:
+        raise ValueError("Artifact destination must be strictly below its trusted root")
+
+    # The root itself is supplied as trusted and may intentionally be a mount or
+    # symlink. Descendants are untrusted: create/walk them one component at a time
+    # and reject intermediate links before any destructive operation.
+    trusted_root.mkdir(parents=True, exist_ok=True)
+    current = trusted_root
+    for index, part in enumerate(relative_destination.parts):
+        current /= part
+        is_destination = index == len(relative_destination.parts) - 1
+        if _is_link(current):
+            if not is_destination:
+                raise OSError(
+                    f"Refusing symlink in artifact destination path: {current}"
+                )
+            _remove_link(current)
+        elif current.exists():
+            if not current.is_dir():
+                if not is_destination:
+                    raise NotADirectoryError(
+                        f"Artifact destination component is not a directory: {current}"
+                    )
+                current.unlink()
+            elif is_destination and replace_destination:
+                shutil.rmtree(current)
+            else:
+                continue
+        current.mkdir()
 
     def _copy(directory: Path, target_dir: Path, relative_dir: Path) -> int:
         copied = 0
         for entry in sorted(directory.iterdir(), key=lambda path: path.name):
             target = target_dir / entry.name
             relative_path = relative_dir / entry.name
-            if entry.is_symlink():
-                logger.warning("Skipping symlink in artifact tree: %s", entry)
+            if _is_link(entry):
+                logger.warning("Skipping link in artifact tree: %s", entry)
                 continue
             if entry.is_dir():
-                if target.is_symlink() or (target.exists() and not target.is_dir()):
+                if _is_link(target):
+                    _remove_link(target)
+                elif target.exists() and not target.is_dir():
                     target.unlink()
                 target.mkdir(parents=True, exist_ok=True)
                 copied += _copy(entry, target, relative_path)
@@ -93,10 +149,12 @@ def copy_artifact_tree(
                     and baseline.get(relative_path.as_posix()) == current_state
                 ):
                     continue
-                if target.is_symlink():
-                    target.unlink()
+                if _is_link(target):
+                    _remove_link(target)
                 elif target.is_dir():
                     shutil.rmtree(target)
+                elif target.exists():
+                    target.unlink()
                 target.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copyfile(entry, target)
                 copied += 1

--- a/tests/unit/rollout/test_file_artifacts.py
+++ b/tests/unit/rollout/test_file_artifacts.py
@@ -5,7 +5,11 @@ from pathlib import Path
 import pytest
 
 from osmosis_ai.rollout.utils import file_artifacts
-from osmosis_ai.rollout.utils.file_artifacts import create_rollout_artifacts_dir
+from osmosis_ai.rollout.utils.file_artifacts import (
+    artifact_tree_state,
+    copy_artifact_tree,
+    create_rollout_artifacts_dir,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -77,3 +81,50 @@ class TestCreateRolloutArtifactsDir:
         result = await create_rollout_artifacts_dir(tmp_path, "r1")
 
         assert result is None
+
+
+class TestCopyArtifactTree:
+    def test_merges_nested_files_and_replaces_conflicting_types(self, tmp_path):
+        source = tmp_path / "source"
+        destination = tmp_path / "destination"
+        (source / "nested").mkdir(parents=True)
+        (source / "nested" / "grader.json").write_text("{}")
+        (source / "now-a-file").write_text("final")
+        (destination / "nested").mkdir(parents=True)
+        (destination / "nested" / "workflow.txt").write_text("kept")
+        (destination / "now-a-file").mkdir(parents=True)
+
+        copied = copy_artifact_tree(source, destination)
+
+        assert copied == 2
+        assert (destination / "nested" / "workflow.txt").read_text() == "kept"
+        assert (destination / "nested" / "grader.json").read_text() == "{}"
+        assert (destination / "now-a-file").read_text() == "final"
+
+    def test_skips_symlinks(self, tmp_path):
+        source = tmp_path / "source"
+        destination = tmp_path / "destination"
+        source.mkdir()
+        secret = tmp_path / "secret.txt"
+        secret.write_text("do not copy")
+        (source / "linked.txt").symlink_to(secret)
+
+        copy_artifact_tree(source, destination)
+
+        assert not (destination / "linked.txt").exists()
+
+    def test_baseline_skips_unchanged_files(self, tmp_path):
+        source = tmp_path / "source"
+        destination = tmp_path / "destination"
+        source.mkdir()
+        unchanged = source / "workflow.txt"
+        unchanged.write_text("workflow")
+        baseline = artifact_tree_state(source)
+        changed = source / "grader.txt"
+        changed.write_text("grader")
+
+        copied = copy_artifact_tree(source, destination, baseline=baseline)
+
+        assert copied == 1
+        assert not (destination / "workflow.txt").exists()
+        assert (destination / "grader.txt").read_text() == "grader"

--- a/tests/unit/rollout/test_file_artifacts.py
+++ b/tests/unit/rollout/test_file_artifacts.py
@@ -1,5 +1,6 @@
 """Tests for osmosis_ai.rollout.utils.file_artifacts."""
 
+import os
 from pathlib import Path
 
 import pytest
@@ -94,7 +95,11 @@ class TestCopyArtifactTree:
         (destination / "nested" / "workflow.txt").write_text("kept")
         (destination / "now-a-file").mkdir(parents=True)
 
-        copied = copy_artifact_tree(source, destination)
+        copied = copy_artifact_tree(
+            source,
+            destination,
+            destination_root=tmp_path,
+        )
 
         assert copied == 2
         assert (destination / "nested" / "workflow.txt").read_text() == "kept"
@@ -109,9 +114,79 @@ class TestCopyArtifactTree:
         secret.write_text("do not copy")
         (source / "linked.txt").symlink_to(secret)
 
-        copy_artifact_tree(source, destination)
+        copy_artifact_tree(
+            source,
+            destination,
+            destination_root=tmp_path,
+        )
 
         assert not (destination / "linked.txt").exists()
+
+    def test_skips_special_files(self, tmp_path):
+        if not hasattr(os, "mkfifo"):
+            pytest.skip("FIFO files are unavailable on this platform")
+
+        source = tmp_path / "source"
+        destination = tmp_path / "destination"
+        source.mkdir()
+        os.mkfifo(source / "pipe")
+
+        copied = copy_artifact_tree(
+            source,
+            destination,
+            destination_root=tmp_path,
+        )
+
+        assert copied == 0
+        assert not (destination / "pipe").exists()
+
+    def test_rejects_intermediate_destination_symlink(self, tmp_path):
+        source = tmp_path / "source"
+        trusted_root = tmp_path / "trusted"
+        outside = tmp_path / "outside"
+        source.mkdir()
+        trusted_root.mkdir()
+        outside.mkdir()
+        (source / "grader.txt").write_text("grader")
+        (trusted_root / "logs").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(OSError, match="symlink in artifact destination path"):
+            copy_artifact_tree(
+                source,
+                trusted_root / "logs" / "artifacts",
+                destination_root=trusted_root,
+            )
+
+        assert not (outside / "artifacts" / "grader.txt").exists()
+
+    def test_rejects_destination_outside_trusted_root(self, tmp_path):
+        source = tmp_path / "source"
+        source.mkdir()
+
+        with pytest.raises(ValueError, match="outside trusted root"):
+            copy_artifact_tree(
+                source,
+                tmp_path / "destination",
+                destination_root=tmp_path / "trusted",
+            )
+
+    def test_replace_destination_removes_stale_entries(self, tmp_path):
+        source = tmp_path / "source"
+        destination = tmp_path / "destination"
+        source.mkdir()
+        destination.mkdir()
+        (source / "fresh.txt").write_text("fresh")
+        (destination / "stale.txt").write_text("stale")
+
+        copy_artifact_tree(
+            source,
+            destination,
+            destination_root=tmp_path,
+            replace_destination=True,
+        )
+
+        assert (destination / "fresh.txt").read_text() == "fresh"
+        assert not (destination / "stale.txt").exists()
 
     def test_baseline_skips_unchanged_files(self, tmp_path):
         source = tmp_path / "source"
@@ -123,7 +198,12 @@ class TestCopyArtifactTree:
         changed = source / "grader.txt"
         changed.write_text("grader")
 
-        copied = copy_artifact_tree(source, destination, baseline=baseline)
+        copied = copy_artifact_tree(
+            source,
+            destination,
+            destination_root=tmp_path,
+            baseline=baseline,
+        )
 
         assert copied == 1
         assert not (destination / "workflow.txt").exists()

--- a/tests/unit/rollout/test_harbor_backend.py
+++ b/tests/unit/rollout/test_harbor_backend.py
@@ -4,6 +4,8 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
 
+import pytest
+
 from osmosis_ai.rollout.agent_workflow import AgentWorkflow
 from osmosis_ai.rollout.backend.harbor.backend import (
     HarborBackend,
@@ -22,7 +24,10 @@ from osmosis_ai.rollout.types import (
     RolloutSample,
     RolloutStatus,
 )
-from osmosis_ai.rollout.utils.file_artifacts import HARBOR_ARTIFACTS_DIR
+from osmosis_ai.rollout.utils.file_artifacts import (
+    GRADER_ARTIFACTS_SNAPSHOT_DIRNAME,
+    HARBOR_ARTIFACTS_DIR,
+)
 
 # Module-level captures so importlib can resolve the workflow/grader by
 # "<module>:<qualname>" and round-trip them through the runners.
@@ -57,8 +62,19 @@ class MetadataCapturingGrader(Grader):
         _GRADER_CAPTURE["metadata"] = ctx.metadata
         _GRADER_CAPTURE["label"] = ctx.label
         _GRADER_CAPTURE["artifacts_dir"] = ctx.artifacts_dir
+        if ctx.artifacts_dir:
+            ctx.artifacts_dir.mkdir(parents=True, exist_ok=True)
+            (ctx.artifacts_dir / "grader.txt").write_text("grader")
         for sample_id in ctx.get_samples():
             ctx.set_sample_reward(sample_id, 1.0)
+
+
+class ArtifactWritingFailingGrader(Grader):
+    async def grade(self, ctx: GraderContext) -> Any:
+        assert ctx.artifacts_dir is not None
+        ctx.artifacts_dir.mkdir(parents=True, exist_ok=True)
+        (ctx.artifacts_dir / "partial.txt").write_text("partial")
+        raise RuntimeError("grader exploded")
 
 
 def _make_backend_for_config(*, grader: bool = False) -> HarborBackend:
@@ -203,6 +219,64 @@ class TestHarborBackend:
         source = backend.trials_dir / "trial-r1" / "artifacts"
         assert (source / "logs" / "artifacts" / "output.txt").exists()
 
+    async def test_on_trial_end_merges_staged_grader_artifacts(self, tmp_path):
+        backend = self._make_trial_end_backend(tmp_path, cleanup=True)
+        self._seed_trial_artifacts(backend)
+        staged = (
+            backend.trials_dir
+            / "trial-r1"
+            / "verifier"
+            / GRADER_ARTIFACTS_SNAPSHOT_DIRNAME
+        )
+        staged.mkdir(parents=True)
+        (staged / "output.txt").write_text("updated by grader")
+        (staged / "grader.json").write_text('{"reward": 1}')
+
+        pending = PendingTrial(AsyncMock(), AsyncMock())
+        pending.workflow_complete_called = True
+        backend.pending["r1"] = pending
+
+        await backend.on_trial_end(self._success_event())
+
+        relocated = backend.artifact_root / "r1" / "artifacts" / "logs" / "artifacts"
+        assert (relocated / "output.txt").read_text() == "updated by grader"
+        assert (relocated / "grader.json").read_text() == '{"reward": 1}'
+
+    async def test_on_trial_end_keeps_result_when_grader_merge_fails(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        backend = self._make_trial_end_backend(tmp_path, cleanup=True)
+        self._seed_trial_artifacts(backend)
+        staged = (
+            backend.trials_dir
+            / "trial-r1"
+            / "verifier"
+            / GRADER_ARTIFACTS_SNAPSHOT_DIRNAME
+        )
+        staged.mkdir(parents=True)
+        (staged / "grader.json").write_text("{}")
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("bad artifact tree")
+
+        monkeypatch.setattr(
+            "osmosis_ai.rollout.backend.harbor.backend.copy_artifact_tree", _boom
+        )
+        on_grader = AsyncMock()
+        pending = PendingTrial(AsyncMock(), on_grader)
+        pending.workflow_complete_called = True
+        backend.pending["r1"] = pending
+
+        with caplog.at_level(
+            logging.WARNING, logger="osmosis_ai.rollout.backend.harbor.backend"
+        ):
+            await backend.on_trial_end(self._success_event())
+
+        assert on_grader.call_args.args[0].status == RolloutStatus.SUCCESS
+        relocated = backend.artifact_root / "r1" / "artifacts"
+        assert (relocated / "logs" / "artifacts" / "output.txt").read_text() == "ok"
+        assert "Failed to merge grader artifacts for rollout r1" in caplog.text
+
     async def test_on_trial_end_keeps_trial_when_relocation_fails(
         self, tmp_path, monkeypatch, caplog
     ):
@@ -290,7 +364,11 @@ class TestGraderRunnerRoundTrip:
 
         _GRADER_CAPTURE.clear()
         verifier_dir = tmp_path / "verifier"
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir()
+        (artifacts_dir / "workflow.txt").write_text("workflow")
         monkeypatch.setattr(grader_runner, "VERIFIER_LOGS_DIR", verifier_dir)
+        monkeypatch.setattr(grader_runner, "HARBOR_ARTIFACTS_DIR", artifacts_dir)
 
         backend = _make_backend_for_config(grader=True)
         metadata = {"tools": ["search"]}
@@ -316,9 +394,12 @@ class TestGraderRunnerRoundTrip:
         grader_runner.main()
 
         assert _GRADER_CAPTURE["metadata"] == metadata
-        assert _GRADER_CAPTURE["artifacts_dir"] == HARBOR_ARTIFACTS_DIR
+        assert _GRADER_CAPTURE["artifacts_dir"] == artifacts_dir
         rewards = json.loads((verifier_dir / "reward.json").read_text())
         assert rewards == {"sample-1": 1.0}
+        snapshot = verifier_dir / GRADER_ARTIFACTS_SNAPSHOT_DIRNAME
+        assert not (snapshot / "workflow.txt").exists()
+        assert (snapshot / "grader.txt").read_text() == "grader"
 
     def test_metadata_only_config_still_grades(self, tmp_path, monkeypatch):
         """A config with metadata but no label still triggers grading."""
@@ -326,7 +407,10 @@ class TestGraderRunnerRoundTrip:
 
         _GRADER_CAPTURE.clear()
         verifier_dir = tmp_path / "verifier"
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir()
         monkeypatch.setattr(grader_runner, "VERIFIER_LOGS_DIR", verifier_dir)
+        monkeypatch.setattr(grader_runner, "HARBOR_ARTIFACTS_DIR", artifacts_dir)
 
         backend = _make_backend_for_config(grader=True)
         request = ExecutionRequest(
@@ -354,3 +438,79 @@ class TestGraderRunnerRoundTrip:
         assert _GRADER_CAPTURE["metadata"] == {"tools": ["search"]}
         rewards = json.loads((verifier_dir / "reward.json").read_text())
         assert rewards == {"sample-1": 1.0}
+
+    def test_grader_failure_still_stages_artifacts(self, tmp_path, monkeypatch):
+        """The finally-block snapshot preserves files written before the crash."""
+        import osmosis_ai.rollout.backend.harbor.grader_runner as grader_runner
+
+        verifier_dir = tmp_path / "verifier"
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir()
+        monkeypatch.setattr(grader_runner, "VERIFIER_LOGS_DIR", verifier_dir)
+        monkeypatch.setattr(grader_runner, "HARBOR_ARTIFACTS_DIR", artifacts_dir)
+
+        backend = _make_backend_for_config(grader=True)
+        backend.grader_path = (
+            f"{ArtifactWritingFailingGrader.__module__}:"
+            f"{ArtifactWritingFailingGrader.__qualname__}"
+        )
+        request = ExecutionRequest(
+            id="r1",
+            prompt=[{"role": "user", "content": "hi"}],
+            label="test-label",
+        )
+        config_path = tmp_path / "rollout_config.json"
+        config_path.write_text(
+            json.dumps(backend.build_rollout_config(request), default=str)
+        )
+        samples_path = tmp_path / "samples.json"
+        self._write_samples(samples_path)
+
+        monkeypatch.setattr(
+            grader_runner,
+            "parse_args",
+            lambda: SimpleNamespace(config=config_path, samples=samples_path),
+        )
+
+        with pytest.raises(RuntimeError, match="grader exploded"):
+            grader_runner.main()
+
+        snapshot = verifier_dir / GRADER_ARTIFACTS_SNAPSHOT_DIRNAME
+        assert (snapshot / "partial.txt").read_text() == "partial"
+        assert not (verifier_dir / "reward.json").exists()
+
+
+class TestStageGraderArtifacts:
+    def test_drops_snapshot_when_grader_wrote_nothing(self, tmp_path, monkeypatch):
+        import osmosis_ai.rollout.backend.harbor.grader_runner as grader_runner
+
+        verifier_dir = tmp_path / "verifier"
+        artifacts_dir = tmp_path / "artifacts"
+        (artifacts_dir / "nested").mkdir(parents=True)
+        (artifacts_dir / "nested" / "workflow.txt").write_text("workflow")
+        monkeypatch.setattr(grader_runner, "VERIFIER_LOGS_DIR", verifier_dir)
+        monkeypatch.setattr(grader_runner, "HARBOR_ARTIFACTS_DIR", artifacts_dir)
+
+        baseline = grader_runner.capture_artifact_baseline()
+        grader_runner.stage_grader_artifacts(baseline)
+
+        assert not (verifier_dir / GRADER_ARTIFACTS_SNAPSHOT_DIRNAME).exists()
+
+    def test_replaces_stale_snapshot_from_previous_run(self, tmp_path, monkeypatch):
+        import osmosis_ai.rollout.backend.harbor.grader_runner as grader_runner
+
+        verifier_dir = tmp_path / "verifier"
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir()
+        (artifacts_dir / "grader.txt").write_text("fresh")
+        stale = verifier_dir / GRADER_ARTIFACTS_SNAPSHOT_DIRNAME
+        stale.mkdir(parents=True)
+        (stale / "stale.txt").write_text("stale")
+        monkeypatch.setattr(grader_runner, "VERIFIER_LOGS_DIR", verifier_dir)
+        monkeypatch.setattr(grader_runner, "HARBOR_ARTIFACTS_DIR", artifacts_dir)
+
+        grader_runner.stage_grader_artifacts({})
+
+        snapshot = verifier_dir / GRADER_ARTIFACTS_SNAPSHOT_DIRNAME
+        assert (snapshot / "grader.txt").read_text() == "fresh"
+        assert not (snapshot / "stale.txt").exists()

--- a/tests/unit/rollout/test_harbor_backend.py
+++ b/tests/unit/rollout/test_harbor_backend.py
@@ -28,6 +28,9 @@ from osmosis_ai.rollout.utils.file_artifacts import (
     GRADER_ARTIFACTS_SNAPSHOT_DIRNAME,
     HARBOR_ARTIFACTS_DIR,
 )
+from osmosis_ai.rollout.utils.file_artifacts import (
+    copy_artifact_tree as real_copy_artifact_tree,
+)
 
 # Module-level captures so importlib can resolve the workflow/grader by
 # "<module>:<qualname>" and round-trip them through the runners.
@@ -75,6 +78,20 @@ class ArtifactWritingFailingGrader(Grader):
         ctx.artifacts_dir.mkdir(parents=True, exist_ok=True)
         (ctx.artifacts_dir / "partial.txt").write_text("partial")
         raise RuntimeError("grader exploded")
+
+
+class ArtifactWritingFailingConstructorGrader(Grader):
+    def __init__(self, _config=None):
+        import osmosis_ai.rollout.backend.harbor.grader_runner as grader_runner
+
+        grader_runner.HARBOR_ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+        (grader_runner.HARBOR_ARTIFACTS_DIR / "constructor.txt").write_text(
+            "constructor"
+        )
+        raise RuntimeError("grader constructor exploded")
+
+    async def grade(self, _ctx: GraderContext) -> Any:
+        raise AssertionError("grade should not run")
 
 
 def _make_backend_for_config(*, grader: bool = False) -> HarborBackend:
@@ -219,6 +236,24 @@ class TestHarborBackend:
         source = backend.trials_dir / "trial-r1" / "artifacts"
         assert (source / "logs" / "artifacts" / "output.txt").exists()
 
+    async def test_on_trial_end_skips_symlinks_when_relocating(self, tmp_path):
+        backend = self._make_trial_end_backend(tmp_path, cleanup=False)
+        self._seed_trial_artifacts(backend)
+        source = backend.trials_dir / "trial-r1" / "artifacts"
+        host_file = tmp_path / "host-secret.txt"
+        host_file.write_text("host secret")
+        (source / "logs" / "artifacts" / "user-link.txt").symlink_to(host_file)
+
+        pending = PendingTrial(AsyncMock(), AsyncMock())
+        pending.workflow_complete_called = True
+        backend.pending["r1"] = pending
+
+        await backend.on_trial_end(self._success_event())
+
+        relocated = backend.artifact_root / "r1" / "artifacts"
+        assert not (relocated / "logs" / "artifacts" / "user-link.txt").exists()
+        assert host_file.read_text() == "host secret"
+
     async def test_on_trial_end_merges_staged_grader_artifacts(self, tmp_path):
         backend = self._make_trial_end_backend(tmp_path, cleanup=True)
         self._seed_trial_artifacts(backend)
@@ -242,6 +277,32 @@ class TestHarborBackend:
         assert (relocated / "output.txt").read_text() == "updated by grader"
         assert (relocated / "grader.json").read_text() == '{"reward": 1}'
 
+    async def test_on_trial_end_rejects_symlinked_grader_merge_parent(
+        self, tmp_path, caplog
+    ):
+        backend = self._make_trial_end_backend(tmp_path, cleanup=False)
+        trial_dir = backend.trials_dir / "trial-r1"
+        trial_artifacts = trial_dir / "artifacts"
+        outside = tmp_path / "outside"
+        trial_artifacts.mkdir(parents=True)
+        outside.mkdir()
+        (trial_artifacts / "logs").symlink_to(outside, target_is_directory=True)
+        staged = trial_dir / "verifier" / GRADER_ARTIFACTS_SNAPSHOT_DIRNAME
+        staged.mkdir(parents=True)
+        (staged / "grader.json").write_text("{}")
+
+        pending = PendingTrial(AsyncMock(), AsyncMock())
+        pending.workflow_complete_called = True
+        backend.pending["r1"] = pending
+
+        with caplog.at_level(
+            logging.WARNING, logger="osmosis_ai.rollout.backend.harbor.backend"
+        ):
+            await backend.on_trial_end(self._success_event())
+
+        assert not (outside / "artifacts" / "grader.json").exists()
+        assert "Failed to merge grader artifacts for rollout r1" in caplog.text
+
     async def test_on_trial_end_keeps_result_when_grader_merge_fails(
         self, tmp_path, monkeypatch, caplog
     ):
@@ -256,11 +317,14 @@ class TestHarborBackend:
         staged.mkdir(parents=True)
         (staged / "grader.json").write_text("{}")
 
-        def _boom(*_args, **_kwargs):
-            raise RuntimeError("bad artifact tree")
+        def _boom_for_staged_snapshot(source, destination, **kwargs):
+            if source == staged:
+                raise RuntimeError("bad artifact tree")
+            return real_copy_artifact_tree(source, destination, **kwargs)
 
         monkeypatch.setattr(
-            "osmosis_ai.rollout.backend.harbor.backend.copy_artifact_tree", _boom
+            "osmosis_ai.rollout.backend.harbor.backend.copy_artifact_tree",
+            _boom_for_staged_snapshot,
         )
         on_grader = AsyncMock()
         pending = PendingTrial(AsyncMock(), on_grader)
@@ -287,7 +351,7 @@ class TestHarborBackend:
             raise OSError("disk full")
 
         monkeypatch.setattr(
-            "osmosis_ai.rollout.backend.harbor.backend.shutil.move", _boom
+            "osmosis_ai.rollout.backend.harbor.backend.copy_artifact_tree", _boom
         )
 
         pending = PendingTrial(AsyncMock(), AsyncMock())
@@ -477,6 +541,47 @@ class TestGraderRunnerRoundTrip:
 
         snapshot = verifier_dir / GRADER_ARTIFACTS_SNAPSHOT_DIRNAME
         assert (snapshot / "partial.txt").read_text() == "partial"
+        assert not (verifier_dir / "reward.json").exists()
+
+    def test_grader_constructor_failure_still_stages_artifacts(
+        self, tmp_path, monkeypatch
+    ):
+        import osmosis_ai.rollout.backend.harbor.grader_runner as grader_runner
+
+        verifier_dir = tmp_path / "verifier"
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir()
+        monkeypatch.setattr(grader_runner, "VERIFIER_LOGS_DIR", verifier_dir)
+        monkeypatch.setattr(grader_runner, "HARBOR_ARTIFACTS_DIR", artifacts_dir)
+
+        backend = _make_backend_for_config(grader=True)
+        backend.grader_path = (
+            f"{ArtifactWritingFailingConstructorGrader.__module__}:"
+            f"{ArtifactWritingFailingConstructorGrader.__qualname__}"
+        )
+        request = ExecutionRequest(
+            id="r1",
+            prompt=[{"role": "user", "content": "hi"}],
+            label="test-label",
+        )
+        config_path = tmp_path / "rollout_config.json"
+        config_path.write_text(
+            json.dumps(backend.build_rollout_config(request), default=str)
+        )
+        samples_path = tmp_path / "samples.json"
+        self._write_samples(samples_path)
+
+        monkeypatch.setattr(
+            grader_runner,
+            "parse_args",
+            lambda: SimpleNamespace(config=config_path, samples=samples_path),
+        )
+
+        with pytest.raises(RuntimeError, match="grader constructor exploded"):
+            grader_runner.main()
+
+        snapshot = verifier_dir / GRADER_ARTIFACTS_SNAPSHOT_DIRNAME
+        assert (snapshot / "constructor.txt").read_text() == "constructor"
         assert not (verifier_dir / "reward.json").exists()
 
 


### PR DESCRIPTION
## What

- Capture the pre-grader artifact state and stage files created or modified during grading in Harbor's verifier output, including files written before a grader failure.
- Merge the staged post-grader snapshot into the trial artifact tree before relocation while keeping artifact handling best-effort.
- Add safe additive artifact-tree copy utilities that skip symlinks and special files.
- Add unit coverage for artifact staging, merging, failure handling, and stale snapshot cleanup.

## Why

Harbor 0.16 collects `/logs/artifacts` before the verifier runs, causing files written or modified by the grader to be silently omitted from the returned artifacts. Harbor returns `/logs/verifier` after verification, so staging the grader changes there allows the backend to merge them into the final artifact tree without affecting rollout or grading results when artifact handling fails.

## How to Test

- `uv run pytest tests/unit/rollout/test_file_artifacts.py tests/unit/rollout/test_harbor_backend.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright osmosis_ai/`
- `uv run pytest`

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Harbor artifact handling to preserve grader-written files and harden artifact copies against symlink/junction traversal. We stage a post-grade snapshot under /logs/verifier and safely merge it before relocating trial artifacts; all steps are best-effort.

- **Bug Fixes**
  - Capture an artifact baseline before resolving/constructing the grader; stage a post-grader snapshot in /logs/verifier/.osmosis-artifacts, removing stale snapshots and dropping empty ones.
  - Merge the snapshot into trial logs/artifacts during on_trial_end; failures are logged and never affect results.
  - Add a guarded copy_artifact_tree: additive, baseline-aware copy of regular files only; validates each destination component under a trusted root; rejects symlinks/junctions and special files; replaces conflicting types.
  - Use the guarded copy for trial relocation with move-on-success, skipping links; tests cover staging/merging, constructor/grader failures, traversal rejection, relocation, and cleanup.

<sup>Written for commit 55ef1e54efd723d959462faa859e39c489d6848c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

