### PR TITLE
[cli] fix: align benchmark catalog and Mini SWE-agent credentials

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -88,7 +88,7 @@ Three rules exist because the platform injects a referenced secret's value as an
 
 - **Env collisions are rejected.** A literal env var with the same name as a referenced secret would be silently overwritten, so submit errors instead. The check is scoped per agent against the effective env (`[env]` merged with that agent's `[agents.env]`), so one agent's secret name may still be another agent's literal env var.
 - **Some model secret names are reserved.** `api_key_secret` cannot be `DAYTONA_API_KEY`, `DAYTONA_API_URL`, `SKYPILOT_SERVICE_ACCOUNT_TOKEN`, or `SKYPILOT_API_SERVER_ENDPOINT` — the runner removes those before model-key aliasing.
-- **Harness credentials travel a separate channel.** `cursor-cli` reads `CURSOR_API_KEY` and must set `harness_api_key_secret` to a record named *exactly* that variable. Mini SWE-agent reuses the model's `api_key_secret` and rejects `harness_api_key_secret`. Neither harness can also set its destination name as a literal env var.
+- **Harness credentials travel a separate channel.** `cursor-cli` reads `CURSOR_API_KEY` and must set `harness_api_key_secret` to a record named *exactly* that variable. Mini SWE-agent rejects `harness_api_key_secret`: for provider and endpoint models, the platform injects the model's `api_key_secret` as `MSWEA_API_KEY`, so that name cannot also be a literal env var; hosted models receive no injected model key and may set `MSWEA_API_KEY` explicitly.
 
 ### SDK vs backend validation
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -30,7 +30,6 @@ task_set = "parity"
 
 [[agents]]                          # required, 1-8 entries
 harness = "mini-swe-agent"
-harness_api_key_secret = "MSWEA_API_KEY"
 
 [agents.model]
 type = "provider"
@@ -59,7 +58,7 @@ LOG_LEVEL = "info"
 |---------|----------|----------------------|
 | `[experiment]` | yes | Only `benchmark`, the benchmark key (`BenchmarkExperimentSection`). |
 | `[tasks]` | no | `categories` and `task_names` are lists of non-blank strings; `task_set` accepts only `"parity"`. Omitting the section selects every task. |
-| `[[agents]]` | yes | An array of tables with 1-8 entries; each has `harness`, `harness_api_key_secret`, `model` (see [Agent models](#agent-models)), and `env` (`BenchmarkAgentSection`). |
+| `[[agents]]` | yes | An array of tables with 1-8 entries; each has `harness`, optional `harness_api_key_secret` (`cursor-cli` only), `model` (see [Agent models](#agent-models)), and `env` (`BenchmarkAgentSection`). |
 | `[execution]` | no | Structure only — known keys are `attempts_per_task`, `max_concurrent_attempts`, `timeout_multiplier`, `max_retries`, `pass_threshold`, `judge_model`, `judge_api_key_secret`; unknown keys rejected, **values forwarded unvalidated**. |
 | `[verifier]` | no | Only `required`, up to 16 secret record names the dataset's verifier reads. Forwarded to the platform as `execution.verifier_secrets`. |
 | `[secrets]` | no | Only `required`, up to 16 names — the only references that may be supplied per run. |
@@ -89,7 +88,7 @@ Three rules exist because the platform injects a referenced secret's value as an
 
 - **Env collisions are rejected.** A literal env var with the same name as a referenced secret would be silently overwritten, so submit errors instead. The check is scoped per agent against the effective env (`[env]` merged with that agent's `[agents.env]`), so one agent's secret name may still be another agent's literal env var.
 - **Some model secret names are reserved.** `api_key_secret` cannot be `DAYTONA_API_KEY`, `DAYTONA_API_URL`, `SKYPILOT_SERVICE_ACCOUNT_TOKEN`, or `SKYPILOT_API_SERVER_ENDPOINT` — the runner removes those before model-key aliasing.
-- **Harness credentials travel a separate channel.** `cursor-cli` reads `CURSOR_API_KEY` and `mini-swe-agent` reads `MSWEA_API_KEY`. A credentialed harness must set `harness_api_key_secret` to a record named *exactly* that variable, and cannot also set that name as a literal env var.
+- **Harness credentials travel a separate channel.** `cursor-cli` reads `CURSOR_API_KEY` and must set `harness_api_key_secret` to a record named *exactly* that variable. Mini SWE-agent reuses the model's `api_key_secret` and rejects `harness_api_key_secret`. Neither harness can also set its destination name as a literal env var.
 
 ### SDK vs backend validation
 

--- a/osmosis_ai/platform/cli/benchmark.py
+++ b/osmosis_ai/platform/cli/benchmark.py
@@ -70,7 +70,6 @@ _BENCHMARK_COLUMNS = [
     ListColumn(key="key", label="Key", no_wrap=True, min_width=20),
     ListColumn(key="last_run", label="Last Run", ratio=3, overflow="fold"),
     ListColumn(key="task_count", label="Tasks", no_wrap=True, ratio=1),
-    ListColumn(key="creator_name", label="Added By", no_wrap=True, ratio=1),
 ]
 
 _SYNC_STATUS_DISPLAY: dict[str, tuple[str, str]] = {
@@ -233,7 +232,6 @@ def list_benchmarks(*, limit: int, all_: bool) -> ListResult:
                 **_benchmark_list_resource(benchmark),
                 "last_run": _last_run_cell(benchmark),
                 "task_count": _list_task_count_display(benchmark),
-                "creator_name": benchmark.creator_name or "–",
             }
             for benchmark in benchmarks
         ],

--- a/osmosis_ai/platform/cli/benchmark_config.py
+++ b/osmosis_ai/platform/cli/benchmark_config.py
@@ -20,6 +20,9 @@ from osmosis_ai.platform.cli.shared_config import (
 _BENCHMARK_CONFIG_LABEL = "benchmark"
 _HARNESS_API_KEY_ENV = {
     "cursor-cli": "CURSOR_API_KEY",
+}
+_HARNESS_INJECTED_ENV = {
+    "cursor-cli": "CURSOR_API_KEY",
     "mini-swe-agent": "MSWEA_API_KEY",
 }
 _RESERVED_MODEL_API_KEY_SECRET_NAMES = frozenset(
@@ -239,28 +242,37 @@ def _validate_secret_references(config: BenchmarkSubmitConfig, path: Path) -> No
                     f"of {path}. The platform injects the secret value under "
                     "that name; remove the env var or rename it."
                 )
-        harness_env_name = _HARNESS_API_KEY_ENV.get(agent.harness or "")
-        if harness_env_name and harness_env_name in effective_env:
-            source = _env_source_label(harness_env_name, index, agent.env)
+        injected_env_name = _HARNESS_INJECTED_ENV.get(agent.harness or "")
+        required_env_name = _HARNESS_API_KEY_ENV.get(agent.harness or "")
+        if injected_env_name and injected_env_name in effective_env:
+            source = _env_source_label(injected_env_name, index, agent.env)
             raise CLIError(
-                f"'{harness_env_name}' appears in {source} but is managed by "
-                f"agent {index}'s {agent.harness} harness API key secret in "
-                f"{path}. Remove the env var and set harness_api_key_secret "
-                "to a Platform secret record name."
+                f"'{injected_env_name}' appears in {source} but is managed by "
+                f"agent {index}'s {agent.harness} harness in {path}. "
+                "Remove the env var."
             )
-        if harness_env_name and agent.harness_api_key_secret is None:
+        if required_env_name and agent.harness_api_key_secret is None:
             raise CLIError(
                 f"Agent {index}'s {agent.harness} harness requires "
                 f"harness_api_key_secret in {path}. Set it to the name of a "
-                f"Platform secret record containing {harness_env_name}."
+                f"Platform secret record containing {required_env_name}."
             )
-        if harness_env_name and agent.harness_api_key_secret != harness_env_name:
+        if required_env_name and agent.harness_api_key_secret != required_env_name:
             raise CLIError(
                 f"Agent {index}'s harness_api_key_secret "
                 f"'{agent.harness_api_key_secret}' in {path} does not match "
                 f"the variable the {agent.harness} harness reads. Store the "
                 f"credential in a Platform secret record named exactly "
-                f"{harness_env_name} and reference that name."
+                f"{required_env_name} and reference that name."
+            )
+        if not required_env_name and agent.harness_api_key_secret is not None:
+            subject = (
+                f"Agent {index}'s {agent.harness} harness"
+                if agent.harness
+                else f"Agent {index}'s official scaffold"
+            )
+            raise CLIError(
+                f"{subject} does not use harness_api_key_secret in {path}. Remove it."
             )
 
 

--- a/osmosis_ai/platform/cli/benchmark_config.py
+++ b/osmosis_ai/platform/cli/benchmark_config.py
@@ -21,10 +21,10 @@ _BENCHMARK_CONFIG_LABEL = "benchmark"
 _HARNESS_API_KEY_ENV = {
     "cursor-cli": "CURSOR_API_KEY",
 }
-_HARNESS_INJECTED_ENV = {
-    "cursor-cli": "CURSOR_API_KEY",
-    "mini-swe-agent": "MSWEA_API_KEY",
-}
+# mini-swe-agent takes no harness secret: the platform injects the agent's
+# model key as MSWEA_API_KEY for provider/endpoint models. Hosted models get no
+# injected model key, so they may set that env var explicitly.
+_MINI_SWE_AGENT_KEY_ENV = "MSWEA_API_KEY"
 _RESERVED_MODEL_API_KEY_SECRET_NAMES = frozenset(
     {
         "DAYTONA_API_KEY",
@@ -242,12 +242,11 @@ def _validate_secret_references(config: BenchmarkSubmitConfig, path: Path) -> No
                     f"of {path}. The platform injects the secret value under "
                     "that name; remove the env var or rename it."
                 )
-        injected_env_name = _HARNESS_INJECTED_ENV.get(agent.harness or "")
         required_env_name = _HARNESS_API_KEY_ENV.get(agent.harness or "")
-        if injected_env_name and injected_env_name in effective_env:
-            source = _env_source_label(injected_env_name, index, agent.env)
+        if required_env_name and required_env_name in effective_env:
+            source = _env_source_label(required_env_name, index, agent.env)
             raise CLIError(
-                f"'{injected_env_name}' appears in {source} but is managed by "
+                f"'{required_env_name}' appears in {source} but is managed by "
                 f"agent {index}'s {agent.harness} harness in {path}. "
                 "Remove the env var."
             )
@@ -273,6 +272,17 @@ def _validate_secret_references(config: BenchmarkSubmitConfig, path: Path) -> No
             )
             raise CLIError(
                 f"{subject} does not use harness_api_key_secret in {path}. Remove it."
+            )
+        if (
+            agent.harness == "mini-swe-agent"
+            and not isinstance(model, BenchmarkHostedModel)
+            and _MINI_SWE_AGENT_KEY_ENV in effective_env
+        ):
+            source = _env_source_label(_MINI_SWE_AGENT_KEY_ENV, index, agent.env)
+            raise CLIError(
+                f"'{_MINI_SWE_AGENT_KEY_ENV}' appears in {source} but the "
+                f"platform injects agent {index}'s model key under that name "
+                f"for the mini-swe-agent harness in {path}. Remove the env var."
             )
 
 

--- a/tests/unit/platform/cli/test_benchmark_catalog.py
+++ b/tests/unit/platform/cli/test_benchmark_catalog.py
@@ -103,7 +103,6 @@ def test_list_benchmarks_returns_catalog_and_git_context(
     ]
     assert result.display_items[0]["key"] == "hle"
     assert result.display_items[0]["task_count"] == "2,500"
-    assert result.display_items[0]["creator_name"] == "Brian"
     last_run = result.display_items[0]["last_run"]
     assert "Finished" in last_run
     assert "ago" in last_run
@@ -117,7 +116,6 @@ def test_list_benchmarks_returns_catalog_and_git_context(
         "key",
         "last_run",
         "task_count",
-        "creator_name",
     ]
     assert result.columns[1].no_wrap is True
     assert result.columns[1].min_width == 20

--- a/tests/unit/platform/cli/test_benchmark_config.py
+++ b/tests/unit/platform/cli/test_benchmark_config.py
@@ -611,7 +611,6 @@ api_key_secret = "OPENAI_API_KEY"
     "harness, destination_env",
     [
         ("cursor-cli", "CURSOR_API_KEY"),
-        ("mini-swe-agent", "MSWEA_API_KEY"),
     ],
 )
 def test_load_benchmark_submit_config_rejects_harness_destination_env_collision(
@@ -619,11 +618,6 @@ def test_load_benchmark_submit_config_rejects_harness_destination_env_collision(
     harness: str,
     destination_env: str,
 ) -> None:
-    secret_line = (
-        f'harness_api_key_secret = "{destination_env}"'
-        if harness == "cursor-cli"
-        else ""
-    )
     path = _write_config(
         tmp_path / "benchmark.toml",
         f"""
@@ -632,7 +626,7 @@ benchmark = "DeepSWE"
 
 [[agents]]
 harness = "{harness}"
-{secret_line}
+harness_api_key_secret = "{destination_env}"
 
 [agents.model]
 type = "hosted"
@@ -687,19 +681,82 @@ benchmark = "DeepSWE"
 harness = "mini-swe-agent"
 
 [agents.model]
-type = "hosted"
-base_model = "Qwen/Qwen3-8B"
-lora_model_name = "deep-swe-agent"
+type = "provider"
+model = "openai/gpt-5"
+api_key_secret = "OPENAI_API_KEY"
 """,
     )
 
     config = load_benchmark_submit_config(path)
 
-    assert config.required_secrets == []
+    assert config.required_secrets == ["OPENAI_API_KEY"]
     assert config.agents[0].harness_api_key_secret is None
 
 
+@pytest.mark.parametrize(
+    "model_config",
+    [
+        'type = "provider"\nmodel = "openai/gpt-5"\napi_key_secret = "OPENAI_API_KEY"',
+        'type = "endpoint"\nbase_url = "https://example.com/v1"\nmodel = "custom"\napi_key_secret = "CUSTOM_API_KEY"',
+        'type = "hosted"\nbase_model = "Qwen/Qwen3-8B"\nlora_model_name = "deep-swe-agent"',
+    ],
+)
 def test_load_benchmark_submit_config_rejects_mini_swe_harness_secret(
+    tmp_path: Path,
+    model_config: str,
+) -> None:
+    path = _write_config(
+        tmp_path / "benchmark.toml",
+        f"""
+[experiment]
+benchmark = "DeepSWE"
+
+[[agents]]
+harness = "mini-swe-agent"
+harness_api_key_secret = "MSWEA_API_KEY"
+
+[agents.model]
+{model_config}
+""",
+    )
+
+    with pytest.raises(CLIError, match=r"does not use harness_api_key_secret"):
+        load_benchmark_submit_config(path)
+
+
+@pytest.mark.parametrize(
+    "model_config",
+    [
+        'type = "provider"\nmodel = "openai/gpt-5"\napi_key_secret = "OPENAI_API_KEY"',
+        'type = "endpoint"\nbase_url = "https://example.com/v1"\nmodel = "custom"\napi_key_secret = "CUSTOM_API_KEY"',
+    ],
+)
+def test_load_benchmark_submit_config_rejects_mini_swe_key_env_collision(
+    tmp_path: Path,
+    model_config: str,
+) -> None:
+    path = _write_config(
+        tmp_path / "benchmark.toml",
+        f"""
+[experiment]
+benchmark = "DeepSWE"
+
+[[agents]]
+harness = "mini-swe-agent"
+
+[agents.model]
+{model_config}
+
+[agents.env]
+MSWEA_API_KEY = "literal-for-the-agent"
+""",
+    )
+
+    with pytest.raises(CLIError, match=r"MSWEA_API_KEY"):
+        load_benchmark_submit_config(path)
+
+
+def test_load_benchmark_submit_config_allows_mini_swe_key_env_for_hosted(
     tmp_path: Path,
 ) -> None:
     path = _write_config(
@@ -710,17 +767,20 @@ benchmark = "DeepSWE"
 
 [[agents]]
 harness = "mini-swe-agent"
-harness_api_key_secret = "MSWEA_API_KEY"
 
 [agents.model]
-type = "provider"
-model = "openai/gpt-5"
-api_key_secret = "OPENAI_API_KEY"
+type = "hosted"
+base_model = "Qwen/Qwen3-8B"
+lora_model_name = "deep-swe-agent"
+
+[agents.env]
+MSWEA_API_KEY = "literal-for-the-agent"
 """,
     )
 
-    with pytest.raises(CLIError, match=r"does not use harness_api_key_secret"):
-        load_benchmark_submit_config(path)
+    config = load_benchmark_submit_config(path)
+
+    assert config.agents[0].env["MSWEA_API_KEY"] == "literal-for-the-agent"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/platform/cli/test_benchmark_config.py
+++ b/tests/unit/platform/cli/test_benchmark_config.py
@@ -545,7 +545,6 @@ api_key_secret = "OPENAI_API_KEY"
     "harness, destination_env",
     [
         ("cursor-cli", "CURSOR_API_KEY"),
-        ("mini-swe-agent", "MSWEA_API_KEY"),
     ],
 )
 def test_load_benchmark_submit_config_accepts_pinned_harness_secret_name(
@@ -579,7 +578,6 @@ api_key_secret = "OPENAI_API_KEY"
     "harness, destination_env",
     [
         ("cursor-cli", "CURSOR_API_KEY"),
-        ("mini-swe-agent", "MSWEA_API_KEY"),
     ],
 )
 def test_load_benchmark_submit_config_rejects_unpinned_harness_secret_name(
@@ -621,6 +619,11 @@ def test_load_benchmark_submit_config_rejects_harness_destination_env_collision(
     harness: str,
     destination_env: str,
 ) -> None:
+    secret_line = (
+        f'harness_api_key_secret = "{destination_env}"'
+        if harness == "cursor-cli"
+        else ""
+    )
     path = _write_config(
         tmp_path / "benchmark.toml",
         f"""
@@ -629,7 +632,7 @@ benchmark = "DeepSWE"
 
 [[agents]]
 harness = "{harness}"
-harness_api_key_secret = "{destination_env}"
+{secret_line}
 
 [agents.model]
 type = "hosted"
@@ -671,7 +674,7 @@ CURSOR_API_KEY = "literal-for-the-agent"
         load_benchmark_submit_config(path)
 
 
-def test_load_benchmark_submit_config_requires_known_harness_secret(
+def test_load_benchmark_submit_config_accepts_mini_swe_without_harness_secret(
     tmp_path: Path,
 ) -> None:
     path = _write_config(
@@ -690,7 +693,33 @@ lora_model_name = "deep-swe-agent"
 """,
     )
 
-    with pytest.raises(CLIError, match=r"requires harness_api_key_secret"):
+    config = load_benchmark_submit_config(path)
+
+    assert config.required_secrets == []
+    assert config.agents[0].harness_api_key_secret is None
+
+
+def test_load_benchmark_submit_config_rejects_mini_swe_harness_secret(
+    tmp_path: Path,
+) -> None:
+    path = _write_config(
+        tmp_path / "benchmark.toml",
+        """
+[experiment]
+benchmark = "DeepSWE"
+
+[[agents]]
+harness = "mini-swe-agent"
+harness_api_key_secret = "MSWEA_API_KEY"
+
+[agents.model]
+type = "provider"
+model = "openai/gpt-5"
+api_key_secret = "OPENAI_API_KEY"
+""",
+    )
+
+    with pytest.raises(CLIError, match=r"does not use harness_api_key_secret"):
         load_benchmark_submit_config(path)
 
 


### PR DESCRIPTION
## What

- Remove the Added By column from the human-readable benchmark catalog while preserving `creator_name` in structured output.
- Require `harness_api_key_secret` only for Cursor CLI and reject it for Mini SWE-agent across provider, endpoint, and hosted models.
- For Mini SWE-agent, reject a literal `MSWEA_API_KEY` when provider or endpoint model credentials are injected under that name, while allowing it for hosted models.
- Update benchmark documentation and unit tests.

## Why

Align the CLI catalog and credential validation with the merged Platform behavior in osmosis-monolith #1002.

## Compatibility

The Platform support is merged, but the released CLI 0.3.0 still cannot submit Mini SWE-agent benchmark runs with this credential contract. An SDK/CLI release containing this PR is required.

## How to Test

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright osmosis_ai/`
- `uv run pytest` (2350 passed, 1 skipped)

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] Ruff check and format pass
- [x] Pyright passes
- [x] Full pytest passes
- [x] Public behavior is documented
- [x] No secrets or credentials included