### PR TITLE
[misc] chore: require LiteLLM 1.91.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,9 @@ dependencies = [
     # requests 2.33.0. Lower bounds only, so they can still float up.
     "python-dotenv>=1.2.2,<2.0.0",
     "requests>=2.33.0,<3.0.0",
-    # >=1.84.0 is the security floor: it patches the proxy auth-bypass /
-    # SSTI / SQLi / RCE advisories (GHSA-4xpc-pv4p-pm3w and siblings).
-    "litellm>=1.84.0,<2.0.0",
+    # 1.91.1 is the tested compatibility floor and includes the proxy
+    # auth-bypass / SSTI / SQLi / RCE fixes from the earlier 1.84.0 floor.
+    "litellm>=1.91.1,<2.0.0",
     # LiteLLM's tool-call path imports orjson at runtime, but only declares it
     # through its larger proxy extra.
     "orjson>=3.11.6,<4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1304,7 +1304,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.89.1"
+version = "1.91.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1320,9 +1320,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/1b/de398e6cef46d4cbc4395c895330f30eab05439bf6d0c5c53b0203661eeb/litellm-1.89.1.tar.gz", hash = "sha256:eb9292f90afe46dcce4bfef6bbeaa54494945813763e1c0917f4e9a1c584c1a4", size = 14071586, upload-time = "2026-06-16T03:12:52.997Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/70/1b419158085e0cc1615642dd62c7a5d4c3254db3de77df65dade3b25165b/litellm-1.91.1.tar.gz", hash = "sha256:49a24593df7e37262c52243a8e07572d451d37c100aa1b1f347d80d501d2e386", size = 14872532, upload-time = "2026-07-08T23:07:04.559Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/24/81f03088876a13b628fdbaf746ee746e1dff127d63f339ef72f1a3801c91/litellm-1.89.1-py3-none-any.whl", hash = "sha256:a52a67625d89cb1787ef48c4b3c1ab9c2574ea304f56900bc631844297a13bd4", size = 15484855, upload-time = "2026-06-16T03:12:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/52/166a934d194afcff2a7ec4e1928f1865504ade2e26f62e24d49aaec400d1/litellm-1.91.1-py3-none-any.whl", hash = "sha256:bf8e3d23cddf0eb4c05714dffcaafd8a944adf0f9c9b01c6c863b2637309de2e", size = 16670790, upload-time = "2026-07-08T23:07:01.151Z" },
 ]
 
 [[package]]
@@ -1990,7 +1990,7 @@ requires-dist = [
     { name = "harbor", extras = ["daytona"], specifier = ">=0.20.0,<0.21" },
     { name = "httpx", specifier = ">=0.25.0,<1.0.0" },
     { name = "keyring", specifier = ">=25.0.0" },
-    { name = "litellm", specifier = ">=1.84.0,<2.0.0" },
+    { name = "litellm", specifier = ">=1.91.1,<2.0.0" },
     { name = "mcp", specifier = ">=1.28.1" },
     { name = "openai-agents", extras = ["litellm"], specifier = ">=0.18.1,<0.19" },
     { name = "orjson", specifier = ">=3.11.6,<4.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -2950,8 +2950,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## What

- Raise the published LiteLLM requirement from `>=1.84.0` to `>=1.91.1`.
- Generate `uv.lock` with `uv lock --upgrade-package 'litellm==1.91.1'` so the development environment uses the tested 1.91.1 release.
- Keep the generator's platform markers for SecretStorage dependencies; these are normalization output from `uv 0.9.7`, not additional package upgrades.

## Why

Forward-port the LiteLLM dependency contract released in [#268](https://github.com/Osmosis-AI/osmosis-sdk-python/pull/268) and [v0.2.31](https://github.com/Osmosis-AI/osmosis-sdk-python/releases/tag/v0.2.31) onto `main`. This intentionally leaves `PACKAGE_VERSION` at `0.3.0rc1` and does not copy the stable-release changelog entry.

Updating `pyproject.toml` as well as generating the lockfile ensures downstream installers and repository development environments both require the tested LiteLLM version. The version-qualified lock command is intentional because an unconstrained `uv lock --upgrade-package litellm` currently selects 1.94.0.

## How to Test

- `uv lock --check`
- `uv sync --locked --extra dev`
- `uv run --locked ruff check .`
- `uv run --locked ruff format --check .`
- `uv run --locked pyright osmosis_ai/`
- `uv run --locked pytest` — 1781 passed
- `uv build` and `twine check --strict`; verify the wheel metadata contains `Requires-Dist: litellm<2.0.0,>=1.91.1`

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included