### PR TITLE
[misc] chore: bump version to 0.2.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+This file records changes to `osmosis-ai`. For earlier versions, see [GitHub Releases](https://github.com/Osmosis-AI/osmosis-sdk-python/releases).
+
+## 0.2.31 - 2026-07-28
+
+### Changed
+
+- LiteLLM 1.91.1 is now the minimum supported version for the SDK's model integrations ([#268](https://github.com/Osmosis-AI/osmosis-sdk-python/pull/268)).
+
+[Full changelog](https://github.com/Osmosis-AI/osmosis-sdk-python/compare/v0.2.30...v0.2.31)

--- a/osmosis_ai/consts.py
+++ b/osmosis_ai/consts.py
@@ -1,3 +1,3 @@
 # package metadata
 package_name = "osmosis-ai"
-PACKAGE_VERSION = "0.2.30"
+PACKAGE_VERSION = "0.2.31"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,9 @@ dependencies = [
     # requests 2.33.0. Lower bounds only, so they can still float up.
     "python-dotenv>=1.2.2,<2.0.0",
     "requests>=2.33.0,<3.0.0",
-    # >=1.84.0 is the security floor: it patches the proxy auth-bypass /
-    # SSTI / SQLi / RCE advisories (GHSA-4xpc-pv4p-pm3w and siblings).
-    "litellm>=1.84.0,<2.0.0",
+    # 1.91.1 is the tested compatibility floor and includes the proxy
+    # auth-bypass / SSTI / SQLi / RCE fixes from the earlier 1.84.0 floor.
+    "litellm>=1.91.1,<2.0.0",
     # LiteLLM's tool-call path imports orjson at runtime, but only declares it
     # through its larger proxy extra.
     "orjson>=3.11.6,<4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1990,7 +1990,7 @@ requires-dist = [
     { name = "harbor", extras = ["daytona"], specifier = ">=0.20.0,<0.21" },
     { name = "httpx", specifier = ">=0.25.0,<1.0.0" },
     { name = "keyring", specifier = ">=25.0.0" },
-    { name = "litellm", specifier = ">=1.84.0,<2.0.0" },
+    { name = "litellm", specifier = ">=1.91.1,<2.0.0" },
     { name = "mcp", specifier = ">=1.28.1" },
     { name = "openai-agents", extras = ["litellm"], specifier = ">=0.18.1,<0.19" },
     { name = "orjson", specifier = ">=3.11.6,<4.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1304,7 +1304,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.89.1"
+version = "1.91.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1320,9 +1320,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/1b/de398e6cef46d4cbc4395c895330f30eab05439bf6d0c5c53b0203661eeb/litellm-1.89.1.tar.gz", hash = "sha256:eb9292f90afe46dcce4bfef6bbeaa54494945813763e1c0917f4e9a1c584c1a4", size = 14071586, upload-time = "2026-06-16T03:12:52.997Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/70/1b419158085e0cc1615642dd62c7a5d4c3254db3de77df65dade3b25165b/litellm-1.91.1.tar.gz", hash = "sha256:49a24593df7e37262c52243a8e07572d451d37c100aa1b1f347d80d501d2e386", size = 14872532, upload-time = "2026-07-08T23:07:04.559Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/24/81f03088876a13b628fdbaf746ee746e1dff127d63f339ef72f1a3801c91/litellm-1.89.1-py3-none-any.whl", hash = "sha256:a52a67625d89cb1787ef48c4b3c1ab9c2574ea304f56900bc631844297a13bd4", size = 15484855, upload-time = "2026-06-16T03:12:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/52/166a934d194afcff2a7ec4e1928f1865504ade2e26f62e24d49aaec400d1/litellm-1.91.1-py3-none-any.whl", hash = "sha256:bf8e3d23cddf0eb4c05714dffcaafd8a944adf0f9c9b01c6c863b2637309de2e", size = 16670790, upload-time = "2026-07-08T23:07:01.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

- Raise the published LiteLLM requirement from `>=1.84.0` to `>=1.91.1` and lock the development environment to 1.91.1.
- Bump `PACKAGE_VERSION` from `0.2.30` to `0.2.31`.
- Add the `0.2.31` changelog entry with `v0.2.30` as the stable comparison tag.

## Release isolation

This PR targets `release-0.2.31`, which points to the `v0.2.30` commit. It intentionally excludes the unreleased breaking rollout-routing change in #235 and the `0.3.0rc1` release work. The final `v0.2.31` tag should be created from the merged release branch, not from `main`.

## Why

Updating only `uv.lock` would align local development and CI but would not change the dependency metadata seen by `pip` users. Raising the lower bound in `pyproject.toml` makes LiteLLM 1.91.1 part of the published `0.2.31` compatibility contract. The current Strands integration constraint resolves LiteLLM to 1.91.1, so the lock and package metadata now agree.

The version bump also allows the platform to raise its supported CLI floor without including any `0.3.0` breaking changes.

## Verification

- `uv sync --locked --extra dev`
- `uv run --locked ruff check .`
- `uv run --locked ruff format --check .`
- `uv run --locked pyright osmosis_ai/`
- `uv run --locked pytest` — 1782 passed
- `uv build` and `twine check --strict`
- Verified wheel metadata contains `Requires-Dist: litellm<2.0.0,>=1.91.1`
- Verified `PACKAGE_VERSION == 0.2.31`, installed LiteLLM is 1.91.1, and the LiteLLM compatibility re-export imports successfully
