### PR TITLE
[5/6][rollout] feat: server admission control, rollout status, and cancel endpoints

### DIFF
--- a/osmosis_ai/rollout/server/app.py
+++ b/osmosis_ai/rollout/server/app.py
@@ -14,6 +14,8 @@ from osmosis_ai.rollout.trajectory import (
     save_trajectories,
 )
 from osmosis_ai.rollout.types import (
+    CancelRolloutsRequest,
+    CancelRolloutsResponse,
     ExecutionRequest,
     ExecutionResult,
     GraderCompleteRequest,
@@ -22,6 +24,7 @@ from osmosis_ai.rollout.types import (
     RolloutInitRequest,
     RolloutInitResponse,
     RolloutStatus,
+    RolloutStatusResponse,
 )
 from osmosis_ai.rollout.utils.http import post_json_with_retry
 
@@ -57,16 +60,52 @@ def create_rollout_server(
     async def health() -> dict[str, Any]:
         return backend.health()
 
-    @app.post("/rollout")
+    # 202: the rollout is queued and runs after this response returns.
+    @app.post("/rollout", status_code=202)
     async def rollout(
         request: RolloutInitRequest, background_tasks: BackgroundTasks
     ) -> RolloutInitResponse:
+        if not backend.has_capacity():
+            raise HTTPException(
+                status_code=429,
+                detail="rollout queue is full; retry later",
+                headers={"Retry-After": "5"},
+            )
         try:
             background_tasks.add_task(_handle_rollout, backend, request)
             return RolloutInitResponse()
         except Exception as e:
             logger.error(traceback.format_exc())
             raise HTTPException(status_code=500, detail=str(e)) from e
+
+    @app.get("/rollout/{rollout_id}/status")
+    async def rollout_status(rollout_id: str) -> RolloutStatusResponse:
+        state = backend.rollout_status(rollout_id)
+        if state is None:
+            return RolloutStatusResponse(
+                rollout_id=rollout_id, status=RolloutStatus.UNKNOWN
+            )
+        return RolloutStatusResponse(rollout_id=rollout_id, **state)
+
+    @app.post("/rollout/cancel")
+    async def cancel(request: CancelRolloutsRequest) -> CancelRolloutsResponse:
+        selectors = sum(
+            [request.ids is not None, request.prefix is not None, request.all]
+        )
+        if selectors != 1:
+            raise HTTPException(
+                status_code=422,
+                detail="pass exactly one selector: ids, prefix, or all",
+            )
+        dispositions = backend.cancel_rollouts(
+            ids=request.ids, prefix=request.prefix, all=request.all
+        )
+        logger.info(
+            "Cancelled %d rollout(s) (%s)",
+            sum(1 for d in dispositions.values() if d.startswith("cancelled")),
+            "all" if request.all else request.prefix or f"{len(request.ids or [])} ids",
+        )
+        return CancelRolloutsResponse(dispositions=dispositions)
 
     return app
 

--- a/tests/unit/rollout/test_server_admission.py
+++ b/tests/unit/rollout/test_server_admission.py
@@ -1,0 +1,118 @@
+"""Admission control and cancellation on the rollout server."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from fastapi.testclient import TestClient
+
+from osmosis_ai.rollout.backend.base import ExecutionBackend, ResultCallback
+from osmosis_ai.rollout.server import create_rollout_server
+from osmosis_ai.rollout.types import ExecutionRequest
+
+
+class StubBackend(ExecutionBackend):
+    def __init__(self, capacity: bool = True) -> None:
+        self.capacity = capacity
+        self.executed = False
+        self.cancel_args: tuple | None = None
+
+    async def execute(
+        self,
+        request: ExecutionRequest,
+        on_workflow_complete: ResultCallback,
+        on_grader_complete: ResultCallback | None = None,
+    ) -> None:
+        self.executed = True
+
+    def has_capacity(self) -> bool:
+        return self.capacity
+
+    def cancel_rollouts(
+        self,
+        ids: Sequence[str] | None = None,
+        prefix: str | None = None,
+        all: bool = False,
+    ) -> dict[str, str]:
+        self.cancel_args = (ids, prefix, all)
+        return {"r1": "cancelled_queued"}
+
+    def rollout_status(self, rollout_id: str) -> dict | None:
+        if rollout_id == "known":
+            return {"status": "success", "reward": 1.0, "err_message": None}
+        return None
+
+
+def init_body() -> dict:
+    return {
+        "rollout_id": "r1",
+        "initial_messages": [{"role": "user", "content": "hi"}],
+        "chat_completions_url": "http://llm",
+        "completion_callback_url": "http://controller/complete",
+    }
+
+
+def test_full_backend_rejects_with_429():
+    backend = StubBackend(capacity=False)
+    client = TestClient(create_rollout_server(backend=backend))
+    response = client.post("/rollout", json=init_body())
+    assert response.status_code == 429
+    assert response.headers["Retry-After"] == "5"
+    assert backend.executed is False
+
+
+def test_backend_with_capacity_accepts():
+    backend = StubBackend(capacity=True)
+    client = TestClient(create_rollout_server(backend=backend))
+    response = client.post("/rollout", json=init_body())
+    assert response.status_code == 202
+    assert backend.executed is True
+
+
+def test_cancel_requires_exactly_one_selector():
+    client = TestClient(create_rollout_server(backend=StubBackend()))
+    assert client.post("/rollout/cancel", json={}).status_code == 422
+    assert (
+        client.post(
+            "/rollout/cancel", json={"ids": ["a"], "all": True}
+        ).status_code
+        == 422
+    )
+
+
+def test_cancel_forwards_selector_and_returns_dispositions():
+    backend = StubBackend()
+    client = TestClient(create_rollout_server(backend=backend))
+    response = client.post("/rollout/cancel", json={"prefix": "job-1-"})
+    assert response.status_code == 200
+    assert response.json() == {"dispositions": {"r1": "cancelled_queued"}}
+    assert backend.cancel_args == (None, "job-1-", False)
+
+
+def test_cancel_default_backend_reports_nothing():
+    class NoCancelBackend(StubBackend):
+        cancel_rollouts = ExecutionBackend.cancel_rollouts
+
+    client = TestClient(create_rollout_server(backend=NoCancelBackend()))
+    response = client.post("/rollout/cancel", json={"all": True})
+    assert response.status_code == 200
+    assert response.json() == {"dispositions": {}}
+
+
+def test_status_returns_backend_state():
+    client = TestClient(create_rollout_server(backend=StubBackend()))
+    response = client.get("/rollout/known/status")
+    assert response.status_code == 200
+    assert response.json() == {
+        "rollout_id": "known",
+        "status": "success",
+        "reward": 1.0,
+        "err_message": None,
+    }
+
+
+def test_status_unknown_rollout():
+    client = TestClient(create_rollout_server(backend=StubBackend()))
+    body = client.get("/rollout/nope/status").json()
+    assert body["status"] == "unknown"
+    assert body["reward"] is None


### PR DESCRIPTION
Part of splitting #272 into reviewable pieces (5/6). Builds on #286 (backend capabilities).

## What this adds

Three server-level behaviors that let a trainer manage load and track rollouts over plain HTTP:

- **Admission control on `POST /rollout`**: when the backend's queue is at `max_queue_depth`, the server answers `429` with a `Retry-After` header instead of accepting work it cannot start. Accepted rollouts return `202`, which states what actually happens: the rollout is queued and runs after the response is sent.
- **`GET /rollout/{id}/status`**: reports `queued`, `running`, or `grading` for live rollouts, and `success` / `failure` / `cancelled` (with reward and error message) for recently finished ones, retained for a fixed window. Anything else returns `unknown`. A trainer polls this as a liveness signal instead of trusting a blind timeout.
- **`POST /rollout/cancel`**: takes exactly one selector — `{"ids": [...]}`, `{"prefix": "tenant-a::"}`, or `{"all": true}` — and returns a disposition per rollout (`cancelled_queued`, `cancelled_running`, `not_found`). Prefix cancellation is what a controller uses to stop everything belonging to one adapter when it is deregistered. Cancelling an already-finished rollout returns `not_found`, so the call is safe to repeat.

## Example

```bash
curl -X POST $SERVER/rollout -d '{"rollout_id": "tenant-a::r1", ...}'
# -> 202 (or 429 + Retry-After: 5 when the queue is full)

curl $SERVER/rollout/tenant-a::r1/status
# -> {"rollout_id": "tenant-a::r1", "status": "running"}

curl -X POST $SERVER/rollout/cancel -d '{"prefix": "tenant-a::"}'
# -> {"dispositions": {"tenant-a::r1": "cancelled_running"}}
```