### PR TITLE
[2/6][rollout] feat: container contract, workflow output types, in-container runner

### DIFF
--- a/osmosis_ai/rollout/container/files.py
+++ b/osmosis_ai/rollout/container/files.py
@@ -1,0 +1,62 @@
+"""The two files exchanged with the rollout container.
+
+ContainerInput is staged into the container before the agent phase;
+ContainerResult comes back when it ends. Both ends are SDK code — user
+harnesses and native agents never touch these. The verifier reward file is
+Harbor's own contract and has one writer here.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+from osmosis_ai.rollout.types import RolloutStatus
+from osmosis_ai.rollout.types.output import AgentWorkflowOutput, Messages
+
+AGENT_LOGS_DIR = Path("/logs/agent")
+VERIFIER_LOGS_DIR = Path("/logs/verifier")
+INPUT_FILENAME = "container_input.json"
+RESULT_FILENAME = "container_result.json"
+
+
+class ContainerInput(BaseModel):
+    """Everything one agent run needs inside the container."""
+
+    version: int = 1
+    rollout_id: str
+    prompt: Messages = []
+    label: str | None = None
+    metadata: dict[str, Any] | None = None
+    chat_completions_url: str = ""
+    api_key: str | None = None
+
+    @classmethod
+    def read(cls, path: Path) -> ContainerInput:
+        return cls.model_validate_json(path.read_text())
+
+    def write(self, path: Path) -> None:
+        path.write_text(self.model_dump_json())
+
+
+class ContainerResult(BaseModel):
+    """How the agent phase went: status, error, and the workflow's output."""
+
+    status: RolloutStatus
+    output: AgentWorkflowOutput | None = None
+    err_message: str | None = None
+
+    @classmethod
+    def read(cls, path: Path) -> ContainerResult:
+        return cls.model_validate_json(path.read_text())
+
+    def write(self, path: Path) -> None:
+        path.write_text(self.model_dump_json())
+
+
+def write_reward(reward: float) -> None:
+    VERIFIER_LOGS_DIR.mkdir(parents=True, exist_ok=True)
+    (VERIFIER_LOGS_DIR / "reward.json").write_text(json.dumps({"reward": reward}))

--- a/osmosis_ai/rollout/container/runner.py
+++ b/osmosis_ai/rollout/container/runner.py
@@ -1,0 +1,190 @@
+"""In-container entrypoints for bundled workflows and graders.
+
+The bundle's generated shim calls ``agent_main(WorkflowClass, config)`` and
+``grader_main(GraderClass, config)`` directly — the class is bound at package
+time, so nothing is resolved at runtime. Both read the ContainerInput staged
+by the backend; the grader additionally reads the agent phase's
+ContainerResult.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import sys
+import traceback
+from pathlib import Path
+from typing import Any
+
+from osmosis_ai.rollout.container.files import (
+    AGENT_LOGS_DIR,
+    INPUT_FILENAME,
+    RESULT_FILENAME,
+    VERIFIER_LOGS_DIR,
+    ContainerInput,
+    ContainerResult,
+    write_reward,
+)
+from osmosis_ai.rollout.container.trajectories import messages_from_trajectory
+from osmosis_ai.rollout.context import (
+    AgentWorkflowContext,
+    GraderContext,
+    RolloutContext,
+)
+from osmosis_ai.rollout.types import RolloutSample, RolloutStatus
+from osmosis_ai.rollout.types.output import AgentWorkflowOutput, coerce_output
+from osmosis_ai.rollout.utils.file_artifacts import (
+    GRADER_ARTIFACTS_SNAPSHOT_DIRNAME,
+    HARBOR_ARTIFACTS_DIR,
+    ArtifactFileState,
+    artifact_tree_state,
+    copy_artifact_tree,
+)
+
+
+async def run_agent(workflow_cls: Any, workflow_config: Any) -> ContainerResult:
+    container_input = ContainerInput.read(AGENT_LOGS_DIR / INPUT_FILENAME)
+    rollout_ctx = RolloutContext(
+        chat_completions_url=container_input.chat_completions_url,
+        api_key=container_input.api_key,
+        rollout_id=container_input.rollout_id,
+    )
+    ctx = AgentWorkflowContext(
+        prompt=container_input.prompt,
+        config=workflow_config,
+        metadata=container_input.metadata,
+        artifacts_dir=HARBOR_ARTIFACTS_DIR,
+    )
+    workflow = workflow_cls(workflow_config)
+    sample = None
+    with rollout_ctx:
+        returned = await workflow.run(ctx)
+        output = coerce_output(returned)
+        if output is None:
+            sample = await rollout_ctx.get_sample()
+            if sample is not None:
+                output = AgentWorkflowOutput(
+                    samples={"default": [dict(m) for m in sample.messages]},
+                    metrics=sample.metrics or {},
+                )
+            else:
+                output = AgentWorkflowOutput()
+    write_trajectory_json(sample, output, container_input.rollout_id)
+    return ContainerResult(status=RolloutStatus.SUCCESS, output=output)
+
+
+def write_trajectory_json(
+    sample: RolloutSample | None, output: AgentWorkflowOutput, rollout_id: str
+) -> None:
+    """Best-effort ATIF trajectory at agent/trajectory.json, where native
+    harbor agents leave theirs."""
+    if sample is None:
+        messages = output.primary_messages()
+        if messages:
+            sample = RolloutSample(messages=messages)
+    if sample is None or sample.trajectory_messages is None:
+        return
+    try:
+        from harbor.utils.trajectory_utils import format_trajectory_json
+
+        from osmosis_ai.rollout.trajectory.converter import (
+            convert_sample_to_trajectory,
+        )
+
+        trajectory = convert_sample_to_trajectory(sample, rollout_id=rollout_id)
+        (AGENT_LOGS_DIR / "trajectory.json").write_text(
+            format_trajectory_json(trajectory.to_json_dict())
+        )
+    except Exception as e:
+        print(f"Failed to write trajectory.json (best-effort): {e}", file=sys.stderr)
+
+
+def agent_main(workflow_cls: Any, workflow_config: Any = None) -> None:
+    try:
+        result = asyncio.run(run_agent(workflow_cls, workflow_config))
+    except Exception as e:
+        traceback.print_exc()
+        result = ContainerResult(status=RolloutStatus.FAILURE, err_message=str(e))
+    result.write(AGENT_LOGS_DIR / RESULT_FILENAME)
+    print(f"Agent runner complete: status={result.status}")
+
+
+def snapshot_grader_artifacts(baseline: ArtifactFileState) -> None:
+    """Stage grader-authored artifact changes where Harbor returns verifier files."""
+    snapshot_dir = VERIFIER_LOGS_DIR / GRADER_ARTIFACTS_SNAPSHOT_DIRNAME
+    try:
+        shutil.rmtree(snapshot_dir, ignore_errors=True)
+        if not HARBOR_ARTIFACTS_DIR.is_dir():
+            return
+        copied = copy_artifact_tree(
+            HARBOR_ARTIFACTS_DIR,
+            snapshot_dir,
+            destination_root=VERIFIER_LOGS_DIR,
+            baseline=baseline,
+        )
+        if not copied:
+            shutil.rmtree(snapshot_dir, ignore_errors=True)
+    except Exception as e:
+        print(f"Failed to stage grader artifacts (best-effort): {e}", file=sys.stderr)
+
+
+TESTS_DIR = Path("/tests")
+
+
+def read_container_input() -> ContainerInput:
+    for directory in (TESTS_DIR, AGENT_LOGS_DIR):
+        path = directory / INPUT_FILENAME
+        if path.exists():
+            return ContainerInput.read(path)
+    raise FileNotFoundError(
+        f"{INPUT_FILENAME} not found in {TESTS_DIR} or {AGENT_LOGS_DIR}"
+    )
+
+
+def load_messages() -> tuple[list[dict[str, Any]] | None, dict[str, float]]:
+    """Messages from the workflow result, else from the agent's trajectory."""
+    result_path = AGENT_LOGS_DIR / RESULT_FILENAME
+    if result_path.exists():
+        output = ContainerResult.read(result_path).output
+        if output is not None:
+            return output.primary_messages(), output.metrics
+    for name in sorted(AGENT_LOGS_DIR.glob("*trajectory*.json")):
+        try:
+            messages = messages_from_trajectory(json.loads(name.read_text()))
+        except (ValueError, OSError):
+            continue
+        if messages:
+            return messages, {}
+    return None, {}
+
+
+def grader_main(grader_cls: Any, grader_config: Any = None) -> None:
+    container_input = read_container_input()
+    messages, metrics = load_messages()
+    if messages is None:
+        print("No messages from the agent phase, skipping grading")
+        write_reward(0.0)
+        return
+
+    sample = RolloutSample(messages=messages, metrics=metrics)
+    try:
+        baseline = artifact_tree_state(HARBOR_ARTIFACTS_DIR)
+    except Exception:
+        baseline = {}
+    try:
+        ctx = GraderContext(
+            label=container_input.label,
+            sample=sample,
+            metadata=container_input.metadata,
+            artifacts_dir=HARBOR_ARTIFACTS_DIR,
+        )
+        grader = grader_cls(grader_config)
+        asyncio.run(grader.grade(ctx))
+    finally:
+        snapshot_grader_artifacts(baseline)
+
+    if ctx.sample is None or ctx.sample.reward is None:
+        raise RuntimeError("Sample has no reward after grading")
+    write_reward(ctx.sample.reward)
+    print(f"Grading complete: reward={ctx.sample.reward}")

--- a/osmosis_ai/rollout/container/trajectories.py
+++ b/osmosis_ai/rollout/container/trajectories.py
@@ -1,0 +1,24 @@
+"""Extract chat messages from the trajectory documents agents leave behind.
+
+Shared by the in-container grader runner and the host-side backend, so it
+must not import Harbor.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+ATIF_ROLE_BY_SOURCE = {"user": "user", "agent": "assistant", "system": "system"}
+
+
+def messages_from_trajectory(document: dict[str, Any]) -> list[dict[str, Any]]:
+    """Accept ATIF (steps) or raw harness formats (a messages list)."""
+    if isinstance(document.get("messages"), list):
+        return document["messages"]
+    messages = []
+    for step in document.get("steps") or []:
+        content = step.get("message")
+        if content is not None:
+            role = ATIF_ROLE_BY_SOURCE.get(step.get("source"), "tool")
+            messages.append({"role": role, "content": content})
+    return messages

--- a/osmosis_ai/rollout/types/__init__.py
+++ b/osmosis_ai/rollout/types/__init__.py
@@ -5,6 +5,8 @@ from .config import (
     GraderConfig,
 )
 from .protocol import (
+    CancelRolloutsRequest,
+    CancelRolloutsResponse,
     GraderCompleteRequest,
     GraderInitRequest,
     GraderInitResponse,
@@ -12,6 +14,7 @@ from .protocol import (
     RolloutCompleteRequest,
     RolloutInitRequest,
     RolloutInitResponse,
+    RolloutStatusResponse,
 )
 from .sample import (
     ExecutionRequest,
@@ -25,6 +28,8 @@ from .sample import (
 __all__ = [
     "AgentWorkflowConfig",
     "BaseConfig",
+    "CancelRolloutsRequest",
+    "CancelRolloutsResponse",
     "ConcurrencyConfig",
     "ExecutionRequest",
     "ExecutionResult",
@@ -40,4 +45,5 @@ __all__ = [
     "RolloutInitResponse",
     "RolloutSample",
     "RolloutStatus",
+    "RolloutStatusResponse",
 ]

--- a/osmosis_ai/rollout/types/output.py
+++ b/osmosis_ai/rollout/types/output.py
@@ -1,0 +1,44 @@
+"""Return type for AgentWorkflow.run."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+Messages = list[dict[str, Any]]
+
+
+class AgentWorkflowOutput(BaseModel):
+    """What a workflow hands back: message histories plus optional measurements.
+
+    ``samples`` maps a name to one agent's message history (multi-agent
+    workflows return several). ``info`` carries workflow-produced context for
+    the grader; the rollout request's ``metadata`` is a separate, input-side
+    field.
+    """
+
+    samples: dict[str, Messages] = Field(default_factory=dict)
+    metrics: dict[str, float] = Field(default_factory=dict)
+    info: dict[str, Any] = Field(default_factory=dict)
+
+    def primary_messages(self) -> Messages | None:
+        if not self.samples:
+            return None
+        if "default" in self.samples:
+            return self.samples["default"]
+        return next(iter(self.samples.values()))
+
+
+def coerce_output(value: Any) -> AgentWorkflowOutput | None:
+    """Normalize a run() return value; None means "use the fallback source"."""
+    if value is None:
+        return None
+    if isinstance(value, AgentWorkflowOutput):
+        return value
+    if isinstance(value, list):
+        return AgentWorkflowOutput(samples={"default": value})
+    raise TypeError(
+        "run() must return AgentWorkflowOutput, a message list, or None; "
+        f"got {type(value).__name__}"
+    )

--- a/osmosis_ai/rollout/types/protocol.py
+++ b/osmosis_ai/rollout/types/protocol.py
@@ -51,6 +51,36 @@ class RolloutInitRequest(BaseModel):
 class RolloutInitResponse(BaseModel): ...
 
 
+class RolloutStatusResponse(BaseModel):
+    """GET /rollout/{rollout_id}/status.
+
+    QUEUED/RUNNING/GRADING while in flight; SUCCESS/FAILURE/CANCELLED for a
+    retention window after the rollout ends; UNKNOWN for ids never seen or
+    whose record aged out.
+    """
+
+    rollout_id: str
+    status: RolloutStatus
+    reward: float | None = None
+    err_message: str | None = None
+
+
+class CancelRolloutsRequest(BaseModel):
+    """Body of the POST to /rollout/cancel. Exactly one selector applies:
+    explicit ``ids``, an id ``prefix``, or ``all``."""
+
+    ids: list[str] | None = None
+    prefix: str | None = None
+    all: bool = False
+
+
+class CancelRolloutsResponse(BaseModel):
+    """Disposition per rollout: ``cancelled_queued``, ``cancelled_running``,
+    or ``not_found`` for unknown/finished ids (cancellation is idempotent)."""
+
+    dispositions: dict[str, str]
+
+
 class RolloutCompleteRequest(BaseModel):
     """Body of the rollout-complete callback.
 

--- a/osmosis_ai/rollout/types/sample.py
+++ b/osmosis_ai/rollout/types/sample.py
@@ -50,9 +50,16 @@ class RolloutSample(BaseModel):
 
 
 class RolloutStatus(StrEnum):
-    PENDING = "pending"
+    """One vocabulary for rollout status everywhere: lifecycle states while
+    in flight (status polling), terminal states as execution outcomes."""
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    GRADING = "grading"
     SUCCESS = "success"
     FAILURE = "failure"
+    CANCELLED = "cancelled"
+    UNKNOWN = "unknown"
 
 
 class RolloutErrorCategory(StrEnum):
@@ -82,3 +89,5 @@ class ExecutionResult(BaseModel):
     sample: RolloutSample | None = None
     err_message: str | None = None
     err_category: RolloutErrorCategory | None = None
+    # Backend diagnostics (failure phase, timings); not part of the wire protocol.
+    extra_fields: dict[str, Any] | None = None

--- a/tests/unit/rollout/test_container_runner.py
+++ b/tests/unit/rollout/test_container_runner.py
@@ -1,0 +1,52 @@
+"""Tests for the in-container runner's trajectory emission."""
+
+import json
+
+import osmosis_ai.rollout.container.runner as runner
+from osmosis_ai.rollout.types import RolloutSample
+from osmosis_ai.rollout.types.output import AgentWorkflowOutput
+
+MESSAGES = [
+    {"role": "system", "content": "multiply things"},
+    {"role": "user", "content": "val1 = 2\nval2 = 3"},
+    {"role": "assistant", "content": "#### 6"},
+]
+
+
+class TestWriteTrajectoryDocument:
+    def test_writes_atif_from_sample(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(runner, "AGENT_LOGS_DIR", tmp_path)
+        sample = RolloutSample(messages=MESSAGES)
+
+        runner.write_trajectory_json(sample, AgentWorkflowOutput(), "r-1")
+
+        doc = json.loads((tmp_path / "trajectory.json").read_text())
+        assert doc["session_id"] == "r-1"
+        assert doc["agent"]["name"] == "osmosis-rollout-sdk"
+        sources = [step["source"] for step in doc["steps"]]
+        assert sources == ["system", "user", "agent"]
+        assert "#### 6" in doc["steps"][-1]["message"]
+
+    def test_falls_back_to_output_messages(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(runner, "AGENT_LOGS_DIR", tmp_path)
+        output = AgentWorkflowOutput(samples={"default": MESSAGES})
+
+        runner.write_trajectory_json(None, output, "r-2")
+
+        doc = json.loads((tmp_path / "trajectory.json").read_text())
+        assert doc["trajectory_id"] == "r-2"
+
+    def test_no_messages_writes_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(runner, "AGENT_LOGS_DIR", tmp_path)
+
+        runner.write_trajectory_json(None, AgentWorkflowOutput(), "r-3")
+
+        assert not (tmp_path / "trajectory.json").exists()
+
+    def test_persistence_opt_out_writes_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(runner, "AGENT_LOGS_DIR", tmp_path)
+        sample = RolloutSample(messages=MESSAGES, trajectory_messages=None)
+
+        runner.write_trajectory_json(sample, AgentWorkflowOutput(), "r-4")
+
+        assert not (tmp_path / "trajectory.json").exists()


### PR DESCRIPTION
Part of splitting #272 into reviewable pieces (2/6).

## What this adds

The data types and the in-container code that let a user's agent workflow run inside a task container and report results back to the host.

- `ContainerInput` / `ContainerResult` (`container/files.py`): the two JSON files exchanged with the container. The host stages `container_input.json` (rollout id, prompt, metadata, chat-completions URL, API key) before the agent starts; the agent phase writes `container_result.json` (status, error, workflow output) when it ends. `write_reward` writes the reward file at the path Harbor's verifier reads (`/logs/verifier/reward.json`).
- `AgentWorkflowOutput` (`types/output.py`): what a workflow's `run()` may return — one or more named message histories plus metrics. Returning nothing is also valid; the runner then collects the conversation recorded at the chat-completions endpoint.
- `RolloutStatus` (`types/sample.py`): one status vocabulary used everywhere — `queued`, `running`, `grading`, `success`, `failure`, `cancelled`, `unknown`. `RolloutSample` gains `extra_fields` for structured diagnostics.
- The runner (`container/runner.py`): the entrypoints that the generated bundle scripts call inside the container. `agent_main` reads the input file, runs the workflow, writes the result file, and saves the conversation as an ATIF `trajectory.json` next to the agent logs — the same location and format native Harbor agents use, so tools that read trajectories work on both. `grader_main` loads the agent's messages (from the result file, or from a trajectory file when the agent was not SDK code), runs the user's grader, and writes the reward. The grader reads its input from `tests/` first: that copy may carry the ground-truth label, while the agent-phase copy has the label removed so the model can never read the answer.
- `messages_from_trajectory` (`container/trajectories.py`): converts a trajectory document (ATIF steps, or a raw messages list from a native harness) into plain chat messages.

## Example

A workflow and grader written against these types:

```python
class MyWorkflow(AgentWorkflow):
    async def run(self, ctx: AgentWorkflowContext) -> None:
        agent = StrandsAgent(model=ctx.config.model, messages=ctx.prompt)
        await agent.invoke_async()
        # returning None is fine: the recorded conversation becomes the sample

class MyGrader(Grader):
    async def grade(self, ctx: GraderContext) -> None:
        answer = ctx.sample.messages[-1]["content"]
        ctx.set_reward(1.0 if answer.strip() == ctx.label else 0.0)
```

Inside the container, the bundle's console scripts call `agent_main(MyWorkflow, config)` and `grader_main(MyGrader, config)`; everything else in this PR is the plumbing those two calls rely on.