### PR TITLE
[misc] chore: introduce 0.3.0 release candidate flow

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: create-pr
+description: 'Create a GitHub pull request for this repository with a title and body that follow the repo''s PULL_REQUEST_TEMPLATE.md conventions. Use when the user says "create a PR", "open a PR", "submit a PR", "make a pull request", or asks to push the current branch as a PR. Enforces the `[module] type: description` title format with 1-3 module brackets, the What/Why/How to Test/Checklist body, and repo-specific labels.'
+---
+
+# Create Pull Request (osmosis-sdk-python)
+
+This skill encodes the PR conventions for the `osmosis-sdk-python` repo so PRs land with a title and body that match `.github/PULL_REQUEST_TEMPLATE.md` and pass the checklist items.
+
+## When To Use
+
+Trigger this skill when the user asks to:
+- Create / open / submit a PR (or "pull request")
+- Push the current branch as a PR
+- Draft a PR description for the current changes
+
+Skip this skill if the user only wants a commit message or is not on a feature branch.
+
+## Title Format
+
+All PR titles MUST follow:
+
+```
+[module] type: description
+```
+
+With optional `[BREAKING]` prefix when the change is backward-incompatible:
+
+```
+[BREAKING][module] type: description
+```
+
+For multi-module changes, the title may include **1-3 module brackets total**:
+
+```
+[mod1][mod2] type: description
+[BREAKING][mod1][mod2][mod3] type: description
+```
+
+### Allowed modules
+
+`reward`, `rollout`, `server`, `cli`, `auth`, `eval`, `misc`, `ci`, `doc`
+
+Pick the module that best matches the primary area of change. If the diff touches multiple modules meaningfully, stack **up to three** brackets in descending importance: `[cli][rollout] ...`.
+
+If the diff spans **more than three modules** or is truly cross-cutting / repo-wide (runtime floor changes, repo tooling, broad modernization), collapse the title to `[misc]` instead of exceeding the bracket limit.
+
+### Allowed types
+
+`feat`, `fix`, `refactor`, `chore`, `test`, `doc`
+
+Type is lowercase. The `description` is a short imperative phrase, lowercase, no trailing period.
+
+### Title examples
+
+Good:
+- `[rollout] feat: add streaming support for chat completions`
+- `[cli] refactor: replace ID-based commands with name/path identifiers`
+- `[BREAKING][rollout] refactor: rename rollout_v2 package to rollout`
+- `[BREAKING][misc] chore: align codebase with Python 3.12`
+- `[ci] chore: update GitHub Actions versions`
+- `[eval] fix: handle empty rubric response`
+
+Bad:
+- `Add streaming support` (no module/type)
+- `[rollout] Feat: Add streaming support.` (capitalized type, trailing period)
+- `feat(rollout): add streaming` (conventional-commits style; this repo uses bracket style)
+- `[cli][auth][eval][rollout] chore: align codebase with Python 3.12` (too many module brackets)
+
+## Body Template
+
+Fill in every section. Keep it concise and specific to the diff — do NOT keep the HTML comments in the final body.
+
+```markdown
+## What
+
+- <Bulleted, scannable list of the concrete changes in this PR.>
+- <One bullet per meaningful change; reference files/modules when useful.>
+
+## Why
+
+<Short prose explaining motivation and context. Link related issues with "Closes #123" when applicable. If this is a breaking change, call it out here and explain the migration.>
+
+## How to Test
+
+- <Concrete commands reviewers can run, e.g. `uv run pytest tests/unit/cli/`>
+- <Manual steps or CLI invocations to exercise the change>
+- <Any `rg` / grep checks that prove an invariant (e.g. "rg 'rollout_v2' . returns no matches")>
+
+## Checklist
+
+- [x] PR title follows `[module] type: description` format
+- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
+- [x] `ruff check .` and `ruff format --check .` pass
+- [x] `pyright osmosis_ai/` passes
+- [x] `pytest` passes (new tests added if applicable)
+- [x] Public API changes are documented
+- [x] No secrets or credentials included
+```
+
+### Rules for the body
+
+- **One paragraph per line.** Do not hard-wrap prose. Each paragraph and each list item is a single line and is allowed to soft-wrap; only semantically meaningful line breaks (a new paragraph, a new list item, code, or table rows) get an actual newline. This matches the repo invariant in `AGENTS.md` and applies to commit messages and PR descriptions too.
+- `## What` uses bullets, not prose. Each bullet is a concrete change.
+- `## Why` is prose (1–3 short paragraphs). Explain motivation, not mechanics.
+- `## How to Test` MUST include runnable commands. Prefer `uv run pytest ...`, `uv run ruff ...`, `uv run pyright ...`, or CLI invocations.
+- `## Checklist`: tick only boxes that are actually true. If a check was not run, leave it `[ ]` — do not fabricate results.
+- Do NOT include AI attribution/footer text such as `Made with [Cursor](https://cursor.com)`, `Made with Claude`, or any auto-generated "Summary by cubic" section. Those are added by tooling, not by the author.
+- If GitHub CLI or local tooling appends an AI footer like `Made with [Cursor](https://cursor.com)` or `Made with Claude`, immediately remove it with `gh pr edit --body ...`.
+
+## Labels
+
+After creating the PR, apply labels that match the change. Available repo labels:
+
+| Category | Labels |
+|----------|--------|
+| Type | `enhancement`, `bug`, `refactor`, `chore`, `ci`, `documentation`, `dependencies`, `breaking` |
+| Module | `reward`, `rollout`, `cli`, `server`, `auth`, `eval` |
+| Triage | `priority: high`, `good first issue`, `help wanted`, `question`, `duplicate`, `invalid`, `wontfix` |
+
+Guidelines:
+- Always add one **type** label matching the PR type (`feat` → `enhancement`, `fix` → `bug`, otherwise match name).
+- Add one or more **module** labels matching the `[module]` brackets in the title when those labels exist.
+- `misc` does **not** have a matching GitHub label in this repo. If the title uses `[misc]`, keep the type label and optionally add specific module labels only when they materially help triage a cross-cutting PR.
+- Add `breaking` whenever the title carries `[BREAKING]`.
+- Do not invent labels; only use ones returned by `gh label list`.
+
+Apply labels with:
+
+```bash
+gh pr edit <pr-number> --add-label "cli,refactor"
+```
+
+Or pass `--label` repeatedly on `gh pr create`.
+
+## Workflow
+
+Follow these steps in order. Batch read-only git/gh calls in parallel where possible.
+
+### 1. Inspect the branch state (parallel reads)
+
+Run in parallel:
+- `git status` — untracked / uncommitted files
+- `git diff` — unstaged changes
+- `git diff --staged` — staged changes
+- `git log --oneline origin/main..HEAD` (or the base branch) — commits included in this PR
+- `git diff origin/main...HEAD --stat` — full diff vs. base
+- `git rev-parse --abbrev-ref HEAD` — current branch
+- `git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null` — whether branch has an upstream
+
+If there are uncommitted changes, STOP and ask the user whether to commit them first. Do not auto-commit.
+
+### 2. Determine base branch
+
+Default base is `main`. If the user specifies otherwise (e.g. a release branch) or if `gh repo view --json defaultBranchRef` returns a different default, use that.
+
+### 3. Classify the change
+
+Look at the diff across ALL commits in the branch (not just HEAD) and decide:
+- **Module**: which top-level area of `osmosis_ai/` changed most (`rollout/`, `cli/`, `eval/`, `platform/auth/` → `auth`, etc.). Map `platform/api/` and `platform/cli/` → `cli`. Map `rollout/server/` → `server` when the server is the primary focus, otherwise `rollout`. Choose at most **three** dominant modules; if four or more areas are meaningfully involved, or the change is repo-wide, use `misc`.
+- **Type**: `feat` (new behavior), `fix` (bug), `refactor` (no behavior change), `chore` (tooling/deps/housekeeping), `test` (tests only), `doc` (docs only).
+- **Breaking?**: removed/renamed public API, changed signatures, changed CLI flags users depend on, renamed packages. If yes, prepend `[BREAKING]`.
+
+### 4. Run the checklist commands (best effort)
+
+Before creating the PR, try to run:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright osmosis_ai/
+uv run pytest
+```
+
+Record which passed. Only tick the corresponding checkbox in the body for commands that actually passed. If a command is not available or the user wants to skip, leave the box unchecked and mention it in `## How to Test`.
+
+### 5. Push the branch (if needed)
+
+```bash
+git push -u origin HEAD
+```
+
+Only push with `-u` on first push. Never force-push without explicit user consent.
+
+### 6. Create the PR
+
+Always pass the body via HEREDOC to preserve formatting:
+
+```bash
+gh pr create \
+  --base main \
+  --title "[cli] feat: add train metrics export" \
+  --body "$(cat <<'EOF'
+## What
+
+- Add `osmosis train metrics <name> --export csv` subcommand.
+- Implement CSV writer in `osmosis_ai/platform/cli/metrics.py`.
+- Add unit tests in `tests/unit/cli/test_train_metrics.py`.
+
+## Why
+
+Users asked for a way to pull training metrics into spreadsheets for post-hoc analysis. Closes #142.
+
+## How to Test
+
+- `uv run pytest tests/unit/cli/test_train_metrics.py`
+- `osmosis train metrics my-run --export csv > metrics.csv`
+
+## Checklist
+
+- [x] PR title follows `[module] type: description` format
+- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
+- [x] `ruff check .` and `ruff format --check .` pass
+- [x] `pyright osmosis_ai/` passes
+- [x] `pytest` passes (new tests added if applicable)
+- [x] Public API changes are documented
+- [x] No secrets or credentials included
+EOF
+)" \
+  --label "cli" --label "enhancement"
+```
+
+### 7. Verify and report
+
+After `gh pr create` succeeds:
+- Capture the PR URL from stdout and return it to the user.
+- Run `gh pr view --json body` and remove any auto-appended AI footer if present.
+- Optionally run `gh pr view --web` only if the user asked to open it in a browser.
+
+## Complete Example
+
+Given a branch that renamed `rollout_v2` → `rollout` across the codebase, the correct invocation is:
+
+- **Title**: `[BREAKING][rollout] refactor: rename rollout_v2 package to rollout`
+- **Labels**: `rollout`, `refactor`, `breaking`
+- **Body**: What bullets list the rename + import updates; Why explains namespace cleanup + migration note; How to Test includes `uv run pytest`, `uv run ruff check .`, `uv run pyright osmosis_ai/`, and `rg "rollout_v2" .` sanity check.
+
+## Anti-Patterns
+
+- Do NOT hard-wrap prose in the body — keep one paragraph / list item per line (see `AGENTS.md`).
+- Do NOT use Conventional Commits syntax (`feat(rollout): ...`) — this repo uses bracket style.
+- Do NOT use more than three module brackets in the title; switch to `[misc]` for broad cross-cutting changes.
+- Do NOT omit `[BREAKING]` when the change removes or renames public API.
+- Do NOT tick checklist boxes for checks you didn't actually run.
+- Do NOT include AI attribution/footer text such as `Made with [Cursor](https://cursor.com)`, `Made with Claude`, or auto-generated sections like `Summary by cubic` in the body you author.
+- Do NOT force-push or amend already-pushed commits without explicit user approval.
+- Do NOT invent labels that don't exist in `gh label list`.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -39,7 +39,7 @@ For multi-module changes, the title may include **1-3 module brackets total**:
 
 ### Allowed modules
 
-`reward`, `rollout`, `server`, `cli`, `auth`, `eval`, `misc`, `ci`, `doc`
+`rollout`, `server`, `cli`, `auth`, `eval`, `misc`, `ci`, `doc`
 
 Pick the module that best matches the primary area of change. If the diff touches multiple modules meaningfully, stack **up to three** brackets in descending importance: `[cli][rollout] ...`.
 

--- a/.agents/skills/prepare-release-pr/SKILL.md
+++ b/.agents/skills/prepare-release-pr/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: prepare-release-pr
+description: Prepare an Osmosis AI Python SDK release pull request by selecting the correct stable or release-candidate comparison tag, curating concise changelog notes from the actual GitHub and git changes, updating the package version, and running release checks. Use when asked to prepare, draft, or update an RC or stable release PR.
+---
+
+# Prepare Release PR
+
+Prepare the version bump and `CHANGELOG.md` entry for an SDK release. Inspect the underlying changes and write the changelog directly in clear language.
+
+## Guardrails
+
+- Read `AGENTS.md` before making changes.
+- Prepare local changes only unless the user explicitly asks to commit, push, or open the PR.
+- Preserve unrelated work. If the worktree contains overlapping changes, stop and explain the conflict before editing.
+- Never create or move a release tag as part of this skill.
+- Never infer that an RC should become the latest stable release.
+
+## 1. Establish the Target
+
+Accept release versions as `X.Y.Z` or `X.Y.ZrcN`, without a leading `v` in source files. Tags use the same version with a leading `v`.
+
+Run the following preflight checks:
+
+```bash
+git status --short --branch
+git fetch origin main --tags
+git tag --list --sort=-version:refname
+gh release list --limit 100
+```
+
+Default the target commit to `origin/main`. Confirm that the target version does not already have a published tag or release. If the requested version is ambiguous, ask the user to specify it before editing files.
+
+## 2. Select the Comparison Tag
+
+Consider only published version tags reachable from the target commit. Apply these rules deterministically:
+
+- Stable target (`X.Y.Z`): select the newest earlier stable tag and ignore every prerelease tag, including RCs for this same version.
+- RC target (`X.Y.ZrcN`): select the newest earlier RC for the same `X.Y.Z` release line. If none exists, select the newest earlier stable tag.
+- Never compare an RC against an RC from a different release line.
+- Never compare a stable release only against its last RC; stable notes must cover the complete change since the prior stable release.
+
+Examples:
+
+| Target | Comparison tag |
+| --- | --- |
+| `0.3.0rc1` | `v0.2.30` |
+| `0.3.0rc2` | `v0.3.0rc1` |
+| `0.3.0` | `v0.2.30` |
+| `0.4.0rc1` | newest stable `v0.3.x` tag |
+
+Report the selected comparison tag before changing files so the choice is visible and auditable.
+
+## 3. Build a Release Inventory
+
+Inspect the complete comparison range rather than relying on commit subjects alone:
+
+```bash
+git log --oneline <previous-tag>..origin/main
+git diff --stat <previous-tag>..origin/main
+```
+
+Use the PR numbers in the commit log to inspect associated PR titles, labels, descriptions, and relevant diffs with `gh pr view`. Verify unclear PR titles against their actual behavior. Include only changes contained in the selected range; do not ask GitHub to generate the changelog text.
+
+## 4. Write the Changelog
+
+Write for SDK users, not repository maintainers:
+
+- Put breaking changes first and state the required migration directly.
+- Use only non-empty headings such as `Breaking Changes`, `Added`, `Changed`, and `Fixed`.
+- Describe outcomes and API or CLI behavior, not internal implementation details.
+- Link each item to its PR when one exists.
+- Consolidate closely related PRs into one bullet.
+- Omit version bumps, formatting, tests, CI refactors, dependency housekeeping, and other internal-only noise unless users must act on them.
+- Keep each bullet to one short sentence whenever possible. Prefer roughly 3–8 meaningful bullets; exceed that only when omitting items would hide material changes.
+- Do not copy raw PR titles when a shorter, clearer summary is possible.
+- Do not add author credits to every bullet; the linked PR already preserves attribution.
+- End the entry with a full comparison link from the selected tag to the target tag.
+
+Keep the changelog concise. It is a release summary, not a narrative of every merged PR.
+
+Avoid unnecessary line breaks. Keep each paragraph and each list item on one physical line and allow the renderer to soft-wrap it. Insert line breaks only for a new heading, paragraph, list item, code block, or table row. Never hard-wrap prose to a fixed column width.
+
+RC entries describe only the delta from the selected prior RC or stable release. Stable entries describe the complete delta from the prior stable release. When preparing a stable release, replace duplicated detail in same-version RC entries with short links to the corresponding RC GitHub releases so the changelog does not repeat the same material several times.
+
+## 5. Apply the Release Changes
+
+Update `PACKAGE_VERSION` in `osmosis_ai/consts.py` and prepend the versioned entry to `CHANGELOG.md` directly. If an entry for the target version already exists, revise it in place instead of creating a duplicate. Do not add a generator script or generated-notes workflow for these two small edits.
+
+Review the resulting diff manually. Confirm that:
+
+- `PACKAGE_VERSION` exactly matches the target without the `v` prefix.
+- The newest changelog heading contains the target version and intended release date.
+- Every changelog claim is supported by a PR or diff in the selected range.
+- The comparison URL uses the selected previous tag and target tag.
+- Prose and bullets are not hard-wrapped.
+
+Use `[misc] chore: bump version to <version>` as the default PR title. If the user asks to open the PR, follow the repository's `create-pr` skill after these changes are ready.
+
+## 6. Verify and Hand Off
+
+Run the focused checks first, then the repository gates:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright osmosis_ai/
+uv run pytest
+git diff --check
+```
+
+Report the target version, comparison tag, changelog scope, files changed, and checks run. Call out any intentionally omitted internal changes or checks that did not run.

--- a/.agents/skills/prepare-release-pr/SKILL.md
+++ b/.agents/skills/prepare-release-pr/SKILL.md
@@ -22,13 +22,15 @@ Accept release versions as `X.Y.Z` or `X.Y.ZrcN`, without a leading `v` in sourc
 Run the following preflight checks:
 
 ```bash
+VERSION=0.3.0rc1  # Replace with the target version.
+TARGET_REF=origin/main
 git status --short --branch
-git fetch origin main --tags
+git fetch origin --tags
 git tag --list --sort=-version:refname
-gh release list --limit 100
+gh release view "v$VERSION"
 ```
 
-Default the target commit to `origin/main`. Confirm that the target version does not already have a published tag or release. If the requested version is ambiguous, ask the user to specify it before editing files.
+Default `TARGET_REF` to `origin/main`. The `gh release view` command must report that the target release does not exist; stop if it finds one. Also confirm that the target tag does not exist locally. If the requested version is ambiguous, ask the user to specify it before editing files.
 
 ## 2. Select the Comparison Tag
 
@@ -50,13 +52,15 @@ Examples:
 
 Report the selected comparison tag before changing files so the choice is visible and auditable.
 
+Set `PREVIOUS_TAG` to the selected tag and confirm that it is a published GitHub release with `gh release view "$PREVIOUS_TAG"`.
+
 ## 3. Build a Release Inventory
 
 Inspect the complete comparison range rather than relying on commit subjects alone:
 
 ```bash
-git log --oneline <previous-tag>..origin/main
-git diff --stat <previous-tag>..origin/main
+git log --oneline "$PREVIOUS_TAG..$TARGET_REF"
+git diff --stat "$PREVIOUS_TAG..$TARGET_REF"
 ```
 
 Use the PR numbers in the commit log to inspect associated PR titles, labels, descriptions, and relevant diffs with `gh pr view`. Verify unclear PR titles against their actual behavior. Include only changes contained in the selected range; do not ask GitHub to generate the changelog text.

--- a/.agents/skills/prepare-release-pr/agents/openai.yaml
+++ b/.agents/skills/prepare-release-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Prepare Release PR"
+  short_description: "Prepare a version bump and concise changelog PR"
+  default_prompt: "Use $prepare-release-pr to prepare the next SDK release PR with a concise changelog."

--- a/.claude/skills/create-pr
+++ b/.claude/skills/create-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/create-pr

--- a/.claude/skills/prepare-release-pr
+++ b/.claude/skills/prepare-release-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/prepare-release-pr

--- a/.cursor/skills/create-pr
+++ b/.cursor/skills/create-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/create-pr

--- a/.cursor/skills/prepare-release-pr
+++ b/.cursor/skills/prepare-release-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/prepare-release-pr

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,14 +22,39 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Verify consts.py version matches the release tag
+      - name: Verify version and release type
         run: |
           VERSION=$(uv run --no-project --python 3.12 python -c 'import re, pathlib; text = pathlib.Path("osmosis_ai/consts.py").read_text(); print(re.search(r"^PACKAGE_VERSION\s*=\s*\"([^\"]+)\"", text, re.MULTILINE).group(1))')
           TAG="${{ github.event.release.tag_name }}"
-          if [ "v$VERSION" != "$TAG" ]; then
-            echo "::error::consts.py PACKAGE_VERSION ($VERSION) does not match release tag ($TAG)"
-            exit 1
-          fi
+          IS_PRERELEASE="${{ github.event.release.prerelease }}"
+          uv run --no-project --python 3.12 python - "$VERSION" "$TAG" "$IS_PRERELEASE" <<'PY'
+          import re
+          import sys
+
+          version, tag, prerelease_value = sys.argv[1:]
+          pattern = r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:rc[1-9]\d*)?"
+          if re.fullmatch(pattern, version) is None:
+              print(
+                  f"::error::PACKAGE_VERSION ({version}) must use canonical "
+                  "X.Y.Z or X.Y.ZrcN format"
+              )
+              sys.exit(1)
+          if tag != f"v{version}":
+              print(
+                  f"::error::consts.py PACKAGE_VERSION ({version}) does not "
+                  f"match release tag ({tag})"
+              )
+              sys.exit(1)
+
+          version_is_prerelease = re.search(r"rc\d+$", version) is not None
+          release_is_prerelease = prerelease_value.lower() == "true"
+          if version_is_prerelease != release_is_prerelease:
+              print(
+                  f"::error::Release prerelease={release_is_prerelease} does not "
+                  f"match PACKAGE_VERSION {version}"
+              )
+              sys.exit(1)
+          PY
 
   publish:
     needs: [tests, check-version]

--- a/.gitignore
+++ b/.gitignore
@@ -56,8 +56,13 @@ todo.md
 /AGENTS.md
 **/superpowers/
 
-.claude/
-.cursor/
+# Agent-specific local state; shared skills live in .agents/skills.
+.claude/*
+!.claude/skills/
+!.claude/skills/**
+.cursor/*
+!.cursor/skills/
+!.cursor/skills/**
 .gemini/
 .mcp.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+This file records changes to `osmosis-ai`. For earlier versions, see [GitHub Releases](https://github.com/Osmosis-AI/osmosis-sdk-python/releases).
+
+## 0.3.0rc1 - 2026-07-28
+
+### Breaking Changes
+
+- Each rollout now produces one `RolloutSample` and one reward; migrate `samples` mappings to `sample`, `register_sample_source()` to `set_sample_source()`, and `set_sample_reward()` to `set_reward()` ([#235](https://github.com/Osmosis-AI/osmosis-sdk-python/pull/235)).
+- Routing now uses rollout-scoped chat-completion and callback URLs; per-call routing headers were removed, request-body `rollout_id` is optional, and `RolloutSample.id` and `MultiTurnMode` no longer exist ([#235](https://github.com/Osmosis-AI/osmosis-sdk-python/pull/235)).
+- Harbor and local backends now exchange `sample.json` and write `reward.json` as `{"reward": <float>}` ([#235](https://github.com/Osmosis-AI/osmosis-sdk-python/pull/235)).
+
+[Full changelog](https://github.com/Osmosis-AI/osmosis-sdk-python/compare/v0.2.30...v0.3.0rc1)

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,4 +36,5 @@ The package (`osmosis_ai/`) is organized into top-level domains. See [architectu
 ## See also
 
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — dev environment, tests, lint, type checking, PR conventions
+- [CHANGELOG.md](../CHANGELOG.md) — SDK changes by release
 - [docs.osmosis.ai/cli/command-reference](https://docs.osmosis.ai/cli/command-reference) — the user-facing command reference

--- a/osmosis_ai/consts.py
+++ b/osmosis_ai/consts.py
@@ -1,3 +1,3 @@
 # package metadata
 package_name = "osmosis-ai"
-PACKAGE_VERSION = "0.2.30"
+PACKAGE_VERSION = "0.3.0rc1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ full = [
 [project.urls]
 Homepage = "https://github.com/Osmosis-AI/osmosis-sdk-python"
 Issues = "https://github.com/Osmosis-AI/osmosis-sdk-python/issues"
+Changelog = "https://github.com/Osmosis-AI/osmosis-sdk-python/blob/main/CHANGELOG.md"
 
 [project.scripts]
 osmosis = "osmosis_ai.cli.main:main"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduce the 0.3.0 release-candidate flow: bump `PACKAGE_VERSION` to 0.3.0rc1, add `CHANGELOG.md` with breaking changes, and harden publish checks for prerelease tags and version format. Aligns with Linear OSM-1651 by making `0.3.0rcN` releases reusable for devel/staging while prod stays on the latest stable.

- **New Features**
  - Add `prepare-release-pr` and `create-pr` skills: deterministic comparison tag selection, concise changelog rules, and enforced PR title/body/labels.
  - Expose shared skills via `.agents/skills` with pointers in `.claude/skills` and `.cursor/skills`; add `agents/openai.yaml` interface metadata.
  - Strengthen `.github/workflows/publish.yml`: ensure `PACKAGE_VERSION` equals the tag, enforce `X.Y.Z` or `X.Y.ZrcN`, and require the prerelease flag to match `rcN`.
  - Add `CHANGELOG.md` for `0.3.0rc1`; link it from `docs/README.md` and `pyproject.toml`.

- **Migration**
  - Tag RCs as `vX.Y.ZrcN` and mark the GitHub release as a prerelease; keep `osmosis_ai/consts.py` at `X.Y.ZrcN`.
  - Use `$prepare-release-pr` to draft the release PR, then run `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright osmosis_ai/`, and `uv run pytest` before publishing.

<sup>Written for commit dd672a05f45d6264402d65c8b243c147ed190daf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

