### PR TITLE
[3/6][misc] feat: package rollout projects into installable wheel bundles

### DIFF
--- a/benchmarks/container_lifecycle/bench_harness/bench_harness/grade.py
+++ b/benchmarks/container_lifecycle/bench_harness/bench_harness/grade.py
@@ -1,0 +1,8 @@
+"""Bench grader: constant reward; exists to exercise the in-env grader path."""
+
+from osmosis_ai.rollout import Grader, GraderContext
+
+
+class BenchGrader(Grader):
+    async def grade(self, ctx: GraderContext) -> None:
+        ctx.set_reward(1.0)

--- a/benchmarks/container_lifecycle/bench_harness/bench_harness/solver.py
+++ b/benchmarks/container_lifecycle/bench_harness/bench_harness/solver.py
@@ -1,0 +1,25 @@
+"""Bench workflow: two chat calls against the rollout context's model URL."""
+
+import httpx
+
+from osmosis_ai.rollout import AgentWorkflow, AgentWorkflowContext, get_rollout_context
+
+
+class BenchWorkflow(AgentWorkflow):
+    async def run(self, ctx: AgentWorkflowContext) -> list[dict]:
+        rollout_ctx = get_rollout_context()
+        url = f"{rollout_ctx.chat_completions_url.rstrip('/')}/chat/completions"
+        headers = {"Authorization": f"Bearer {rollout_ctx.api_key}"}
+        messages = list(ctx.prompt)
+
+        async with httpx.AsyncClient(timeout=60) as client:
+            for _ in range(2):
+                response = await client.post(
+                    url,
+                    json={"model": "bench", "messages": messages},
+                    headers=headers,
+                )
+                response.raise_for_status()
+                messages.append(response.json()["choices"][0]["message"])
+
+        return messages

--- a/benchmarks/container_lifecycle/bench_harness/pyproject.toml
+++ b/benchmarks/container_lifecycle/bench_harness/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "bench-harness"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "osmosis-ai @ https://github.com/Osmosis-AI/osmosis-sdk-python/archive/refs/heads/feat/harbor-backend-v2.tar.gz",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["bench_harness*"]

--- a/osmosis_ai/packaging.py
+++ b/osmosis_ai/packaging.py
@@ -1,0 +1,260 @@
+"""Build an installable wheel from an agent/harness project dir.
+
+Stages the user's project (their pyproject.toml, dependencies, and build
+backend included), injects a generated shim with literal imports, and exposes
+``<package>-agent`` / ``<package>-grade`` console scripts. The wheel installs
+anywhere with one ``pip install`` — a rollout container or a user's own box.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+import tempfile
+import tomllib
+import zipfile
+from dataclasses import dataclass
+from importlib.metadata import PathDistribution
+from pathlib import Path
+
+import platformdirs
+import toml
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+BUNDLES_DIR = platformdirs.user_cache_path("osmosis") / "bundles"
+
+AGENT_MAIN_TEMPLATE = """\
+
+
+def agent_main():
+    runner.agent_main({workflow_class}, {workflow_config})
+"""
+
+GRADER_MAIN_TEMPLATE = """\
+
+
+def grader_main():
+    runner.grader_main({grader_class}, {grader_config})
+"""
+
+EXCLUDE_DIRS = {
+    "__pycache__",
+    ".git",
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+    "node_modules",
+    ".pytest_cache",
+    ".ruff_cache",
+}
+
+
+@dataclass(frozen=True)
+class BundleInfo:
+    wheel: Path
+    agent_script: str | None
+    grader_script: str | None
+    requirements: list[str]
+
+
+def agent_script_name(package: str) -> str:
+    return f"{package.replace('_', '-')}-agent"
+
+
+def grader_script_name(package: str) -> str:
+    return f"{package.replace('_', '-')}-grade"
+
+
+def content_hash(path: Path, *, extra: str = "") -> str:
+    digest = hashlib.sha256(extra.encode())
+    for file in sorted(
+        p for p in path.rglob("*") if p.is_file() and not (set(p.parts) & EXCLUDE_DIRS)
+    ):
+        digest.update(str(file.relative_to(path)).encode())
+        digest.update(file.read_bytes())
+    return digest.hexdigest()[:32]
+
+
+def find_package(code_dir: Path) -> str:
+    packages = sorted(
+        d.name
+        for d in code_dir.iterdir()
+        if d.is_dir() and (d / "__init__.py").exists() and d.name not in EXCLUDE_DIRS
+    )
+    if len(packages) != 1:
+        raise ValueError(
+            f"expected exactly one python package in {code_dir}, "
+            f"found {packages or 'none'}; pass package= explicitly"
+        )
+    return packages[0]
+
+
+def requirement_name(spec: str) -> str:
+    return canonicalize_name(Requirement(spec).name)
+
+
+def split_ref(ref: str, label: str) -> tuple[str, str]:
+    if ":" not in ref:
+        raise ValueError(f"{label} must be 'module:attr', got {ref!r}")
+    module, attr = ref.rsplit(":", 1)
+    return module, attr
+
+
+def project_dir_for(obj: object) -> Path:
+    """Locate the project dir (containing pyproject.toml) of *obj*'s package."""
+    import inspect
+
+    package_dir = Path(
+        inspect.getfile(type(obj) if not isinstance(obj, type) else obj)
+    ).parent
+    while (package_dir.parent / "__init__.py").exists():
+        package_dir = package_dir.parent
+    project_dir = package_dir.parent
+    if not (project_dir / "pyproject.toml").is_file():
+        raise ValueError(
+            f"no pyproject.toml next to package {package_dir.name!r} "
+            f"(looked in {project_dir}); pass code_dir= explicitly"
+        )
+    return project_dir
+
+
+def extra_gated(spec: str) -> bool:
+    marker = Requirement(spec).marker
+    return marker is not None and "extra ==" in str(marker)
+
+
+def inspect_bundle(wheel: Path) -> BundleInfo:
+    """Read the bundle's console scripts and dependencies from wheel metadata.
+
+    Extra-gated dependencies are dropped; environment markers (python_version,
+    sys_platform, …) ship verbatim since pip evaluates them inside the
+    container, where they may resolve differently than on this host.
+    """
+    dist_info = next(
+        entry
+        for entry in zipfile.Path(wheel).iterdir()
+        if entry.name.endswith(".dist-info")
+    )
+    dist = PathDistribution(dist_info)
+    scripts = {
+        ep.name: ep.value for ep in dist.entry_points if ep.group == "console_scripts"
+    }
+    agent = next(
+        (n for n, t in scripts.items() if t.endswith(".bundle_main:agent_main")), None
+    )
+    grader = next(
+        (n for n, t in scripts.items() if t.endswith(".bundle_main:grader_main")), None
+    )
+    if agent is None and grader is None:
+        raise ValueError(f"{wheel.name} is not an osmosis bundle (no runner scripts)")
+    return BundleInfo(
+        wheel=wheel,
+        agent_script=agent,
+        grader_script=grader,
+        requirements=[spec for spec in dist.requires or [] if not extra_gated(spec)],
+    )
+
+
+def build_bundle(
+    code_dir: Path,
+    *,
+    workflow: str | None = None,
+    grader: str | None = None,
+    workflow_config: str | None = None,
+    grader_config: str | None = None,
+    deps: list[str] | None = None,
+    package: str | None = None,
+    bundles_dir: Path = BUNDLES_DIR,
+) -> Path:
+    """Package the project at *code_dir* into a wheel; rebuild only on change.
+
+    workflow/grader are 'module:Class' refs; the config refs point at
+    module-level instances and are passed to the runner as-is. Grader-only
+    bundles (workflow=None) carry just the grading script. Entries in *deps*
+    replace same-named dependencies from the project's pyproject.toml.
+    """
+    code_dir = code_dir.resolve()
+    pyproject_path = code_dir / "pyproject.toml"
+    if not pyproject_path.is_file():
+        raise ValueError(f"project dir must contain pyproject.toml: {code_dir}")
+    if workflow is None and grader is None:
+        raise ValueError("pass workflow and/or grader")
+    package = package or find_package(code_dir)
+
+    imports = []
+    references = {}
+    for label, ref in (
+        ("workflow", workflow),
+        ("grader", grader),
+        ("workflow_config", workflow_config),
+        ("grader_config", grader_config),
+    ):
+        if ref is None:
+            references[label] = "None"
+            continue
+        module, attr = split_ref(ref, label)
+        imports.append(f"from {module} import {attr}")
+        references[label] = attr
+
+    shim = "\n".join(imports) + "\nfrom osmosis_ai.rollout.container import runner\n"
+    scripts = {}
+    if workflow:
+        shim += AGENT_MAIN_TEMPLATE.format(
+            workflow_class=references["workflow"],
+            workflow_config=references["workflow_config"],
+        )
+        scripts[agent_script_name(package)] = f"{package}.bundle_main:agent_main"
+    if grader:
+        shim += GRADER_MAIN_TEMPLATE.format(
+            grader_class=references["grader"],
+            grader_config=references["grader_config"],
+        )
+        scripts[grader_script_name(package)] = f"{package}.bundle_main:grader_main"
+
+    project = tomllib.loads(pyproject_path.read_text()).get("project", {})
+    name = project.get("name") or f"osmosis-harness-{package}"
+    bundle_key = content_hash(
+        code_dir, extra=pyproject_path.read_text() + shim + repr(deps or [])
+    )
+    bundles_dir.mkdir(parents=True, exist_ok=True)
+    wheel_glob = f"{name.replace('-', '_')}-*.whl"
+    marker = bundles_dir / f"{name}-{bundle_key}.key"
+    cached = sorted(bundles_dir.glob(wheel_glob))
+    if cached and marker.exists():
+        return cached[0]
+
+    for old in bundles_dir.glob(f"{name}-*.key"):
+        old.unlink()
+    with tempfile.TemporaryDirectory() as staging:
+        stage = Path(staging)
+        shutil.copytree(
+            code_dir,
+            stage,
+            dirs_exist_ok=True,
+            ignore=shutil.ignore_patterns(*EXCLUDE_DIRS, "*.pyc"),
+        )
+        (stage / package / "bundle_main.py").write_text(shim)
+        staged = tomllib.loads((stage / "pyproject.toml").read_text())
+        staged_project = staged.setdefault("project", {})
+        overridden = {requirement_name(d) for d in deps or []}
+        staged_project["dependencies"] = [
+            d
+            for d in staged_project.get("dependencies", [])
+            if requirement_name(d) not in overridden
+        ] + list(deps or [])
+        staged_project["scripts"] = {**staged_project.get("scripts", {}), **scripts}
+        (stage / "pyproject.toml").write_text(toml.dumps(staged))
+        subprocess.run(
+            ["uv", "build", "--wheel", "--out-dir", str(bundles_dir), str(stage)],
+            check=True,
+            capture_output=True,
+        )
+
+    marker.touch()
+    wheels = sorted(bundles_dir.glob(wheel_glob))
+    if not wheels:
+        raise RuntimeError(f"uv build produced no wheel in {bundles_dir}")
+    return wheels[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     # Requirement parsing for the submit preflight. Transitive via setuptools and
     # litellm, but declared because the CLI imports it directly.
     "packaging>=24.0",
+    "platformdirs>=4.0",
     # CLI framework. <0.28 keeps cli/_click_compat.py's private imports stable.
     "typer>=0.27,<0.28",
     # Do not directly constrain typer-slim: versions <0.22 shared typer/* with

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -1,0 +1,157 @@
+"""Packaging: wheel build, caching, and bundle inspection."""
+
+import zipfile
+
+import pytest
+
+from osmosis_ai.packaging import build_bundle, inspect_bundle
+
+PYPROJECT = """\
+[project]
+name = "my-harness"
+version = "0.1.0"
+dependencies = ["httpx>=0.27"]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["my_harness*"]
+"""
+
+
+@pytest.fixture
+def project(tmp_path):
+    code_dir = tmp_path / "harness"
+    package = code_dir / "my_harness"
+    package.mkdir(parents=True)
+    (package / "__init__.py").touch()
+    (package / "solver.py").write_text("class MyWorkflow: pass\n")
+    (package / "grade.py").write_text("class MyGrader: pass\n")
+    (code_dir / "pyproject.toml").write_text(PYPROJECT)
+    return code_dir
+
+
+def test_build_produces_scripts_and_keeps_deps(project, tmp_path):
+    wheel = build_bundle(
+        project,
+        workflow="my_harness.solver:MyWorkflow",
+        grader="my_harness.grade:MyGrader",
+        bundles_dir=tmp_path / "bundles",
+    )
+    with zipfile.ZipFile(wheel) as archive:
+        names = archive.namelist()
+        metadata = archive.read(
+            next(n for n in names if n.endswith("METADATA"))
+        ).decode()
+        shim = archive.read("my_harness/bundle_main.py").decode()
+
+    assert "my_harness/solver.py" in names
+    assert "Requires-Dist: httpx>=0.27" in metadata
+    assert "from my_harness.solver import MyWorkflow" in shim
+    assert "runner.agent_main(MyWorkflow, None)" in shim
+
+    info = inspect_bundle(wheel)
+    assert info.agent_script == "my-harness-agent"
+    assert info.grader_script == "my-harness-grade"
+
+
+def test_deps_override_same_named_pyproject_entries(project, tmp_path):
+    wheel = build_bundle(
+        project,
+        workflow="my_harness.solver:MyWorkflow",
+        deps=["httpx @ https://example.com/httpx.tar.gz"],
+        bundles_dir=tmp_path / "bundles",
+    )
+    with zipfile.ZipFile(wheel) as archive:
+        metadata = archive.read(
+            next(n for n in archive.namelist() if n.endswith("METADATA"))
+        ).decode()
+    assert "Requires-Dist: httpx>=0.27" not in metadata
+    assert "Requires-Dist: httpx @ https://example.com/httpx.tar.gz" in metadata
+
+
+def test_requirements_keep_markers_drop_extras(tmp_path):
+    code_dir = tmp_path / "harness"
+    package = code_dir / "my_harness"
+    package.mkdir(parents=True)
+    (package / "__init__.py").touch()
+    (package / "solver.py").write_text("class W: pass\n")
+    (code_dir / "pyproject.toml").write_text(
+        """\
+[project]
+name = "my-harness"
+version = "0.1.0"
+dependencies = ["httpx>=0.27", "tomli; python_version < '3.11'"]
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["my_harness*"]
+"""
+    )
+    wheel = build_bundle(
+        code_dir, workflow="my_harness.solver:W", bundles_dir=tmp_path / "bundles"
+    )
+    requirements = inspect_bundle(wheel).requirements
+    assert "httpx>=0.27" in requirements
+    assert any(r.startswith("tomli") for r in requirements)
+    assert not any("pytest" in r for r in requirements)
+
+
+def test_grader_optional(project, tmp_path):
+    wheel = build_bundle(
+        project,
+        workflow="my_harness.solver:MyWorkflow",
+        bundles_dir=tmp_path / "bundles",
+    )
+    info = inspect_bundle(wheel)
+    assert info.grader_script is None
+
+
+def test_cache_hits_until_source_changes(project, tmp_path):
+    bundles_dir = tmp_path / "bundles"
+    kwargs = dict(workflow="my_harness.solver:MyWorkflow", bundles_dir=bundles_dir)
+
+    first = build_bundle(project, **kwargs)
+    first_mtime = first.stat().st_mtime_ns
+    assert build_bundle(project, **kwargs).stat().st_mtime_ns == first_mtime
+
+    (project / "my_harness" / "solver.py").write_text(
+        "class MyWorkflow:\n    changed = True\n"
+    )
+    assert build_bundle(project, **kwargs).stat().st_mtime_ns != first_mtime
+
+
+def test_rejects_bad_refs_and_missing_pyproject(project, tmp_path):
+    with pytest.raises(ValueError, match="module:attr"):
+        build_bundle(project, workflow="not-a-ref", bundles_dir=tmp_path / "b")
+    with pytest.raises(ValueError, match=r"pyproject\.toml"):
+        build_bundle(tmp_path / "nowhere", workflow="a:B", bundles_dir=tmp_path / "b")
+
+
+def test_project_dir_for_locates_bench_harness():
+    import sys
+    from pathlib import Path
+
+    from osmosis_ai.packaging import project_dir_for
+
+    harness_dir = (
+        Path(__file__).parents[2]
+        / "benchmarks"
+        / "container_lifecycle"
+        / "bench_harness"
+    )
+    sys.path.insert(0, str(harness_dir))
+    try:
+        from bench_harness.solver import BenchWorkflow
+
+        assert project_dir_for(BenchWorkflow) == harness_dir
+    finally:
+        sys.path.remove(str(harness_dir))

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -1944,6 +1944,7 @@ dependencies = [
     { name = "openai-agents", extra = ["litellm"] },
     { name = "orjson" },
     { name = "packaging" },
+    { name = "platformdirs" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "questionary" },
@@ -1998,6 +1999,7 @@ requires-dist = [
     { name = "osmosis-ai", extras = ["server"], marker = "extra == 'dev'" },
     { name = "osmosis-ai", extras = ["server"], marker = "extra == 'full'" },
     { name = "packaging", specifier = ">=24.0" },
+    { name = "platformdirs", specifier = ">=4.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.6.0,<5.0.0" },
     { name = "pyarrow", marker = "extra == 'platform'", specifier = ">=23.0.1" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },


### PR DESCRIPTION
Part of splitting #272 into reviewable pieces (3/6).

## What this adds

`osmosis_ai/packaging.py`: builds a standard Python wheel from a user's rollout project so the project can be installed inside a task container with one `pip install`.

- `build_bundle(project_dir, workflow=..., grader=...)` produces a wheel containing the project's package plus a generated `bundle_main.py` shim. The shim imports the user's classes directly (`from my_harness.solver import MyWorkflow`) and exposes two console scripts, `<package>-agent` and `<package>-grade`, which call the runner entrypoints from #284. Nothing is resolved dynamically at runtime; the class binding happens at build time.
- Wheels are cached by a content hash of the project files under the user cache directory (`platformdirs`), so rebuilding an unchanged project is free.
- `inspect_bundle(wheel)` reads the wheel's metadata with `importlib.metadata` and returns the declared dependencies (keeping environment markers, dropping extras-gated entries) plus the two script names. The Harbor backend (next in the stack) uses this list to pre-install dependencies into the task image.

Also includes the `bench_harness` fixture project the packaging tests build against, and the `platformdirs` dependency.

## Example

```python
from osmosis_ai.packaging import build_bundle, inspect_bundle

wheel = build_bundle(
    Path("my_rollout_project"),
    workflow="my_harness.solver:MyWorkflow",
    grader="my_harness.grade:MyGrader",
)
info = inspect_bundle(wheel)
info.agent_script    # "my-harness-agent"
info.requirements    # ["strands-agents>=1.0", "httpx>=0.27", ...]
```

Inside a container, `pip install my_harness-0.1.0-py3-none-any.whl` followed by running `my-harness-agent` executes the user's workflow with no other setup.