### PR TITLE
[rollout] fix: restore lint and verifytypes on main

### DIFF
--- a/osmosis_ai/rollout/backend/harbor/backend_v2.py
+++ b/osmosis_ai/rollout/backend/harbor/backend_v2.py
@@ -148,7 +148,7 @@ class HarborBackendV2(ExecutionBackend):
                 "native_agent_kwargs configures native harbor agents; "
                 "workflow agents take workflow_config"
             )
-        self.native_agent_kwargs = (
+        self.native_agent_kwargs: dict[str, Any] | None = (
             dict(native_agent_kwargs) if native_agent_kwargs else None
         )
         if self.native and not self.native.trainable:

--- a/tests/unit/rollout/test_harbor_backend_v2.py
+++ b/tests/unit/rollout/test_harbor_backend_v2.py
@@ -457,7 +457,9 @@ class TestNativeAgents:
         config = backend.build_agent_config(template_task, container_input)
         assert config.kwargs["api_base"] == "http://t/v1"
 
-    def test_native_agent_kwargs_rejected_for_workflow_agents(self, bundle, template_task):
+    def test_native_agent_kwargs_rejected_for_workflow_agents(
+        self, bundle, template_task
+    ):
         with pytest.raises(ValueError, match="native_agent_kwargs"):
             HarborBackendV2(
                 orchestrator=TrialQueue(n_concurrent=1),


### PR DESCRIPTION
## What

- Reformat `tests/unit/rollout/test_harbor_backend_v2.py` so it satisfies `ruff format --check`.
- Annotate `HarborBackendV2.native_agent_kwargs` as `dict[str, Any] | None`.

## Why

`main` is currently red. Its most recent Tests run fails on two independent checks, and every branch cut from it inherits both — including #294, whose two failures are entirely this, not anything that PR changed.

`lint` fails because `tests/unit/rollout/test_harbor_backend_v2.py` does not satisfy `ruff format --check` under the pinned ruff 0.16.0. Reproducible locally with the same version: `git show main:tests/unit/rollout/test_harbor_backend_v2.py > /tmp/t.py && ruff format --check /tmp/t.py` reports one file would be reformatted. The fix is the formatter's own output; no behavior changes.

`typecheck-pyright` fails on the `--verifytypes` step, which reports `native_agent_kwargs` as "missing type annotation and could be inferred differently by type checkers". The attribute is assigned a conditional expression, and pyright will not commit to a type other checkers are guaranteed to agree on. Annotating it explicitly restores a clean run and does not change the value.

Both fixes are also present in #291, which is part of a larger stack that is not merging yet. Pulling them out lets `main` go green now rather than waiting on that review.

## How to Test

- `uv run ruff check . && uv run ruff format --check .`
- `uv run pyright osmosis_ai/` — 0 errors.
- `uv run --no-editable pyright --verifytypes osmosis_ai --ignoreexternal`, filtered the way `.github/workflows/tests.yml` filters it (skipping the `agent_adapter`, `convert_sample_to_trajectory`, and `harness_agent` baselines), reports no remaining errors.
- `uv run pytest` — 2019 passed.

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Appropriate labels added (e.g. `enhancement`, `bug`, `breaking`)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore CI by fixing `ruff` formatting and `pyright --verifytypes` failures on main. Reformats `tests/unit/rollout/test_harbor_backend_v2.py` and annotates `HarborBackendV2.native_agent_kwargs` as `dict[str, Any] | None`, with no behavior changes.

<sup>Written for commit fa2dc94492d59cb243ae57c947e537480ecd9b9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

