### PR TITLE
[cli] fix: dev server

### DIFF
--- a/osmosis_ai/platform/cli/dev_server.py
+++ b/osmosis_ai/platform/cli/dev_server.py
@@ -67,11 +67,15 @@ def up(*, ttl_hours: int | None, yes: bool = False) -> OperationResult:
         credentials=ctx.credentials,
         git_identity=ctx.git_identity,
     )
+    api_key = result.get("api_key")
     return OperationResult(
         operation="dev.server.up",
         status="success",
         resource=result,
         message=f"Rollout server provisioning at {result['url']} — it may take a few minutes to become ready; check with 'osmosis dev server list'.",
+        display_next_steps=(
+            [f"api_key: {api_key}"] if isinstance(api_key, str) and api_key else []
+        ),
     )
 
 

--- a/tests/unit/cli/test_dev_server_commands.py
+++ b/tests/unit/cli/test_dev_server_commands.py
@@ -116,6 +116,44 @@ class TestDevServerUp:
         assert "provisioning" in result.message
         assert FAKE_SERVER["url"] in result.message
         assert "osmosis dev server list" in result.message
+        assert result.display_next_steps == []
+
+    def test_up_prints_api_key(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        rollout_dir = tmp_path / "rollouts" / "multiply"
+        rollout_dir.mkdir(parents=True)
+        (rollout_dir / "main.py").write_text("# main", encoding="utf-8")
+
+        monkeypatch.setattr(
+            dev_server_module,
+            "resolve_git_workspace_directory_context",
+            lambda: _fake_ctx(workspace_directory=tmp_path),
+        )
+        monkeypatch.setattr(
+            dev_server_module,
+            "summarize_local_git_state",
+            lambda cwd: _fake_git_state(),
+        )
+        monkeypatch.setattr(
+            dev_server_module,
+            "check_pinned_commit",
+            lambda **kwargs: _fake_pinned_check(),
+        )
+        monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: rollout_dir))
+
+        provisioned = {**FAKE_SERVER, "api_key": "key-from-platform"}
+
+        class FakeClient:
+            def provision_dev_rollout_server(self, **kwargs):
+                return provisioned
+
+        monkeypatch.setattr(api_client_module, "OsmosisClient", FakeClient)
+        monkeypatch.setattr(dev_server_module, "OsmosisClient", FakeClient)
+
+        result = dev_server_module.up(ttl_hours=24, yes=False)
+
+        assert result.display_next_steps == ["api_key: key-from-platform"]
 
     def test_up_no_ttl_passes_none(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path


### PR DESCRIPTION
## What

- Print a non-empty `api_key` from the provision response as a next-step line after `osmosis dev server up`.
- Leave next steps empty when the platform omits the key, matching the existing happy-path fixture.
- Add `test_up_prints_api_key` in `tests/unit/cli/test_dev_server_commands.py`.

## Why

The provision endpoint can return a one-time API key used as a Bearer token against the new rollout server. The CLI already stored that response on `OperationResult.resource` but never showed the key in human-readable output, so `osmosis dev server up` left users with a URL and no credential.

## How to Test

- `uv run pytest tests/unit/cli/test_dev_server_commands.py`
- `uv run ruff check . && uv run ruff format --check .`
- `uv run pyright osmosis_ai/`
- From a rollout folder with `main.py`, run `osmosis dev server up` and confirm a line `api_key: ...` is printed when the platform returns a key.

## Checklist

- [x] PR title follows `[module] type: description` format
      (labels are derived from it automatically — no need to add them by hand)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces the one-time API key from the dev rollout server provision response after `osmosis dev server up` so users can authenticate immediately. Previously the CLI only showed the server URL and hid the key; now it prints "api_key: <value>" in next steps when the platform returns a non-empty key, and leaves next steps empty otherwise.

- Change is scoped to `dev_server.up`; no output change when the platform omits the key.
- Adds `test_up_prints_api_key` and keeps the existing happy-path test asserting empty next steps.

<sup>Written for commit 18869d1b3ae5bf209806b83ea2f5eb8aeec05b10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

