### PR TITLE
[misc] chore: bump version to 0.2.29

### DIFF
--- a/osmosis_ai/consts.py
+++ b/osmosis_ai/consts.py
@@ -1,3 +1,3 @@
 # package metadata
 package_name = "osmosis-ai"
-PACKAGE_VERSION = "0.2.28"
+PACKAGE_VERSION = "0.2.29"

--- a/osmosis_ai/templates/_scaffolds/rollout/pyproject.toml.tpl
+++ b/osmosis_ai/templates/_scaffolds/rollout/pyproject.toml.tpl
@@ -4,7 +4,7 @@ description = "Placeholder rollout scaffolded by `osmosis rollout init`."
 version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
-    "osmosis-ai[server]>=0.2.28",
+    "osmosis-ai[server]>=0.2.29",
 ]
 
 [build-system]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped `PACKAGE_VERSION` to 0.2.29 and updated the rollout scaffold to require `osmosis-ai[server]>=0.2.29`.
This ensures new scaffolds pull the latest server features and fixes.

<sup>Written for commit 1ce45043cb3a7b4f77c7d75112cd64325a9c22db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

