### PR TITLE
[ci] fix: accept stacked-PR title prefixes and gate on the PR author

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -44,7 +44,7 @@ For a PR that is one link in a stack, prefix the **whole** title with its positi
 [N/M][BREAKING][mod1][mod2] type: description
 ```
 
-Number the stack bottom-to-top, so `[1/M]` is the PR based on `main` and `[M/M]` sits at the top. Use it only for a genuine stack (each PR based on the one below it); a lone PR takes no prefix.
+Number the stack bottom-to-top, so `[1/M]` is the PR based on `main` and `[M/M]` sits at the top. Use positive integers without leading zeroes, with `1 <= N <= M` and `M >= 2`. Use the prefix only for a genuine stack (each PR based on the one below it); a lone PR takes no prefix.
 
 ### Allowed modules
 

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -129,6 +129,7 @@ After creating the PR, apply labels that match the change. Available repo labels
 |----------|--------|
 | Type | `enhancement`, `bug`, `refactor`, `chore`, `ci`, `documentation`, `dependencies`, `breaking` |
 | Module | `reward`, `rollout`, `cli`, `server`, `auth`, `eval` |
+| Workflow | `stacked-pr` |
 | Triage | `priority: high`, `good first issue`, `help wanted`, `question`, `duplicate`, `invalid`, `wontfix` |
 
 Guidelines:
@@ -136,6 +137,7 @@ Guidelines:
 - Add one or more **module** labels matching the `[module]` brackets in the title when those labels exist.
 - `misc` does **not** have a matching GitHub label in this repo. If the title uses `[misc]`, keep the type label and optionally add specific module labels only when they materially help triage a cross-cutting PR.
 - Add `breaking` whenever the title carries `[BREAKING]`.
+- Add `stacked-pr` whenever the title carries an `[N/M]` prefix. The auto-label workflow normally applies it, but verify it is present.
 - Do not invent labels; only use ones returned by `gh label list`.
 
 Apply labels with:

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -37,6 +37,15 @@ For multi-module changes, the title may include **1-3 module brackets total**:
 [BREAKING][mod1][mod2][mod3] type: description
 ```
 
+For a PR that is one link in a stack, prefix the **whole** title with its position, ahead of `[BREAKING]`:
+
+```
+[N/M][module] type: description
+[N/M][BREAKING][mod1][mod2] type: description
+```
+
+Number the stack bottom-to-top, so `[1/M]` is the PR based on `main` and `[M/M]` sits at the top. Use it only for a genuine stack (each PR based on the one below it); a lone PR takes no prefix.
+
 ### Allowed modules
 
 `rollout`, `server`, `cli`, `auth`, `eval`, `misc`, `ci`, `doc`
@@ -60,12 +69,16 @@ Good:
 - `[BREAKING][misc] chore: align codebase with Python 3.12`
 - `[ci] chore: update GitHub Actions versions`
 - `[eval] fix: handle empty rubric response`
+- `[2/5][rollout] fix: surface harbor agent failures` (second of a five-PR stack)
+- `[1/2][BREAKING][rollout] refactor: remove the legacy Harbor backend` (stack position precedes `[BREAKING]`)
 
 Bad:
 - `Add streaming support` (no module/type)
 - `[rollout] Feat: Add streaming support.` (capitalized type, trailing period)
 - `feat(rollout): add streaming` (conventional-commits style; this repo uses bracket style)
 - `[cli][auth][eval][rollout] chore: align codebase with Python 3.12` (too many module brackets)
+- `[BREAKING][1/2][rollout] refactor: drop the old backend` (stack position must come first)
+- `[1/2] feat: add a thing` (stack position does not replace the module bracket)
 
 ## Body Template
 
@@ -153,6 +166,17 @@ If there are uncommitted changes, STOP and ask the user whether to commit them f
 ### 2. Determine base branch
 
 Default base is `main`. If the user specifies otherwise (e.g. a release branch) or if `gh repo view --json defaultBranchRef` returns a different default, use that.
+
+For a stack, each PR's base is the branch below it, and only the bottom one targets `main`. Pointing the bases at each other is necessary but not sufficient: GitHub also models the stack as its own object, which drives the stack navigation UI and rebases the remaining bases when one link merges. Create that with the `gh stack` extension (`github/gh-stack`) rather than by hand.
+
+`gh stack submit` is the primary path but opens an interactive editor. When that is unavailable — a non-interactive shell, or PRs that already exist — use `gh stack link`, which takes PR numbers or branch names bottom-to-top, needs no local tracking state, and reuses any PRs that are already open:
+
+```bash
+gh stack link 291 292        # existing PRs, bottom first
+gh stack link feat/a feat/b  # or branch names; missing PRs are created
+```
+
+Also give each PR an `[N/M]` title prefix (see Title Format above).
 
 ### 3. Classify the change
 

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-pr
-description: 'Create a GitHub pull request for this repository with a title and body that follow the repo''s PULL_REQUEST_TEMPLATE.md conventions. Use when the user says "create a PR", "open a PR", "submit a PR", "make a pull request", or asks to push the current branch as a PR. Enforces the `[module] type: description` title format with 1-3 module brackets, the What/Why/How to Test/Checklist body, and repo-specific labels.'
+description: 'Create a GitHub pull request for this repository with a title and body that follow the repo''s PULL_REQUEST_TEMPLATE.md conventions. Use when the user says "create a PR", "open a PR", "submit a PR", "make a pull request", or asks to push the current branch as a PR. Enforces the `[module] type: description` title format with 1-3 module brackets, and the What/Why/How to Test/Checklist body.'
 ---
 
 # Create Pull Request (osmosis-sdk-python)
@@ -103,7 +103,7 @@ Fill in every section. Keep it concise and specific to the diff — do NOT keep 
 ## Checklist
 
 - [x] PR title follows `[module] type: description` format
-- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
+      (labels are derived from it automatically — no need to add them by hand)
 - [x] `ruff check .` and `ruff format --check .` pass
 - [x] `pyright osmosis_ai/` passes
 - [x] `pytest` passes (new tests added if applicable)
@@ -123,30 +123,20 @@ Fill in every section. Keep it concise and specific to the diff — do NOT keep 
 
 ## Labels
 
-After creating the PR, apply labels that match the change. Available repo labels:
+**Do not apply type, module, `breaking`, or `stacked-pr` labels.** The `auto-label-pr` workflow derives all of them from the title, and `wip` from draft state. Do not pass `--label` to `gh pr create` and do not follow up with `gh pr edit --add-label`.
+
+This is not merely redundant — it breaks the workflow. Reconciliation removes only labels it applied itself, identified by their `github-actions[bot]` timeline attribution. A label applied by you is attributed to you and is therefore treated as a deliberate manual override that survives every later title change. Applying the labels by hand at creation time permanently pins the PR to whatever the title said on day one.
+
+Labels the workflow never touches, and which you may set when the user asks for them:
 
 | Category | Labels |
 |----------|--------|
-| Type | `enhancement`, `bug`, `refactor`, `chore`, `ci`, `documentation`, `dependencies`, `breaking` |
-| Module | `reward`, `rollout`, `cli`, `server`, `auth`, `eval` |
-| Workflow | `stacked-pr` |
 | Triage | `priority: high`, `good first issue`, `help wanted`, `question`, `duplicate`, `invalid`, `wontfix` |
+| Other | `dependencies`, `reward` |
 
-Guidelines:
-- Always add one **type** label matching the PR type (`feat` → `enhancement`, `fix` → `bug`, otherwise match name).
-- Add one or more **module** labels matching the `[module]` brackets in the title when those labels exist.
-- `misc` does **not** have a matching GitHub label in this repo. If the title uses `[misc]`, keep the type label and optionally add specific module labels only when they materially help triage a cross-cutting PR.
-- Add `breaking` whenever the title carries `[BREAKING]`.
-- Add `stacked-pr` whenever the title carries an `[N/M]` prefix. The auto-label workflow normally applies it, but verify it is present.
-- Do not invent labels; only use ones returned by `gh label list`.
+For reference, what the title produces: `feat:` → `enhancement`, `fix:` → `bug`, `doc:`/`[doc]` → `documentation`, `refactor:` → `refactor`, `chore:`/`test:` → `chore`, `[BREAKING]` → `breaking`, `[N/M]` → `stacked-pr`, and `[rollout]`/`[server]`/`[cli]`/`[auth]`/`[eval]`/`[ci]` → the matching module label. `[misc]` produces none.
 
-Apply labels with:
-
-```bash
-gh pr edit <pr-number> --add-label "cli,refactor"
-```
-
-Or pass `--label` repeatedly on `gh pr create`.
+If the labels look wrong after the workflow runs, fix the **title** — that is the input.
 
 ## Workflow
 
@@ -235,15 +225,14 @@ Users asked for a way to pull training metrics into spreadsheets for post-hoc an
 ## Checklist
 
 - [x] PR title follows `[module] type: description` format
-- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
+      (labels are derived from it automatically — no need to add them by hand)
 - [x] `ruff check .` and `ruff format --check .` pass
 - [x] `pyright osmosis_ai/` passes
 - [x] `pytest` passes (new tests added if applicable)
 - [x] Public API changes are documented
 - [x] No secrets or credentials included
 EOF
-)" \
-  --label "cli" --label "enhancement"
+)"
 ```
 
 ### 7. Verify and report
@@ -258,7 +247,7 @@ After `gh pr create` succeeds:
 Given a branch that renamed `rollout_v2` → `rollout` across the codebase, the correct invocation is:
 
 - **Title**: `[BREAKING][rollout] refactor: rename rollout_v2 package to rollout`
-- **Labels**: `rollout`, `refactor`, `breaking`
+- **Labels**: none passed to `gh pr create`; the workflow derives `rollout`, `refactor`, and `breaking` from that title
 - **Body**: What bullets list the rename + import updates; Why explains namespace cleanup + migration note; How to Test includes `uv run pytest`, `uv run ruff check .`, `uv run pyright osmosis_ai/`, and `rg "rollout_v2" .` sanity check.
 
 ## Anti-Patterns
@@ -271,3 +260,4 @@ Given a branch that renamed `rollout_v2` → `rollout` across the codebase, the 
 - Do NOT include AI attribution/footer text such as `Made with [Cursor](https://cursor.com)`, `Made with Claude`, or auto-generated sections like `Summary by cubic` in the body you author.
 - Do NOT force-push or amend already-pushed commits without explicit user approval.
 - Do NOT invent labels that don't exist in `gh label list`.
+- Do NOT pass `--label` to `gh pr create` or run `gh pr edit --add-label` for type/module/`breaking`/`stacked-pr` labels — a manually applied label is pinned forever and stops tracking the title.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,12 @@
 PR Title Format: [module] type: description
   modules: rollout, server, cli, auth, eval, misc, ci, doc
   types:   feat, fix, refactor, chore, test, doc
+  stacked: prefix the whole title with [N/M]
 
 Examples:
   [rollout] feat: add streaming support for chat completions
   [BREAKING][rollout] refactor: change Grader.grade signature
+  [2/5][rollout] fix: surface harbor agent failures
   [ci] chore: update GitHub Actions versions
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 PR Title Format: [module] type: description
   modules: rollout, server, cli, auth, eval, misc, ci, doc
   types:   feat, fix, refactor, chore, test, doc
-  stacked: prefix the whole title with [N/M]
+  stacked: prefix with [N/M], where 1 <= N <= M, M >= 2, with no leading zeroes
 
 Examples:
   [rollout] feat: add streaming support for chat completions

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,7 +27,7 @@ Examples:
 ## Checklist
 
 - [ ] PR title follows `[module] type: description` format
-- [ ] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
+      (labels are derived from it automatically — no need to add them by hand)
 - [ ] `ruff check .` and `ruff format --check .` pass
 - [ ] `pyright osmosis_ai/` passes
 - [ ] `pytest` passes (new tests added if applicable)

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            // Grammar mirrors check-pr-title.yml, which is the source of truth
-            // and additionally validates the [N/M] range. Keep the two in sync.
+            // Grammar and stack validation mirror check-pr-title.yml. Keep the
+            // two in sync.
             const TITLE_PATTERN =
-              /^(\[\d+\/\d+\])?(\[BREAKING\])?((?:\[(?:rollout|server|cli|auth|eval|misc|ci|doc)\]){1,3}) (feat|fix|refactor|chore|test|doc): .+/;
+              /^(\[\d+\/\d+\])?(\[BREAKING\])?((?:\[(?:rollout|server|cli|auth|eval|misc|ci|doc)\]){1,3}) (feat|fix|refactor|chore|test|doc): .+$/;
 
             // [misc] deliberately maps to no label.
             const MODULE_LABELS = {
@@ -79,6 +79,24 @@ jobs:
             }
 
             const [, stack, breaking, modules, type] = match;
+            if (stack) {
+              const [positionText, totalText] = stack.slice(1, -1).split('/');
+              const position = BigInt(positionText);
+              const total = BigInt(totalText);
+              if (
+                positionText.startsWith('0') ||
+                totalText.startsWith('0') ||
+                total < 2n ||
+                position > total
+              ) {
+                core.setFailed(
+                  `Invalid stacked PR position ${stack}. Expected 1 <= N <= M ` +
+                    'and M >= 2, without leading zeroes. Labels were left untouched.',
+                );
+                return;
+              }
+            }
+
             const desired = new Set([TYPE_LABELS[type]]);
             if (stack) desired.add('stacked-pr');
             if (breaking) desired.add('breaking');

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -12,60 +12,101 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Apply labels based on PR title
+      - name: Reconcile labels based on PR title
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           labels=()
+          managed_labels=(
+            auth breaking bug chore ci cli documentation enhancement eval refactor
+            rollout server stacked-pr
+          )
+          remaining="$PR_TITLE"
 
           # Stacked PR
-          if [[ "$PR_TITLE" =~ ^\[[0-9]+/[0-9]+\] ]]; then
+          if [[ "$remaining" =~ ^\[[0-9]+/[0-9]+\] ]]; then
             labels+=("stacked-pr")
+            remaining="${remaining#*]}"
           fi
 
-          # Breaking change, after an optional stack position
-          if [[ "$PR_TITLE" =~ ^(\[[0-9]+/[0-9]+\])?\[BREAKING\] ]]; then
+          # Breaking change
+          if [[ "$remaining" == "[BREAKING]"* ]]; then
             labels+=("breaking")
-          fi
-
-          # Type-based labels (maps to release.yml categories)
-          if [[ "$PR_TITLE" =~ \]\ feat: ]]; then
-            labels+=("enhancement")
-          elif [[ "$PR_TITLE" =~ \]\ fix: ]]; then
-            labels+=("bug")
-          elif [[ "$PR_TITLE" =~ \]\ doc: ]]; then
-            labels+=("documentation")
-          elif [[ "$PR_TITLE" =~ \]\ chore: ]]; then
-            labels+=("chore")
-          elif [[ "$PR_TITLE" =~ \]\ refactor: ]]; then
-            labels+=("refactor")
-          elif [[ "$PR_TITLE" =~ \]\ test: ]]; then
-            labels+=("chore")
+            remaining="${remaining#*]}"
           fi
 
           # Module labels from [module] tags in title (supports multi-module like [rollout][auth])
-          remaining="$PR_TITLE"
-          while [[ "$remaining" =~ \[([a-z]+)\] ]]; do
+          while [[ "$remaining" =~ ^\[([a-z]+)\] ]]; do
             module="${BASH_REMATCH[1]}"
             remaining="${remaining#*]}"
-            if [[ "$module" == "doc" ]]; then
-              labels+=("documentation")
-            elif [[ "$module" != "misc" ]]; then
-              labels+=("$module")
-            fi
+            case "$module" in
+              doc) labels+=("documentation") ;;
+              auth|ci|cli|eval|rollout|server) labels+=("$module") ;;
+            esac
           done
 
-          if [ ${#labels[@]} -eq 0 ]; then
-            echo "No labels to apply"
-            exit 0
-          fi
+          # Type-based labels (maps to release.yml categories)
+          case "$remaining" in
+            " feat: "*) labels+=("enhancement") ;;
+            " fix: "*) labels+=("bug") ;;
+            " doc: "*) labels+=("documentation") ;;
+            " chore: "*) labels+=("chore") ;;
+            " refactor: "*) labels+=("refactor") ;;
+            " test: "*) labels+=("chore") ;;
+          esac
 
           # Deduplicate
           labels=($(printf '%s\n' "${labels[@]}" | sort -u))
 
-          echo "Applying labels: ${labels[*]}"
-          gh pr edit "$PR_NUMBER" \
-            --repo "${{ github.repository }}" \
-            --add-label "$(IFS=,; echo "${labels[*]}")"
+          has_label() {
+            local needle="$1"
+            shift
+            local label
+            for label in "$@"; do
+              if [[ "$label" == "$needle" ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          current_labels=()
+          while IFS= read -r label; do
+            if [[ -n "$label" ]]; then
+              current_labels+=("$label")
+            fi
+          done < <(
+            gh pr view "$PR_NUMBER" --repo "$REPOSITORY" \
+              --json labels --jq '.labels[].name'
+          )
+          add_labels=()
+          remove_labels=()
+
+          for label in "${labels[@]}"; do
+            if ! has_label "$label" "${current_labels[@]}"; then
+              add_labels+=("$label")
+            fi
+          done
+          for label in "${current_labels[@]}"; do
+            if has_label "$label" "${managed_labels[@]}" \
+              && ! has_label "$label" "${labels[@]}"; then
+              remove_labels+=("$label")
+            fi
+          done
+
+          if [ ${#remove_labels[@]} -gt 0 ]; then
+            echo "Removing stale title labels: ${remove_labels[*]}"
+            gh pr edit "$PR_NUMBER" --repo "$REPOSITORY" \
+              --remove-label "$(IFS=,; echo "${remove_labels[*]}")"
+          fi
+          if [ ${#add_labels[@]} -gt 0 ]; then
+            echo "Adding title labels: ${add_labels[*]}"
+            gh pr edit "$PR_NUMBER" --repo "$REPOSITORY" \
+              --add-label "$(IFS=,; echo "${add_labels[*]}")"
+          fi
+          if [ ${#remove_labels[@]} -eq 0 ] && [ ${#add_labels[@]} -eq 0 ]; then
+            echo "Title labels are already up to date"
+          fi

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -2,7 +2,7 @@ name: Auto Label PR
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, ready_for_review, converted_to_draft]
 
 jobs:
   label:
@@ -10,103 +10,109 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      # Covers both the timeline read and the label write: GitHub lists
+      # GET /issues/{n}/timeline and PUT /issues/{n}/labels under either the
+      # Issues or the Pull requests permission.
       pull-requests: write
     steps:
-      - name: Reconcile labels based on PR title
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          REPOSITORY: ${{ github.repository }}
-        run: |
-          labels=()
-          managed_labels=(
-            auth breaking bug chore ci cli documentation enhancement eval refactor
-            rollout server stacked-pr
-          )
-          remaining="$PR_TITLE"
+      - name: Reconcile labels from PR title and draft state
+        uses: actions/github-script@v9
+        with:
+          script: |
+            // Grammar mirrors check-pr-title.yml, which is the source of truth
+            // and additionally validates the [N/M] range. Keep the two in sync.
+            const TITLE_PATTERN =
+              /^(\[\d+\/\d+\])?(\[BREAKING\])?((?:\[(?:rollout|server|cli|auth|eval|misc|ci|doc)\]){1,3}) (feat|fix|refactor|chore|test|doc): .+/;
 
-          # Stacked PR
-          if [[ "$remaining" =~ ^\[[0-9]+/[0-9]+\] ]]; then
-            labels+=("stacked-pr")
-            remaining="${remaining#*]}"
-          fi
+            // [misc] deliberately maps to no label.
+            const MODULE_LABELS = {
+              auth: 'auth',
+              ci: 'ci',
+              cli: 'cli',
+              doc: 'documentation',
+              eval: 'eval',
+              rollout: 'rollout',
+              server: 'server',
+            };
+            // Maps to the categories in .github/release.yml.
+            const TYPE_LABELS = {
+              chore: 'chore',
+              doc: 'documentation',
+              feat: 'enhancement',
+              fix: 'bug',
+              refactor: 'refactor',
+              test: 'chore',
+            };
 
-          # Breaking change
-          if [[ "$remaining" == "[BREAKING]"* ]]; then
-            labels+=("breaking")
-            remaining="${remaining#*]}"
-          fi
+            // Labels this job is allowed to remove. github-actions[bot] is a
+            // shared identity, so bot attribution on its own would let this job
+            // delete labels some future workflow owns. A label must be both in
+            // this set and bot-applied before it is removed.
+            const MANAGED = new Set([
+              ...Object.values(MODULE_LABELS),
+              ...Object.values(TYPE_LABELS),
+              'breaking',
+              'stacked-pr',
+              'wip',
+            ]);
+            const BOT = 'github-actions[bot]';
 
-          # Module labels from [module] tags in title (supports multi-module like [rollout][auth])
-          while [[ "$remaining" =~ ^\[([a-z]+)\] ]]; do
-            module="${BASH_REMATCH[1]}"
-            remaining="${remaining#*]}"
-            case "$module" in
-              doc) labels+=("documentation") ;;
-              auth|ci|cli|eval|rollout|server) labels+=("$module") ;;
-            esac
-          done
+            const pr = context.payload.pull_request;
+            const match = TITLE_PATTERN.exec(pr.title);
+            if (!match) {
+              core.setFailed(
+                'PR title does not match the required format, so labels were ' +
+                  'left untouched. Fix the title (see the check-title job) and ' +
+                  'labels reconcile on the next edit.\n' +
+                  `Got: ${pr.title}`,
+              );
+              return;
+            }
 
-          # Type-based labels (maps to release.yml categories)
-          case "$remaining" in
-            " feat: "*) labels+=("enhancement") ;;
-            " fix: "*) labels+=("bug") ;;
-            " doc: "*) labels+=("documentation") ;;
-            " chore: "*) labels+=("chore") ;;
-            " refactor: "*) labels+=("refactor") ;;
-            " test: "*) labels+=("chore") ;;
-          esac
+            const [, stack, breaking, modules, type] = match;
+            const desired = new Set([TYPE_LABELS[type]]);
+            if (stack) desired.add('stacked-pr');
+            if (breaking) desired.add('breaking');
+            if (pr.draft) desired.add('wip');
+            for (const [, module] of modules.matchAll(/\[([a-z]+)\]/g)) {
+              if (MODULE_LABELS[module]) desired.add(MODULE_LABELS[module]);
+            }
 
-          # Deduplicate
-          labels=($(printf '%s\n' "${labels[@]}" | sort -u))
+            // Who applied each label currently on the PR. A label a human added
+            // stays even once the title stops implying it. An unknown applier
+            // (no timeline entry yet) is treated as human, so the conservative
+            // outcome of a race is to keep the label rather than drop it.
+            const timeline = await github.paginate(
+              github.rest.issues.listEventsForTimeline,
+              { ...context.repo, issue_number: pr.number, per_page: 100 },
+            );
+            const appliedBy = new Map();
+            for (const event of timeline) {
+              if (event.event === 'labeled') {
+                appliedBy.set(event.label.name, event.actor?.login);
+              } else if (event.event === 'unlabeled') {
+                appliedBy.delete(event.label.name);
+              }
+            }
 
-          has_label() {
-            local needle="$1"
-            shift
-            local label
-            for label in "$@"; do
-              if [[ "$label" == "$needle" ]]; then
-                return 0
-              fi
-            done
-            return 1
-          }
+            const current = new Set(pr.labels.map((label) => label.name));
+            const final = new Set(desired);
+            for (const name of current) {
+              if (!MANAGED.has(name) || appliedBy.get(name) !== BOT) {
+                final.add(name);
+              }
+            }
 
-          current_labels=()
-          while IFS= read -r label; do
-            if [[ -n "$label" ]]; then
-              current_labels+=("$label")
-            fi
-          done < <(
-            gh pr view "$PR_NUMBER" --repo "$REPOSITORY" \
-              --json labels --jq '.labels[].name'
-          )
-          add_labels=()
-          remove_labels=()
-
-          for label in "${labels[@]}"; do
-            if ! has_label "$label" "${current_labels[@]}"; then
-              add_labels+=("$label")
-            fi
-          done
-          for label in "${current_labels[@]}"; do
-            if has_label "$label" "${managed_labels[@]}" \
-              && ! has_label "$label" "${labels[@]}"; then
-              remove_labels+=("$label")
-            fi
-          done
-
-          if [ ${#remove_labels[@]} -gt 0 ]; then
-            echo "Removing stale title labels: ${remove_labels[*]}"
-            gh pr edit "$PR_NUMBER" --repo "$REPOSITORY" \
-              --remove-label "$(IFS=,; echo "${remove_labels[*]}")"
-          fi
-          if [ ${#add_labels[@]} -gt 0 ]; then
-            echo "Adding title labels: ${add_labels[*]}"
-            gh pr edit "$PR_NUMBER" --repo "$REPOSITORY" \
-              --add-label "$(IFS=,; echo "${add_labels[*]}")"
-          fi
-          if [ ${#remove_labels[@]} -eq 0 ] && [ ${#add_labels[@]} -eq 0 ]; then
-            echo "Title labels are already up to date"
-          fi
+            const added = [...final].filter((name) => !current.has(name)).sort();
+            const removed = [...current].filter((name) => !final.has(name)).sort();
+            if (added.length === 0 && removed.length === 0) {
+              core.info(`Labels already up to date: ${[...current].sort().join(', ') || '(none)'}`);
+              return;
+            }
+            if (added.length > 0) core.info(`Adding: ${added.join(', ')}`);
+            if (removed.length > 0) core.info(`Removing stale bot labels: ${removed.join(', ')}`);
+            await github.rest.issues.setLabels({
+              ...context.repo,
+              issue_number: pr.number,
+              labels: [...final],
+            });

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   label:
-    if: ${{ !endsWith(github.actor, '[bot]') && (github.event.action != 'edited' || github.event.changes.title) }}
+    if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') && (github.event.action != 'edited' || github.event.changes.title) }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -20,8 +20,13 @@ jobs:
         run: |
           labels=()
 
-          # Breaking change
-          if [[ "$PR_TITLE" =~ ^\[BREAKING\] ]]; then
+          # Stacked PR
+          if [[ "$PR_TITLE" =~ ^\[[0-9]+/[0-9]+\] ]]; then
+            labels+=("stacked-pr")
+          fi
+
+          # Breaking change, after an optional stack position
+          if [[ "$PR_TITLE" =~ ^(\[[0-9]+/[0-9]+\])?\[BREAKING\] ]]; then
             labels+=("breaking")
           fi
 

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -4,15 +4,17 @@ on:
   pull_request_target:
     types: [opened, edited, reopened, ready_for_review, converted_to_draft]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   label:
-    if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') && (github.event.action != 'edited' || github.event.changes.title) }}
+    if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      # Covers both the timeline read and the label write: GitHub lists
-      # GET /issues/{n}/timeline and PUT /issues/{n}/labels under either the
-      # Issues or the Pull requests permission.
+      # Covers the current PR read, timeline read, and label writes.
       pull-requests: write
     steps:
       - name: Reconcile labels from PR title and draft state
@@ -57,7 +59,14 @@ jobs:
             ]);
             const BOT = 'github-actions[bot]';
 
-            const pr = context.payload.pull_request;
+            const pullNumber = context.payload.pull_request.number;
+            // Event payloads are snapshots. Read the current PR so an older
+            // queued event converges on the latest title, draft state, and
+            // labels instead of restoring stale state.
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: pullNumber,
+            });
             const match = TITLE_PATTERN.exec(pr.title);
             if (!match) {
               core.setFailed(
@@ -84,7 +93,7 @@ jobs:
             // outcome of a race is to keep the label rather than drop it.
             const timeline = await github.paginate(
               github.rest.issues.listEventsForTimeline,
-              { ...context.repo, issue_number: pr.number, per_page: 100 },
+              { ...context.repo, issue_number: pullNumber, per_page: 100 },
             );
             const appliedBy = new Map();
             for (const event of timeline) {
@@ -96,23 +105,44 @@ jobs:
             }
 
             const current = new Set(pr.labels.map((label) => label.name));
-            const final = new Set(desired);
-            for (const name of current) {
-              if (!MANAGED.has(name) || appliedBy.get(name) !== BOT) {
-                final.add(name);
-              }
-            }
-
-            const added = [...final].filter((name) => !current.has(name)).sort();
-            const removed = [...current].filter((name) => !final.has(name)).sort();
+            const added = [...desired].filter((name) => !current.has(name)).sort();
+            const removed = [...current]
+              .filter(
+                (name) =>
+                  MANAGED.has(name) &&
+                  !desired.has(name) &&
+                  appliedBy.get(name) === BOT,
+              )
+              .sort();
             if (added.length === 0 && removed.length === 0) {
               core.info(`Labels already up to date: ${[...current].sort().join(', ') || '(none)'}`);
               return;
             }
             if (added.length > 0) core.info(`Adding: ${added.join(', ')}`);
             if (removed.length > 0) core.info(`Removing stale bot labels: ${removed.join(', ')}`);
-            await github.rest.issues.setLabels({
-              ...context.repo,
-              issue_number: pr.number,
-              labels: [...final],
-            });
+            // Mutate only the labels this workflow owns. setLabels replaces the
+            // complete set and can erase a human label added after the PR read.
+            if (added.length > 0) {
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: pullNumber,
+                labels: added,
+              });
+            }
+            for (const name of removed) {
+              try {
+                await github.rest.issues.removeLabel({
+                  ...context.repo,
+                  issue_number: pullNumber,
+                  name,
+                });
+              } catch (error) {
+                // Another actor may remove the same stale label between our
+                // read and write. That already achieved the desired state.
+                if (error.status === 404) {
+                  core.info(`Already removed: ${name}`);
+                } else {
+                  throw error;
+                }
+              }
+            }

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -41,4 +41,13 @@ jobs:
             echo "Got: $PR_TITLE"
             exit 1
           fi
+          if [[ "$PR_TITLE" =~ ^\[([0-9]+)/([0-9]+)\] ]]; then
+            position="${BASH_REMATCH[1]}"
+            total="${BASH_REMATCH[2]}"
+            if [[ "$position" == 0* || "$total" == 0* ]] \
+              || (( 10#$total < 2 || 10#$position > 10#$total )); then
+              echo "::error::Invalid stacked PR position [$position/$total]. Expected 1 <= N <= M and M >= 2, without leading zeroes."
+              exit 1
+            fi
+          fi
           echo "PR title is valid: $PR_TITLE"

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -13,16 +13,21 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Validate PR title format
-        if: ${{ !endsWith(github.actor, '[bot]') && (github.event.action != 'edited' || github.event.changes.title) }}
+        # Gate on the PR author, not github.actor. github.actor is whoever
+        # triggered *this run*, so a bot touching a human's PR (a review app
+        # pushing a commit, for example) skipped the check — and a skipped step
+        # reports the job as success, silently turning a failing title green.
+        if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') && (github.event.action != 'edited' || github.event.changes.title) }}
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PATTERN='^(\[BREAKING\])?(\[(rollout|server|cli|auth|eval|misc|ci|doc)\]){1,3} (feat|fix|refactor|chore|test|doc): .+'
+          PATTERN='^(\[[0-9]+/[0-9]+\])?(\[BREAKING\])?(\[(rollout|server|cli|auth|eval|misc|ci|doc)\]){1,3} (feat|fix|refactor|chore|test|doc): .+'
           if [[ ! "$PR_TITLE" =~ $PATTERN ]]; then
             echo "::error::PR title does not match required format."
             echo ""
             echo "Expected format: [module] type: description"
             echo "  Multi-module:  [mod1][mod2] type: description (up to 3 modules)"
+            echo "  Stacked PR:    [N/M] prefixes the whole title"
             echo "  modules: rollout, server, cli, auth, eval, misc, ci, doc"
             echo "  types:   feat, fix, refactor, chore, test, doc"
             echo ""
@@ -30,6 +35,7 @@ jobs:
             echo "  [rollout] feat: add streaming support for chat completions"
             echo "  [rollout][auth] refactor: extract LifecycleManager"
             echo "  [BREAKING][rollout] refactor: change Grader.grade signature"
+            echo "  [2/5][rollout] fix: surface harbor agent failures"
             echo "  [ci] chore: update GitHub Actions versions"
             echo ""
             echo "Got: $PR_TITLE"

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -22,6 +22,7 @@ jobs:
         # non-title edits would let a body edit turn an invalid title green.
         if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
         env:
+          LC_ALL: C
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           PATTERN='^(\[[0-9]+/[0-9]+\])?(\[BREAKING\])?(\[(rollout|server|cli|auth|eval|misc|ci|doc)\]){1,3} (feat|fix|refactor|chore|test|doc): .+$'
@@ -47,8 +48,17 @@ jobs:
           if [[ "$PR_TITLE" =~ ^\[([0-9]+)/([0-9]+)\] ]]; then
             position="${BASH_REMATCH[1]}"
             total="${BASH_REMATCH[2]}"
-            if [[ "$position" == 0* || "$total" == 0* ]] \
-              || (( 10#$total < 2 || 10#$position > 10#$total )); then
+            invalid_stack=false
+            if [[ "$position" == 0* || "$total" == 0* || "$total" == "1" ]]; then
+              invalid_stack=true
+            elif (( ${#position} > ${#total} )); then
+              invalid_stack=true
+            elif (( ${#position} == ${#total} )) && [[ "$position" > "$total" ]]; then
+              # Compare equal-width decimal strings instead of using fixed-width
+              # shell arithmetic, so validation agrees with the BigInt labeler.
+              invalid_stack=true
+            fi
+            if [[ "$invalid_stack" == true ]]; then
               echo "::error::Invalid stacked PR position [$position/$total]. Expected 1 <= N <= M and M >= 2, without leading zeroes."
               exit 1
             fi

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PATTERN='^(\[[0-9]+/[0-9]+\])?(\[BREAKING\])?(\[(rollout|server|cli|auth|eval|misc|ci|doc)\]){1,3} (feat|fix|refactor|chore|test|doc): .+'
+          PATTERN='^(\[[0-9]+/[0-9]+\])?(\[BREAKING\])?(\[(rollout|server|cli|auth|eval|misc|ci|doc)\]){1,3} (feat|fix|refactor|chore|test|doc): .+$'
           if [[ ! "$PR_TITLE" =~ $PATTERN ]]; then
             echo "::error::PR title does not match required format."
             echo ""

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -7,17 +7,20 @@ on:
 permissions:
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   check-title:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Validate PR title format
-        # Gate on the PR author, not github.actor. github.actor is whoever
-        # triggered *this run*, so a bot touching a human's PR (a review app
-        # pushing a commit, for example) skipped the check — and a skipped step
-        # reports the job as success, silently turning a failing title green.
-        if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') && (github.event.action != 'edited' || github.event.changes.title) }}
+        # Gate on the PR author, not github.actor. Validate every event: a
+        # conditionally skipped required check reports success, so skipping
+        # non-title edits would let a body edit turn an invalid title green.
+        if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,12 @@ For a stacked PR, prefix the whole title with its position in the stack:
 
 Use positive integers without leading zeroes, with `1 <= N <= M` and `M >= 2`.
 
+A title prefix alone does not create a stack. Each PR must be based on the branch directly below it, with only `[1/M]` targeting `main`, and the PRs must be linked in GitHub from bottom to top. Use `gh stack submit` from the `github/gh-stack` extension when managing the stack locally, or link existing PRs without local tracking state:
+
+```bash
+gh stack link 291 292
+```
+
 **Examples:**
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,8 @@ For a stacked PR, prefix the whole title with its position in the stack:
 [N/M][module] type: description
 ```
 
+Use positive integers without leading zeroes, with `1 <= N <= M` and `M >= 2`.
+
 **Examples:**
 
 ```
@@ -147,6 +149,6 @@ If the title does not match the convention, the labeling job fails rather than r
 1. Fork the repository and create a feature branch
 2. Make your changes
 3. Run `uv run pytest` and `uv run ruff check .`
-4. Submit a pull request with a properly formatted title and label
+4. Submit a pull request with a properly formatted title; title-derived labels are added automatically
 
 CI will run linting, type checking (pyright), tests on supported Python versions (see `requires-python` in `pyproject.toml`), PR title validation, and a build validation on every PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,12 @@ For breaking changes, add `[BREAKING]` before the modules:
 [BREAKING][module] type: description
 ```
 
+For a stacked PR, prefix the whole title with its position in the stack:
+
+```
+[N/M][module] type: description
+```
+
 **Examples:**
 
 ```
@@ -109,6 +115,7 @@ For breaking changes, add `[BREAKING]` before the modules:
 [server] fix: handle timeout in rollout init
 [cli] chore: update dependency versions
 [BREAKING][rollout] refactor: change Grader.grade signature
+[2/5][rollout] fix: surface harbor agent failures
 ```
 
 PR titles appear directly in auto-generated GitHub Release Notes, so keep them clear and descriptive.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ PR titles appear directly in auto-generated GitHub Release Notes, so keep them c
 
 ### Labels
 
-Add a label to your PR so it gets categorized correctly in Release Notes:
+PR title labels are automatically reconciled whenever the title changes so the PR is categorized correctly in Release Notes:
 
 | Label | Use when |
 |-------|----------|
@@ -132,7 +132,7 @@ Add a label to your PR so it gets categorized correctly in Release Notes:
 | `documentation` | Docs update |
 | `chore` / `ci` / `refactor` / `dependencies` | Maintenance work |
 
-Module-specific labels (`rollout`, `server`, `cli`, `auth`, `eval`) can also be added for filtering. Rollout work typically touches `osmosis_ai.rollout` and related CLI commands.
+Module-specific labels (`rollout`, `server`, `cli`, `auth`, `eval`) are also derived from the title for filtering. Rollout work typically touches `osmosis_ai.rollout` and related CLI commands. Labels outside the title convention, such as priority and triage labels, are preserved and can be managed manually.
 
 The `stacked-pr` label is automatically added when a title starts with `[N/M]`. It is filtering metadata and does not change the Release Notes category.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,19 +122,25 @@ PR titles appear directly in auto-generated GitHub Release Notes, so keep them c
 
 ### Labels
 
-PR title labels are automatically reconciled whenever the title changes so the PR is categorized correctly in Release Notes:
+**You do not need to add labels.** They are derived from the PR title and draft state and re-derived whenever the title changes, which is what keeps Release Notes categorized correctly:
 
-| Label | Use when |
-|-------|----------|
-| `enhancement` | New feature |
-| `bug` | Bug fix |
-| `breaking` | Breaking change |
-| `documentation` | Docs update |
-| `chore` / `ci` / `refactor` / `dependencies` | Maintenance work |
+| Label | Derived from |
+|-------|--------------|
+| `enhancement` | `feat:` |
+| `bug` | `fix:` |
+| `documentation` | `doc:` or `[doc]` |
+| `refactor` | `refactor:` |
+| `chore` | `chore:` or `test:` |
+| `breaking` | a leading `[BREAKING]` |
+| `stacked-pr` | a leading `[N/M]` |
+| `wip` | the PR being a draft |
+| `rollout` / `server` / `cli` / `auth` / `eval` / `ci` | the matching `[module]` bracket |
 
-Module-specific labels (`rollout`, `server`, `cli`, `auth`, `eval`) are also derived from the title for filtering. Rollout work typically touches `osmosis_ai.rollout` and related CLI commands. Labels outside the title convention, such as priority and triage labels, are preserved and can be managed manually.
+`[misc]` has no label of its own. `stacked-pr` and `wip` are filtering metadata and do not change the Release Notes category. Rollout work typically touches `osmosis_ai.rollout` and related CLI commands.
 
-The `stacked-pr` label is automatically added when a title starts with `[N/M]`. It is filtering metadata and does not change the Release Notes category.
+Labels you add yourself are never removed — priority and triage labels, `dependencies`, `reward`, and also any label the table above can produce. Adding `documentation` to a `[ci] fix:` PR that happens to touch the docs works and sticks; the workflow only reaps labels it applied itself. The flip side is that a label you add by hand is yours to remove by hand.
+
+If the title does not match the convention, the labeling job fails rather than reconciling, so a malformed title cannot strip a PR's labels.
 
 ### Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,8 @@ Add a label to your PR so it gets categorized correctly in Release Notes:
 
 Module-specific labels (`rollout`, `server`, `cli`, `auth`, `eval`) can also be added for filtering. Rollout work typically touches `osmosis_ai.rollout` and related CLI commands.
 
+The `stacked-pr` label is automatically added when a title starts with `[N/M]`. It is filtering metadata and does not change the Release Notes category.
+
 ### Workflow
 
 1. Fork the repository and create a feature branch


### PR DESCRIPTION
## What

- Accept an optional leading `[N/M]` in PR titles, before `[BREAKING]`, and validate that `1 <= N <= M`, `M >= 2`, with no leading zeroes.
- Gate title validation and auto-labeling on the PR author rather than the actor that triggered the workflow run.
- Reconcile title-derived labels whenever a PR is opened, reopened, or its title changes: remove stale type/module/breaking/stack labels, add the labels implied by the latest title, and preserve priority, triage, and other manually managed labels.
- Add the `stacked-pr` label for `[N/M]` titles and recognize `[BREAKING]` after an optional stack prefix.
- Parse only leading module brackets so bracketed text in the description cannot create accidental module labels.
- Document the stacked title format, labels, and `gh stack link`/`submit` workflow in `CONTRIBUTING.md`, the PR template, and the create-PR skill.

## Why

The `[N/M]` prefix used by this repository's stacked PRs did not match the title check, so every stack needed to ignore or work around a failing gate. The convention was also absent from the contributor docs and PR template.

The title check used `github.actor`, which identifies whoever triggered the current run rather than who opened the PR. A bot touching a human-authored PR could therefore skip validation and make an invalid title appear green.

Auto-labeling previously only added labels. After a title changed, labels derived from the old title remained indefinitely. It also scanned bracketed text anywhere in the title, so description text such as `[server]` could be mistaken for a module. Reconciliation makes the latest title the source of truth for title-managed labels while leaving unrelated labels untouched.

## How to Test

- Parse both workflows, syntax-check the title validator's Bash, and syntax-check the auto-labeler's JavaScript in the async wrapper used by `actions/github-script`:
  ```bash
  uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/check-pr-title.yml')); yaml.safe_load(open('.github/workflows/auto-label-pr.yml'))"
  uv run python -c "import yaml; print(yaml.safe_load(open('.github/workflows/check-pr-title.yml'))['jobs']['check-title']['steps'][0]['run'])" | bash -n
  uv run python -c "import yaml; s=yaml.safe_load(open('.github/workflows/auto-label-pr.yml'))['jobs']['label']['steps'][0]['with']['script']; print('(async()=>{\\n'+s+'\\n})()')" | node --check
  ```
- Execute the title workflow's exact Bash block against standard, stacked, stacked-breaking, zero, leading-zero, reversed, missing-module, and values beyond Bash's fixed-width integer range. Valid cases pass; `[0/2]`, `[1/1]`, `[3/2]`, `[01/02]`, `[1/0]`, `[9223372036854775808/2]`, and `[1/2] fix: x` fail, while `[1/9223372036854775808]` passes without overflow.
- Execute the auto-label workflow's exact JavaScript with mocked `github`, `context`, and `core` objects:
  - changing a stacked breaking rollout refactor into a CLI fix removes `breaking`, `refactor`, `rollout`, and `stacked-pr`, then adds `bug` and `cli`;
  - `priority: high` remains untouched;
  - `[ci] fix: document [server] labels` adds only `bug` and `ci`;
  - invalid stack positions fail without label writes;
  - an already-correct label set performs no writes.
- `git diff --check`
- `gh pr checks 294 --repo Osmosis-AI/osmosis-sdk-python`

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added
- [x] Workflow YAML, Bash, and JavaScript parse successfully
- [x] Title and label reconciliation cases exercised directly
- [x] Full GitHub CI passes
- [x] Public contributor documentation updated
- [x] No secrets or credentials included