### PR TITLE
[1/6][rollout] feat: add TtlCache utility

### DIFF
--- a/osmosis_ai/rollout/utils/ttl_cache.py
+++ b/osmosis_ai/rollout/utils/ttl_cache.py
@@ -1,0 +1,39 @@
+"""Dict with a uniform per-entry TTL and amortized O(1) expiry.
+
+Uniform TTLs expire in insertion order, so a deque of (deadline, key)
+tombstones is pruned from the head on every write. The deadline doubles as
+the tombstone marker: overwriting a key refreshes its deadline, which
+orphans the old tombstone harmlessly.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+
+
+class TtlCache[K, V]:
+    def __init__(self, ttl_sec: float) -> None:
+        self.ttl_sec = ttl_sec
+        self.entries: dict[K, tuple[float, V]] = {}
+        self.tombstones: deque[tuple[float, K]] = deque()
+
+    def set(self, key: K, value: V) -> None:
+        now = time.monotonic()
+        while self.tombstones and self.tombstones[0][0] <= now:
+            deadline, stale = self.tombstones.popleft()
+            entry = self.entries.get(stale)
+            if entry is not None and entry[0] == deadline:
+                del self.entries[stale]
+        deadline = now + self.ttl_sec
+        self.entries[key] = (deadline, value)
+        self.tombstones.append((deadline, key))
+
+    def get(self, key: K) -> V | None:
+        entry = self.entries.get(key)
+        if entry is None or entry[0] <= time.monotonic():
+            return None
+        return entry[1]
+
+    def __len__(self) -> int:
+        return len(self.entries)

--- a/tests/unit/rollout/test_utils_ttl_cache.py
+++ b/tests/unit/rollout/test_utils_ttl_cache.py
@@ -1,0 +1,44 @@
+"""TtlCache: uniform-TTL dict with tombstone-based amortized expiry."""
+
+from unittest.mock import patch
+
+from osmosis_ai.rollout.utils.ttl_cache import TtlCache
+
+
+def test_set_get_and_expiry():
+    clock = [0.0]
+    with patch("osmosis_ai.rollout.utils.ttl_cache.time.monotonic", lambda: clock[0]):
+        cache = TtlCache(ttl_sec=10.0)
+        cache.set("a", 1)
+        assert cache.get("a") == 1
+        clock[0] = 9.9
+        assert cache.get("a") == 1
+        clock[0] = 10.0
+        assert cache.get("a") is None
+
+
+def test_writes_prune_expired_entries():
+    clock = [0.0]
+    with patch("osmosis_ai.rollout.utils.ttl_cache.time.monotonic", lambda: clock[0]):
+        cache = TtlCache(ttl_sec=10.0)
+        cache.set("a", 1)
+        cache.set("b", 2)
+        clock[0] = 11.0
+        cache.set("c", 3)
+        assert len(cache) == 1
+        assert not cache.tombstones or cache.tombstones[0][1] == "c"
+
+
+def test_overwrite_refreshes_and_orphans_old_tombstone():
+    clock = [0.0]
+    with patch("osmosis_ai.rollout.utils.ttl_cache.time.monotonic", lambda: clock[0]):
+        cache = TtlCache(ttl_sec=10.0)
+        cache.set("a", 1)
+        clock[0] = 5.0
+        cache.set("a", 2)
+        # Past the first deadline: the stale tombstone must not evict the refresh.
+        clock[0] = 12.0
+        cache.set("other", 3)
+        assert cache.get("a") == 2
+        clock[0] = 15.0
+        assert cache.get("a") is None


### PR DESCRIPTION
<!--
PR Title Format: [module] type: description
  modules: rollout, server, cli, auth, eval, misc, ci, doc
  types:   feat, fix, refactor, chore, test, doc

Examples:
  [rollout] feat: add streaming support for chat completions
  [BREAKING][rollout] refactor: change Grader.grade signature
  [ci] chore: update GitHub Actions versions
-->

## What

<!-- Brief description of the changes. What does this PR do? -->

## Why

<!-- Why are these changes needed? Link any related issues. -->
<!-- Closes #<issue_number> -->

## How to Test

<!-- Describe how reviewers can verify these changes. -->

## Checklist

- [ ] PR title follows `[module] type: description` format
- [ ] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pyright osmosis_ai/` passes
- [ ] `pytest` passes (new tests added if applicable)
- [ ] Public API changes are documented
- [ ] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `TtlCache` to `rollout` for uniform TTL-based caching with amortized O(1) expiry using tombstones. Provides simple set/get semantics with TTL refresh on overwrite and is fully unit tested.

- **New Features**
  - Dict-like cache using `time.monotonic` with a single TTL for all entries.
  - Expired entries are pruned on writes via a deque of tombstones.
  - Overwrites refresh TTL; stale tombstones won’t evict refreshed entries.
  - `get` returns None for missing/expired keys; `__len__` reflects live entries.
  - Added unit tests for expiry, pruning on write, and overwrite behavior.

<sup>Written for commit ac3cf164f13df403d6dca0a3051365cdd4cea9cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

