### PR TITLE
[cli] refactor: defer heavy imports on CLI startup

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,7 +66,7 @@ from osmosis_ai.rollout.integrations.agents.openai_agents import OsmosisAgent
 CLI startup must stay fast (~150 ms vs ~1 s), so heavy dependencies load on first use, not at import time:
 
 - **Top-level package** — [../osmosis_ai/__init__.py](../osmosis_ai/__init__.py) resolves rubric exports (`evaluate_rubric`, `RubricResult`, error types) through `__getattr__`. Only `__version__` is eager.
-- **Command shells** — every file in [../osmosis_ai/cli/commands/](../osmosis_ai/cli/commands/) uses function-level imports for heavy deps (`rollout.*`, `platform.api.*`, `platform.cli.*`, `eval.*`). Module-level imports stay light: `typer`, `cli.console`, `cli.errors`, the lightweight `platform.constants`, and stdlib.
+- **Command shells** — every file in [../osmosis_ai/cli/commands/](../osmosis_ai/cli/commands/) uses function-level imports for heavy deps (`rollout.*`, `platform.api.*`, `platform.cli.*`, `eval.*`, `cli.console`). Module-level imports stay light: `typer`, `cli.errors`, the lightweight `platform.constants`, and stdlib.
 - **No eager `cli.main`** — [../osmosis_ai/cli/__init__.py](../osmosis_ai/cli/__init__.py) does not import `cli.main`, which prevents circular imports when rollout/server modules import `cli.console`. The entry point is `osmosis_ai.cli.main:main` directly.
 - **`_litellm_compat.py`** stays at the package top level because `eval/rubric/` depends on it.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,7 +17,7 @@ Files in [../osmosis_ai/cli/commands/](../osmosis_ai/cli/commands/) are thin Typ
 - platform-facing logic lives in [../osmosis_ai/platform/cli/](../osmosis_ai/platform/cli/) (e.g. `dataset.py`, `train.py`, `eval.py`, `secret.py`);
 - eval/rubric logic lives in [../osmosis_ai/eval/](../osmosis_ai/eval/).
 
-Module-level imports in `commands/` are kept light: `typer`, `cli.console`, `cli.errors`, the lightweight `osmosis_ai.platform.constants` (pagination limits), and stdlib. Everything heavy (`rollout.*`, `platform.api.*`, `platform.cli.*`, `eval.*`) must be imported **inside the function** to keep CLI startup fast — see the lazy-loading section of [architecture.md](./architecture.md).
+Module-level imports in `commands/` are kept light: `typer`, `cli.errors`, the lightweight `osmosis_ai.platform.constants` (pagination limits), and stdlib. Everything heavy (`rollout.*`, `platform.api.*`, `platform.cli.*`, `eval.*`, `cli.console`) must be imported **inside the function** to keep CLI startup fast — see the lazy-loading section of [architecture.md](./architecture.md).
 
 `osmosis benchmark` puts the benchmark first, mirroring the platform's
 Benchmarks pages: top-level `list` and `info` act on benchmarks (the workspace
@@ -49,7 +49,7 @@ Serializers that turn API models into these shapes live in [../osmosis_ai/cli/ou
 
 [../osmosis_ai/cli/output/renderer.py](../osmosis_ai/cli/output/renderer.py) builds the machine contract. Every JSON success envelope carries `schema_version: 1` and a shape matching the result type (`_envelope_list`, `_envelope_sectioned_list`, `_envelope_detail`, `_envelope_operation`, `_envelope_message`). Rich is the default for humans; `--plain` is intentionally low-noise text (not a strict schema).
 
-The output context, format enum, and selector resolution live in [../osmosis_ai/cli/output/context.py](../osmosis_ai/cli/output/context.py); the full output surface is re-exported from [../osmosis_ai/cli/output/__init__.py](../osmosis_ai/cli/output/__init__.py).
+The output context, format enum, and selector resolution live in [../osmosis_ai/cli/output/context.py](../osmosis_ai/cli/output/context.py); the full output surface is re-exported from [../osmosis_ai/cli/output/__init__.py](../osmosis_ai/cli/output/__init__.py). Serializer names are lazy (PEP 562) so importing the package does not load platform API models.
 
 ## Errors
 

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -7,7 +7,7 @@
 Reads an evaluation config TOML, validates its **structure** locally, and POSTs it to the platform over the same git-sync flow as `osmosis train submit`. The two commands share one implementation — only the literal strings, the config loader, and the API call differ.
 
 - Command shell: [../osmosis_ai/cli/commands/eval.py](../osmosis_ai/cli/commands/eval.py) (`eval_submit`)
-- Handler + submit spec: [../osmosis_ai/platform/cli/eval.py](../osmosis_ai/platform/cli/eval.py) (`submit`, `_EVAL_SUBMIT_SPEC`)
+- Handler + submit spec: [../osmosis_ai/platform/cli/eval.py](../osmosis_ai/platform/cli/eval.py) (`submit`)
 - Config loader: [../osmosis_ai/platform/cli/eval_config.py](../osmosis_ai/platform/cli/eval_config.py)
 - Shared submit flow: [../osmosis_ai/platform/cli/shared_submit.py](../osmosis_ai/platform/cli/shared_submit.py) (`run_cloud_submit`)
 - Shared config primitives: [../osmosis_ai/platform/cli/shared_config.py](../osmosis_ai/platform/cli/shared_config.py)

--- a/osmosis_ai/cli/commands/auth.py
+++ b/osmosis_ai/cli/commands/auth.py
@@ -8,7 +8,6 @@ from typing import Any
 
 import typer
 
-from osmosis_ai.cli.console import console
 from osmosis_ai.cli.errors import CLIError
 
 app: typer.Typer = typer.Typer(
@@ -298,6 +297,7 @@ def _machine_login_with_env_token(*, env_token: str) -> Any:
 
 def _rich_login(force: bool, token: str | None) -> Any:
     """Run rich, interactive login behavior."""
+    from osmosis_ai.cli.console import console
     from osmosis_ai.platform.auth import (
         LoginError,
         device_login,
@@ -425,6 +425,7 @@ def logout(
     ),
 ) -> Any:
     """Logout from Osmosis AI CLI."""
+    from osmosis_ai.cli.console import console
     from osmosis_ai.cli.output import OperationResult, OutputFormat, get_output_context
     from osmosis_ai.cli.prompts import confirm
     from osmosis_ai.platform.auth import load_credentials
@@ -523,6 +524,7 @@ def logout(
 @app.command("whoami")
 def whoami() -> Any:
     """Show current authenticated user."""
+    from osmosis_ai.cli.console import console
     from osmosis_ai.cli.output import (
         DetailField,
         DetailResult,

--- a/osmosis_ai/cli/console.py
+++ b/osmosis_ai/cli/console.py
@@ -4,6 +4,9 @@ Rich automatically strips ANSI control codes when output is not directed
 to a terminal (e.g., piped to a file), and respects the NO_COLOR
 environment variable.
 
+Rich is imported on first use in rich mode so ``--json`` / ``--plain``
+paths can import this module without loading the UI stack.
+
 Usage:
     from osmosis_ai.cli.console import console
 
@@ -18,20 +21,19 @@ from __future__ import annotations
 import sys
 from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from rich import box
-from rich.console import Console as RichConsole
-from rich.markup import escape as rich_escape
-from rich.panel import Panel
-from rich.style import Style
-from rich.table import Table
-from rich.text import Text
+if TYPE_CHECKING:
+    from rich.console import Console as RichConsole
+    from rich.text import Text
 
 
 def _url_link_text(
     url: str, label: str | None = None, style: str | None = None
 ) -> Text:
+    from rich.style import Style
+    from rich.text import Text
+
     link_style = Style(link=url)
     if style:
         link_style = Style.parse(style) + link_style
@@ -61,15 +63,27 @@ class Console:
             no_color: Disable all colors, even in TTY mode.
             width: Fixed terminal width (for testing). None = auto-detect.
         """
-        file = file or sys.stdout
+        self._file = file or sys.stdout
+        self._stderr_file = sys.stderr
+        self._force_terminal = force_terminal
         self._no_color = no_color
 
         # When TERM=dumb, Rich's Console.size short-circuits to 80x25 unless both width and
         # height are set; width alone is ignored (see rich.console.Console.size).
-        rich_size: dict[str, Any] = {}
+        self._rich_size: dict[str, Any] = {}
         if width is not None:
-            rich_size["width"] = width
-            rich_size["height"] = 25
+            self._rich_size["width"] = width
+            self._rich_size["height"] = 25
+
+        self._rich_stdout: RichConsole | None = None
+        self._rich_stderr_console: RichConsole | None = None
+        # Rich Status of a currently-live spinner, if any. print_warning stops
+        # it before printing and restarts it after, so the transient spinner
+        # line is not left stranded on screen mid-spin.
+        self._active_status: Any = None
+
+    def _make_rich_console(self, *, file: Any, **extra: Any) -> RichConsole:
+        from rich.console import Console as RichConsole
 
         # Disable Rich's default auto-highlighter: ReprHighlighter recolors
         # numbers, hex strings, UUIDs, URLs, etc. inside printed strings,
@@ -77,23 +91,28 @@ class Console:
         # a "green" message would show mixed colors on tokens like
         # "step-40-lora" or "2d7a22"). Callers can opt back in per-call via
         # `console.print(..., highlight=True)`.
-        self._rich = RichConsole(
+        return RichConsole(
             file=file,
-            force_terminal=force_terminal,
-            no_color=no_color,
+            no_color=self._no_color,
             highlight=False,
-            **rich_size,
+            **self._rich_size,
+            **extra,
         )
-        self._rich_stderr = RichConsole(
-            file=sys.stderr,
-            no_color=no_color,
-            highlight=False,
-            **rich_size,
-        )
-        # Rich Status of a currently-live spinner, if any. print_warning stops
-        # it before printing and restarts it after, so the transient spinner
-        # line is not left stranded on screen mid-spin.
-        self._active_status: Any = None
+
+    @property
+    def _rich(self) -> RichConsole:
+        if self._rich_stdout is None:
+            self._rich_stdout = self._make_rich_console(
+                file=self._file,
+                force_terminal=self._force_terminal,
+            )
+        return self._rich_stdout
+
+    @property
+    def _rich_stderr(self) -> RichConsole:
+        if self._rich_stderr_console is None:
+            self._rich_stderr_console = self._make_rich_console(file=self._stderr_file)
+        return self._rich_stderr_console
 
     @property
     def is_tty(self) -> bool:
@@ -240,6 +259,8 @@ class Console:
         """
         if not self._is_rich_mode():
             return
+        from rich.panel import Panel
+
         panel = Panel(content, title=title, border_style=style, padding=padding)
         self._rich.print(panel)
 
@@ -259,6 +280,9 @@ class Console:
         """
         if not self._is_rich_mode():
             return
+        from rich import box
+        from rich.table import Table
+
         table = Table(
             title=title,
             box=box.ROUNDED,
@@ -285,6 +309,8 @@ class Console:
         """
         if text is None:
             return ""
+        from rich.markup import escape as rich_escape
+
         return rich_escape(str(text))
 
     def format_styled(self, text: str, style: str) -> str:
@@ -299,6 +325,8 @@ class Console:
         Returns:
             Styled text string with Rich markup.
         """
+        from rich.markup import escape as rich_escape
+
         return f"[{style}]{rich_escape(text)}[/{style}]"
 
     def format_text(self, text: Any, style: str | None = None) -> Text:
@@ -306,6 +334,8 @@ class Console:
 
         Use this for dynamic values that should never be parsed as Rich markup.
         """
+        from rich.text import Text
+
         value = "" if text is None else str(text)
         if style is None:
             return Text(value)

--- a/osmosis_ai/cli/main.py
+++ b/osmosis_ai/cli/main.py
@@ -6,7 +6,6 @@ import warnings
 
 import typer
 import typer.core
-from dotenv import find_dotenv, load_dotenv
 
 from osmosis_ai.cli._click_compat import (
     ClickException,
@@ -120,6 +119,8 @@ def _callback(
     )
     install_output_context(ctx, output)
     ctx.call_on_close(verify_output_emitted)
+    from dotenv import find_dotenv, load_dotenv
+
     load_dotenv(find_dotenv(usecwd=True))
 
 
@@ -232,8 +233,14 @@ def _register_commands() -> None:
 
 def main(argv: list[str] | None = None) -> int:
     """Entry point for the Osmosis CLI."""
+    argv = argv if argv is not None else sys.argv[1:]
+    # Bare -V/--version skips command registration. Combined with other flags
+    # (e.g. --json --version) still goes through Typer so output stays identical.
+    if argv == ["--version"] or argv == ["-V"]:
+        typer.echo(f"{package_name} {PACKAGE_VERSION}")
+        return 0
     _register_commands()
-    argv = hoist_format_selectors(argv if argv is not None else sys.argv[1:])
+    argv = hoist_format_selectors(argv)
     try:
         result = app(argv, standalone_mode=False)
         # standalone_mode=False returns the command result on success, or the

--- a/osmosis_ai/cli/main.py
+++ b/osmosis_ai/cli/main.py
@@ -79,6 +79,10 @@ app: typer.Typer = typer.Typer(
 )
 
 
+def _emit_version() -> None:
+    typer.echo(f"{package_name} {PACKAGE_VERSION}")
+
+
 @app.callback(invoke_without_command=True)
 def _callback(
     ctx: typer.Context,
@@ -106,7 +110,7 @@ def _callback(
     """
     warnings.filterwarnings("ignore")
     if version:
-        typer.echo(f"{package_name} {PACKAGE_VERSION}")
+        _emit_version()
         raise typer.Exit()
 
     selected_format = resolve_format_selectors(
@@ -237,7 +241,7 @@ def main(argv: list[str] | None = None) -> int:
     # Bare -V/--version skips command registration. Combined with other flags
     # (e.g. --json --version) still goes through Typer so output stays identical.
     if argv == ["--version"] or argv == ["-V"]:
-        typer.echo(f"{package_name} {PACKAGE_VERSION}")
+        _emit_version()
         return 0
     _register_commands()
     argv = hoist_format_selectors(argv)

--- a/osmosis_ai/cli/output/__init__.py
+++ b/osmosis_ai/cli/output/__init__.py
@@ -1,4 +1,12 @@
-"""Public surface of the CLI output package."""
+"""Public surface of the CLI output package.
+
+Serializer re-exports are resolved lazily so importing this package (or any
+submodule) does not create platform API model classes at CLI startup.
+"""
+
+from typing import TYPE_CHECKING
+
+from osmosis_ai._imports import public_module_dir, resolve_lazy_export
 
 from .context import (
     OutputContext,
@@ -28,18 +36,65 @@ from .result import (
     SectionedListResult,
     detail_fields,
 )
-from .serializers import (
-    serialize_benchmark_run,
-    serialize_checkpoint,
-    serialize_dataset,
-    serialize_dev_rollout_server,
-    serialize_environment_secret,
-    serialize_eval_run,
-    serialize_lora_model,
-    serialize_model,
-    serialize_rollout,
-    serialize_training_run,
-)
+
+if TYPE_CHECKING:
+    from .serializers import (
+        serialize_benchmark_run,
+        serialize_checkpoint,
+        serialize_dataset,
+        serialize_dev_rollout_server,
+        serialize_environment_secret,
+        serialize_eval_run,
+        serialize_lora_model,
+        serialize_model,
+        serialize_rollout,
+        serialize_training_run,
+    )
+
+_SERIALIZER_EXPORTS: dict[str, tuple[str, str]] = {
+    "serialize_benchmark_run": (
+        "osmosis_ai.cli.output.serializers",
+        "serialize_benchmark_run",
+    ),
+    "serialize_checkpoint": (
+        "osmosis_ai.cli.output.serializers",
+        "serialize_checkpoint",
+    ),
+    "serialize_dataset": ("osmosis_ai.cli.output.serializers", "serialize_dataset"),
+    "serialize_dev_rollout_server": (
+        "osmosis_ai.cli.output.serializers",
+        "serialize_dev_rollout_server",
+    ),
+    "serialize_environment_secret": (
+        "osmosis_ai.cli.output.serializers",
+        "serialize_environment_secret",
+    ),
+    "serialize_eval_run": ("osmosis_ai.cli.output.serializers", "serialize_eval_run"),
+    "serialize_lora_model": (
+        "osmosis_ai.cli.output.serializers",
+        "serialize_lora_model",
+    ),
+    "serialize_model": ("osmosis_ai.cli.output.serializers", "serialize_model"),
+    "serialize_rollout": ("osmosis_ai.cli.output.serializers", "serialize_rollout"),
+    "serialize_training_run": (
+        "osmosis_ai.cli.output.serializers",
+        "serialize_training_run",
+    ),
+}
+
+
+def __getattr__(name: str) -> object:
+    return resolve_lazy_export(
+        name,
+        module_name=__name__,
+        namespace=globals(),
+        exports=_SERIALIZER_EXPORTS,
+    )
+
+
+def __dir__() -> list[str]:
+    return public_module_dir(globals(), _SERIALIZER_EXPORTS)
+
 
 __all__ = [
     "CommandResult",

--- a/osmosis_ai/cli/upgrade.py
+++ b/osmosis_ai/cli/upgrade.py
@@ -6,12 +6,10 @@ import json
 import shutil
 import subprocess
 import sys
-import urllib.request
 from typing import Any
 
 import typer
 
-from osmosis_ai.cli.console import console
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.cli.output import OperationResult, OutputFormat, get_output_context
 from osmosis_ai.consts import PACKAGE_VERSION, package_name
@@ -46,6 +44,8 @@ def _is_up_to_date(installed: str, latest: str) -> bool:
 
 def _fetch_latest_version() -> str | None:
     """Fetch the latest version from PyPI."""
+    import urllib.request
+
     try:
         req = urllib.request.Request(PYPI_URL, headers={"Accept": "application/json"})
         with urllib.request.urlopen(req, timeout=10) as resp:
@@ -115,6 +115,8 @@ def _upgrade_resource(
 
 def upgrade() -> Any:
     """Upgrade the Osmosis CLI to the latest version."""
+    from osmosis_ai.cli.console import console
+
     installed = PACKAGE_VERSION
     output = get_output_context()
     structured_output = output.format is not OutputFormat.rich

--- a/osmosis_ai/platform/cli/benchmark.py
+++ b/osmosis_ai/platform/cli/benchmark.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from osmosis_ai.cli.console import console
 from osmosis_ai.cli.errors import CLIError
@@ -38,20 +38,6 @@ from osmosis_ai.platform.api.models import (
     SubmitBenchmarkRunResult,
 )
 from osmosis_ai.platform.auth.platform_client import PlatformAPIError
-from osmosis_ai.platform.cli.benchmark_config import (
-    BenchmarkSubmitConfig,
-    load_benchmark_submit_config,
-)
-from osmosis_ai.platform.cli.secret_resolution import resolve_run_secrets
-from osmosis_ai.platform.cli.shared_config import (
-    build_env_table_rows,
-    build_secret_table_rows,
-)
-from osmosis_ai.platform.cli.shared_submit import (
-    _enrich_missing_secret_error,
-    _fetch_secret_scopes,
-    _missing_secret_message,
-)
 from osmosis_ai.platform.cli.utils import (
     build_logs_result,
     format_benchmark_status,
@@ -71,6 +57,9 @@ from osmosis_ai.platform.cli.workspace_directory_contract import (
     ensure_workspace_directory_config_path,
     validate_workspace_directory_contract,
 )
+
+if TYPE_CHECKING:
+    from osmosis_ai.platform.cli.benchmark_config import BenchmarkSubmitConfig
 
 _HLE_PARITY_WARNING = (
     'For HLE, we recommend [tasks] task_set = "parity" so results are '
@@ -1150,6 +1139,18 @@ def submit(
     config_path: Path, *, yes: bool, secrets_file: str | None = None
 ) -> OperationResult:
     """Submit a benchmark run."""
+    from osmosis_ai.platform.cli.benchmark_config import load_benchmark_submit_config
+    from osmosis_ai.platform.cli.secret_resolution import resolve_run_secrets
+    from osmosis_ai.platform.cli.shared_config import (
+        build_env_table_rows,
+        build_secret_table_rows,
+    )
+    from osmosis_ai.platform.cli.shared_submit import (
+        _enrich_missing_secret_error,
+        _fetch_secret_scopes,
+        _missing_secret_message,
+    )
+
     context = require_git_workspace_directory_context()
     workspace_directory = Path(context.workspace_directory)
     validate_workspace_directory_contract(workspace_directory)

--- a/osmosis_ai/platform/cli/dataset.py
+++ b/osmosis_ai/platform/cli/dataset.py
@@ -83,8 +83,6 @@ def _abort_upload(
 # (weekly cron Lambda + S3 lifecycle rules), so this retry is the
 # primary client-side defense, not the only one.
 
-from osmosis_ai.platform.api.upload import BACKOFF_BASE, BACKOFF_CAP, MAX_RETRIES
-
 PARQUET_VALIDATION_SKIPPED_WARNING = (
     "pyarrow not installed; parquet content validation skipped. "
     "Install with: pip install 'osmosis-ai[parquet]'"
@@ -105,6 +103,8 @@ def _complete_with_retry(
     On final failure, prints recovery information so the user can retry
     manually with ``osmosis dataset complete <id>``.
     """
+    from osmosis_ai.platform.api.upload import BACKOFF_BASE, BACKOFF_CAP, MAX_RETRIES
+
     last_error: Exception | None = None
     for attempt in range(MAX_RETRIES):
         if attempt > 0:

--- a/osmosis_ai/platform/cli/eval.py
+++ b/osmosis_ai/platform/cli/eval.py
@@ -5,15 +5,10 @@ from __future__ import annotations
 import math
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from osmosis_ai.cli.console import console
 from osmosis_ai.cli.errors import CLIError
-from osmosis_ai.cli.metrics_export import (
-    METRICS_EXPORT_MIGRATION_NOTICE,
-    build_eval_export_dict,
-    resolve_eval_metrics_output,
-)
 from osmosis_ai.cli.output import (
     DetailResult,
     DetailSection,
@@ -39,12 +34,6 @@ from osmosis_ai.platform.api.models import (
     SubmitRunResult,
 )
 from osmosis_ai.platform.auth.platform_client import PlatformAPIError
-from osmosis_ai.platform.cli.eval_config import (
-    EvalSubmitConfig,
-    load_eval_submit_config,
-    validate_eval_submit_context_paths,
-)
-from osmosis_ai.platform.cli.shared_submit import CloudSubmitSpec, run_cloud_submit
 from osmosis_ai.platform.cli.utils import (
     build_logs_result,
     format_env_config,
@@ -59,6 +48,9 @@ from osmosis_ai.platform.cli.utils import (
     validate_list_options,
 )
 from osmosis_ai.platform.cli.workspace_directory_context import git_result_context
+
+if TYPE_CHECKING:
+    from osmosis_ai.platform.cli.eval_config import EvalSubmitConfig
 
 
 def _ref_name(ref: dict[str, Any] | None) -> str | None:
@@ -347,28 +339,30 @@ def _eval_next_steps(
     return display, structured
 
 
-_EVAL_SUBMIT_SPEC: CloudSubmitSpec[EvalSubmitConfig] = CloudSubmitSpec(
-    config_dir="configs/eval",
-    command_label="`osmosis eval submit`",
-    table_title="Evaluation Run",
-    confirm_prompt="Submit this evaluation run?",
-    status_message="Submitting evaluation run...",
-    operation="eval.submit",
-    success_message_format="Evaluation run submitted: {name}",
-    load_config=load_eval_submit_config,
-    validate_context=validate_eval_submit_context_paths,
-    submit=_submit_eval,
-    build_next_steps=_eval_next_steps,
-)
-
-
 def submit(
     config_path: Path, *, yes: bool, secrets_file: str | None = None
 ) -> OperationResult:
     """Submit an evaluation run."""
-    return run_cloud_submit(
-        config_path, yes=yes, spec=_EVAL_SUBMIT_SPEC, secrets_file=secrets_file
+    from osmosis_ai.platform.cli.eval_config import (
+        load_eval_submit_config,
+        validate_eval_submit_context_paths,
     )
+    from osmosis_ai.platform.cli.shared_submit import CloudSubmitSpec, run_cloud_submit
+
+    spec = CloudSubmitSpec(
+        config_dir="configs/eval",
+        command_label="`osmosis eval submit`",
+        table_title="Evaluation Run",
+        confirm_prompt="Submit this evaluation run?",
+        status_message="Submitting evaluation run...",
+        operation="eval.submit",
+        success_message_format="Evaluation run submitted: {name}",
+        load_config=load_eval_submit_config,
+        validate_context=validate_eval_submit_context_paths,
+        submit=_submit_eval,
+        build_next_steps=_eval_next_steps,
+    )
+    return run_cloud_submit(config_path, yes=yes, spec=spec, secrets_file=secrets_file)
 
 
 def list_eval_runs(*, limit: int, all_: bool) -> ListResult:
@@ -456,6 +450,12 @@ def logs(name: str, *, limit: int, cursor: str | None = None) -> ListResult:
 
 def info(name: str, *, output: str | None) -> DetailResult:
     """Show evaluation run details, results, and metrics."""
+    from osmosis_ai.cli.metrics_export import (
+        METRICS_EXPORT_MIGRATION_NOTICE,
+        build_eval_export_dict,
+        resolve_eval_metrics_output,
+    )
+
     context = require_git_workspace_directory_context()
     credentials = context.credentials
 

--- a/osmosis_ai/platform/cli/train.py
+++ b/osmosis_ai/platform/cli/train.py
@@ -4,15 +4,10 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from osmosis_ai.cli.console import console
 from osmosis_ai.cli.errors import CLIError
-from osmosis_ai.cli.metrics_export import (
-    build_export_dict,
-    resolve_default_metrics_output,
-    resolve_metrics_output_path,
-)
 from osmosis_ai.cli.output import (
     DetailField,
     DetailResult,
@@ -40,12 +35,6 @@ from osmosis_ai.platform.api.models import (
     SubmitRunResult,
 )
 from osmosis_ai.platform.auth.platform_client import PlatformAPIError
-from osmosis_ai.platform.cli.shared_submit import CloudSubmitSpec, run_cloud_submit
-from osmosis_ai.platform.cli.training_config import (
-    TrainSubmitConfig,
-    load_train_submit_config,
-    validate_train_submit_context_paths,
-)
 from osmosis_ai.platform.cli.utils import (
     build_logs_result,
     build_run_detail_rows,
@@ -62,6 +51,9 @@ from osmosis_ai.platform.cli.utils import (
     validate_list_options,
 )
 from osmosis_ai.platform.cli.workspace_directory_context import git_result_context
+
+if TYPE_CHECKING:
+    from osmosis_ai.platform.cli.training_config import TrainSubmitConfig
 
 
 def _format_train_config(config: dict[str, Any] | None) -> str | None:
@@ -155,28 +147,30 @@ def _train_next_steps(
     return display, structured
 
 
-_TRAIN_SUBMIT_SPEC: CloudSubmitSpec[TrainSubmitConfig] = CloudSubmitSpec(
-    config_dir="configs/training",
-    command_label="`osmosis train submit`",
-    table_title="Training Run",
-    confirm_prompt="Submit this training run?",
-    status_message="Submitting training run...",
-    operation="train.submit",
-    success_message_format="Training run submitted: {name}",
-    load_config=load_train_submit_config,
-    validate_context=validate_train_submit_context_paths,
-    submit=_submit_training,
-    build_next_steps=_train_next_steps,
-)
-
-
 def submit(
     config_path: Path, *, yes: bool, secrets_file: str | None = None
 ) -> OperationResult:
     """Submit a new training run."""
-    return run_cloud_submit(
-        config_path, yes=yes, spec=_TRAIN_SUBMIT_SPEC, secrets_file=secrets_file
+    from osmosis_ai.platform.cli.shared_submit import CloudSubmitSpec, run_cloud_submit
+    from osmosis_ai.platform.cli.training_config import (
+        load_train_submit_config,
+        validate_train_submit_context_paths,
     )
+
+    spec = CloudSubmitSpec(
+        config_dir="configs/training",
+        command_label="`osmosis train submit`",
+        table_title="Training Run",
+        confirm_prompt="Submit this training run?",
+        status_message="Submitting training run...",
+        operation="train.submit",
+        success_message_format="Training run submitted: {name}",
+        load_config=load_train_submit_config,
+        validate_context=validate_train_submit_context_paths,
+        submit=_submit_training,
+        build_next_steps=_train_next_steps,
+    )
+    return run_cloud_submit(config_path, yes=yes, spec=spec, secrets_file=secrets_file)
 
 
 def list_training_runs(*, limit: int, all_: bool) -> ListResult:
@@ -263,6 +257,12 @@ def logs(name: str, *, limit: int, cursor: str | None = None) -> ListResult:
 
 def info(name: str, *, output: str | None) -> DetailResult:
     """Show training run details, checkpoints, and metrics."""
+    from osmosis_ai.cli.metrics_export import (
+        build_export_dict,
+        resolve_default_metrics_output,
+        resolve_metrics_output_path,
+    )
+
     context = require_git_workspace_directory_context()
     credentials = context.credentials
 

--- a/tests/integration/test_cli_subprocess_contract.py
+++ b/tests/integration/test_cli_subprocess_contract.py
@@ -10,6 +10,16 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 
 
+def _write_workspace_template(root: Path) -> Path:
+    (root / "configs").mkdir(parents=True)
+    (root / "AGENTS.md").write_text("template agents\n", encoding="utf-8")
+    (root / "CLAUDE.md").write_text("template claude\n", encoding="utf-8")
+    (root / "configs" / "AGENTS.md").write_text(
+        "template config agents\n", encoding="utf-8"
+    )
+    return root
+
+
 def test_project_doctor_fix_in_git_repo_creates_runtime_free_scaffold(
     tmp_path: Path,
 ) -> None:
@@ -22,6 +32,9 @@ def test_project_doctor_fix_in_git_repo_creates_runtime_free_scaffold(
     env = {**os.environ}
     env["PYTHONPATH"] = os.pathsep.join(
         [str(ROOT), *(path for path in [env.get("PYTHONPATH")] if path)]
+    )
+    env["OSMOSIS_WORKSPACE_TEMPLATE_PATH"] = str(
+        _write_workspace_template(tmp_path / "workspace-template")
     )
 
     proc = subprocess.run(

--- a/tests/unit/cli/test_auth_login_json.py
+++ b/tests/unit/cli/test_auth_login_json.py
@@ -552,7 +552,7 @@ def test_login_rich_with_invalid_env_token_mentions_unset(
         ),
     )
     monkeypatch.setattr(
-        "osmosis_ai.cli.commands.auth.console.print_error",
+        "osmosis_ai.cli.console.console.print_error",
         lambda message: errors.append(message),
     )
 

--- a/tests/unit/cli/test_lazy_loading.py
+++ b/tests/unit/cli/test_lazy_loading.py
@@ -116,8 +116,10 @@ def test_module_has_getattr():
 # -- CLI startup import invariants (subprocess) --------------------------------
 
 
-def _sys_modules_after_cli(args: list[str], *, cwd: str | None = None) -> set[str]:
-    """Return ``sys.modules`` names after ``main(args)`` in a fresh process."""
+def _sys_modules_after_cli(
+    args: list[str], *, cwd: str | None = None
+) -> tuple[int, set[str]]:
+    """Return ``(exit_code, sys.modules names)`` after ``main(args)`` in a fresh process."""
     with tempfile.NamedTemporaryFile(
         prefix="osmosis-modules-", suffix=".json", delete=False
     ) as dump:
@@ -129,11 +131,9 @@ def _sys_modules_after_cli(args: list[str], *, cwd: str | None = None) -> set[st
         import sys
         from osmosis_ai.cli.main import main
 
-        try:
-            main(sys.argv[1:])
-        finally:
-            with open(os.environ["OSMOSIS_MODULE_DUMP"], "w", encoding="utf-8") as fh:
-                json.dump(list(sys.modules), fh)
+        rc = main(sys.argv[1:])
+        with open(os.environ["OSMOSIS_MODULE_DUMP"], "w", encoding="utf-8") as fh:
+            json.dump({"rc": rc, "modules": list(sys.modules)}, fh)
         """
     )
     env = os.environ.copy()
@@ -148,8 +148,8 @@ def _sys_modules_after_cli(args: list[str], *, cwd: str | None = None) -> set[st
             cwd=cwd,
         )
         with open(dump_path, encoding="utf-8") as fh:
-            loaded = json.load(fh)
-        return set(loaded)
+            payload = json.load(fh)
+        return payload["rc"], set(payload["modules"])
     finally:
         os.unlink(dump_path)
 
@@ -167,7 +167,8 @@ def test_json_cli_does_not_load_rich_stack() -> None:
     the Rich stack just because it was imported.
     """
     with tempfile.TemporaryDirectory() as tmp:
-        loaded = _sys_modules_after_cli(["--json", "dataset", "list"], cwd=tmp)
+        rc, loaded = _sys_modules_after_cli(["--json", "dataset", "list"], cwd=tmp)
+    assert rc == 1
     assert "osmosis_ai.platform.cli.dataset" in loaded
     assert "osmosis_ai.cli.console" in loaded
     roots = _top_level_modules(loaded)
@@ -183,7 +184,8 @@ def test_json_train_list_does_not_load_pydantic() -> None:
     in a scratch cwd — no login or network required.
     """
     with tempfile.TemporaryDirectory() as tmp:
-        loaded = _sys_modules_after_cli(["--json", "train", "list"], cwd=tmp)
+        rc, loaded = _sys_modules_after_cli(["--json", "train", "list"], cwd=tmp)
+    assert rc == 1
     assert "osmosis_ai.platform.cli.train" in loaded
     roots = _top_level_modules(loaded)
     leaked = {"rich", "pygments", "markdown_it"} & roots
@@ -193,7 +195,8 @@ def test_json_train_list_does_not_load_pydantic() -> None:
 
 def test_help_does_not_load_heavy_optional_deps() -> None:
     """``osmosis --help`` must not import httpx, keyring, urllib.request, litellm, fastapi."""
-    loaded = _sys_modules_after_cli(["--help"])
+    rc, loaded = _sys_modules_after_cli(["--help"])
+    assert rc == 0
     roots = _top_level_modules(loaded)
     leaked_roots = {"httpx", "keyring", "litellm", "fastapi"} & roots
     assert not leaked_roots, f"--help loaded optional deps: {sorted(leaked_roots)}"

--- a/tests/unit/cli/test_lazy_loading.py
+++ b/tests/unit/cli/test_lazy_loading.py
@@ -175,6 +175,22 @@ def test_json_cli_does_not_load_rich_stack() -> None:
     assert not leaked, f"JSON CLI loaded UI stack: {sorted(leaked)}"
 
 
+def test_json_train_list_does_not_load_pydantic() -> None:
+    """``osmosis --json train list`` must not import pydantic.
+
+    ``platform.cli.train`` hosts every train subcommand, so module-level
+    submit-config imports would pull pydantic onto the list path. Fail closed
+    in a scratch cwd — no login or network required.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        loaded = _sys_modules_after_cli(["--json", "train", "list"], cwd=tmp)
+    assert "osmosis_ai.platform.cli.train" in loaded
+    roots = _top_level_modules(loaded)
+    leaked = {"rich", "pygments", "markdown_it"} & roots
+    assert not leaked, f"JSON train list loaded UI stack: {sorted(leaked)}"
+    assert "pydantic" not in roots, "JSON train list loaded pydantic"
+
+
 def test_help_does_not_load_heavy_optional_deps() -> None:
     """``osmosis --help`` must not import httpx, keyring, urllib.request, litellm, fastapi."""
     loaded = _sys_modules_after_cli(["--help"])

--- a/tests/unit/cli/test_lazy_loading.py
+++ b/tests/unit/cli/test_lazy_loading.py
@@ -116,7 +116,7 @@ def test_module_has_getattr():
 # -- CLI startup import invariants (subprocess) --------------------------------
 
 
-def _sys_modules_after_cli(args: list[str]) -> set[str]:
+def _sys_modules_after_cli(args: list[str], *, cwd: str | None = None) -> set[str]:
     """Return ``sys.modules`` names after ``main(args)`` in a fresh process."""
     with tempfile.NamedTemporaryFile(
         prefix="osmosis-modules-", suffix=".json", delete=False
@@ -145,6 +145,7 @@ def _sys_modules_after_cli(args: list[str]) -> set[str]:
             capture_output=True,
             text=True,
             env=env,
+            cwd=cwd,
         )
         with open(dump_path, encoding="utf-8") as fh:
             loaded = json.load(fh)
@@ -158,12 +159,17 @@ def _top_level_modules(loaded: set[str]) -> set[str]:
 
 
 def test_json_cli_does_not_load_rich_stack() -> None:
-    """``osmosis --json <flag>`` must not import rich / pygments / markdown_it.
+    """``osmosis --json dataset list`` must not import rich / pygments / markdown_it.
 
-    Uses ``--json --version`` so command registration still runs, but no
-    handler that lazily imports ``cli.console`` (e.g. dataset list) executes.
+    Runs a real command in a scratch cwd so the handler imports ``cli.console``
+    (via ``platform.cli.dataset``) and then fails closed on workspace
+    validation — no login or network required. ``cli.console`` must not pull
+    the Rich stack just because it was imported.
     """
-    loaded = _sys_modules_after_cli(["--json", "--version"])
+    with tempfile.TemporaryDirectory() as tmp:
+        loaded = _sys_modules_after_cli(["--json", "dataset", "list"], cwd=tmp)
+    assert "osmosis_ai.platform.cli.dataset" in loaded
+    assert "osmosis_ai.cli.console" in loaded
     roots = _top_level_modules(loaded)
     leaked = {"rich", "pygments", "markdown_it"} & roots
     assert not leaked, f"JSON CLI loaded UI stack: {sorted(leaked)}"

--- a/tests/unit/cli/test_lazy_loading.py
+++ b/tests/unit/cli/test_lazy_loading.py
@@ -1,15 +1,22 @@
-"""Tests for lazy loading in osmosis_ai.__init__.
+"""Tests for lazy loading in osmosis_ai.__init__ and the CLI entry point.
 
 Verifies that importing ``osmosis_ai`` does NOT eagerly pull in heavy
 dependencies (litellm, openai, fastapi) and that rubric exports remain
 accessible on demand. Rollout SDK types are not re-exported at package
 top level — import from ``osmosis_ai.rollout`` directly.
+
+CLI subprocess probes lock startup import discipline: ``--json`` must not
+pull Rich, and ``--help`` must not pull optional/network stacks.
 """
 
 from __future__ import annotations
 
+import json
+import os
 import subprocess
 import sys
+import tempfile
+import textwrap
 
 import pytest
 
@@ -104,3 +111,84 @@ def test_module_has_getattr():
     """The module must define __getattr__ for rubric lazy loading."""
     assert hasattr(osmosis_ai, "__getattr__")
     assert callable(osmosis_ai.__getattr__)
+
+
+# -- CLI startup import invariants (subprocess) --------------------------------
+
+
+def _sys_modules_after_cli(args: list[str]) -> set[str]:
+    """Return ``sys.modules`` names after ``main(args)`` in a fresh process."""
+    with tempfile.NamedTemporaryFile(
+        prefix="osmosis-modules-", suffix=".json", delete=False
+    ) as dump:
+        dump_path = dump.name
+    script = textwrap.dedent(
+        """\
+        import json
+        import os
+        import sys
+        from osmosis_ai.cli.main import main
+
+        try:
+            main(sys.argv[1:])
+        finally:
+            with open(os.environ["OSMOSIS_MODULE_DUMP"], "w", encoding="utf-8") as fh:
+                json.dump(list(sys.modules), fh)
+        """
+    )
+    env = os.environ.copy()
+    env["OSMOSIS_MODULE_DUMP"] = dump_path
+    try:
+        subprocess.run(
+            [sys.executable, "-c", script, *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        with open(dump_path, encoding="utf-8") as fh:
+            loaded = json.load(fh)
+        return set(loaded)
+    finally:
+        os.unlink(dump_path)
+
+
+def _top_level_modules(loaded: set[str]) -> set[str]:
+    return {name.partition(".")[0] for name in loaded}
+
+
+def test_json_cli_does_not_load_rich_stack() -> None:
+    """``osmosis --json <flag>`` must not import rich / pygments / markdown_it.
+
+    Uses ``--json --version`` so command registration still runs, but no
+    handler that lazily imports ``cli.console`` (e.g. dataset list) executes.
+    """
+    loaded = _sys_modules_after_cli(["--json", "--version"])
+    roots = _top_level_modules(loaded)
+    leaked = {"rich", "pygments", "markdown_it"} & roots
+    assert not leaked, f"JSON CLI loaded UI stack: {sorted(leaked)}"
+
+
+def test_help_does_not_load_heavy_optional_deps() -> None:
+    """``osmosis --help`` must not import httpx, keyring, urllib.request, litellm, fastapi."""
+    loaded = _sys_modules_after_cli(["--help"])
+    roots = _top_level_modules(loaded)
+    leaked_roots = {"httpx", "keyring", "litellm", "fastapi"} & roots
+    assert not leaked_roots, f"--help loaded optional deps: {sorted(leaked_roots)}"
+    assert "urllib.request" not in loaded, "urllib.request was loaded during --help"
+
+
+def test_output_package_import_does_not_load_api_models() -> None:
+    """Importing an output submodule must not run serializers → platform.api.models."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from osmosis_ai.cli.output.context import OutputContext; import sys; "
+            "assert 'osmosis_ai.cli.output.serializers' not in sys.modules; "
+            "assert 'osmosis_ai.platform.api.models' not in sys.modules",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/unit/platform/cli/test_benchmark_submit.py
+++ b/tests/unit/platform/cli/test_benchmark_submit.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 
 import osmosis_ai.platform.cli.benchmark as benchmark_module
+import osmosis_ai.platform.cli.shared_submit as shared_submit_module
 from osmosis_ai.cli.errors import CLIError
 from osmosis_ai.cli.output import OperationResult
 from osmosis_ai.platform.api.models import SubmitBenchmarkRunResult
@@ -130,7 +131,7 @@ def test_submit_sends_benchmark_config_and_returns_operation_result(
     )
     monkeypatch.setattr(benchmark_module, "OsmosisClient", FakeClient)
     monkeypatch.setattr(
-        benchmark_module,
+        shared_submit_module,
         "_fetch_secret_scopes",
         lambda *args, **kwargs: ({"OPENAI_API_KEY", "CURSOR_API_KEY"}, set()),
     )
@@ -195,7 +196,7 @@ def test_submit_warns_before_confirmation_for_hle_without_parity(
     )
     monkeypatch.setattr(benchmark_module, "OsmosisClient", _FakeSubmitClient)
     monkeypatch.setattr(
-        benchmark_module,
+        shared_submit_module,
         "_fetch_secret_scopes",
         lambda *args, **kwargs: ({"OPENAI_API_KEY", "HF_TOKEN"}, set()),
     )
@@ -241,7 +242,7 @@ def test_submit_does_not_warn_when_hle_uses_parity(
     )
     monkeypatch.setattr(benchmark_module, "OsmosisClient", _FakeSubmitClient)
     monkeypatch.setattr(
-        benchmark_module,
+        shared_submit_module,
         "_fetch_secret_scopes",
         lambda *args, **kwargs: ({"OPENAI_API_KEY", "HF_TOKEN"}, set()),
     )
@@ -275,7 +276,7 @@ def test_submit_warns_before_hle_missing_secret_failure(
     )
     monkeypatch.setattr(benchmark_module, "OsmosisClient", _FakeSubmitClient)
     monkeypatch.setattr(
-        benchmark_module,
+        shared_submit_module,
         "_fetch_secret_scopes",
         lambda *args, **kwargs: (set(), set()),
     )
@@ -343,7 +344,7 @@ required = ["WEATHER_API_KEY"]
     )
     monkeypatch.setattr(benchmark_module, "OsmosisClient", FakeClient)
     monkeypatch.setattr(
-        benchmark_module,
+        shared_submit_module,
         "_fetch_secret_scopes",
         lambda *args, **kwargs: ({"OPENAI_API_KEY"}, set()),
     )

--- a/tests/unit/platform/cli/test_login.py
+++ b/tests/unit/platform/cli/test_login.py
@@ -270,8 +270,7 @@ def test_login_success_prompts_clone_and_doctor_not_workspace_link(
         lambda **kw: (result, new_creds),
     )
     monkeypatch.setattr(
-        auth_module,
-        "console",
+        "osmosis_ai.cli.console.console",
         Console(force_terminal=False, no_color=True, width=100),
     )
 
@@ -302,8 +301,7 @@ def test_login_next_steps_omit_workspace_specific_guidance(monkeypatch, capsys) 
         lambda **kw: (result, new_creds),
     )
     monkeypatch.setattr(
-        auth_module,
-        "console",
+        "osmosis_ai.cli.console.console",
         Console(force_terminal=False, no_color=True, width=100),
     )
 
@@ -339,8 +337,7 @@ def test_whoami_prints_local_identity_outside_workspace_directory(monkeypatch) -
         lambda: (_ for _ in ()).throw(CLIError("not in workspace directory")),
     )
     monkeypatch.setattr(
-        auth_module,
-        "console",
+        "osmosis_ai.cli.console.console",
         Console(file=output, force_terminal=False, no_color=True, width=80),
     )
 


### PR DESCRIPTION
## What

- Move `cli.console` and `urllib.request` imports in `commands/auth.py` and `cli/upgrade.py` into the functions that use them so command registration no longer loads Rich or the HTTP stack.
- Fast-path bare `-V` / `--version` in `main()` before `_register_commands()`; `--json --version` still goes through Typer.
- Lazy-export serializers from `cli/output/__init__.py` via PEP 562 so importing any output submodule does not create `platform.api.models` dataclasses.
- Import `dotenv` inside the root callback instead of at module scope.
- Defer Rich inside `cli.console` until a rich-mode render, so `--json` / `--plain` handlers that import the console facade do not load `rich` / `pygments` / `markdown_it`.
- Keep `dataset list` off the upload/httpx path.
- Defer `shared_submit`, `*_config`, `metrics_export`, and `secret_resolution` imports in `platform/cli/train.py`, `eval.py`, and `benchmark.py` into the handlers that use them (`TYPE_CHECKING` for annotations), so list commands do not load pydantic.
- Add subprocess import-invariant tests: `--json dataset list` must not load the Rich stack; `--json train list` must not load pydantic; `--help` must not load optional/network deps.

## Why

CLI startup paid for auth ASCII art, the upgrade downloader, platform API model class creation, Rich, and pydantic submit-config machinery on paths that never submit. Agents that shell out repeatedly multiply that cost. This is P1–P5 plus P1b and P1c from the CLI implementation review; no user-visible output changes.

Measured on this machine (warm cache, `.venv/bin/osmosis`, fail-closed scratch cwd unless noted; `/usr/bin/time -p`, min of ~10 runs):

| Invocation | Before | After |
| --- | --- | --- |
| `osmosis --version` | 0.08s | 0.04s |
| `osmosis --json --version` (registration, no handler) | 0.07s | 0.04s |
| `osmosis --json dataset list` (P1b) | 0.18s (779 modules, Rich loaded) | 0.14–0.15s (643 modules, Rich gone) |
| `osmosis --json train list` (P1c) | 0.18s min (pydantic loaded) | 0.15s min (642 modules, pydantic gone) |
| `osmosis --json eval list` (P1c) | (same pydantic tax as train list) | 0.14s min |
| `osmosis --json benchmark list` (P1c) | (same pydantic tax as train list) | 0.13s min |

`train list` / `eval list` / `benchmark list` now match `dataset list` startup (~140–150ms). Logged-in `dataset list` wall time is still dominated by TLS and the API round-trip.

## How to Test

- `uv run pytest tests/unit/cli/test_lazy_loading.py`
- `uv run pytest`
- `uv run ruff check . && uv run ruff format --check . && uv run pyright osmosis_ai/`
- `/usr/bin/time -p osmosis --version`
- `/usr/bin/time -p osmosis --json dataset list` (scratch cwd for startup; or a logged-in workspace for the network path)
- `/usr/bin/time -p osmosis --json train list` (scratch cwd; should match dataset list)

## Checklist

- [x] PR title follows `[module] type: description` format
      (labels are derived from it automatically — no need to add them by hand)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included