### PR TITLE
[1/3][BREAKING][rollout][server] feat: add local evaluation primitives

### DIFF
--- a/.github/scripts/verify-wheel-install.py
+++ b/.github/scripts/verify-wheel-install.py
@@ -69,6 +69,7 @@ EXTRA_REQUIREMENTS: dict[str, set[str]] = {
     },
     "rubric": {"aiohttp", "click", "litellm", "orjson", "tqdm"},
     "parquet": {"pyarrow"},
+    "eval-run": {"aiohttp", "click", "fastapi", "uvicorn"},
     "full": {"osmosis-ai"},
 }
 
@@ -194,6 +195,7 @@ BARE_IMPORTABLE_MODULES = (
     "osmosis_ai.rollout.types.protocol",
     "osmosis_ai.rollout.utils.errors",
     "osmosis_ai.rollout.utils.ttl_cache",
+    "osmosis_ai.rollout.controller.store",
 )
 
 # Leaf modules that must stay unimportable until their extra is installed.
@@ -206,6 +208,9 @@ EXTRA_ONLY_MODULES = (
     "osmosis_ai.rollout.integrations.agents.openai_agents",
     "osmosis_ai.rollout.integrations.agents.strands",
     "osmosis_ai.rollout.server.app",
+    "osmosis_ai.rollout.controller.listener",
+    "osmosis_ai.rollout.controller.proxy_client",
+    "osmosis_ai.rollout.http_driver",
 )
 
 
@@ -218,6 +223,12 @@ def _assert_extra_only_modules_absent() -> None:
         except ModuleNotFoundError as error:
             if module_name == "osmosis_ai.packaging":
                 assert 'pip install "osmosis-ai[harbor]"' in str(error), str(error)
+            elif module_name in {
+                "osmosis_ai.rollout.controller.listener",
+                "osmosis_ai.rollout.controller.proxy_client",
+                "osmosis_ai.rollout.http_driver",
+            }:
+                assert 'pip install "osmosis-ai[eval-run]"' in str(error), str(error)
             continue
         raise AssertionError(f"{module_name} imported without its extra")
 
@@ -322,6 +333,17 @@ def _smoke_parquet() -> None:
     assert callable(dataset.validate)
 
 
+def _smoke_eval_run() -> None:
+    _assert_public_exports(
+        "osmosis_ai.rollout.controller",
+        ("CallbackStore", "CallbackListener", "EvalProxyClient"),
+    )
+    _assert_public_exports(
+        "osmosis_ai.rollout.http_driver",
+        ("HttpRolloutDriver",),
+    )
+
+
 SCENARIO_SMOKE: dict[str, Callable[[], None]] = {
     "bare": _smoke_bare,
     "server": _smoke_server,
@@ -330,6 +352,7 @@ SCENARIO_SMOKE: dict[str, Callable[[], None]] = {
     "harbor": _smoke_harbor,
     "rubric": _smoke_rubric,
     "parquet": _smoke_parquet,
+    "eval-run": _smoke_eval_run,
 }
 
 SCENARIO_PRESENT: dict[str, set[str]] = {
@@ -340,6 +363,7 @@ SCENARIO_PRESENT: dict[str, set[str]] = {
     "harbor": {"dockerfile-parse", "harbor", "platformdirs", "toml", "uv"},
     "rubric": {"litellm", "orjson", "tqdm"},
     "parquet": {"pyarrow"},
+    "eval-run": {"aiohttp", "fastapi", "uvicorn"},
     "full": {
         "fastapi",
         "dockerfile-parse",
@@ -433,6 +457,19 @@ SCENARIO_ABSENT: dict[str, set[str]] = {
         "tqdm",
         "uv",
         "uvicorn",
+    },
+    "eval-run": {
+        "dockerfile-parse",
+        "harbor",
+        "litellm",
+        "openai-agents",
+        "orjson",
+        "platformdirs",
+        "pyarrow",
+        "strands-agents",
+        "toml",
+        "tqdm",
+        "uv",
     },
     "full": set(),
 }

--- a/.github/scripts/verify-wheel-install.py
+++ b/.github/scripts/verify-wheel-install.py
@@ -69,7 +69,7 @@ EXTRA_REQUIREMENTS: dict[str, set[str]] = {
     },
     "rubric": {"aiohttp", "click", "litellm", "orjson", "tqdm"},
     "parquet": {"pyarrow"},
-    "eval-run": {"aiohttp", "click", "fastapi", "uvicorn"},
+    "eval-run": {"click", "fastapi", "uvicorn"},
     "full": {"osmosis-ai"},
 }
 
@@ -196,6 +196,8 @@ BARE_IMPORTABLE_MODULES = (
     "osmosis_ai.rollout.utils.errors",
     "osmosis_ai.rollout.utils.ttl_cache",
     "osmosis_ai.rollout.controller.store",
+    "osmosis_ai.rollout.controller.proxy_client",
+    "osmosis_ai.rollout.http_driver",
 )
 
 # Leaf modules that must stay unimportable until their extra is installed.
@@ -209,8 +211,6 @@ EXTRA_ONLY_MODULES = (
     "osmosis_ai.rollout.integrations.agents.strands",
     "osmosis_ai.rollout.server.app",
     "osmosis_ai.rollout.controller.listener",
-    "osmosis_ai.rollout.controller.proxy_client",
-    "osmosis_ai.rollout.http_driver",
 )
 
 
@@ -223,11 +223,7 @@ def _assert_extra_only_modules_absent() -> None:
         except ModuleNotFoundError as error:
             if module_name == "osmosis_ai.packaging":
                 assert 'pip install "osmosis-ai[harbor]"' in str(error), str(error)
-            elif module_name in {
-                "osmosis_ai.rollout.controller.listener",
-                "osmosis_ai.rollout.controller.proxy_client",
-                "osmosis_ai.rollout.http_driver",
-            }:
+            elif module_name == "osmosis_ai.rollout.controller.listener":
                 assert 'pip install "osmosis-ai[eval-run]"' in str(error), str(error)
             continue
         raise AssertionError(f"{module_name} imported without its extra")
@@ -363,7 +359,7 @@ SCENARIO_PRESENT: dict[str, set[str]] = {
     "harbor": {"dockerfile-parse", "harbor", "platformdirs", "toml", "uv"},
     "rubric": {"litellm", "orjson", "tqdm"},
     "parquet": {"pyarrow"},
-    "eval-run": {"aiohttp", "fastapi", "uvicorn"},
+    "eval-run": {"fastapi", "uvicorn"},
     "full": {
         "fastapi",
         "dockerfile-parse",

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -178,6 +178,8 @@ jobs:
             extra: "[rubric]"
           - scenario: parquet
             extra: "[parquet]"
+          - scenario: eval-run
+            extra: "[eval-run]"
           - scenario: full
             extra: "[full]"
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file records changes to `osmosis-ai`. For earlier versions, see [GitHub Rel
 
 ## Unreleased
 
+### Breaking Changes
+
+- `RolloutDriver.run` now takes a single `RolloutRunRequest` argument; update custom drivers and callers to pass the request object ([#307](https://github.com/Osmosis-AI/osmosis-sdk-python/pull/307)).
+
 ### Changed
 
 - Standardized the CLI machine contract: `--json` errors now contain `{code, message, details}` without `request_id`, command paths come from the live command registry, authentication/subscription/billing failures use dedicated codes, and non-finite values can no longer produce invalid JSON ([#304](https://github.com/Osmosis-AI/osmosis-sdk-python/pull/304)).

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ The package (`osmosis_ai/`) is organized into top-level domains. See [architectu
 | Eval helpers | [../osmosis_ai/eval/](../osmosis_ai/eval/) | Rubric (LLM-as-judge) | `from osmosis_ai.eval.rubric import evaluate_rubric` |
 | Workspace templates | [../osmosis_ai/templates/](../osmosis_ai/templates/) | `osmosis template` recipe catalog + source resolution | (internal) |
 
-The single `osmosis-ai` distribution always includes the CLI and framework-neutral rollout core. Install extras only for the feature you use: `server`, `strands`, `openai-agents`, `harbor`, `rubric`, `parquet`, or `full`. The Harbor extra installs plain Harbor for an externally provided SkyPilot runtime; Daytona is retired, and Harbor's `skypilot` extra is intentionally unsupported.
+The single `osmosis-ai` distribution always includes the CLI and framework-neutral rollout core. Install extras only for the feature you use: `server`, `strands`, `openai-agents`, `harbor`, `rubric`, `parquet`, `eval-run`, or `full`. The Harbor extra installs plain Harbor for an externally provided SkyPilot runtime; Daytona is retired, and Harbor's `skypilot` extra is intentionally unsupported.
 
 ## Pages
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,8 +21,8 @@ osmosis_ai/
 │   ├── grader.py          # Grader ABC
 │   ├── context.py         # RolloutContext / AgentWorkflowContext / GraderContext
 │   ├── driver.py          # RolloutDriver / RolloutRunRequest — eval-facing execution contract
-│   ├── http_driver.py     # optional concrete HTTP driver (`[eval-run]`)
-│   ├── controller/        # callback store (core); listener + eval-proxy client (`[eval-run]`)
+│   ├── http_driver.py     # concrete HTTP driver over the callback protocol
+│   ├── controller/        # callback store + eval-proxy client (core); localhost listener (`[eval-run]`)
 │   ├── server/            # optional generic FastAPI server (`[server]`) + ControllerAuth
 │   ├── backend/           # ExecutionBackend ABC + Local / optional Harbor backend
 │   ├── container/         # in-container agent + grader runner and its file contract
@@ -67,7 +67,7 @@ from osmosis_ai.rollout.controller import (
 from osmosis_ai.rollout.http_driver import HttpRolloutDriver
 ```
 
-`osmosis_ai.rollout` is **not** re-exported at the package top level — import it directly. Its public surface is framework-neutral core only; it does not export the server or Strands integration. `server`, `harbor`, `strands`, `openai-agents`, and `eval-run` each require their matching installation extra. The generic server has no Harbor dependency. `CallbackStore` is in-process and does not require `[eval-run]`; the localhost listener, eval-proxy client, and `HttpRolloutDriver` do.
+`osmosis_ai.rollout` is **not** re-exported at the package top level — import it directly. Its public surface is framework-neutral core only; it does not export the server or Strands integration. `server`, `harbor`, `strands`, `openai-agents`, and `eval-run` each require their matching installation extra. The generic server has no Harbor dependency. `CallbackStore`, `EvalProxyClient`, and `HttpRolloutDriver` only need the base install; `[eval-run]` covers the localhost callback listener that a local eval run must run to receive callbacks.
 
 ## Lazy loading
 
@@ -110,7 +110,7 @@ The controller delivers results asynchronously via the two callback URLs, so it 
 
 ### Eval path
 
-The eval-facing contract is `RolloutDriver` / `RolloutRunRequest` / `RolloutOutcome` in [../osmosis_ai/rollout/driver.py](../osmosis_ai/rollout/driver.py). The optional HTTP implementation is [../osmosis_ai/rollout/http_driver.py](../osmosis_ai/rollout/http_driver.py), with a generic callback store and localhost listener under [../osmosis_ai/rollout/controller/](../osmosis_ai/rollout/controller/). The store exposes separate `wait_completion` and `wait_terminal` rendezvous so callers can await workflow completion separately from the terminal grader result. Eval supplies data + an LLM endpoint and consumes trace + reward, without caring whether execution was in-process or over HTTP.
+The eval-facing contract is `RolloutDriver` / `RolloutRunRequest` / `RolloutOutcome` in [../osmosis_ai/rollout/driver.py](../osmosis_ai/rollout/driver.py). The optional HTTP implementation is [../osmosis_ai/rollout/http_driver.py](../osmosis_ai/rollout/http_driver.py), with a generic callback store and localhost listener under [../osmosis_ai/rollout/controller/](../osmosis_ai/rollout/controller/). The store exposes a single `wait_terminal` rendezvous; a completion callback is recorded on the live session for duplicate detection but is not awaited separately. Eval supplies data + an LLM endpoint and consumes trace + reward, without caring whether execution was in-process or over HTTP.
 
 ## Backend validation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,9 @@ osmosis_ai/
 │   ├── agent_workflow.py  # AgentWorkflow ABC
 │   ├── grader.py          # Grader ABC
 │   ├── context.py         # RolloutContext / AgentWorkflowContext / GraderContext
-│   ├── driver.py          # RolloutDriver — eval-facing execution contract
+│   ├── driver.py          # RolloutDriver / RolloutRunRequest — eval-facing execution contract
+│   ├── http_driver.py     # optional concrete HTTP driver (`[eval-run]`)
+│   ├── controller/        # callback store (core); listener + eval-proxy client (`[eval-run]`)
 │   ├── server/            # optional generic FastAPI server (`[server]`) + ControllerAuth
 │   ├── backend/           # ExecutionBackend ABC + Local / optional Harbor backend
 │   ├── container/         # in-container agent + grader runner and its file contract
@@ -57,9 +59,15 @@ from osmosis_ai.rollout.server import create_rollout_server
 from osmosis_ai.rollout.backend.harbor import HarborBackend
 from osmosis_ai.rollout.integrations.agents.strands import OsmosisStrandsAgent
 from osmosis_ai.rollout.integrations.agents.openai_agents import OsmosisAgent
+from osmosis_ai.rollout.controller import (
+    CallbackStore,
+    CallbackListener,
+    EvalProxyClient,
+)
+from osmosis_ai.rollout.http_driver import HttpRolloutDriver
 ```
 
-`osmosis_ai.rollout` is **not** re-exported at the package top level — import it directly. Its public surface is framework-neutral core only; it does not export the server or Strands integration. `server`, `harbor`, `strands`, and `openai-agents` each require their matching installation extra. The generic server has no Harbor dependency.
+`osmosis_ai.rollout` is **not** re-exported at the package top level — import it directly. Its public surface is framework-neutral core only; it does not export the server or Strands integration. `server`, `harbor`, `strands`, `openai-agents`, and `eval-run` each require their matching installation extra. The generic server has no Harbor dependency. `CallbackStore` is in-process and does not require `[eval-run]`; the localhost listener, eval-proxy client, and `HttpRolloutDriver` do.
 
 ## Lazy loading
 
@@ -81,7 +89,7 @@ sequenceDiagram
     participant W as AgentWorkflow.run
     participant G as Grader.grade
     C->>S: POST /rollout (RolloutInitRequest)
-    Note over S: returns RolloutInitResponse immediately (background task)
+    Note over S: schedules the execution task, then returns 202 immediately
     S->>W: backend.execute(ExecutionRequest)
     W->>C: POST chat_completions_url (messages + tools)
     C-->>W: LLM response (tool_calls)
@@ -94,7 +102,7 @@ sequenceDiagram
 Anchors:
 
 - Server + endpoints + callbacks: [../osmosis_ai/rollout/server/app.py](../osmosis_ai/rollout/server/app.py) (`create_rollout_server`, `POST /rollout`, `GET /health`, `_handle_rollout`).
-- Wire types: [../osmosis_ai/rollout/types/protocol.py](../osmosis_ai/rollout/types/protocol.py) (`RolloutInitRequest`, `RolloutCompleteRequest`, `GraderCompleteRequest`, `GraderStatus`).
+- Wire types: [../osmosis_ai/rollout/types/protocol.py](../osmosis_ai/rollout/types/protocol.py) (`RolloutInitRequest`, `RolloutCompleteRequest`, `GraderCompleteRequest`, `GraderStatus`). Callbacks use `controller_api_key`; the optional `llm_api_key` is the chat/proxy bearer. When `llm_api_key` is omitted (`None`) the server falls back to the controller key; an explicit empty string is rejected. `GET /rollout/{id}/status` is backend-authoritative (`LocalBackend` may report `UNKNOWN`).
 - Execution contract: [../osmosis_ai/rollout/backend/base.py](../osmosis_ai/rollout/backend/base.py) — `ExecutionBackend.execute(request, on_workflow_complete, on_grader_complete)`, where the two callbacks are `ResultCallback` parameters (not methods).
 - Sample/result types: [../osmosis_ai/rollout/types/sample.py](../osmosis_ai/rollout/types/sample.py) (`RolloutSample`, `RolloutStatus`, `RolloutErrorCategory`, `ExecutionRequest`, `ExecutionResult`).
 
@@ -102,7 +110,7 @@ The controller delivers results asynchronously via the two callback URLs, so it 
 
 ### Eval path
 
-For local evaluation the same workflow/grader run behind a different driver. The eval-facing contract is `RolloutDriver` / `RolloutOutcome` in [../osmosis_ai/rollout/driver.py](../osmosis_ai/rollout/driver.py): eval supplies data + an LLM endpoint and consumes trace + reward, without caring whether execution was in-process or over HTTP.
+The eval-facing contract is `RolloutDriver` / `RolloutRunRequest` / `RolloutOutcome` in [../osmosis_ai/rollout/driver.py](../osmosis_ai/rollout/driver.py). The optional HTTP implementation is [../osmosis_ai/rollout/http_driver.py](../osmosis_ai/rollout/http_driver.py), with a generic callback store and localhost listener under [../osmosis_ai/rollout/controller/](../osmosis_ai/rollout/controller/). The store exposes separate `wait_completion` and `wait_terminal` rendezvous so callers can await workflow completion separately from the terminal grader result. Eval supplies data + an LLM endpoint and consumes trace + reward, without caring whether execution was in-process or over HTTP.
 
 ## Backend validation
 

--- a/docs/rollout-sdk.md
+++ b/docs/rollout-sdk.md
@@ -26,7 +26,7 @@ Optional features use these canonical modules:
 | `harbor` | `from osmosis_ai.rollout.backend.harbor import HarborBackend, TaskMode` | Harbor execution backend |
 | `strands` | `from osmosis_ai.rollout.integrations.agents.strands import OsmosisStrandsAgent, OsmosisRolloutModel` | Strands integration |
 | `openai-agents` | `from osmosis_ai.rollout.integrations.agents.openai_agents import OsmosisAgent` | OpenAI Agents integration |
-| `eval-run` | `from osmosis_ai.rollout.controller import CallbackStore, CallbackListener, EvalProxyClient` / `from osmosis_ai.rollout.http_driver import HttpRolloutDriver` | Localhost callback listener, eval-proxy session client, and HTTP rollout driver. Install with `pip install "osmosis-ai[eval-run]"`. No LiteLLM. |
+| `eval-run` | `from osmosis_ai.rollout.controller import CallbackListener` | Localhost callback listener. Install with `pip install "osmosis-ai[eval-run]"`. No LiteLLM. `CallbackStore`, `EvalProxyClient`, and `HttpRolloutDriver` ship in the base install, but a local eval run needs the listener to receive callbacks. |
 
 The `Messages` return type is available from `osmosis_ai.rollout.types`.
 

--- a/docs/rollout-sdk.md
+++ b/docs/rollout-sdk.md
@@ -26,6 +26,7 @@ Optional features use these canonical modules:
 | `harbor` | `from osmosis_ai.rollout.backend.harbor import HarborBackend, TaskMode` | Harbor execution backend |
 | `strands` | `from osmosis_ai.rollout.integrations.agents.strands import OsmosisStrandsAgent, OsmosisRolloutModel` | Strands integration |
 | `openai-agents` | `from osmosis_ai.rollout.integrations.agents.openai_agents import OsmosisAgent` | OpenAI Agents integration |
+| `eval-run` | `from osmosis_ai.rollout.controller import CallbackStore, CallbackListener, EvalProxyClient` / `from osmosis_ai.rollout.http_driver import HttpRolloutDriver` | Localhost callback listener, eval-proxy session client, and HTTP rollout driver. Install with `pip install "osmosis-ai[eval-run]"`. No LiteLLM. |
 
 The `Messages` return type is available from `osmosis_ai.rollout.types`.
 
@@ -206,7 +207,7 @@ backend = LocalBackend(
 app = create_rollout_server(backend=backend)  # FastAPI: POST /rollout, GET /health
 ```
 
-- `create_rollout_server` ([server/app.py](../osmosis_ai/rollout/server/app.py)) is provided by the `server` extra. It wires the protocol: it runs the backend in a background task and posts the completion + grader callbacks. It has no Harbor dependency.
+- `create_rollout_server` ([server/app.py](../osmosis_ai/rollout/server/app.py)) is provided by the `server` extra. It wires the protocol: it schedules the backend execution task before the 202 response is sent (so a dropped response cannot lose the rollout) and posts the completion + grader callbacks. Admission is idempotent per `rollout_id`: an identical duplicate request returns 202 without scheduling again (409 on a conflicting body), with completed-rollout digests retained for a bounded 15-minute window. It has no Harbor dependency.
 - `ControllerAuth` ([server/auth.py](../osmosis_ai/rollout/server/auth.py)) supplies the bearer headers for callbacks.
 - `ExecutionBackend` ([backend/base.py](../osmosis_ai/rollout/backend/base.py)) is the ABC; pick one:
   - `LocalBackend` ([backend/local/](../osmosis_ai/rollout/backend/local/)) — runs workflow + grader in-process. Re-exported from `osmosis_ai.rollout`. Used by the scaffold and eval.

--- a/osmosis_ai/_imports.py
+++ b/osmosis_ai/_imports.py
@@ -33,7 +33,7 @@ EXTRA_MODULES: Final[Mapping[str, frozenset[str]]] = {
     ),
     "rubric": frozenset({"aiohttp", "click", "litellm", "orjson", "tqdm"}),
     "parquet": frozenset({"pyarrow"}),
-    "eval-run": frozenset({"aiohttp", "click", "fastapi", "uvicorn"}),
+    "eval-run": frozenset({"click", "fastapi", "uvicorn"}),
 }
 
 

--- a/osmosis_ai/_imports.py
+++ b/osmosis_ai/_imports.py
@@ -33,6 +33,7 @@ EXTRA_MODULES: Final[Mapping[str, frozenset[str]]] = {
     ),
     "rubric": frozenset({"aiohttp", "click", "litellm", "orjson", "tqdm"}),
     "parquet": frozenset({"pyarrow"}),
+    "eval-run": frozenset({"aiohttp", "click", "fastapi", "uvicorn"}),
 }
 
 

--- a/osmosis_ai/rollout/controller/__init__.py
+++ b/osmosis_ai/rollout/controller/__init__.py
@@ -1,6 +1,6 @@
 """Generic rollout callback controller primitives.
 
-Optional FastAPI/aiohttp symbols load on first access and require the
+Optional FastAPI/uvicorn symbols load on first access and require the
 ``eval-run`` extra. ``CallbackStore`` is in-process only and has no extra.
 """
 
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
         EvalProxyClient,
         EvalProxyError,
         EvalProxySession,
-        create_eval_proxy_stub_app,
     )
     from osmosis_ai.rollout.controller.store import (
         CallbackStore,
@@ -64,10 +63,6 @@ _EXPORTS: dict[str, tuple[str, str]] = {
         "osmosis_ai.rollout.controller.listener",
         "create_callback_app",
     ),
-    "create_eval_proxy_stub_app": (
-        "osmosis_ai.rollout.controller.proxy_client",
-        "create_eval_proxy_stub_app",
-    ),
 }
 
 
@@ -101,5 +96,4 @@ __all__ = [
     "TerminalCallbackResult",
     "UnknownRolloutIdError",
     "create_callback_app",
-    "create_eval_proxy_stub_app",
 ]

--- a/osmosis_ai/rollout/controller/__init__.py
+++ b/osmosis_ai/rollout/controller/__init__.py
@@ -1,0 +1,105 @@
+"""Generic rollout callback controller primitives.
+
+Optional FastAPI/aiohttp symbols load on first access and require the
+``eval-run`` extra. ``CallbackStore`` is in-process only and has no extra.
+"""
+
+from typing import TYPE_CHECKING
+
+from osmosis_ai._imports import (
+    public_module_dir,
+    raise_optional_dependency_error,
+    resolve_lazy_export,
+)
+
+if TYPE_CHECKING:
+    from osmosis_ai.rollout.controller.listener import (
+        CallbackListener,
+        create_callback_app,
+    )
+    from osmosis_ai.rollout.controller.proxy_client import (
+        EvalProxyClient,
+        EvalProxyError,
+        EvalProxySession,
+        create_eval_proxy_stub_app,
+    )
+    from osmosis_ai.rollout.controller.store import (
+        CallbackStore,
+        DuplicateRegistrationError,
+        TerminalCallbackResult,
+        UnknownRolloutIdError,
+    )
+
+_EXPORTS: dict[str, tuple[str, str]] = {
+    "CallbackListener": (
+        "osmosis_ai.rollout.controller.listener",
+        "CallbackListener",
+    ),
+    "CallbackStore": ("osmosis_ai.rollout.controller.store", "CallbackStore"),
+    "DuplicateRegistrationError": (
+        "osmosis_ai.rollout.controller.store",
+        "DuplicateRegistrationError",
+    ),
+    "EvalProxyClient": (
+        "osmosis_ai.rollout.controller.proxy_client",
+        "EvalProxyClient",
+    ),
+    "EvalProxyError": (
+        "osmosis_ai.rollout.controller.proxy_client",
+        "EvalProxyError",
+    ),
+    "EvalProxySession": (
+        "osmosis_ai.rollout.controller.proxy_client",
+        "EvalProxySession",
+    ),
+    "TerminalCallbackResult": (
+        "osmosis_ai.rollout.controller.store",
+        "TerminalCallbackResult",
+    ),
+    "UnknownRolloutIdError": (
+        "osmosis_ai.rollout.controller.store",
+        "UnknownRolloutIdError",
+    ),
+    "create_callback_app": (
+        "osmosis_ai.rollout.controller.listener",
+        "create_callback_app",
+    ),
+    "create_eval_proxy_stub_app": (
+        "osmosis_ai.rollout.controller.proxy_client",
+        "create_eval_proxy_stub_app",
+    ),
+}
+
+
+def __getattr__(name: str) -> object:
+    try:
+        return resolve_lazy_export(
+            name,
+            module_name=__name__,
+            namespace=globals(),
+            exports=_EXPORTS,
+        )
+    except ModuleNotFoundError as exc:
+        raise_optional_dependency_error(
+            exc,
+            extra="eval-run",
+            feature="Local evaluation",
+        )
+
+
+def __dir__() -> list[str]:
+    return public_module_dir(globals(), _EXPORTS)
+
+
+__all__ = [
+    "CallbackListener",
+    "CallbackStore",
+    "DuplicateRegistrationError",
+    "EvalProxyClient",
+    "EvalProxyError",
+    "EvalProxySession",
+    "TerminalCallbackResult",
+    "UnknownRolloutIdError",
+    "create_callback_app",
+    "create_eval_proxy_stub_app",
+]

--- a/osmosis_ai/rollout/controller/listener.py
+++ b/osmosis_ai/rollout/controller/listener.py
@@ -1,0 +1,292 @@
+"""Localhost-only callback listener around :class:`CallbackStore`.
+
+No LLM code lives here. The listener authenticates bearer tokens, checks that
+the URL-scoped rollout id matches the body, accepts only terminal callback
+statuses, and returns the store's acknowledgment only after a terminal commit
+hook has finished. Binding is IPv4 loopback only (``localhost`` normalizes to
+``127.0.0.1``); IPv6 is rejected explicitly rather than failing at bind time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import secrets
+import socket
+from contextlib import suppress
+from typing import Any
+from urllib.parse import quote
+
+from osmosis_ai._imports import raise_optional_dependency_error
+
+try:
+    import uvicorn
+    from fastapi import Depends, FastAPI, HTTPException, Request
+except ModuleNotFoundError as _exc:
+    raise_optional_dependency_error(
+        _exc,
+        extra="eval-run",
+        feature="Local evaluation",
+    )
+
+from osmosis_ai.rollout.controller.store import CallbackStore, UnknownRolloutIdError
+from osmosis_ai.rollout.types import (
+    GraderCompleteRequest,
+    GraderStatus,
+    RolloutCompleteRequest,
+    RolloutStatus,
+)
+from osmosis_ai.rollout.utils.identifiers import is_single_path_segment
+
+_BIND_RETRY_DELAY_SEC = 0.05
+_START_POLL_ATTEMPTS = 500
+_START_POLL_INTERVAL_SEC = 0.01
+
+# Only terminal statuses may cross the callback boundary; in-flight states
+# must never be able to win a rollout's terminal result.
+_TERMINAL_COMPLETION_STATUSES = frozenset(
+    {RolloutStatus.SUCCESS, RolloutStatus.FAILURE, RolloutStatus.CANCELLED}
+)
+_TERMINAL_GRADER_STATUSES = frozenset({GraderStatus.SUCCESS, GraderStatus.FAILURE})
+
+
+def _assert_non_empty_auth_token(auth_token: str) -> None:
+    if not auth_token or not auth_token.strip():
+        raise ValueError("callback auth_token must be a non-empty string")
+
+
+def _normalize_loopback_host(host: str) -> str:
+    """Return the IPv4 loopback bind address, rejecting everything else.
+
+    The server binds an AF_INET socket, so IPv6 loopback would fail later
+    with an opaque bind error; reject it here instead.
+    """
+    candidate = host.strip().lower()
+    if candidate == "localhost":
+        return "127.0.0.1"
+    try:
+        parsed = ipaddress.ip_address(candidate)
+    except ValueError:
+        parsed = None
+    if isinstance(parsed, ipaddress.IPv4Address) and parsed.is_loopback:
+        return candidate
+    raise ValueError(
+        "callback listener host must be IPv4 loopback "
+        f"(127.0.0.1 or localhost), got {host!r}"
+    )
+
+
+class LocalhostUvicornServer:
+    """Bind a socket first, then serve. Never pick-free-close-bind."""
+
+    def __init__(
+        self,
+        app: Any,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        bind_retries: int = 5,
+    ) -> None:
+        self._app = app
+        self._host = _normalize_loopback_host(host)
+        self._port = port
+        self._bind_retries = bind_retries
+        self._socket: socket.socket | None = None
+        self._server: uvicorn.Server | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._base_url: str | None = None
+
+    @property
+    def base_url(self) -> str:
+        if self._base_url is None:
+            raise RuntimeError("localhost server has not started")
+        return self._base_url
+
+    async def start(self) -> str:
+        if self._task is not None:
+            return self.base_url
+        sock: socket.socket | None = None
+        try:
+            sock = await self._reserve_socket()
+            self._socket = sock
+            host, port = sock.getsockname()[:2]
+            self._base_url = f"http://{host}:{port}"
+            config = uvicorn.Config(
+                self._app,
+                host=host,
+                port=port,
+                log_level="warning",
+                lifespan="off",
+                ws="none",
+            )
+            server = uvicorn.Server(config)
+            self._server = server
+            self._task = asyncio.create_task(server.serve(sockets=[sock]))
+            for _ in range(_START_POLL_ATTEMPTS):
+                if server.started:
+                    return self._base_url
+                if self._task.done():
+                    await self._task
+                    raise RuntimeError("localhost server exited before becoming ready")
+                await asyncio.sleep(_START_POLL_INTERVAL_SEC)
+            raise RuntimeError("localhost server failed to start")
+        except BaseException:
+            await self._reset(sock)
+            raise
+
+    async def stop(self) -> None:
+        try:
+            if self._server is not None:
+                self._server.should_exit = True
+            if self._task is not None:
+                await self._task
+        finally:
+            await self._reset()
+
+    async def __aenter__(self) -> LocalhostUvicornServer:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        await self.stop()
+
+    async def _reset(self, sock: socket.socket | None = None) -> None:
+        task = self._task
+        server = self._server
+        to_close = self._socket if self._socket is not None else sock
+        self._task = None
+        self._server = None
+        self._socket = None
+        self._base_url = None
+        if server is not None:
+            server.should_exit = True
+        if task is not None:
+            if not task.done():
+                task.cancel()
+            with suppress(asyncio.CancelledError, Exception):
+                await task
+        if to_close is not None:
+            with suppress(OSError):
+                to_close.close()
+
+    async def _reserve_socket(self) -> socket.socket:
+        attempts = 1 if self._port == 0 else max(1, self._bind_retries)
+        last_error: OSError | None = None
+        for attempt in range(attempts):
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.bind((self._host, self._port))
+                return sock
+            except OSError as exc:
+                last_error = exc
+                sock.close()
+                if attempt + 1 < attempts:
+                    await asyncio.sleep(_BIND_RETRY_DELAY_SEC)
+        raise OSError(
+            f"failed to bind localhost server on {self._host}:{self._port}: "
+            f"{last_error}"
+        ) from last_error
+
+
+def create_callback_app(store: CallbackStore, *, auth_token: str) -> FastAPI:
+    """Build the FastAPI app that receives completion and grader callbacks."""
+    _assert_non_empty_auth_token(auth_token)
+    app = FastAPI()
+
+    async def require_auth(request: Request) -> None:
+        header = request.headers.get("Authorization")
+        scheme, _, credentials = (header or "").partition(" ")
+        if scheme.lower() != "bearer" or not secrets.compare_digest(
+            credentials.encode(), auth_token.encode()
+        ):
+            raise HTTPException(status_code=401, detail="Unauthorized")
+
+    def _rollout_id(path_id: str, body_id: str | None) -> str:
+        if not is_single_path_segment(path_id):
+            raise HTTPException(status_code=422, detail="invalid rollout_id")
+        if body_id is not None and body_id != path_id:
+            raise HTTPException(status_code=422, detail="rollout_id mismatch")
+        return path_id
+
+    @app.post(
+        "/v1/rollouts/{rollout_id}/completion",
+        dependencies=[Depends(require_auth)],
+    )
+    async def completion(
+        rollout_id: str, request: RolloutCompleteRequest
+    ) -> dict[str, Any]:
+        _rollout_id(rollout_id, request.rollout_id)
+        if request.status not in _TERMINAL_COMPLETION_STATUSES:
+            raise HTTPException(
+                status_code=422,
+                detail="completion callback status must be terminal",
+            )
+        try:
+            return await store.handle_completion(rollout_id, request)
+        except UnknownRolloutIdError as exc:
+            raise HTTPException(status_code=404, detail="unknown rollout_id") from exc
+
+    @app.post(
+        "/v1/rollouts/{rollout_id}/grader",
+        dependencies=[Depends(require_auth)],
+    )
+    async def grader(rollout_id: str, request: GraderCompleteRequest) -> dict[str, Any]:
+        _rollout_id(rollout_id, request.rollout_id)
+        if request.status not in _TERMINAL_GRADER_STATUSES:
+            raise HTTPException(
+                status_code=422,
+                detail="grader callback status must be terminal",
+            )
+        try:
+            return await store.handle_grader(rollout_id, request)
+        except UnknownRolloutIdError as exc:
+            raise HTTPException(status_code=404, detail="unknown rollout_id") from exc
+
+    return app
+
+
+class CallbackListener:
+    """Owns a reserved localhost socket and serves :func:`create_callback_app`."""
+
+    def __init__(
+        self,
+        store: CallbackStore,
+        *,
+        auth_token: str,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        bind_retries: int = 5,
+    ) -> None:
+        _assert_non_empty_auth_token(auth_token)
+        self._server = LocalhostUvicornServer(
+            create_callback_app(store, auth_token=auth_token),
+            host=host,
+            port=port,
+            bind_retries=bind_retries,
+        )
+
+    @property
+    def base_url(self) -> str:
+        return self._server.base_url
+
+    def completion_url(self, rollout_id: str) -> str:
+        encoded = quote(rollout_id, safe="")
+        return f"{self.base_url}/v1/rollouts/{encoded}/completion"
+
+    def grader_url(self, rollout_id: str) -> str:
+        encoded = quote(rollout_id, safe="")
+        return f"{self.base_url}/v1/rollouts/{encoded}/grader"
+
+    async def start(self) -> str:
+        return await self._server.start()
+
+    async def stop(self) -> None:
+        await self._server.stop()
+
+    async def __aenter__(self) -> CallbackListener:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        await self.stop()

--- a/osmosis_ai/rollout/controller/proxy_client.py
+++ b/osmosis_ai/rollout/controller/proxy_client.py
@@ -93,8 +93,19 @@ class EvalProxySession:
     run_index: int | None = None
 
 
+def _require_single_segment_id(rollout_id: str) -> str:
+    # quote() cannot make "." or ".." safe: dots are unreserved characters,
+    # and HTTP stacks normalize dot segments before the request leaves the
+    # client, silently retargeting management calls outside the session path.
+    if not is_single_path_segment(rollout_id):
+        raise EvalProxyError(
+            f"rollout_id must be a single path segment, got {rollout_id!r}"
+        )
+    return rollout_id
+
+
 def _session_api_base(rollout_id: str) -> str:
-    return f"/v1/eval-sessions/{quote(rollout_id, safe='')}"
+    return f"/v1/eval-sessions/{quote(_require_single_segment_id(rollout_id), safe='')}"
 
 
 def _consume_best_effort_close(task: asyncio.Task[None]) -> None:
@@ -130,6 +141,7 @@ class EvalProxyClient:
         row_index: int | None = None,
         run_index: int | None = None,
     ) -> EvalProxySession:
+        _require_single_segment_id(rollout_id)
         payload: dict[str, Any] = {
             "rollout_id": rollout_id,
             "model_path": model_path,
@@ -242,10 +254,10 @@ class EvalProxyClient:
         return await self._request_json("GET", self._usage_path(rollout_id))
 
     def _close_path(self, rollout_id: str) -> str:
-        return f"/v1/eval-sessions/{quote(rollout_id, safe='')}"
+        return _session_api_base(rollout_id)
 
     def _usage_path(self, rollout_id: str) -> str:
-        return f"/v1/eval-sessions/{quote(rollout_id, safe='')}/usage"
+        return f"{_session_api_base(rollout_id)}/usage"
 
     async def _ensure_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:

--- a/osmosis_ai/rollout/controller/proxy_client.py
+++ b/osmosis_ai/rollout/controller/proxy_client.py
@@ -1,6 +1,6 @@
 """Eval-proxy session client and local OpenAI-compatible contract stub.
 
-Frozen production contract (Phase 0):
+Frozen production contract:
 - integration model ``openai/osmosis-rollout``
 - wire body model ``osmosis-rollout``
 - ``POST /v1/eval-sessions`` bound to ``rollout_id`` + ``model_path``

--- a/osmosis_ai/rollout/controller/proxy_client.py
+++ b/osmosis_ai/rollout/controller/proxy_client.py
@@ -1,0 +1,440 @@
+"""Eval-proxy session client and local OpenAI-compatible contract stub.
+
+Frozen production contract (Phase 0):
+- integration model ``openai/osmosis-rollout``
+- wire body model ``osmosis-rollout``
+- ``POST /v1/eval-sessions`` bound to ``rollout_id`` + ``model_path``
+  (optional ``row_index`` / ``run_index``)
+- clients must not select the synthetic model
+- session ``api_base`` is ``/v1/eval-sessions/<rollout-id>`` and must not
+  include ``/chat/completions``
+- chat endpoint ``POST /v1/eval-sessions/<rollout-id>/chat/completions``
+- ``stream=true`` is required; ``stream_options`` may be absent; if
+  ``include_usage`` is present it must be ``true``
+- SSE: content chunk, ``finish_reason="stop"`` chunk, ``choices=[]``
+  usage-only chunk, then ``[DONE]``
+
+Close and usage HTTP paths are **not** frozen. ``close_session`` and
+``get_usage`` are public logical methods; path construction stays private.
+Management-plane create/usage/close uses the platform bearer token. Chat
+uses the session bearer token.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import secrets
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import quote
+
+from osmosis_ai._imports import raise_optional_dependency_error
+
+try:
+    import aiohttp
+except ModuleNotFoundError as _exc:
+    raise_optional_dependency_error(
+        _exc,
+        extra="eval-run",
+        feature="Local evaluation",
+    )
+
+try:
+    from fastapi import FastAPI, Header, HTTPException, Request
+    from fastapi.responses import StreamingResponse
+except ModuleNotFoundError as _exc:
+    raise_optional_dependency_error(
+        _exc,
+        extra="eval-run",
+        feature="Local evaluation",
+    )
+
+from osmosis_ai.rollout.utils.identifiers import is_single_path_segment
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+EVAL_PROXY_INTEGRATION_MODEL = "openai/osmosis-rollout"
+EVAL_PROXY_WIRE_MODEL = "osmosis-rollout"
+
+_CREATE_FORBIDDEN_FIELDS = frozenset(
+    {"model", "integration_model", "wire_model", "synthetic_model"}
+)
+_DEFAULT_STUB_PLATFORM_TOKEN = "platform-token"
+
+
+class EvalProxyError(Exception):
+    """HTTP or contract failure talking to the eval-proxy.
+
+    This is not an error-taxonomy type. Platform auth/model/budget codes are
+    not frozen and must not be inferred here.
+    """
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+@dataclass(frozen=True)
+class EvalProxySession:
+    """Session-scoped eval-proxy credentials for one rollout."""
+
+    rollout_id: str
+    model_path: str
+    api_base: str
+    api_base_url: str
+    # Bearer credential; excluded from repr so sessions can be logged safely.
+    token: str = field(repr=False)
+    integration_model: str = EVAL_PROXY_INTEGRATION_MODEL
+    wire_model: str = EVAL_PROXY_WIRE_MODEL
+    row_index: int | None = None
+    run_index: int | None = None
+
+
+def _session_api_base(rollout_id: str) -> str:
+    return f"/v1/eval-sessions/{quote(rollout_id, safe='')}"
+
+
+def _consume_best_effort_close(task: asyncio.Task[None]) -> None:
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.debug("best-effort eval-proxy session close failed", exc_info=exc)
+
+
+class EvalProxyClient:
+    """HTTP client for eval-proxy session create (and provisional close/usage)."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        auth_token: str,
+        session: aiohttp.ClientSession | None = None,
+    ) -> None:
+        if not auth_token or not auth_token.strip():
+            raise ValueError("auth_token (platform management token) must be non-empty")
+        self._base_url = base_url.rstrip("/")
+        self._auth_token = auth_token
+        self._session = session
+        self._owns_session = session is None
+
+    async def create_session(
+        self,
+        *,
+        rollout_id: str,
+        model_path: str,
+        row_index: int | None = None,
+        run_index: int | None = None,
+    ) -> EvalProxySession:
+        payload: dict[str, Any] = {
+            "rollout_id": rollout_id,
+            "model_path": model_path,
+        }
+        if row_index is not None:
+            payload["row_index"] = row_index
+        if run_index is not None:
+            payload["run_index"] = run_index
+        try:
+            data = await self._request_json("POST", "/v1/eval-sessions", json=payload)
+            return self._session_from_create_response(
+                requested_id=rollout_id,
+                model_path=model_path,
+                data=data,
+                row_index=row_index,
+                run_index=run_index,
+            )
+        except BaseException:
+            # The create may have reached the server even when the response
+            # is invalid or this coroutine is cancelled; close by requested
+            # id so a half-created session is not leaked. The original
+            # exception always propagates.
+            await self._close_after_failed_create(rollout_id)
+            raise
+
+    async def _close_after_failed_create(self, rollout_id: str) -> None:
+        closer = asyncio.ensure_future(self.close_session(rollout_id))
+        closer.add_done_callback(_consume_best_effort_close)
+        try:
+            await asyncio.shield(closer)
+        except BaseException:
+            # Best effort only: the shielded close keeps running even if this
+            # wait is cancelled again, and close failures are just logged.
+            return
+
+    def _session_from_create_response(
+        self,
+        *,
+        requested_id: str,
+        model_path: str,
+        data: dict[str, Any],
+        row_index: int | None,
+        run_index: int | None,
+    ) -> EvalProxySession:
+        returned_id = data.get("rollout_id")
+        if returned_id != requested_id:
+            raise EvalProxyError(
+                "eval-proxy create response rollout_id does not match the request"
+            )
+        api_base = data.get("api_base")
+        expected_api_base = _session_api_base(requested_id)
+        if api_base != expected_api_base:
+            raise EvalProxyError(
+                "eval-proxy api_base must be exactly "
+                f"{expected_api_base} (path only, same origin)"
+            )
+        api_base = expected_api_base
+        integration_model = data.get("integration_model")
+        if integration_model != EVAL_PROXY_INTEGRATION_MODEL:
+            raise EvalProxyError(
+                "eval-proxy create response integration_model must be "
+                f"{EVAL_PROXY_INTEGRATION_MODEL}"
+            )
+        wire_model = data.get("wire_model")
+        if wire_model != EVAL_PROXY_WIRE_MODEL:
+            raise EvalProxyError(
+                f"eval-proxy create response wire_model must be {EVAL_PROXY_WIRE_MODEL}"
+            )
+        token = data.get("token")
+        if not isinstance(token, str) or not token:
+            raise EvalProxyError(
+                "eval-proxy create response token must be a non-empty string"
+            )
+        if secrets.compare_digest(token.encode(), self._auth_token.encode()):
+            raise EvalProxyError(
+                "eval-proxy returned the platform management token as the "
+                "session token; refusing to hand it to workload code"
+            )
+        return EvalProxySession(
+            rollout_id=requested_id,
+            model_path=model_path,
+            api_base=api_base,
+            api_base_url=f"{self._base_url}{api_base}",
+            token=token,
+            integration_model=EVAL_PROXY_INTEGRATION_MODEL,
+            wire_model=EVAL_PROXY_WIRE_MODEL,
+            row_index=row_index,
+            run_index=run_index,
+        )
+
+    async def aclose(self) -> None:
+        if self._owns_session and self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    async def close_session(self, rollout_id: str) -> None:
+        """Close a proxy session.
+
+        Path is provisional: production close is not a frozen contract.
+        Uses the platform bearer token, not the session token.
+        """
+        await self._request_json("DELETE", self._close_path(rollout_id))
+
+    async def get_usage(self, rollout_id: str) -> dict[str, Any]:
+        """Fetch session usage.
+
+        Path is provisional: production usage is not a frozen contract.
+        Uses the platform bearer token, not the session token.
+        """
+        return await self._request_json("GET", self._usage_path(rollout_id))
+
+    def _close_path(self, rollout_id: str) -> str:
+        return f"/v1/eval-sessions/{quote(rollout_id, safe='')}"
+
+    def _usage_path(self, rollout_id: str) -> str:
+        return f"/v1/eval-sessions/{quote(rollout_id, safe='')}/usage"
+
+    async def _ensure_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+            self._owns_session = True
+        return self._session
+
+    async def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        session = await self._ensure_session()
+        headers = {"Authorization": f"Bearer {self._auth_token}"}
+        url = f"{self._base_url}{path}"
+        async with session.request(method, url, json=json, headers=headers) as response:
+            if response.status >= 400:
+                detail = await response.text()
+                raise EvalProxyError(
+                    f"eval-proxy {method} {path} failed: {response.status} {detail}",
+                    status_code=response.status,
+                )
+            if response.status == 204:
+                return {}
+            payload = await response.json()
+            if not isinstance(payload, dict):
+                raise EvalProxyError("eval-proxy returned a non-object JSON body")
+            return payload
+
+
+def create_eval_proxy_stub_app(
+    *, platform_token: str = _DEFAULT_STUB_PLATFORM_TOKEN
+) -> FastAPI:
+    """Local contract stub for SDK tests. Not a production eval-proxy."""
+    app = FastAPI()
+    app.state.sessions = {}
+    app.state.create_requests = []
+    app.state.chat_requests = []
+    app.state.platform_token = platform_token
+
+    def _require_platform(authorization: str | None) -> None:
+        expected = f"Bearer {platform_token}"
+        if authorization != expected:
+            raise HTTPException(status_code=401, detail="Unauthorized")
+
+    def _require_session(rollout_id: str, authorization: str | None) -> dict[str, Any]:
+        session = app.state.sessions.get(rollout_id)
+        if session is None:
+            raise HTTPException(status_code=404, detail="unknown session")
+        expected = f"Bearer {session['token']}"
+        if authorization != expected:
+            raise HTTPException(status_code=401, detail="Unauthorized")
+        return session
+
+    @app.post("/v1/eval-sessions")
+    async def create_session(
+        request: Request,
+        authorization: str | None = Header(default=None),
+    ) -> dict[str, Any]:
+        _require_platform(authorization)
+        body = await request.json()
+        if not isinstance(body, dict):
+            raise HTTPException(status_code=400, detail="expected a JSON object")
+        forbidden = _CREATE_FORBIDDEN_FIELDS & body.keys()
+        if forbidden:
+            raise HTTPException(
+                status_code=400,
+                detail="clients may not select the synthetic model",
+            )
+        rollout_id = body.get("rollout_id")
+        model_path = body.get("model_path")
+        if not isinstance(rollout_id, str) or not is_single_path_segment(rollout_id):
+            raise HTTPException(status_code=400, detail="invalid rollout_id")
+        if not isinstance(model_path, str) or not model_path:
+            raise HTTPException(status_code=400, detail="model_path is required")
+        token = secrets.token_urlsafe(16)
+        app.state.create_requests.append(dict(body))
+        app.state.sessions[rollout_id] = {
+            "token": token,
+            "model_path": model_path,
+            "usage": {
+                "prompt_tokens": 1,
+                "completion_tokens": 1,
+                "total_tokens": 2,
+            },
+        }
+        return {
+            "rollout_id": rollout_id,
+            "api_base": _session_api_base(rollout_id),
+            "token": token,
+            "integration_model": EVAL_PROXY_INTEGRATION_MODEL,
+            "wire_model": EVAL_PROXY_WIRE_MODEL,
+        }
+
+    @app.post("/v1/eval-sessions/{rollout_id}/chat/completions")
+    async def chat_completions(
+        rollout_id: str,
+        request: Request,
+        authorization: str | None = Header(default=None),
+    ) -> StreamingResponse:
+        _require_session(rollout_id, authorization)
+        body = await request.json()
+        if not isinstance(body, dict):
+            raise HTTPException(status_code=400, detail="expected a JSON object")
+        app.state.chat_requests.append(
+            {"path": str(request.url.path), "body": dict(body)}
+        )
+        if body.get("stream") is not True:
+            raise HTTPException(status_code=400, detail="stream=true is required")
+        if body.get("model") != EVAL_PROXY_WIRE_MODEL:
+            raise HTTPException(status_code=400, detail="model must be osmosis-rollout")
+        stream_options = body.get("stream_options")
+        if (
+            isinstance(stream_options, dict)
+            and "include_usage" in stream_options
+            and stream_options.get("include_usage") is not True
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="include_usage must be true when present",
+            )
+
+        async def events() -> AsyncIterator[str]:
+            completion_id = "chatcmpl-stub"
+            chunks = [
+                {
+                    "id": completion_id,
+                    "object": "chat.completion.chunk",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"role": "assistant", "content": "ok"},
+                            "finish_reason": None,
+                        }
+                    ],
+                },
+                {
+                    "id": completion_id,
+                    "object": "chat.completion.chunk",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                },
+                {
+                    "id": completion_id,
+                    "object": "chat.completion.chunk",
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                },
+            ]
+            for chunk in chunks:
+                yield f"data: {json.dumps(chunk)}\n\n"
+            yield "data: [DONE]\n\n"
+
+        return StreamingResponse(events(), media_type="text/event-stream")
+
+    @app.delete("/v1/eval-sessions/{rollout_id}")
+    async def close_session_provisional(
+        rollout_id: str,
+        authorization: str | None = Header(default=None),
+    ) -> dict[str, Any]:
+        # Provisional path. Not part of the frozen chat/session-create contract.
+        _require_platform(authorization)
+        session = app.state.sessions.get(rollout_id)
+        if session is None:
+            raise HTTPException(status_code=404, detail="unknown session")
+        app.state.sessions.pop(rollout_id, None)
+        return {"ok": True}
+
+    @app.get("/v1/eval-sessions/{rollout_id}/usage")
+    async def usage_provisional(
+        rollout_id: str,
+        authorization: str | None = Header(default=None),
+    ) -> dict[str, Any]:
+        # Provisional path. Not part of the frozen chat/session-create contract.
+        _require_platform(authorization)
+        session = app.state.sessions.get(rollout_id)
+        if session is None:
+            raise HTTPException(status_code=404, detail="unknown session")
+        return dict(session["usage"])
+
+    return app

--- a/osmosis_ai/rollout/controller/proxy_client.py
+++ b/osmosis_ai/rollout/controller/proxy_client.py
@@ -272,7 +272,12 @@ class EvalProxyClient:
                 )
             if response.status == 204:
                 return {}
-            payload = await response.json()
+            try:
+                payload = await response.json()
+            except (aiohttp.ContentTypeError, ValueError) as exc:
+                raise EvalProxyError(
+                    f"eval-proxy {method} {path} returned invalid JSON"
+                ) from exc
             if not isinstance(payload, dict):
                 raise EvalProxyError("eval-proxy returned a non-object JSON body")
             return payload

--- a/osmosis_ai/rollout/controller/proxy_client.py
+++ b/osmosis_ai/rollout/controller/proxy_client.py
@@ -64,6 +64,10 @@ _CREATE_FORBIDDEN_FIELDS = frozenset(
 )
 _DEFAULT_STUB_PLATFORM_TOKEN = "platform-token"
 
+# Bounded wait for the best-effort close after a failed create; the close
+# keeps running in the background if it outlives this window.
+_FAILED_CREATE_CLOSE_TIMEOUT_SEC = 10.0
+
 
 class EvalProxyError(Exception):
     """HTTP or contract failure talking to the eval-proxy.
@@ -171,10 +175,13 @@ class EvalProxyClient:
         closer = asyncio.ensure_future(self.close_session(rollout_id))
         closer.add_done_callback(_consume_best_effort_close)
         try:
-            await asyncio.shield(closer)
+            await asyncio.wait_for(
+                asyncio.shield(closer), _FAILED_CREATE_CLOSE_TIMEOUT_SEC
+            )
         except BaseException:
             # Best effort only: the shielded close keeps running even if this
-            # wait is cancelled again, and close failures are just logged.
+            # wait times out or is cancelled again, and close failures are
+            # just logged.
             return
 
     def _session_from_create_response(

--- a/osmosis_ai/rollout/controller/proxy_client.py
+++ b/osmosis_ai/rollout/controller/proxy_client.py
@@ -1,4 +1,4 @@
-"""Eval-proxy session client and local OpenAI-compatible contract stub.
+"""Eval-proxy session client.
 
 Frozen production contract:
 - integration model ``openai/osmosis-rollout``
@@ -14,43 +14,21 @@ Frozen production contract:
 - SSE: content chunk, ``finish_reason="stop"`` chunk, ``choices=[]``
   usage-only chunk, then ``[DONE]``
 
-Close and usage HTTP paths are **not** frozen. ``close_session`` and
-``get_usage`` are public logical methods; path construction stays private.
-Management-plane create/usage/close uses the platform bearer token. Chat
-uses the session bearer token.
+The close HTTP path is **not** frozen: ``close_session`` is a public logical
+method and path construction stays private. Management-plane create/close
+uses the platform bearer token. Chat uses the session bearer token.
 """
 
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import secrets
-from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import quote
 
-from osmosis_ai._imports import raise_optional_dependency_error
-
-try:
-    import aiohttp
-except ModuleNotFoundError as _exc:
-    raise_optional_dependency_error(
-        _exc,
-        extra="eval-run",
-        feature="Local evaluation",
-    )
-
-try:
-    from fastapi import FastAPI, Header, HTTPException, Request
-    from fastapi.responses import StreamingResponse
-except ModuleNotFoundError as _exc:
-    raise_optional_dependency_error(
-        _exc,
-        extra="eval-run",
-        feature="Local evaluation",
-    )
+import httpx
 
 from osmosis_ai.rollout.utils.identifiers import is_single_path_segment
 
@@ -59,18 +37,12 @@ logger: logging.Logger = logging.getLogger(__name__)
 EVAL_PROXY_INTEGRATION_MODEL = "openai/osmosis-rollout"
 EVAL_PROXY_WIRE_MODEL = "osmosis-rollout"
 
-_CREATE_FORBIDDEN_FIELDS = frozenset(
-    {"model", "integration_model", "wire_model", "synthetic_model"}
-)
-_DEFAULT_STUB_PLATFORM_TOKEN = "platform-token"
-
 # Bounded wait for the best-effort close after a failed create; the close
 # keeps running in the background if it outlives this window.
 _FAILED_CREATE_CLOSE_TIMEOUT_SEC = 10.0
 
-# Total timeout for management calls on the client-owned session: small JSON
-# round-trips must fail fast instead of inheriting aiohttp's 300s default.
-# A caller-supplied session keeps whatever timeout the caller configured.
+# Total timeout for management calls: these are small JSON round-trips, so
+# they must not hang a rollout, but the bound still tolerates a cold proxy.
 _MANAGEMENT_REQUEST_TIMEOUT_SEC = 30.0
 
 
@@ -126,21 +98,14 @@ def _consume_best_effort_close(task: asyncio.Task[None]) -> None:
 
 
 class EvalProxyClient:
-    """HTTP client for eval-proxy session create (and provisional close/usage)."""
+    """HTTP client for eval-proxy session create (and provisional close)."""
 
-    def __init__(
-        self,
-        *,
-        base_url: str,
-        auth_token: str,
-        session: aiohttp.ClientSession | None = None,
-    ) -> None:
+    def __init__(self, *, base_url: str, auth_token: str) -> None:
         if not auth_token or not auth_token.strip():
             raise ValueError("auth_token (platform management token) must be non-empty")
         self._base_url = base_url.rstrip("/")
         self._auth_token = auth_token
-        self._session = session
-        self._owns_session = session is None
+        self._http = httpx.AsyncClient(timeout=_MANAGEMENT_REQUEST_TIMEOUT_SEC)
 
     async def create_session(
         self,
@@ -168,7 +133,7 @@ class EvalProxyClient:
                 row_index=row_index,
                 run_index=run_index,
             )
-        except (Exception, asyncio.CancelledError):
+        except (Exception, asyncio.CancelledError) as exc:
             # The create may have reached the server even when the response
             # is invalid or this coroutine is cancelled; close by requested
             # id so a half-created session is not leaked. The original
@@ -176,8 +141,12 @@ class EvalProxyClient:
             # (KeyboardInterrupt, SystemExit, GeneratorExit) skip the network
             # cleanup: awaiting here would delay shutdown, and awaiting during
             # GeneratorExit is illegal; the eval-proxy session TTL reaps the
-            # leftover.
-            await self._close_after_failed_create(rollout_id)
+            # leftover. A definitive 4xx is the one rejection we must not
+            # clean up after: nothing was created, and on a 409 the id belongs
+            # to another run whose live session the DELETE would destroy.
+            status = exc.status_code if isinstance(exc, EvalProxyError) else None
+            if status is None or not 400 <= status < 500:
+                await self._close_after_failed_create(rollout_id)
             raise
 
     async def _close_after_failed_create(self, rollout_id: str) -> None:
@@ -249,9 +218,7 @@ class EvalProxyClient:
         )
 
     async def aclose(self) -> None:
-        if self._owns_session and self._session is not None:
-            await self._session.close()
-            self._session = None
+        await self._http.aclose()
 
     async def close_session(self, rollout_id: str) -> None:
         """Close a proxy session.
@@ -261,27 +228,8 @@ class EvalProxyClient:
         """
         await self._request_json("DELETE", self._close_path(rollout_id))
 
-    async def get_usage(self, rollout_id: str) -> dict[str, Any]:
-        """Fetch session usage.
-
-        Path is provisional: production usage is not a frozen contract.
-        Uses the platform bearer token, not the session token.
-        """
-        return await self._request_json("GET", self._usage_path(rollout_id))
-
     def _close_path(self, rollout_id: str) -> str:
         return _session_api_base(rollout_id)
-
-    def _usage_path(self, rollout_id: str) -> str:
-        return f"{_session_api_base(rollout_id)}/usage"
-
-    async def _ensure_session(self) -> aiohttp.ClientSession:
-        if self._session is None or self._session.closed:
-            self._session = aiohttp.ClientSession(
-                timeout=aiohttp.ClientTimeout(total=_MANAGEMENT_REQUEST_TIMEOUT_SEC)
-            )
-            self._owns_session = True
-        return self._session
 
     async def _request_json(
         self,
@@ -290,190 +238,26 @@ class EvalProxyClient:
         *,
         json: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        session = await self._ensure_session()
-        headers = {"Authorization": f"Bearer {self._auth_token}"}
-        url = f"{self._base_url}{path}"
-        # A caller-supplied session may enable raise_for_status; the error
-        # contract here is EvalProxyError, so keep status handling local.
-        async with session.request(
-            method, url, json=json, headers=headers, raise_for_status=False
-        ) as response:
-            if not 200 <= response.status < 300:
-                detail = await response.text()
-                raise EvalProxyError(
-                    f"eval-proxy {method} {path} failed: {response.status} {detail}",
-                    status_code=response.status,
-                )
-            if response.status == 204:
-                return {}
-            try:
-                payload = await response.json()
-            except (aiohttp.ContentTypeError, ValueError) as exc:
-                raise EvalProxyError(
-                    f"eval-proxy {method} {path} returned invalid JSON"
-                ) from exc
-            if not isinstance(payload, dict):
-                raise EvalProxyError("eval-proxy returned a non-object JSON body")
-            return payload
-
-
-def create_eval_proxy_stub_app(
-    *, platform_token: str = _DEFAULT_STUB_PLATFORM_TOKEN
-) -> FastAPI:
-    """Local contract stub for SDK tests. Not a production eval-proxy."""
-    app = FastAPI()
-    app.state.sessions = {}
-    app.state.create_requests = []
-    app.state.chat_requests = []
-    app.state.platform_token = platform_token
-
-    def _require_platform(authorization: str | None) -> None:
-        expected = f"Bearer {platform_token}"
-        if authorization != expected:
-            raise HTTPException(status_code=401, detail="Unauthorized")
-
-    def _require_session(rollout_id: str, authorization: str | None) -> dict[str, Any]:
-        session = app.state.sessions.get(rollout_id)
-        if session is None:
-            raise HTTPException(status_code=404, detail="unknown session")
-        expected = f"Bearer {session['token']}"
-        if authorization != expected:
-            raise HTTPException(status_code=401, detail="Unauthorized")
-        return session
-
-    @app.post("/v1/eval-sessions")
-    async def create_session(
-        request: Request,
-        authorization: str | None = Header(default=None),
-    ) -> dict[str, Any]:
-        _require_platform(authorization)
-        body = await request.json()
-        if not isinstance(body, dict):
-            raise HTTPException(status_code=400, detail="expected a JSON object")
-        forbidden = _CREATE_FORBIDDEN_FIELDS & body.keys()
-        if forbidden:
-            raise HTTPException(
-                status_code=400,
-                detail="clients may not select the synthetic model",
-            )
-        rollout_id = body.get("rollout_id")
-        model_path = body.get("model_path")
-        if not isinstance(rollout_id, str) or not is_single_path_segment(rollout_id):
-            raise HTTPException(status_code=400, detail="invalid rollout_id")
-        if not isinstance(model_path, str) or not model_path:
-            raise HTTPException(status_code=400, detail="model_path is required")
-        token = secrets.token_urlsafe(16)
-        app.state.create_requests.append(dict(body))
-        app.state.sessions[rollout_id] = {
-            "token": token,
-            "model_path": model_path,
-            "usage": {
-                "prompt_tokens": 1,
-                "completion_tokens": 1,
-                "total_tokens": 2,
-            },
-        }
-        return {
-            "rollout_id": rollout_id,
-            "api_base": _session_api_base(rollout_id),
-            "token": token,
-            "integration_model": EVAL_PROXY_INTEGRATION_MODEL,
-            "wire_model": EVAL_PROXY_WIRE_MODEL,
-        }
-
-    @app.post("/v1/eval-sessions/{rollout_id}/chat/completions")
-    async def chat_completions(
-        rollout_id: str,
-        request: Request,
-        authorization: str | None = Header(default=None),
-    ) -> StreamingResponse:
-        _require_session(rollout_id, authorization)
-        body = await request.json()
-        if not isinstance(body, dict):
-            raise HTTPException(status_code=400, detail="expected a JSON object")
-        app.state.chat_requests.append(
-            {"path": str(request.url.path), "body": dict(body)}
+        response = await self._http.request(
+            method,
+            f"{self._base_url}{path}",
+            json=json,
+            headers={"Authorization": f"Bearer {self._auth_token}"},
         )
-        if body.get("stream") is not True:
-            raise HTTPException(status_code=400, detail="stream=true is required")
-        if body.get("model") != EVAL_PROXY_WIRE_MODEL:
-            raise HTTPException(status_code=400, detail="model must be osmosis-rollout")
-        stream_options = body.get("stream_options")
-        if (
-            isinstance(stream_options, dict)
-            and "include_usage" in stream_options
-            and stream_options.get("include_usage") is not True
-        ):
-            raise HTTPException(
-                status_code=400,
-                detail="include_usage must be true when present",
+        if not 200 <= response.status_code < 300:
+            raise EvalProxyError(
+                f"eval-proxy {method} {path} failed: "
+                f"{response.status_code} {response.text}",
+                status_code=response.status_code,
             )
-
-        async def events() -> AsyncIterator[str]:
-            completion_id = "chatcmpl-stub"
-            chunks = [
-                {
-                    "id": completion_id,
-                    "object": "chat.completion.chunk",
-                    "choices": [
-                        {
-                            "index": 0,
-                            "delta": {"role": "assistant", "content": "ok"},
-                            "finish_reason": None,
-                        }
-                    ],
-                },
-                {
-                    "id": completion_id,
-                    "object": "chat.completion.chunk",
-                    "choices": [
-                        {
-                            "index": 0,
-                            "delta": {},
-                            "finish_reason": "stop",
-                        }
-                    ],
-                },
-                {
-                    "id": completion_id,
-                    "object": "chat.completion.chunk",
-                    "choices": [],
-                    "usage": {
-                        "prompt_tokens": 1,
-                        "completion_tokens": 1,
-                        "total_tokens": 2,
-                    },
-                },
-            ]
-            for chunk in chunks:
-                yield f"data: {json.dumps(chunk)}\n\n"
-            yield "data: [DONE]\n\n"
-
-        return StreamingResponse(events(), media_type="text/event-stream")
-
-    @app.delete("/v1/eval-sessions/{rollout_id}")
-    async def close_session_provisional(
-        rollout_id: str,
-        authorization: str | None = Header(default=None),
-    ) -> dict[str, Any]:
-        # Provisional path. Not part of the frozen chat/session-create contract.
-        _require_platform(authorization)
-        session = app.state.sessions.get(rollout_id)
-        if session is None:
-            raise HTTPException(status_code=404, detail="unknown session")
-        app.state.sessions.pop(rollout_id, None)
-        return {"ok": True}
-
-    @app.get("/v1/eval-sessions/{rollout_id}/usage")
-    async def usage_provisional(
-        rollout_id: str,
-        authorization: str | None = Header(default=None),
-    ) -> dict[str, Any]:
-        # Provisional path. Not part of the frozen chat/session-create contract.
-        _require_platform(authorization)
-        session = app.state.sessions.get(rollout_id)
-        if session is None:
-            raise HTTPException(status_code=404, detail="unknown session")
-        return dict(session["usage"])
-
-    return app
+        if response.status_code == 204:
+            return {}
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise EvalProxyError(
+                f"eval-proxy {method} {path} returned invalid JSON"
+            ) from exc
+        if not isinstance(payload, dict):
+            raise EvalProxyError("eval-proxy returned a non-object JSON body")
+        return payload

--- a/osmosis_ai/rollout/controller/proxy_client.py
+++ b/osmosis_ai/rollout/controller/proxy_client.py
@@ -68,6 +68,11 @@ _DEFAULT_STUB_PLATFORM_TOKEN = "platform-token"
 # keeps running in the background if it outlives this window.
 _FAILED_CREATE_CLOSE_TIMEOUT_SEC = 10.0
 
+# Total timeout for management calls on the client-owned session: small JSON
+# round-trips must fail fast instead of inheriting aiohttp's 300s default.
+# A caller-supplied session keeps whatever timeout the caller configured.
+_MANAGEMENT_REQUEST_TIMEOUT_SEC = 30.0
+
 
 class EvalProxyError(Exception):
     """HTTP or contract failure talking to the eval-proxy.
@@ -163,11 +168,15 @@ class EvalProxyClient:
                 row_index=row_index,
                 run_index=run_index,
             )
-        except BaseException:
+        except (Exception, asyncio.CancelledError):
             # The create may have reached the server even when the response
             # is invalid or this coroutine is cancelled; close by requested
             # id so a half-created session is not leaked. The original
-            # exception always propagates.
+            # exception always propagates. Process-level exits
+            # (KeyboardInterrupt, SystemExit, GeneratorExit) skip the network
+            # cleanup: awaiting here would delay shutdown, and awaiting during
+            # GeneratorExit is illegal; the eval-proxy session TTL reaps the
+            # leftover.
             await self._close_after_failed_create(rollout_id)
             raise
 
@@ -178,7 +187,7 @@ class EvalProxyClient:
             await asyncio.wait_for(
                 asyncio.shield(closer), _FAILED_CREATE_CLOSE_TIMEOUT_SEC
             )
-        except BaseException:
+        except (Exception, asyncio.CancelledError):
             # Best effort only: the shielded close keeps running even if this
             # wait times out or is cancelled again, and close failures are
             # just logged.
@@ -268,7 +277,9 @@ class EvalProxyClient:
 
     async def _ensure_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
-            self._session = aiohttp.ClientSession()
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=_MANAGEMENT_REQUEST_TIMEOUT_SEC)
+            )
             self._owns_session = True
         return self._session
 
@@ -283,7 +294,7 @@ class EvalProxyClient:
         headers = {"Authorization": f"Bearer {self._auth_token}"}
         url = f"{self._base_url}{path}"
         async with session.request(method, url, json=json, headers=headers) as response:
-            if response.status >= 400:
+            if not 200 <= response.status < 300:
                 detail = await response.text()
                 raise EvalProxyError(
                     f"eval-proxy {method} {path} failed: {response.status} {detail}",

--- a/osmosis_ai/rollout/controller/proxy_client.py
+++ b/osmosis_ai/rollout/controller/proxy_client.py
@@ -293,7 +293,11 @@ class EvalProxyClient:
         session = await self._ensure_session()
         headers = {"Authorization": f"Bearer {self._auth_token}"}
         url = f"{self._base_url}{path}"
-        async with session.request(method, url, json=json, headers=headers) as response:
+        # A caller-supplied session may enable raise_for_status; the error
+        # contract here is EvalProxyError, so keep status handling local.
+        async with session.request(
+            method, url, json=json, headers=headers, raise_for_status=False
+        ) as response:
             if not 200 <= response.status < 300:
                 detail = await response.text()
                 raise EvalProxyError(

--- a/osmosis_ai/rollout/controller/store.py
+++ b/osmosis_ai/rollout/controller/store.py
@@ -2,12 +2,12 @@
 
 The store is eval-agnostic: callers supply an async terminal-commit hook
 (local eval journals here; other tooling can no-op or persist elsewhere).
-Each live session has separate completion and terminal futures. Callers
-register before dispatch, may ``wait_completion`` then ``wait_terminal``,
-and discard both in ``finally``. Accepted terminal acknowledgments stay
-until the process exits so duplicate callbacks can be acknowledged after
-cleanup. Journal replay is a small ``seed_terminal`` API; this module
-does not read a journal.
+Callers register before dispatch, ``wait_terminal``, and discard in
+``finally``. A completion callback is recorded on the live session for
+duplicate detection but is not a rendezvous of its own. Accepted terminal
+acknowledgments stay until the process exits so duplicate callbacks can be
+acknowledged after cleanup. Journal replay is a small ``seed_terminal``
+API; this module does not read a journal.
 
 The terminal commit is single-flight: the first grader/timeout contender
 creates one commit task per session and every contender (including
@@ -83,9 +83,6 @@ async def _default_commit(_result: TerminalCallbackResult) -> None:
 class _LiveSession:
     completion: RolloutCompleteRequest | None = None
     completion_ack: dict[str, Any] = field(default_factory=lambda: {"ok": True})
-    completion_future: asyncio.Future[RolloutCompleteRequest] = field(
-        default_factory=lambda: asyncio.get_running_loop().create_future()
-    )
     terminal: TerminalCallbackResult | None = None
     terminal_future: asyncio.Future[TerminalCallbackResult] = field(
         default_factory=lambda: asyncio.get_running_loop().create_future()
@@ -157,17 +154,8 @@ class CallbackStore:
             return
         async with session.lock:
             self._sessions.pop(rollout_id, None)
-            if not session.completion_future.done():
-                session.completion_future.cancel()
             if not session.terminal_future.done():
                 session.terminal_future.cancel()
-
-    def completion_for(self, rollout_id: str) -> RolloutCompleteRequest | None:
-        session = self._sessions.get(rollout_id)
-        if session is not None:
-            return session.completion
-        finalized = self._finalized.get(rollout_id)
-        return None if finalized is None else finalized.completion
 
     def terminal_for(self, rollout_id: str) -> TerminalCallbackResult | None:
         session = self._sessions.get(rollout_id)
@@ -186,8 +174,6 @@ class CallbackStore:
         async with session.lock:
             if session.completion is None:
                 session.completion = request
-                if not session.completion_future.done():
-                    session.completion_future.set_result(request)
             elif not duplicate_callback_payload(session.completion, request):
                 logger.error(
                     "Conflicting duplicate completion callback for rollout %s",
@@ -313,20 +299,6 @@ class CallbackStore:
                 # The in-flight commit failed without a durable result;
                 # re-arbitrate so cancellation can install its tombstone.
                 continue
-
-    async def wait_completion(self, rollout_id: str) -> RolloutCompleteRequest:
-        """Return the first accepted completion callback for this rollout.
-
-        Training/dev consumers can wait here before waiting for the terminal
-        grader result, preserving the two-stage remote-rollout lifecycle.
-        """
-        session, finalized = self._session_or_finalized(rollout_id)
-        if finalized is not None:
-            if finalized.completion is None:
-                raise UnknownRolloutIdError(rollout_id)
-            return finalized.completion
-        assert session is not None
-        return await asyncio.shield(session.completion_future)
 
     async def wait_terminal(self, rollout_id: str) -> TerminalCallbackResult:
         session, finalized = self._session_or_finalized(rollout_id)

--- a/osmosis_ai/rollout/controller/store.py
+++ b/osmosis_ai/rollout/controller/store.py
@@ -1,0 +1,423 @@
+"""In-memory callback rendezvous for one process.
+
+The store is eval-agnostic: callers supply an async terminal-commit hook
+(local eval journals here; other tooling can no-op or persist elsewhere).
+Each live session has separate completion and terminal futures. Callers
+register before dispatch, may ``wait_completion`` then ``wait_terminal``,
+and discard both in ``finally``. Accepted terminal acknowledgments stay
+until the process exits so duplicate callbacks can be acknowledged after
+cleanup. Journal replay is a small ``seed_terminal`` API; this module
+does not read a journal.
+
+The terminal commit is single-flight: the first grader/timeout contender
+creates one commit task per session and every contender (including
+cancellation) awaits that same task through ``asyncio.shield``, so
+cancelling a callback handler or timeout waiter never cancels persistence
+and never lets a second contender rerun the hook. A hook that raises is
+treated as not-durable: the failed task is cleared so a retry can commit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from osmosis_ai.rollout.types import GraderCompleteRequest, RolloutCompleteRequest
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+TerminalSource = Literal["grader", "timeout", "seeded", "cancelled"]
+
+
+class UnknownRolloutIdError(KeyError):
+    """No live session or seeded terminal exists for this rollout id."""
+
+
+class DuplicateRegistrationError(ValueError):
+    """``register`` was called twice for the same live rollout id."""
+
+
+@dataclass(frozen=True)
+class TerminalCallbackResult:
+    """First-accepted terminal callback (or timeout) for one rollout."""
+
+    rollout_id: str
+    source: TerminalSource
+    completion: RolloutCompleteRequest | None = None
+    grader: GraderCompleteRequest | None = None
+    acknowledgment: Mapping[str, Any] = field(default_factory=lambda: {"ok": True})
+
+
+TerminalCommitHook = Callable[
+    [TerminalCallbackResult], Awaitable[Mapping[str, Any] | None]
+]
+
+
+def duplicate_callback_payload(left: BaseModel | None, right: BaseModel | None) -> bool:
+    """True when two protocol bodies serialize to the same JSON object."""
+    if left is None or right is None:
+        return left is right
+    return left.model_dump(mode="json") == right.model_dump(mode="json")
+
+
+def _terminal_payloads_match(
+    left: TerminalCallbackResult, right: TerminalCallbackResult
+) -> bool:
+    return (
+        duplicate_callback_payload(left.grader, right.grader)
+        and duplicate_callback_payload(left.completion, right.completion)
+        and dict(left.acknowledgment) == dict(right.acknowledgment)
+    )
+
+
+async def _default_commit(_result: TerminalCallbackResult) -> None:
+    return None
+
+
+@dataclass
+class _LiveSession:
+    completion: RolloutCompleteRequest | None = None
+    completion_ack: dict[str, Any] = field(default_factory=lambda: {"ok": True})
+    completion_future: asyncio.Future[RolloutCompleteRequest] = field(
+        default_factory=lambda: asyncio.get_running_loop().create_future()
+    )
+    terminal: TerminalCallbackResult | None = None
+    terminal_future: asyncio.Future[TerminalCallbackResult] = field(
+        default_factory=lambda: asyncio.get_running_loop().create_future()
+    )
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    # Single-flight terminal commit; contenders await it via asyncio.shield.
+    commit_task: asyncio.Task[TerminalCallbackResult] | None = None
+
+
+class CallbackStore:
+    """One in-memory rendezvous per rollout, plus a durable-ack finalized map."""
+
+    def __init__(
+        self,
+        *,
+        on_terminal_commit: TerminalCommitHook | None = None,
+    ) -> None:
+        self._on_terminal_commit = on_terminal_commit or _default_commit
+        self._sessions: dict[str, _LiveSession] = {}
+        self._finalized: dict[str, TerminalCallbackResult] = {}
+
+    async def register(self, rollout_id: str) -> None:
+        if rollout_id in self._sessions or rollout_id in self._finalized:
+            raise DuplicateRegistrationError(
+                f"callback session already registered for {rollout_id}"
+            )
+        self._sessions[rollout_id] = _LiveSession()
+
+    def seed_terminal(
+        self,
+        rollout_id: str,
+        *,
+        acknowledgment: Mapping[str, Any],
+        grader: GraderCompleteRequest | None = None,
+        completion: RolloutCompleteRequest | None = None,
+    ) -> None:
+        """Record an already-durable terminal result for duplicate detection.
+
+        First-wins: live sessions and existing finalized rows are not
+        overwritten. An identical repeated seed is a no-op; a conflicting
+        seed keeps the stored result and logs ERROR.
+        """
+        incoming = TerminalCallbackResult(
+            rollout_id=rollout_id,
+            source="seeded",
+            completion=completion,
+            grader=grader,
+            acknowledgment=dict(acknowledgment),
+        )
+        if rollout_id in self._sessions:
+            logger.error(
+                "seed_terminal ignored; live session exists for rollout %s",
+                rollout_id,
+            )
+            return
+        existing = self._finalized.get(rollout_id)
+        if existing is not None:
+            if not _terminal_payloads_match(existing, incoming):
+                logger.error(
+                    "Conflicting seed_terminal for rollout %s; keeping first result",
+                    rollout_id,
+                )
+            return
+        self._finalized[rollout_id] = incoming
+
+    async def discard(self, rollout_id: str) -> None:
+        session = self._sessions.get(rollout_id)
+        if session is None:
+            return
+        async with session.lock:
+            self._sessions.pop(rollout_id, None)
+            if not session.completion_future.done():
+                session.completion_future.cancel()
+            if not session.terminal_future.done():
+                session.terminal_future.cancel()
+
+    def completion_for(self, rollout_id: str) -> RolloutCompleteRequest | None:
+        session = self._sessions.get(rollout_id)
+        if session is not None:
+            return session.completion
+        finalized = self._finalized.get(rollout_id)
+        return None if finalized is None else finalized.completion
+
+    def terminal_for(self, rollout_id: str) -> TerminalCallbackResult | None:
+        session = self._sessions.get(rollout_id)
+        if session is not None and session.terminal is not None:
+            return session.terminal
+        return self._finalized.get(rollout_id)
+
+    async def handle_completion(
+        self, rollout_id: str, request: RolloutCompleteRequest
+    ) -> dict[str, Any]:
+        session, finalized = self._session_or_finalized(rollout_id)
+        if finalized is not None:
+            return self._ack_stored_completion(rollout_id, finalized, request)
+
+        assert session is not None
+        async with session.lock:
+            if session.completion is None:
+                session.completion = request
+                if not session.completion_future.done():
+                    session.completion_future.set_result(request)
+            elif not duplicate_callback_payload(session.completion, request):
+                logger.error(
+                    "Conflicting duplicate completion callback for rollout %s",
+                    rollout_id,
+                )
+            if session.terminal is not None:
+                return dict(session.terminal.acknowledgment)
+            return dict(session.completion_ack)
+
+    async def handle_grader(
+        self, rollout_id: str, request: GraderCompleteRequest
+    ) -> dict[str, Any]:
+        session, finalized = self._session_or_finalized(rollout_id)
+        if finalized is not None:
+            return self._ack_duplicate_terminal(rollout_id, finalized, request)
+
+        assert session is not None
+        async with session.lock:
+            if session.terminal is not None:
+                return self._ack_duplicate_terminal(
+                    rollout_id, session.terminal, request
+                )
+            task = session.commit_task
+            if task is None:
+                result = TerminalCallbackResult(
+                    rollout_id=rollout_id,
+                    source="grader",
+                    completion=session.completion,
+                    grader=request,
+                )
+                task = self._start_commit(session, result)
+        stored = await asyncio.shield(task)
+        return self._ack_duplicate_terminal(rollout_id, stored, request)
+
+    async def finalize_timeout(
+        self,
+        rollout_id: str,
+        *,
+        acknowledgment: Mapping[str, Any] | None = None,
+    ) -> TerminalCallbackResult:
+        """Win or observe the terminal race with a timeout result.
+
+        When an observed in-flight commit fails without producing a durable
+        result, the timeout re-arbitrates and may claim the terminal slot
+        with its own commit. A failure of the timeout's own commit
+        propagates. Task cancellation always propagates.
+        """
+        session, finalized = self._session_or_finalized(rollout_id)
+        if finalized is not None:
+            return finalized
+
+        assert session is not None
+        while True:
+            created = False
+            async with session.lock:
+                if session.terminal is not None:
+                    return session.terminal
+                task = session.commit_task
+                if task is None:
+                    result = TerminalCallbackResult(
+                        rollout_id=rollout_id,
+                        source="timeout",
+                        completion=session.completion,
+                        grader=None,
+                        acknowledgment=dict(acknowledgment or {"ok": True}),
+                    )
+                    task = self._start_commit(session, result)
+                    created = True
+            try:
+                return await asyncio.shield(task)
+            except Exception:
+                if created:
+                    raise
+                # An observed commit failed without a durable result;
+                # re-arbitrate so the timeout can claim the terminal slot.
+                continue
+
+    async def acknowledge_without_commit(
+        self,
+        rollout_id: str,
+        *,
+        source: TerminalSource = "cancelled",
+        acknowledgment: Mapping[str, Any] | None = None,
+    ) -> TerminalCallbackResult:
+        """Mark terminal without running the commit hook (cancellation).
+
+        Subsequent completion/grader callbacks receive the stored
+        acknowledgment. First accepted terminal still wins: an in-flight
+        commit is observed, not replaced — but if that commit fails without
+        a durable result, cancellation re-arbitrates and installs its
+        non-durable tombstone. Task cancellation always propagates. An
+        unknown rollout id raises ``UnknownRolloutIdError`` instead of
+        creating a tombstone that would poison a future registration.
+        """
+        finalized = self._finalized.get(rollout_id)
+        if finalized is not None:
+            return finalized
+
+        session = self._sessions.get(rollout_id)
+        if session is None:
+            raise UnknownRolloutIdError(rollout_id)
+
+        while True:
+            async with session.lock:
+                if session.terminal is not None:
+                    return session.terminal
+                task = session.commit_task
+                if task is None:
+                    result = TerminalCallbackResult(
+                        rollout_id=rollout_id,
+                        source=source,
+                        completion=session.completion,
+                        acknowledgment=dict(acknowledgment or {"ok": True}),
+                    )
+                    session.terminal = result
+                    self._finalized[rollout_id] = result
+                    if not session.terminal_future.done():
+                        session.terminal_future.set_result(result)
+                    return result
+            try:
+                return await asyncio.shield(task)
+            except Exception:
+                # The in-flight commit failed without a durable result;
+                # re-arbitrate so cancellation can install its tombstone.
+                continue
+
+    async def wait_completion(self, rollout_id: str) -> RolloutCompleteRequest:
+        """Return the first accepted completion callback for this rollout.
+
+        Training/dev consumers can wait here before waiting for the terminal
+        grader result, preserving the two-stage remote-rollout lifecycle.
+        """
+        session, finalized = self._session_or_finalized(rollout_id)
+        if finalized is not None:
+            if finalized.completion is None:
+                raise UnknownRolloutIdError(rollout_id)
+            return finalized.completion
+        assert session is not None
+        return await asyncio.shield(session.completion_future)
+
+    async def wait_terminal(self, rollout_id: str) -> TerminalCallbackResult:
+        session, finalized = self._session_or_finalized(rollout_id)
+        if finalized is not None:
+            return finalized
+        assert session is not None
+        return await asyncio.shield(session.terminal_future)
+
+    def _session_or_finalized(
+        self, rollout_id: str
+    ) -> tuple[_LiveSession | None, TerminalCallbackResult | None]:
+        """Return the live session, else a finalized tombstone, else raise."""
+        session = self._sessions.get(rollout_id)
+        if session is not None:
+            return session, None
+        finalized = self._finalized.get(rollout_id)
+        if finalized is not None:
+            return None, finalized
+        raise UnknownRolloutIdError(rollout_id)
+
+    def _start_commit(
+        self,
+        session: _LiveSession,
+        result: TerminalCallbackResult,
+    ) -> asyncio.Task[TerminalCallbackResult]:
+        """Create the session's single in-flight commit task (lock held)."""
+        task = asyncio.create_task(self._run_commit(session, result))
+        session.commit_task = task
+        return task
+
+    async def _run_commit(
+        self,
+        session: _LiveSession,
+        result: TerminalCallbackResult,
+    ) -> TerminalCallbackResult:
+        try:
+            ack = await self._on_terminal_commit(result)
+        except BaseException:
+            # A failed/cancelled hook produced no durable result; clear the
+            # task so a retried callback can commit again.
+            session.commit_task = None
+            raise
+        stored_ack = dict(ack) if ack is not None else dict(result.acknowledgment)
+        stored = TerminalCallbackResult(
+            rollout_id=result.rollout_id,
+            source=result.source,
+            completion=result.completion,
+            grader=result.grader,
+            acknowledgment=stored_ack,
+        )
+        session.terminal = stored
+        self._finalized[result.rollout_id] = stored
+        if not session.terminal_future.done():
+            session.terminal_future.set_result(stored)
+        return stored
+
+    def _ack_stored_completion(
+        self,
+        rollout_id: str,
+        stored: TerminalCallbackResult,
+        request: RolloutCompleteRequest,
+    ) -> dict[str, Any]:
+        # A timeout/cancel result that never stored a completion payload may
+        # legitimately receive a late completion; only a stored real payload
+        # that differs is a conflict.
+        if stored.completion is not None and not duplicate_callback_payload(
+            stored.completion, request
+        ):
+            logger.error(
+                "Conflicting duplicate completion callback for rollout %s "
+                "(stored source=%s)",
+                rollout_id,
+                stored.source,
+            )
+        return dict(stored.acknowledgment)
+
+    def _ack_duplicate_terminal(
+        self,
+        rollout_id: str,
+        stored: TerminalCallbackResult,
+        request: GraderCompleteRequest,
+    ) -> dict[str, Any]:
+        # A timeout/cancel result carries no grader payload; a late grader
+        # callback after it is the expected protocol flow, not a conflict.
+        if stored.grader is not None and not duplicate_callback_payload(
+            stored.grader, request
+        ):
+            logger.error(
+                "Conflicting duplicate terminal callback for rollout %s "
+                "(stored source=%s)",
+                rollout_id,
+                stored.source,
+            )
+        return dict(stored.acknowledgment)

--- a/osmosis_ai/rollout/driver.py
+++ b/osmosis_ai/rollout/driver.py
@@ -38,9 +38,8 @@ class RolloutOutcome:
 class RolloutRunRequest:
     """Inputs for one ``RolloutDriver.run`` call.
 
-    Scheduler identity (row/run indices) belongs in ``extra_fields`` or
-    ``metadata`` when a caller needs it. This type stays reusable outside
-    local eval.
+    Scheduler identity (row/run indices) belongs in ``extra_fields`` when a
+    caller needs it. This type stays reusable outside local eval.
     """
 
     messages: list[MessageDict]

--- a/osmosis_ai/rollout/driver.py
+++ b/osmosis_ai/rollout/driver.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
-from osmosis_ai.rollout.types import RolloutSample, RolloutStatus
+from osmosis_ai.rollout.types import MessageDict, RolloutSample, RolloutStatus
 
 
 @dataclass
@@ -34,6 +34,24 @@ class RolloutOutcome:
     skipped: bool = False
 
 
+@dataclass
+class RolloutRunRequest:
+    """Inputs for one ``RolloutDriver.run`` call.
+
+    Scheduler identity (row/run indices) belongs in ``extra_fields`` or
+    ``metadata`` when a caller needs it. This type stays reusable outside
+    local eval.
+    """
+
+    messages: list[MessageDict]
+    label: str | None = None
+    metadata: dict[str, Any] | None = None
+    rollout_id: str = ""
+    agent_timeout_sec: float | None = None
+    grader_timeout_sec: float | None = None
+    extra_fields: dict[str, Any] | None = None
+
+
 class RolloutDriver(ABC):
     """Drives a rollout execution."""
 
@@ -43,13 +61,8 @@ class RolloutDriver(ABC):
         return 0
 
     @abstractmethod
-    async def run(
-        self,
-        messages: list[dict[str, Any]],
-        label: str | None = None,
-        rollout_id: str = "",
-    ) -> RolloutOutcome:
+    async def run(self, request: RolloutRunRequest) -> RolloutOutcome:
         raise NotImplementedError
 
 
-__all__ = ["RolloutDriver", "RolloutOutcome"]
+__all__ = ["RolloutDriver", "RolloutOutcome", "RolloutRunRequest"]

--- a/osmosis_ai/rollout/http_driver.py
+++ b/osmosis_ai/rollout/http_driver.py
@@ -1,7 +1,8 @@
 """Concrete ``RolloutDriver`` over the v0.3 HTTP + callback protocol.
 
-Owns admission (202 / 429 / status recovery), callback rendezvous, and
-``/rollout/cancel``. Persistent dispatch/running state and user-requested
+Owns admission (202 / 429 / status recovery), the callback rendezvous, and
+the best-effort ``/rollout/cancel`` teardown that follows a callback timeout
+or task cancellation. Persistent dispatch/running state and user-requested
 cancellation terminal semantics belong to a supervisor, not this driver.
 """
 
@@ -18,12 +19,11 @@ from urllib.parse import quote
 import httpx
 from pydantic import ValidationError
 
-from osmosis_ai._imports import raise_optional_dependency_error
-from osmosis_ai.rollout.controller.store import (
-    CallbackStore,
-    TerminalCallbackResult,
-    UnknownRolloutIdError,
+from osmosis_ai.rollout.controller.proxy_client import (
+    EvalProxyClient,
+    EvalProxySession,
 )
+from osmosis_ai.rollout.controller.store import CallbackStore, TerminalCallbackResult
 from osmosis_ai.rollout.driver import RolloutDriver, RolloutOutcome, RolloutRunRequest
 from osmosis_ai.rollout.types import (
     CancelRolloutsRequest,
@@ -33,19 +33,11 @@ from osmosis_ai.rollout.types import (
     RolloutStatusResponse,
 )
 
-try:
-    from osmosis_ai.rollout.controller.proxy_client import (
-        EvalProxyClient,
-        EvalProxySession,
-    )
-except ModuleNotFoundError as _exc:
-    raise_optional_dependency_error(
-        _exc,
-        extra="eval-run",
-        feature="Local evaluation",
-    )
-
 logger: logging.Logger = logging.getLogger(__name__)
+
+# Ceiling on a server-dictated Retry-After: the backpressure wait is
+# uninterruptible, so an outsized header must not park a rollout for hours.
+_MAX_RETRY_AFTER_SEC = 60.0
 
 
 class _AdmissionProbe(StrEnum):
@@ -63,7 +55,7 @@ class RolloutProtocolError(RuntimeError):
 
 
 def _retry_after_seconds(response: httpx.Response, default: float = 1.0) -> float:
-    """Parse Retry-After into a finite, non-negative wait; else the default."""
+    """Parse Retry-After into a finite, non-negative, capped wait; else the default."""
     raw = response.headers.get("Retry-After")
     if raw is None:
         return default
@@ -73,16 +65,15 @@ def _retry_after_seconds(response: httpx.Response, default: float = 1.0) -> floa
         return default
     if not math.isfinite(value):
         return default
-    return max(0.0, value)
+    return min(max(0.0, value), _MAX_RETRY_AFTER_SEC)
 
 
 def _optional_index(request: RolloutRunRequest, name: str) -> int | None:
-    for source in (request.extra_fields, request.metadata):
-        if not source:
-            continue
-        value = source.get(name)
-        if isinstance(value, int) and not isinstance(value, bool):
-            return value
+    if not request.extra_fields:
+        return None
+    value = request.extra_fields.get(name)
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
     return None
 
 
@@ -169,36 +160,12 @@ class HttpRolloutDriver(RolloutDriver):
             if proxy_session is not None:
                 await self._close_proxy_session(proxy_session)
 
-    async def cancel(self, rollout_id: str) -> dict[str, str]:
-        """Tombstone a known active run and forward the remote cancel.
-
-        Unknown ids never mutate the callback store (a tombstone would poison
-        a later registration); the remote cancel is still forwarded because
-        the server may know the rollout.
-        """
-        try:
-            await self._store.acknowledge_without_commit(rollout_id)
-        except UnknownRolloutIdError:
-            logger.warning(
-                "Cancel for unknown rollout %s; forwarding remote cancel only",
-                rollout_id,
-            )
-        return await self._cancel_rollout(rollout_id)
-
-    def _is_cancelled_locally(self, rollout_id: str) -> bool:
-        terminal = self._store.terminal_for(rollout_id)
-        return terminal is not None and terminal.source == "cancelled"
-
     async def _admit(self, init: RolloutInitRequest) -> None:
         rollout_id = init.rollout_id
         if rollout_id is None:
             raise ValueError("rollout_id is required for admission")
         payload = init.model_dump(mode="json")
         while True:
-            # cancel() may land while we wait through 429 backpressure or
-            # status recovery; never POST work that is already cancelled.
-            if self._is_cancelled_locally(rollout_id):
-                return
             try:
                 response = await self._http.post(
                     f"{self._rollout_base_url}/rollout",
@@ -207,7 +174,6 @@ class HttpRolloutDriver(RolloutDriver):
             except httpx.RequestError:
                 probe = await self._recover_after_ambiguous_post(rollout_id)
                 if probe is _AdmissionProbe.ADMITTED:
-                    await self._cancel_remotely_if_cancelled_locally(rollout_id)
                     return
                 if probe is _AdmissionProbe.UNKNOWN:
                     continue
@@ -221,7 +187,6 @@ class HttpRolloutDriver(RolloutDriver):
                     "status recovery stayed indeterminate"
                 ) from None
             if response.status_code == 202:
-                await self._cancel_remotely_if_cancelled_locally(rollout_id)
                 return
             if response.status_code == 429:
                 await asyncio.sleep(_retry_after_seconds(response))
@@ -230,11 +195,6 @@ class HttpRolloutDriver(RolloutDriver):
                 f"POST /rollout returned {response.status_code}; "
                 "only 202 and 429 are accepted"
             )
-
-    async def _cancel_remotely_if_cancelled_locally(self, rollout_id: str) -> None:
-        """Re-issue the remote cancel when cancel() raced a successful POST."""
-        if self._is_cancelled_locally(rollout_id):
-            await self._cancel_rollout(rollout_id)
 
     async def _recover_after_ambiguous_post(self, rollout_id: str) -> _AdmissionProbe:
         last = _AdmissionProbe.INDETERMINATE

--- a/osmosis_ai/rollout/http_driver.py
+++ b/osmosis_ai/rollout/http_driver.py
@@ -1,0 +1,387 @@
+"""Concrete ``RolloutDriver`` over the v0.3 HTTP + callback protocol.
+
+Owns admission (202 / 429 / status recovery), callback rendezvous, and
+``/rollout/cancel``. Persistent dispatch/running state and user-requested
+cancellation terminal semantics belong to a supervisor, not this driver.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+from collections.abc import Callable
+from contextlib import suppress
+from enum import StrEnum
+from urllib.parse import quote
+
+import httpx
+from pydantic import ValidationError
+
+from osmosis_ai._imports import raise_optional_dependency_error
+from osmosis_ai.rollout.controller.store import (
+    CallbackStore,
+    TerminalCallbackResult,
+    UnknownRolloutIdError,
+)
+from osmosis_ai.rollout.driver import RolloutDriver, RolloutOutcome, RolloutRunRequest
+from osmosis_ai.rollout.types import (
+    CancelRolloutsRequest,
+    GraderStatus,
+    RolloutInitRequest,
+    RolloutStatus,
+    RolloutStatusResponse,
+)
+
+try:
+    from osmosis_ai.rollout.controller.proxy_client import (
+        EvalProxyClient,
+        EvalProxySession,
+    )
+except ModuleNotFoundError as _exc:
+    raise_optional_dependency_error(
+        _exc,
+        extra="eval-run",
+        feature="Local evaluation",
+    )
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class _AdmissionProbe(StrEnum):
+    ADMITTED = "admitted"
+    UNKNOWN = "unknown"
+    INDETERMINATE = "indeterminate"
+
+
+class AdmissionUncertainError(RuntimeError):
+    """Status recovery could not determine whether POST /rollout was admitted."""
+
+
+class RolloutProtocolError(RuntimeError):
+    """The rollout server returned a response outside the v0.3 admission contract."""
+
+
+def _retry_after_seconds(response: httpx.Response, default: float = 1.0) -> float:
+    """Parse Retry-After into a finite, non-negative wait; else the default."""
+    raw = response.headers.get("Retry-After")
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    if not math.isfinite(value):
+        return default
+    return max(0.0, value)
+
+
+def _optional_index(request: RolloutRunRequest, name: str) -> int | None:
+    for source in (request.extra_fields, request.metadata):
+        if not source:
+            continue
+        value = source.get(name)
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+    return None
+
+
+def _status_path(rollout_id: str) -> str:
+    return f"/rollout/{quote(rollout_id, safe='')}/status"
+
+
+class HttpRolloutDriver(RolloutDriver):
+    """POST /rollout driver with in-memory callback rendezvous."""
+
+    def __init__(
+        self,
+        *,
+        rollout_base_url: str,
+        callback_store: CallbackStore,
+        completion_url_for: Callable[[str], str],
+        grader_url_for: Callable[[str], str],
+        proxy_client: EvalProxyClient,
+        controller_api_key: str,
+        model_path: str,
+        http_client: httpx.AsyncClient | None = None,
+        callback_timeout_sec: float | None = None,
+        status_poll_attempts: int = 5,
+        status_poll_interval_sec: float = 0.05,
+    ) -> None:
+        self._rollout_base_url = rollout_base_url.rstrip("/")
+        self._store = callback_store
+        self._completion_url_for = completion_url_for
+        self._grader_url_for = grader_url_for
+        self._proxy_client = proxy_client
+        self._controller_api_key = controller_api_key
+        self._model_path = model_path
+        self._owns_http = http_client is None
+        self._http = http_client or httpx.AsyncClient()
+        self._callback_timeout_sec = callback_timeout_sec
+        self._status_poll_attempts = status_poll_attempts
+        self._status_poll_interval_sec = status_poll_interval_sec
+
+    async def aclose(self) -> None:
+        if self._owns_http:
+            await self._http.aclose()
+
+    async def run(self, request: RolloutRunRequest) -> RolloutOutcome:
+        rollout_id = request.rollout_id
+        if not rollout_id:
+            raise ValueError("RolloutRunRequest.rollout_id is required")
+
+        proxy_session: EvalProxySession | None = None
+        registered = False
+        try:
+            await self._store.register(rollout_id)
+            registered = True
+            proxy_session = await self._proxy_client.create_session(
+                rollout_id=rollout_id,
+                model_path=self._model_path,
+                row_index=_optional_index(request, "row_index"),
+                run_index=_optional_index(request, "run_index"),
+            )
+            init = RolloutInitRequest(
+                initial_messages=request.messages,
+                label=request.label,
+                metadata=request.metadata,
+                rollout_id=rollout_id,
+                chat_completions_url=proxy_session.api_base_url,
+                controller_api_key=self._controller_api_key,
+                llm_api_key=proxy_session.token,
+                completion_callback_url=self._completion_url_for(rollout_id),
+                grader_callback_url=self._grader_url_for(rollout_id),
+                agent_timeout_sec=request.agent_timeout_sec,
+                grader_timeout_sec=request.grader_timeout_sec,
+                extra_fields=request.extra_fields,
+            )
+            await self._admit(init)
+            terminal = await self._wait_for_terminal(rollout_id)
+            return _outcome_from_terminal(terminal)
+        except asyncio.CancelledError:
+            if registered:
+                await self._store.acknowledge_without_commit(rollout_id)
+            await self._cancel_rollout(rollout_id)
+            raise
+        finally:
+            if registered:
+                await self._store.discard(rollout_id)
+            if proxy_session is not None:
+                await self._close_proxy_session(proxy_session)
+
+    async def cancel(self, rollout_id: str) -> dict[str, str]:
+        """Tombstone a known active run and forward the remote cancel.
+
+        Unknown ids never mutate the callback store (a tombstone would poison
+        a later registration); the remote cancel is still forwarded because
+        the server may know the rollout.
+        """
+        try:
+            await self._store.acknowledge_without_commit(rollout_id)
+        except UnknownRolloutIdError:
+            logger.warning(
+                "Cancel for unknown rollout %s; forwarding remote cancel only",
+                rollout_id,
+            )
+        return await self._cancel_rollout(rollout_id)
+
+    def _is_cancelled_locally(self, rollout_id: str) -> bool:
+        terminal = self._store.terminal_for(rollout_id)
+        return terminal is not None and terminal.source == "cancelled"
+
+    async def _admit(self, init: RolloutInitRequest) -> None:
+        rollout_id = init.rollout_id
+        if rollout_id is None:
+            raise ValueError("rollout_id is required for admission")
+        payload = init.model_dump(mode="json")
+        while True:
+            # cancel() may land while we wait through 429 backpressure or
+            # status recovery; never POST work that is already cancelled.
+            if self._is_cancelled_locally(rollout_id):
+                return
+            try:
+                response = await self._http.post(
+                    f"{self._rollout_base_url}/rollout",
+                    json=payload,
+                )
+            except httpx.RequestError:
+                probe = await self._recover_after_ambiguous_post(rollout_id)
+                if probe is _AdmissionProbe.ADMITTED:
+                    await self._cancel_remotely_if_cancelled_locally(rollout_id)
+                    return
+                if probe is _AdmissionProbe.UNKNOWN:
+                    continue
+                # The POST may have been admitted even though recovery stayed
+                # indeterminate; best-effort remote cancel so an unobserved
+                # rollout cannot keep running. _cancel_rollout swallows its
+                # own failures, so the admission error below always wins.
+                await self._cancel_rollout(rollout_id)
+                raise AdmissionUncertainError(
+                    f"admission uncertain for rollout {rollout_id}: "
+                    "status recovery stayed indeterminate"
+                ) from None
+            if response.status_code == 202:
+                await self._cancel_remotely_if_cancelled_locally(rollout_id)
+                return
+            if response.status_code == 429:
+                await asyncio.sleep(_retry_after_seconds(response))
+                continue
+            raise RolloutProtocolError(
+                f"POST /rollout returned {response.status_code}; "
+                "only 202 and 429 are accepted"
+            )
+
+    async def _cancel_remotely_if_cancelled_locally(self, rollout_id: str) -> None:
+        """Re-issue the remote cancel when cancel() raced a successful POST."""
+        if self._is_cancelled_locally(rollout_id):
+            await self._cancel_rollout(rollout_id)
+
+    async def _recover_after_ambiguous_post(self, rollout_id: str) -> _AdmissionProbe:
+        last = _AdmissionProbe.INDETERMINATE
+        attempts = max(1, self._status_poll_attempts)
+        for attempt in range(attempts):
+            last = await self._probe_status(rollout_id)
+            if last is _AdmissionProbe.ADMITTED:
+                return last
+            if last is _AdmissionProbe.UNKNOWN:
+                return last
+            if attempt + 1 < attempts:
+                await asyncio.sleep(self._status_poll_interval_sec)
+        return last
+
+    async def _probe_status(self, rollout_id: str) -> _AdmissionProbe:
+        try:
+            response = await self._http.get(
+                f"{self._rollout_base_url}{_status_path(rollout_id)}"
+            )
+        except httpx.RequestError:
+            return _AdmissionProbe.INDETERMINATE
+        if response.status_code != 200:
+            return _AdmissionProbe.INDETERMINATE
+        try:
+            body = RolloutStatusResponse.model_validate_json(response.content)
+        except ValidationError:
+            return _AdmissionProbe.INDETERMINATE
+        if body.rollout_id != rollout_id:
+            # An answer about a different rollout must never trigger a
+            # re-POST; treat it as indeterminate.
+            return _AdmissionProbe.INDETERMINATE
+        if body.status is RolloutStatus.UNKNOWN:
+            return _AdmissionProbe.UNKNOWN
+        return _AdmissionProbe.ADMITTED
+
+    async def _wait_for_terminal(self, rollout_id: str) -> TerminalCallbackResult:
+        timeout = self._callback_timeout_sec
+        if timeout is None:
+            return await self._store.wait_terminal(rollout_id)
+        waiter = asyncio.create_task(self._store.wait_terminal(rollout_id))
+        try:
+            return await asyncio.wait_for(asyncio.shield(waiter), timeout)
+        except TimeoutError:
+            result = await self._store.finalize_timeout(
+                rollout_id,
+                acknowledgment={"ok": True, "error_type": "callback_timeout"},
+            )
+            if result.source == "timeout":
+                await self._cancel_rollout(rollout_id)
+            return result
+        finally:
+            if not waiter.done():
+                waiter.cancel()
+                with suppress(asyncio.CancelledError):
+                    await waiter
+
+    async def _cancel_rollout(self, rollout_id: str) -> dict[str, str]:
+        request = CancelRolloutsRequest(ids=[rollout_id])
+        try:
+            response = await self._http.post(
+                f"{self._rollout_base_url}/rollout/cancel",
+                json=request.model_dump(mode="json"),
+            )
+        except httpx.RequestError:
+            logger.warning(
+                "Failed to cancel rollout %s",
+                rollout_id,
+                exc_info=True,
+            )
+            return {}
+        if response.status_code >= 400:
+            logger.warning(
+                "Cancel rollout %s returned HTTP %s",
+                rollout_id,
+                response.status_code,
+            )
+            return {}
+        try:
+            payload = response.json()
+        except ValueError:
+            logger.warning(
+                "Cancel rollout %s returned malformed JSON",
+                rollout_id,
+                exc_info=True,
+            )
+            return {}
+        if not isinstance(payload, dict):
+            logger.warning(
+                "Cancel rollout %s returned a non-object JSON body",
+                rollout_id,
+            )
+            return {}
+        dispositions = payload.get("dispositions", {})
+        if not isinstance(dispositions, dict):
+            logger.warning(
+                "Cancel rollout %s returned malformed dispositions",
+                rollout_id,
+            )
+            return {}
+        return dispositions
+
+    async def _close_proxy_session(self, session: EvalProxySession) -> None:
+        try:
+            await self._proxy_client.close_session(session.rollout_id)
+        except Exception:
+            logger.warning(
+                "eval-proxy session close failed for %s",
+                session.rollout_id,
+                exc_info=True,
+            )
+
+
+def _outcome_from_terminal(terminal: TerminalCallbackResult) -> RolloutOutcome:
+    if terminal.source == "timeout":
+        return RolloutOutcome(
+            status=RolloutStatus.FAILURE,
+            error="callback_timeout",
+            rollout_id=terminal.rollout_id,
+        )
+    if terminal.source == "cancelled":
+        return RolloutOutcome(
+            status=RolloutStatus.CANCELLED,
+            error="cancelled",
+            rollout_id=terminal.rollout_id,
+        )
+    grader = terminal.grader
+    if grader is None:
+        return RolloutOutcome(
+            status=RolloutStatus.FAILURE,
+            error="missing terminal grader callback",
+            rollout_id=terminal.rollout_id,
+        )
+    status = (
+        RolloutStatus.SUCCESS
+        if grader.status == GraderStatus.SUCCESS
+        else RolloutStatus.FAILURE
+    )
+    return RolloutOutcome(
+        status=status,
+        sample=grader.sample,
+        error=grader.err_message,
+        rollout_id=terminal.rollout_id,
+    )
+
+
+__all__ = [
+    "AdmissionUncertainError",
+    "HttpRolloutDriver",
+    "RolloutProtocolError",
+]

--- a/osmosis_ai/rollout/server/app.py
+++ b/osmosis_ai/rollout/server/app.py
@@ -89,7 +89,7 @@ def create_rollout_server(
     active_digests: dict[str, str] = {}
     completed_digests: TtlCache[str, str] = TtlCache(_COMPLETED_DIGEST_TTL_SEC)
     # Strong references so eagerly scheduled rollout tasks are never GC'd.
-    scheduled_tasks: set[asyncio.Task[None]] = set()
+    scheduled_tasks: set[asyncio.Task[bool]] = set()
     # The instance id env var is immutable for the process lifetime.
     instance_id = os.environ.get("_OSMOSIS_ROLLOUT_INSTANCE_ID")
 
@@ -100,7 +100,7 @@ def create_rollout_server(
             payload["instance_id"] = instance_id
         return payload
 
-    def _finish_rollout_task(rollout_id: str | None, task: asyncio.Task[None]) -> None:
+    def _finish_rollout_task(rollout_id: str | None, task: asyncio.Task[bool]) -> None:
         scheduled_tasks.discard(task)
         exc = None if task.cancelled() else task.exception()
         if exc is not None:
@@ -108,11 +108,13 @@ def create_rollout_server(
         if rollout_id is None:
             return
         digest = active_digests.pop(rollout_id, None)
-        # A crashed or cancelled task never delivered its terminal callbacks,
-        # so its digest must not enter completed retention: a duplicate retry
-        # would dedupe into a 202 and wait forever for a callback that is
+        # Retain the digest only when every required terminal callback was
+        # delivered. A crashed, cancelled, or delivery-failed task left the
+        # controller without its terminal callback; a duplicate retry deduped
+        # against it would get a 202 and wait forever for a callback that is
         # never coming. Dropping the digest lets the retry re-execute.
-        if digest is not None and exc is None and not task.cancelled():
+        delivered = not task.cancelled() and exc is None and task.result()
+        if digest is not None and delivered:
             completed_digests.set(rollout_id, digest)
 
     # 202: the rollout is scheduled before this response is sent, so a
@@ -185,7 +187,11 @@ def create_rollout_server(
 
 async def _handle_rollout(
     backend: ExecutionBackend, request: RolloutInitRequest
-) -> None:
+) -> bool:
+    """Execute one rollout; return whether every required terminal callback
+    was delivered (the completion callback, plus the grader callback when
+    ``grader_callback_url`` is set). The admission layer retains the
+    idempotency digest only for delivered rollouts."""
     # Routing identity is in the URLs; ``rollout_id`` in the body is debug
     # metadata. We prefer the caller's id (so logs/cache rows correlate
     # across systems) and synthesize one only if the caller omits it.
@@ -362,6 +368,7 @@ async def _handle_rollout(
                     ).model_dump(),
                     headers=auth.as_bearer_headers(),
                 )
+                completion_posted = True
                 report = report_from_response(resp) or report
             except Exception:
                 logger.error(
@@ -387,3 +394,4 @@ async def _handle_rollout(
                 report=report,
                 diagnostics=last_diagnostics,
             )
+    return completion_posted and (not request.grader_callback_url or grader_posted)

--- a/osmosis_ai/rollout/server/app.py
+++ b/osmosis_ai/rollout/server/app.py
@@ -1,9 +1,14 @@
+import asyncio
+import hashlib
+import json
 import logging
+import os
 import traceback
 import uuid
+from functools import partial
 from typing import Any
 
-from fastapi import BackgroundTasks, FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException
 
 from osmosis_ai.rollout.backend.base import ExecutionBackend
 from osmosis_ai.rollout.context import RolloutContext
@@ -28,8 +33,28 @@ from osmosis_ai.rollout.types import (
     RolloutStatusResponse,
 )
 from osmosis_ai.rollout.utils.http import post_json_with_retry
+from osmosis_ai.rollout.utils.ttl_cache import TtlCache
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+# Credentials never enter the idempotency digest.
+_IDEMPOTENCY_EXCLUDED_FIELDS = {"controller_api_key", "llm_api_key"}
+
+# Completed idempotency digests are retained for this window so a duplicate
+# retry of a finished rollout dedupes instead of re-executing. 15 minutes
+# comfortably covers the driver's retry/status-recovery horizon while keeping
+# memory bounded on long-lived training servers (same window as the Harbor
+# backend's STATUS_RETENTION_SEC). Active entries never expire.
+_COMPLETED_DIGEST_TTL_SEC = 900.0
+
+
+def _canonical_request_digest(request: RolloutInitRequest) -> str:
+    """Stable digest of one init body, excluding callback/LLM secrets."""
+    payload = request.model_dump(mode="json", exclude=_IDEMPOTENCY_EXCLUDED_FIELDS)
+    encoded = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    )
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
 def _configure_default_logging() -> None:
@@ -56,16 +81,55 @@ def create_rollout_server(
     if configure_logging:
         _configure_default_logging()
     app = FastAPI(lifespan=lifespan)
+    # Idempotency: rollout_id -> canonical request digest. Active entries
+    # cover scheduled/running executions and never expire; when execution
+    # finishes, only id + digest move into bounded recent retention. Digests
+    # only; raw payloads and credentials are not retained. /status stays
+    # backend-authoritative.
+    active_digests: dict[str, str] = {}
+    completed_digests: TtlCache[str, str] = TtlCache(_COMPLETED_DIGEST_TTL_SEC)
+    # Strong references so eagerly scheduled rollout tasks are never GC'd.
+    scheduled_tasks: set[asyncio.Task[None]] = set()
+    # The instance id env var is immutable for the process lifetime.
+    instance_id = os.environ.get("_OSMOSIS_ROLLOUT_INSTANCE_ID")
 
     @app.get("/health")
     async def health() -> dict[str, Any]:
-        return backend.health()
+        payload = dict(backend.health())
+        if instance_id:
+            payload["instance_id"] = instance_id
+        return payload
 
-    # 202: the rollout is queued and runs after this response returns.
+    def _finish_rollout_task(rollout_id: str | None, task: asyncio.Task[None]) -> None:
+        scheduled_tasks.discard(task)
+        if rollout_id is not None:
+            digest = active_digests.pop(rollout_id, None)
+            if digest is not None:
+                completed_digests.set(rollout_id, digest)
+        if not task.cancelled():
+            exc = task.exception()
+            if exc is not None:
+                logger.error("Rollout task for %s crashed", rollout_id, exc_info=exc)
+
+    # 202: the rollout is scheduled before this response is sent, so a
+    # failed/disconnected response cannot record a digest for an execution
+    # that never ran (the retry would dedupe against it and hang forever).
     @app.post("/rollout", status_code=202)
-    async def rollout(
-        request: RolloutInitRequest, background_tasks: BackgroundTasks
-    ) -> RolloutInitResponse:
+    async def rollout(request: RolloutInitRequest) -> RolloutInitResponse:
+        rollout_id = request.rollout_id or None
+        digest: str | None = None
+        if rollout_id is not None:
+            digest = _canonical_request_digest(request)
+            existing = active_digests.get(rollout_id)
+            if existing is None:
+                existing = completed_digests.get(rollout_id)
+            if existing is not None:
+                if existing == digest:
+                    return RolloutInitResponse()
+                raise HTTPException(
+                    status_code=409,
+                    detail="conflicting duplicate rollout_id",
+                )
         if not backend.has_capacity():
             raise HTTPException(
                 status_code=429,
@@ -73,20 +137,24 @@ def create_rollout_server(
                 headers={"Retry-After": "5"},
             )
         try:
-            background_tasks.add_task(_handle_rollout, backend, request)
-            return RolloutInitResponse()
+            task = asyncio.create_task(_handle_rollout(backend, request))
         except Exception as e:
             logger.error(traceback.format_exc())
             raise HTTPException(status_code=500, detail=str(e)) from e
+        scheduled_tasks.add(task)
+        if rollout_id is not None and digest is not None:
+            active_digests[rollout_id] = digest
+        task.add_done_callback(partial(_finish_rollout_task, rollout_id))
+        return RolloutInitResponse()
 
     @app.get("/rollout/{rollout_id}/status")
     async def rollout_status(rollout_id: str) -> RolloutStatusResponse:
         state = backend.rollout_status(rollout_id)
-        if state is None:
-            return RolloutStatusResponse(
-                rollout_id=rollout_id, status=RolloutStatus.UNKNOWN
-            )
-        return RolloutStatusResponse(rollout_id=rollout_id, **state)
+        if state is not None:
+            return RolloutStatusResponse(rollout_id=rollout_id, **state)
+        return RolloutStatusResponse(
+            rollout_id=rollout_id, status=RolloutStatus.UNKNOWN
+        )
 
     @app.post("/rollout/cancel")
     async def cancel(request: CancelRolloutsRequest) -> CancelRolloutsResponse:
@@ -120,9 +188,14 @@ async def _handle_rollout(
     rollout_id = request.rollout_id or uuid.uuid4().hex
     auth = ControllerAuth(api_key=request.controller_api_key)
 
+    llm_api_key = (
+        request.controller_api_key
+        if request.llm_api_key is None
+        else request.llm_api_key
+    )
     rollout_ctx = RolloutContext(
         chat_completions_url=request.chat_completions_url,
-        api_key=request.controller_api_key,
+        api_key=llm_api_key,
         rollout_id=rollout_id,
     )
 

--- a/osmosis_ai/rollout/server/app.py
+++ b/osmosis_ai/rollout/server/app.py
@@ -5,6 +5,8 @@ import logging
 import os
 import traceback
 import uuid
+from collections.abc import AsyncIterator
+from contextlib import AsyncExitStack, asynccontextmanager
 from functools import partial
 from typing import Any
 
@@ -47,6 +49,11 @@ _IDEMPOTENCY_EXCLUDED_FIELDS = {"controller_api_key", "llm_api_key"}
 # backend's STATUS_RETENTION_SEC). Active entries never expire.
 _COMPLETED_DIGEST_TTL_SEC = 900.0
 
+# Graceful shutdown waits this long for in-flight rollouts before cancelling
+# them. Uvicorn closes its listeners before lifespan shutdown, so nothing new
+# is admitted while draining.
+_SHUTDOWN_DRAIN_SEC = 10.0
+
 
 def _canonical_request_digest(request: RolloutInitRequest) -> str:
     """Stable digest of one init body, excluding callback/LLM secrets."""
@@ -80,7 +87,34 @@ def create_rollout_server(
     """
     if configure_logging:
         _configure_default_logging()
-    app = FastAPI(lifespan=lifespan)
+    # Strong references so eagerly scheduled rollout tasks are never GC'd.
+    scheduled_tasks: set[asyncio.Task[bool]] = set()
+
+    async def _drain_scheduled_tasks() -> None:
+        if not scheduled_tasks:
+            return
+        logger.info("Draining %d in-flight rollout(s)", len(scheduled_tasks))
+        _done, pending = await asyncio.wait(
+            set(scheduled_tasks), timeout=_SHUTDOWN_DRAIN_SEC
+        )
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+    @asynccontextmanager
+    async def _lifespan_with_drain(app: FastAPI) -> AsyncIterator[None]:
+        # The drain runs inside the caller's lifespan: in-flight rollouts may
+        # still use resources that lifespan owns.
+        async with AsyncExitStack() as stack:
+            if lifespan is not None:
+                await stack.enter_async_context(lifespan(app))
+            try:
+                yield
+            finally:
+                await _drain_scheduled_tasks()
+
+    app = FastAPI(lifespan=_lifespan_with_drain)
     # Idempotency: rollout_id -> canonical request digest. Active entries
     # cover scheduled/running executions and never expire; when execution
     # finishes, only id + digest move into bounded recent retention. Digests
@@ -88,8 +122,6 @@ def create_rollout_server(
     # backend-authoritative.
     active_digests: dict[str, str] = {}
     completed_digests: TtlCache[str, str] = TtlCache(_COMPLETED_DIGEST_TTL_SEC)
-    # Strong references so eagerly scheduled rollout tasks are never GC'd.
-    scheduled_tasks: set[asyncio.Task[bool]] = set()
     # The instance id env var is immutable for the process lifetime.
     instance_id = os.environ.get("_OSMOSIS_ROLLOUT_INSTANCE_ID")
 

--- a/osmosis_ai/rollout/server/app.py
+++ b/osmosis_ai/rollout/server/app.py
@@ -102,14 +102,18 @@ def create_rollout_server(
 
     def _finish_rollout_task(rollout_id: str | None, task: asyncio.Task[None]) -> None:
         scheduled_tasks.discard(task)
-        if rollout_id is not None:
-            digest = active_digests.pop(rollout_id, None)
-            if digest is not None:
-                completed_digests.set(rollout_id, digest)
-        if not task.cancelled():
-            exc = task.exception()
-            if exc is not None:
-                logger.error("Rollout task for %s crashed", rollout_id, exc_info=exc)
+        exc = None if task.cancelled() else task.exception()
+        if exc is not None:
+            logger.error("Rollout task for %s crashed", rollout_id, exc_info=exc)
+        if rollout_id is None:
+            return
+        digest = active_digests.pop(rollout_id, None)
+        # A crashed or cancelled task never delivered its terminal callbacks,
+        # so its digest must not enter completed retention: a duplicate retry
+        # would dedupe into a 202 and wait forever for a callback that is
+        # never coming. Dropping the digest lets the retry re-execute.
+        if digest is not None and exc is None and not task.cancelled():
+            completed_digests.set(rollout_id, digest)
 
     # 202: the rollout is scheduled before this response is sent, so a
     # failed/disconnected response cannot record a digest for an execution

--- a/osmosis_ai/rollout/types/protocol.py
+++ b/osmosis_ai/rollout/types/protocol.py
@@ -22,6 +22,13 @@ class RolloutInitRequest(BaseModel):
     the body for debug logging on the rollout-server side and for
     correlation in user-side dashboards; the SDK does not rely on it for
     routing, so it is optional.
+
+    ``controller_api_key`` authenticates callbacks back to the controller
+    listener. ``llm_api_key`` authenticates the agent to
+    ``chat_completions_url`` (the eval-proxy session token). When
+    ``llm_api_key`` is omitted (``None``), the server falls back to
+    ``controller_api_key`` so existing single-secret callers keep working.
+    An explicit empty string is rejected; only ``None`` triggers fallback.
     """
 
     initial_messages: list[MessageDict]
@@ -32,6 +39,7 @@ class RolloutInitRequest(BaseModel):
 
     chat_completions_url: str
     controller_api_key: str | None = None
+    llm_api_key: str | None = None
     completion_callback_url: str
     grader_callback_url: str | None = None
 
@@ -47,6 +55,18 @@ class RolloutInitRequest(BaseModel):
         if value is None:
             return None
         return ensure_single_path_segment(value, label="rollout_id")
+
+    @field_validator("llm_api_key")
+    @classmethod
+    def _validate_llm_api_key(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if value == "":
+            raise ValueError(
+                "llm_api_key must be omitted or a non-empty string; "
+                "empty string is not a legacy fallback"
+            )
+        return value
 
     @field_validator("agent_timeout_sec", "grader_timeout_sec")
     @classmethod

--- a/osmosis_ai/rollout/utils/file_artifacts.py
+++ b/osmosis_ai/rollout/utils/file_artifacts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import shutil
 from pathlib import Path
 
@@ -171,7 +172,13 @@ def default_artifact_root() -> Path:
     Each rollout's outputs live at ``<root>/<rollout_id>/`` — file
     artifacts under ``artifacts/`` and the archived trajectory as
     ``trajectory.json`` — which the platform persists to durable storage.
+
+    ``_OSMOSIS_ROLLOUT_ARTIFACT_ROOT`` overrides the default when set. Both
+    backends cache the resolved root in ``__init__``, so the variable must be
+    present before backend construction.
     """
+    if value := os.environ.get("_OSMOSIS_ROLLOUT_ARTIFACT_ROOT"):
+        return Path(value)
     return Path.home() / ".osmosis"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,6 @@ eval-run = [
     "fastapi>=0.100.0,<1.0.0",
     "uvicorn>=0.23.0,<1.0.0",
     "click>=8.3.3",
-    "aiohttp>=3.14.3",
 ]
 
 # Full installation with all optional features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,9 +126,18 @@ parquet = [
     "pyarrow>=23.0.1",
 ]
 
+# Local eval-run primitives: localhost callback listener + eval-proxy client.
+# No LiteLLM — LLM bridging lives in the hosted eval-proxy.
+eval-run = [
+    "fastapi>=0.100.0,<1.0.0",
+    "uvicorn>=0.23.0,<1.0.0",
+    "click>=8.3.3",
+    "aiohttp>=3.14.3",
+]
+
 # Full installation with all optional features
 full = [
-    "osmosis-ai[server,strands,openai-agents,harbor,rubric,parquet]",
+    "osmosis-ai[server,strands,openai-agents,harbor,rubric,parquet,eval-run]",
 ]
 
 [dependency-groups]

--- a/tests/golden/rollout/shared_wire/completion_failure.json
+++ b/tests/golden/rollout/shared_wire/completion_failure.json
@@ -1,0 +1,6 @@
+{
+  "status": "failure",
+  "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "err_message": "agent exploded",
+  "err_category": "agent_error"
+}

--- a/tests/golden/rollout/shared_wire/completion_success.json
+++ b/tests/golden/rollout/shared_wire/completion_success.json
@@ -1,0 +1,4 @@
+{
+  "status": "success",
+  "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}

--- a/tests/golden/rollout/shared_wire/grader_with_reward.json
+++ b/tests/golden/rollout/shared_wire/grader_with_reward.json
@@ -1,0 +1,8 @@
+{
+  "status": "success",
+  "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "sample": {
+    "reward": 1.0,
+    "remove_sample": false
+  }
+}

--- a/tests/golden/rollout/shared_wire/init_request.json
+++ b/tests/golden/rollout/shared_wire/init_request.json
@@ -1,0 +1,12 @@
+{
+  "initial_messages": [{"role": "user", "content": "hi"}],
+  "label": "yes",
+  "metadata": {"row_index": 0},
+  "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "chat_completions_url": "http://127.0.0.1:9000/v1/chat/completions",
+  "controller_api_key": "controller-key",
+  "completion_callback_url": "http://127.0.0.1:8000/v1/rollouts/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/completion",
+  "grader_callback_url": "http://127.0.0.1:8000/v1/rollouts/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/grader",
+  "agent_timeout_sec": 30.0,
+  "grader_timeout_sec": 10.0
+}

--- a/tests/unit/rollout/controller/test_listener.py
+++ b/tests/unit/rollout/controller/test_listener.py
@@ -156,7 +156,7 @@ async def test_completion_rejects_non_terminal_statuses(status: str) -> None:
             headers=_auth(),
         )
     assert response.status_code == 422
-    assert store.completion_for(ROLLOUT_ID) is None
+    assert store._sessions[ROLLOUT_ID].completion is None
 
 
 async def test_grader_rejects_pending_status() -> None:

--- a/tests/unit/rollout/controller/test_listener.py
+++ b/tests/unit/rollout/controller/test_listener.py
@@ -1,0 +1,323 @@
+"""Tests for the localhost callback listener."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+from httpx import ASGITransport
+
+from osmosis_ai.rollout.controller.listener import (
+    CallbackListener,
+    create_callback_app,
+)
+from osmosis_ai.rollout.controller.store import CallbackStore, TerminalCallbackResult
+from osmosis_ai.rollout.types import GraderStatus, RolloutSample, RolloutStatus
+
+ROLLOUT_ID = "b" * 32
+TOKEN = "callback-secret"
+
+
+def _auth(token: str = TOKEN) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _completion_body(rollout_id: str = ROLLOUT_ID) -> dict[str, object]:
+    return {"status": RolloutStatus.SUCCESS, "rollout_id": rollout_id}
+
+
+def _grader_body(rollout_id: str = ROLLOUT_ID) -> dict[str, object]:
+    return {
+        "status": GraderStatus.SUCCESS,
+        "rollout_id": rollout_id,
+        "sample": {
+            "messages": [{"role": "assistant", "content": "ok"}],
+            "reward": 1.0,
+        },
+    }
+
+
+async def _client(store: CallbackStore) -> httpx.AsyncClient:
+    app = create_callback_app(store, auth_token=TOKEN)
+    return httpx.AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://127.0.0.1",
+    )
+
+
+async def test_completion_and_grader_routes_require_bearer_auth() -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    async with await _client(store) as client:
+        completion_path = f"/v1/rollouts/{ROLLOUT_ID}/completion"
+        grader_path = f"/v1/rollouts/{ROLLOUT_ID}/grader"
+        assert (
+            await client.post(completion_path, json=_completion_body())
+        ).status_code == 401
+        assert (
+            await client.post(
+                completion_path, json=_completion_body(), headers=_auth("nope")
+            )
+        ).status_code == 401
+        assert (await client.post(grader_path, json=_grader_body())).status_code == 401
+        assert (
+            await client.post(grader_path, json=_grader_body(), headers=_auth("nope"))
+        ).status_code == 401
+
+
+async def test_valid_bearer_auth_accepts_callbacks() -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    async with await _client(store) as client:
+        completion = await client.post(
+            f"/v1/rollouts/{ROLLOUT_ID}/completion",
+            json=_completion_body(),
+            headers=_auth(),
+        )
+        grader = await client.post(
+            f"/v1/rollouts/{ROLLOUT_ID}/grader",
+            json=_grader_body(),
+            headers=_auth(),
+        )
+    assert completion.status_code == 200
+    assert grader.status_code == 200
+    assert grader.json() == {"ok": True}
+
+
+async def test_body_rollout_id_must_match_path() -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    async with await _client(store) as client:
+        response = await client.post(
+            f"/v1/rollouts/{ROLLOUT_ID}/grader",
+            json=_grader_body(rollout_id="c" * 32),
+            headers=_auth(),
+        )
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize("bad_id", [".", "..", "has/slash", "has\\slash"])
+async def test_malicious_or_invalid_rollout_ids_are_rejected(bad_id: str) -> None:
+    store = CallbackStore()
+    async with await _client(store) as client:
+        response = await client.post(
+            f"/v1/rollouts/{bad_id}/grader",
+            json={
+                "status": GraderStatus.SUCCESS,
+                "sample": RolloutSample(messages=[]).model_dump(mode="json"),
+            },
+            headers=_auth(),
+        )
+    assert response.status_code in {400, 404, 422}
+
+
+async def test_grader_response_waits_for_commit_hook() -> None:
+    released = asyncio.Event()
+    started = asyncio.Event()
+    order: list[str] = []
+
+    async def commit(result: TerminalCallbackResult) -> dict[str, object]:
+        order.append("commit")
+        started.set()
+        await released.wait()
+        order.append("committed")
+        return {"ok": True}
+
+    store = CallbackStore(on_terminal_commit=commit)
+    await store.register(ROLLOUT_ID)
+    async with await _client(store) as client:
+
+        async def post() -> None:
+            response = await client.post(
+                f"/v1/rollouts/{ROLLOUT_ID}/grader",
+                json=_grader_body(),
+                headers=_auth(),
+            )
+            assert response.status_code == 200
+            order.append("http-returned")
+
+        task = asyncio.create_task(post())
+        await started.wait()
+        assert order == ["commit"]
+        released.set()
+        await task
+    assert order == ["commit", "committed", "http-returned"]
+
+
+@pytest.mark.parametrize("status", ["queued", "running", "grading", "unknown"])
+async def test_completion_rejects_non_terminal_statuses(status: str) -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    async with await _client(store) as client:
+        response = await client.post(
+            f"/v1/rollouts/{ROLLOUT_ID}/completion",
+            json={"status": status, "rollout_id": ROLLOUT_ID},
+            headers=_auth(),
+        )
+    assert response.status_code == 422
+    assert store.completion_for(ROLLOUT_ID) is None
+
+
+async def test_grader_rejects_pending_status() -> None:
+    commits = 0
+
+    async def commit(result: TerminalCallbackResult) -> dict[str, object]:
+        nonlocal commits
+        commits += 1
+        return {"ok": True}
+
+    store = CallbackStore(on_terminal_commit=commit)
+    await store.register(ROLLOUT_ID)
+    async with await _client(store) as client:
+        response = await client.post(
+            f"/v1/rollouts/{ROLLOUT_ID}/grader",
+            json={"status": "pending", "rollout_id": ROLLOUT_ID, "sample": None},
+            headers=_auth(),
+        )
+    assert response.status_code == 422
+    assert store.terminal_for(ROLLOUT_ID) is None
+    assert commits == 0
+
+
+async def test_listener_binds_reserved_localhost_socket() -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    listener = CallbackListener(store, auth_token=TOKEN, host="127.0.0.1", port=0)
+    async with listener:
+        assert listener.base_url.startswith("http://127.0.0.1:")
+        async with httpx.AsyncClient() as http:
+            response = await http.post(
+                listener.completion_url(ROLLOUT_ID),
+                json=_completion_body(),
+                headers=_auth(),
+            )
+        assert response.status_code == 200
+        assert listener.grader_url(ROLLOUT_ID).endswith(
+            f"/v1/rollouts/{ROLLOUT_ID}/grader"
+        )
+
+
+def test_empty_auth_token_is_rejected() -> None:
+    store = CallbackStore()
+    with pytest.raises(ValueError, match="auth_token"):
+        create_callback_app(store, auth_token="")
+    with pytest.raises(ValueError, match="auth_token"):
+        CallbackListener(store, auth_token="   ")
+
+
+def test_non_loopback_bind_host_is_rejected() -> None:
+    store = CallbackStore()
+    with pytest.raises(ValueError, match="loopback"):
+        CallbackListener(store, auth_token=TOKEN, host="0.0.0.0")
+    with pytest.raises(ValueError, match="loopback"):
+        CallbackListener(store, auth_token=TOKEN, host="192.168.1.1")
+
+
+@pytest.mark.parametrize("host", ["::1", "[::1]", "::ffff:127.0.0.1"])
+def test_ipv6_hosts_are_rejected_at_construction(host: str) -> None:
+    # The listener binds an AF_INET socket; claiming ::1 support would fail
+    # later with an opaque bind error, so IPv6 is rejected explicitly.
+    store = CallbackStore()
+    with pytest.raises(ValueError, match="loopback"):
+        CallbackListener(store, auth_token=TOKEN, host=host)
+
+
+async def test_localhost_normalizes_to_ipv4_loopback() -> None:
+    store = CallbackStore()
+    listener = CallbackListener(store, auth_token=TOKEN, host="localhost")
+    async with listener:
+        assert listener.base_url.startswith("http://127.0.0.1:")
+
+
+async def test_callback_urls_encode_rollout_ids() -> None:
+    from urllib.parse import quote
+
+    store = CallbackStore()
+    listener = CallbackListener(store, auth_token=TOKEN)
+    async with listener:
+        special_id = "rid:1"
+        encoded = quote(special_id, safe="")
+        assert listener.completion_url(special_id).endswith(
+            f"/v1/rollouts/{encoded}/completion"
+        )
+        assert listener.grader_url(special_id).endswith(
+            f"/v1/rollouts/{encoded}/grader"
+        )
+
+
+async def _serve_until_exit(self, sockets=None):
+    self.started = True
+    while not self.should_exit:
+        await asyncio.sleep(0)
+
+
+async def test_failed_start_resets_and_is_retryable(monkeypatch) -> None:
+    import uvicorn
+
+    store = CallbackStore()
+    listener = CallbackListener(store, auth_token=TOKEN)
+
+    async def boom(self, sockets=None):
+        raise RuntimeError("serve exploded")
+
+    monkeypatch.setattr(uvicorn.Server, "serve", boom)
+    with pytest.raises(RuntimeError, match="serve exploded"):
+        await listener.start()
+    assert listener._server._task is None
+    assert listener._server._socket is None
+    assert listener._server._base_url is None
+
+    monkeypatch.setattr(uvicorn.Server, "serve", _serve_until_exit)
+    url = await listener.start()
+    assert url.startswith("http://127.0.0.1:")
+    await listener.stop()
+    assert listener._server._task is None
+    assert listener._server._socket is None
+
+
+async def test_start_timeout_resets_and_is_retryable(monkeypatch) -> None:
+    import uvicorn
+
+    from osmosis_ai.rollout.controller import listener as listener_module
+
+    monkeypatch.setattr(listener_module, "_START_POLL_ATTEMPTS", 2)
+    monkeypatch.setattr(listener_module, "_START_POLL_INTERVAL_SEC", 0)
+
+    store = CallbackStore()
+    listener = CallbackListener(store, auth_token=TOKEN)
+
+    async def hang(self, sockets=None):
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(uvicorn.Server, "serve", hang)
+    with pytest.raises(RuntimeError, match="failed to start"):
+        await listener.start()
+    assert listener._server._task is None
+    assert listener._server._socket is None
+
+    monkeypatch.setattr(listener_module, "_START_POLL_ATTEMPTS", 500)
+    monkeypatch.setattr(listener_module, "_START_POLL_INTERVAL_SEC", 0.01)
+    monkeypatch.setattr(uvicorn.Server, "serve", _serve_until_exit)
+    url = await listener.start()
+    assert url.startswith("http://127.0.0.1:")
+    await listener.stop()
+
+
+async def test_stop_failure_still_resets_and_is_retryable() -> None:
+    store = CallbackStore()
+    listener = CallbackListener(store, auth_token=TOKEN)
+    await listener.start()
+    real_task = listener._server._task
+    assert real_task is not None
+    listener._server._server.should_exit = True
+    await real_task
+    failed = asyncio.get_running_loop().create_future()
+    failed.set_exception(RuntimeError("join failed"))
+    listener._server._task = failed  # type: ignore[assignment]
+    with pytest.raises(RuntimeError, match="join failed"):
+        await listener.stop()
+    assert listener._server._task is None
+    assert listener._server._socket is None
+    await listener.start()
+    await listener.stop()

--- a/tests/unit/rollout/controller/test_proxy_client.py
+++ b/tests/unit/rollout/controller/test_proxy_client.py
@@ -188,6 +188,36 @@ async def test_client_create_session_surfaces_http_errors() -> None:
             await client.aclose()
 
 
+@pytest.mark.parametrize(
+    "content,media_type",
+    [
+        ("not-json", "text/plain"),  # aiohttp.ContentTypeError
+        ("{truncated", "application/json"),  # json.JSONDecodeError
+    ],
+)
+async def test_malformed_2xx_body_raises_eval_proxy_error(
+    content: str, media_type: str
+) -> None:
+    from fastapi import FastAPI
+    from fastapi.responses import Response
+
+    app = FastAPI()
+
+    @app.post("/v1/eval-sessions")
+    async def create() -> Response:
+        return Response(content=content, media_type=media_type)
+
+    async with LocalhostUvicornServer(app) as server:
+        client = EvalProxyClient(base_url=server.base_url, auth_token=PLATFORM_TOKEN)
+        try:
+            with pytest.raises(EvalProxyError, match="invalid JSON"):
+                await client.create_session(
+                    rollout_id=ROLLOUT_ID, model_path=MODEL_PATH
+                )
+        finally:
+            await client.aclose()
+
+
 def _create_response_app(body: dict) -> object:
     from fastapi import FastAPI
 

--- a/tests/unit/rollout/controller/test_proxy_client.py
+++ b/tests/unit/rollout/controller/test_proxy_client.py
@@ -18,12 +18,15 @@ from osmosis_ai.rollout.controller.proxy_client import (
     EvalProxyClient,
     EvalProxyError,
     EvalProxySession,
+)
+from tests.unit.rollout.eval_proxy_stub import (
+    DEFAULT_STUB_PLATFORM_TOKEN,
     create_eval_proxy_stub_app,
 )
 
 ROLLOUT_ID = "d" * 32
 MODEL_PATH = "openai/gpt-4.1-mini"
-PLATFORM_TOKEN = "platform-token"
+PLATFORM_TOKEN = DEFAULT_STUB_PLATFORM_TOKEN
 
 
 def _platform() -> dict[str, str]:
@@ -152,7 +155,7 @@ async def test_client_create_session_posts_frozen_fields_only() -> None:
     app = create_eval_proxy_stub_app()
     async with LocalhostUvicornServer(app) as server:
         origin = server.base_url
-        client = EvalProxyClient(base_url=origin, auth_token="platform-token")
+        client = EvalProxyClient(base_url=origin, auth_token=PLATFORM_TOKEN)
         try:
             session = await client.create_session(
                 rollout_id=ROLLOUT_ID,
@@ -194,29 +197,6 @@ async def test_client_create_session_surfaces_http_errors() -> None:
     assert excinfo.value.status_code == 401
 
 
-async def test_error_contract_holds_for_raise_for_status_sessions() -> None:
-    # A caller-supplied session with raise_for_status=True must not replace
-    # the client's EvalProxyError contract with aiohttp.ClientResponseError.
-    import aiohttp
-
-    app = create_eval_proxy_stub_app()
-    async with LocalhostUvicornServer(app) as server:
-        session = aiohttp.ClientSession(raise_for_status=True)
-        try:
-            client = EvalProxyClient(
-                base_url=server.base_url,
-                auth_token="wrong-token",
-                session=session,
-            )
-            with pytest.raises(EvalProxyError) as excinfo:
-                await client.create_session(
-                    rollout_id=ROLLOUT_ID, model_path=MODEL_PATH
-                )
-        finally:
-            await session.close()
-    assert excinfo.value.status_code == 401
-
-
 @pytest.mark.parametrize("bad_id", ["..", ".", "a/b", "a\\b", "", "a\x00b"])
 async def test_session_methods_reject_non_single_segment_ids(bad_id: str) -> None:
     # quote() leaves dots intact and HTTP stacks normalize dot segments, so
@@ -228,8 +208,6 @@ async def test_session_methods_reject_non_single_segment_ids(bad_id: str) -> Non
             await client.create_session(rollout_id=bad_id, model_path=MODEL_PATH)
         with pytest.raises(EvalProxyError, match="single path segment"):
             await client.close_session(bad_id)
-        with pytest.raises(EvalProxyError, match="single path segment"):
-            await client.get_usage(bad_id)
     finally:
         await client.aclose()
 
@@ -237,8 +215,8 @@ async def test_session_methods_reject_non_single_segment_ids(bad_id: str) -> Non
 @pytest.mark.parametrize(
     "content,media_type",
     [
-        ("not-json", "text/plain"),  # aiohttp.ContentTypeError
-        ("{truncated", "application/json"),  # json.JSONDecodeError
+        ("not-json", "text/plain"),
+        ("{truncated", "application/json"),
     ],
 )
 async def test_malformed_2xx_body_raises_eval_proxy_error(
@@ -390,6 +368,43 @@ async def test_malformed_create_response_triggers_best_effort_close() -> None:
     assert closed == [ROLLOUT_ID]
 
 
+def _rejecting_app(status_code: int) -> tuple[Any, set[str]]:
+    """Create is rejected; the id already names a session owned elsewhere."""
+    from fastapi import FastAPI, HTTPException
+
+    live_sessions = {ROLLOUT_ID}
+    app = FastAPI()
+
+    @app.post("/v1/eval-sessions")
+    async def create() -> dict:
+        raise HTTPException(status_code=status_code, detail="rejected")
+
+    @app.delete("/v1/eval-sessions/{rollout_id}")
+    async def close(rollout_id: str) -> dict:
+        live_sessions.discard(rollout_id)
+        return {"ok": True}
+
+    return app, live_sessions
+
+
+@pytest.mark.parametrize("status_code", [401, 409])
+async def test_definitive_4xx_create_rejection_skips_cleanup(status_code: int) -> None:
+    # A 4xx create never took effect, so there is nothing to close; on a 409
+    # the DELETE would close another run's live session.
+    app, live_sessions = _rejecting_app(status_code)
+    async with LocalhostUvicornServer(app) as server:
+        client = EvalProxyClient(base_url=server.base_url, auth_token=PLATFORM_TOKEN)
+        try:
+            with pytest.raises(EvalProxyError) as excinfo:
+                await client.create_session(
+                    rollout_id=ROLLOUT_ID, model_path=MODEL_PATH
+                )
+        finally:
+            await client.aclose()
+    assert excinfo.value.status_code == status_code
+    assert live_sessions == {ROLLOUT_ID}
+
+
 async def test_cancelled_create_attempts_cleanup_without_masking_cancellation() -> None:
     from fastapi import FastAPI
 
@@ -476,7 +491,7 @@ async def test_failed_create_cleanup_wait_is_bounded(monkeypatch) -> None:
             await client.aclose()
 
 
-async def test_management_routes_use_platform_token_not_session_token() -> None:
+async def test_close_route_uses_platform_token_not_session_token() -> None:
     app = create_eval_proxy_stub_app()
     async with await _asgi_client(app) as client:
         created = await client.post(
@@ -485,31 +500,19 @@ async def test_management_routes_use_platform_token_not_session_token() -> None:
             headers=_platform(),
         )
         session_token = created.json()["token"]
-        session_headers = {"Authorization": f"Bearer {session_token}"}
-        usage_session = await client.get(
-            f"/v1/eval-sessions/{ROLLOUT_ID}/usage",
-            headers=session_headers,
-        )
         close_session = await client.delete(
             f"/v1/eval-sessions/{ROLLOUT_ID}",
-            headers=session_headers,
-        )
-        usage_platform = await client.get(
-            f"/v1/eval-sessions/{ROLLOUT_ID}/usage",
-            headers=_platform(),
+            headers={"Authorization": f"Bearer {session_token}"},
         )
         close_platform = await client.delete(
             f"/v1/eval-sessions/{ROLLOUT_ID}",
             headers=_platform(),
         )
-    assert usage_session.status_code == 401
     assert close_session.status_code == 401
-    assert usage_platform.status_code == 200
-    assert usage_platform.json()["total_tokens"] == 2
     assert close_platform.status_code == 200
 
 
-async def test_public_get_usage_and_close_session() -> None:
+async def test_public_close_session_is_idempotent_only_once() -> None:
     app = create_eval_proxy_stub_app()
     async with LocalhostUvicornServer(app) as server:
         client = EvalProxyClient(base_url=server.base_url, auth_token=PLATFORM_TOKEN)
@@ -517,48 +520,9 @@ async def test_public_get_usage_and_close_session() -> None:
             session = await client.create_session(
                 rollout_id=ROLLOUT_ID, model_path=MODEL_PATH
             )
-            usage = await client.get_usage(session.rollout_id)
-            assert usage["total_tokens"] == 2
             await client.close_session(session.rollout_id)
             with pytest.raises(EvalProxyError) as exc:
-                await client.get_usage(session.rollout_id)
+                await client.close_session(session.rollout_id)
             assert exc.value.status_code == 404
         finally:
             await client.aclose()
-
-
-async def test_terminal_commit_hook_can_fetch_usage_before_ack() -> None:
-    from osmosis_ai.rollout.controller.store import CallbackStore
-    from osmosis_ai.rollout.types import (
-        GraderCompleteRequest,
-        GraderStatus,
-        RolloutSample,
-    )
-
-    app = create_eval_proxy_stub_app()
-    async with LocalhostUvicornServer(app) as server:
-        proxy = EvalProxyClient(base_url=server.base_url, auth_token=PLATFORM_TOKEN)
-        try:
-            await proxy.create_session(rollout_id=ROLLOUT_ID, model_path=MODEL_PATH)
-
-            async def commit(result):
-                usage = await proxy.get_usage(result.rollout_id)
-                return {"ok": True, "usage": usage}
-
-            store = CallbackStore(on_terminal_commit=commit)
-            await store.register(ROLLOUT_ID)
-            ack = await store.handle_grader(
-                ROLLOUT_ID,
-                GraderCompleteRequest(
-                    status=GraderStatus.SUCCESS,
-                    rollout_id=ROLLOUT_ID,
-                    sample=RolloutSample(
-                        messages=[{"role": "assistant", "content": "ok"}],
-                        reward=1.0,
-                    ),
-                ),
-            )
-            assert ack["ok"] is True
-            assert ack["usage"]["total_tokens"] == 2
-        finally:
-            await proxy.aclose()

--- a/tests/unit/rollout/controller/test_proxy_client.py
+++ b/tests/unit/rollout/controller/test_proxy_client.py
@@ -10,6 +10,7 @@ import httpx
 import pytest
 from httpx import ASGITransport
 
+from osmosis_ai.rollout.controller import proxy_client as proxy_client_module
 from osmosis_ai.rollout.controller.listener import LocalhostUvicornServer
 from osmosis_ai.rollout.controller.proxy_client import (
     EVAL_PROXY_INTEGRATION_MODEL,
@@ -178,14 +179,19 @@ async def test_client_create_session_posts_frozen_fields_only() -> None:
 
 
 async def test_client_create_session_surfaces_http_errors() -> None:
+    # Drive a real HTTP error: an invalid rollout_id would be rejected by
+    # local validation before any request, so use a wrong platform token.
     app = create_eval_proxy_stub_app()
     async with LocalhostUvicornServer(app) as server:
-        client = EvalProxyClient(base_url=server.base_url, auth_token=PLATFORM_TOKEN)
+        client = EvalProxyClient(base_url=server.base_url, auth_token="wrong-token")
         try:
-            with pytest.raises(EvalProxyError):
-                await client.create_session(rollout_id="", model_path=MODEL_PATH)
+            with pytest.raises(EvalProxyError) as excinfo:
+                await client.create_session(
+                    rollout_id=ROLLOUT_ID, model_path=MODEL_PATH
+                )
         finally:
             await client.aclose()
+    assert excinfo.value.status_code == 401
 
 
 @pytest.mark.parametrize("bad_id", ["..", ".", "a/b", "a\\b", "", "a\x00b"])
@@ -398,6 +404,47 @@ async def test_cancelled_create_attempts_cleanup_without_masking_cancellation() 
         finally:
             await client.aclose()
     assert closed == [ROLLOUT_ID]
+
+
+async def test_failed_create_cleanup_wait_is_bounded(monkeypatch) -> None:
+    from fastapi import FastAPI, HTTPException
+
+    monkeypatch.setattr(proxy_client_module, "_FAILED_CREATE_CLOSE_TIMEOUT_SEC", 0.05)
+    delete_entered = asyncio.Event()
+    release = asyncio.Event()
+    app = FastAPI()
+
+    @app.post("/v1/eval-sessions")
+    async def create() -> dict:
+        raise HTTPException(status_code=502, detail="upstream exploded")
+
+    @app.delete("/v1/eval-sessions/{rollout_id}")
+    async def close(rollout_id: str) -> dict:
+        delete_entered.set()
+        await release.wait()
+        return {"ok": True}
+
+    async with LocalhostUvicornServer(app) as server:
+        client = EvalProxyClient(base_url=server.base_url, auth_token=PLATFORM_TOKEN)
+        task = asyncio.create_task(
+            client.create_session(rollout_id=ROLLOUT_ID, model_path=MODEL_PATH)
+        )
+        try:
+            # No cancellation here: the task must come back on its own once
+            # the bounded cleanup wait expires, despite the hanging DELETE.
+            done, _pending = await asyncio.wait({task}, timeout=2.0)
+            assert task in done, (
+                "create_session must return within the bounded cleanup wait "
+                "even when the cleanup DELETE hangs"
+            )
+            with pytest.raises(EvalProxyError) as excinfo:
+                task.result()
+            assert excinfo.value.status_code == 502
+            await asyncio.wait_for(delete_entered.wait(), timeout=2.0)
+        finally:
+            release.set()
+            await asyncio.gather(task, return_exceptions=True)
+            await client.aclose()
 
 
 async def test_management_routes_use_platform_token_not_session_token() -> None:

--- a/tests/unit/rollout/controller/test_proxy_client.py
+++ b/tests/unit/rollout/controller/test_proxy_client.py
@@ -194,6 +194,29 @@ async def test_client_create_session_surfaces_http_errors() -> None:
     assert excinfo.value.status_code == 401
 
 
+async def test_error_contract_holds_for_raise_for_status_sessions() -> None:
+    # A caller-supplied session with raise_for_status=True must not replace
+    # the client's EvalProxyError contract with aiohttp.ClientResponseError.
+    import aiohttp
+
+    app = create_eval_proxy_stub_app()
+    async with LocalhostUvicornServer(app) as server:
+        session = aiohttp.ClientSession(raise_for_status=True)
+        try:
+            client = EvalProxyClient(
+                base_url=server.base_url,
+                auth_token="wrong-token",
+                session=session,
+            )
+            with pytest.raises(EvalProxyError) as excinfo:
+                await client.create_session(
+                    rollout_id=ROLLOUT_ID, model_path=MODEL_PATH
+                )
+        finally:
+            await session.close()
+    assert excinfo.value.status_code == 401
+
+
 @pytest.mark.parametrize("bad_id", ["..", ".", "a/b", "a\\b", "", "a\x00b"])
 async def test_session_methods_reject_non_single_segment_ids(bad_id: str) -> None:
     # quote() leaves dots intact and HTTP stacks normalize dot segments, so

--- a/tests/unit/rollout/controller/test_proxy_client.py
+++ b/tests/unit/rollout/controller/test_proxy_client.py
@@ -426,6 +426,7 @@ async def test_failed_create_cleanup_wait_is_bounded(monkeypatch) -> None:
 
     async with LocalhostUvicornServer(app) as server:
         client = EvalProxyClient(base_url=server.base_url, auth_token=PLATFORM_TOKEN)
+        tasks_before = asyncio.all_tasks()
         task = asyncio.create_task(
             client.create_session(rollout_id=ROLLOUT_ID, model_path=MODEL_PATH)
         )
@@ -444,6 +445,11 @@ async def test_failed_create_cleanup_wait_is_bounded(monkeypatch) -> None:
         finally:
             release.set()
             await asyncio.gather(task, return_exceptions=True)
+            # Join the background best-effort closer (and the released DELETE
+            # handler) so aclose() and test teardown never race live tasks.
+            leftovers = asyncio.all_tasks() - tasks_before - {task}
+            if leftovers:
+                await asyncio.wait(leftovers, timeout=2.0)
             await client.aclose()
 
 

--- a/tests/unit/rollout/controller/test_proxy_client.py
+++ b/tests/unit/rollout/controller/test_proxy_client.py
@@ -188,6 +188,23 @@ async def test_client_create_session_surfaces_http_errors() -> None:
             await client.aclose()
 
 
+@pytest.mark.parametrize("bad_id", ["..", ".", "a/b", "a\\b", "", "a\x00b"])
+async def test_session_methods_reject_non_single_segment_ids(bad_id: str) -> None:
+    # quote() leaves dots intact and HTTP stacks normalize dot segments, so
+    # these ids must be rejected before any request is built. The unreachable
+    # base_url guarantees the test fails loudly if a request were attempted.
+    client = EvalProxyClient(base_url="http://127.0.0.1:1", auth_token=PLATFORM_TOKEN)
+    try:
+        with pytest.raises(EvalProxyError, match="single path segment"):
+            await client.create_session(rollout_id=bad_id, model_path=MODEL_PATH)
+        with pytest.raises(EvalProxyError, match="single path segment"):
+            await client.close_session(bad_id)
+        with pytest.raises(EvalProxyError, match="single path segment"):
+            await client.get_usage(bad_id)
+    finally:
+        await client.aclose()
+
+
 @pytest.mark.parametrize(
     "content,media_type",
     [

--- a/tests/unit/rollout/controller/test_proxy_client.py
+++ b/tests/unit/rollout/controller/test_proxy_client.py
@@ -1,0 +1,441 @@
+"""Tests for the eval-proxy session client and local contract stub."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+import pytest
+from httpx import ASGITransport
+
+from osmosis_ai.rollout.controller.listener import LocalhostUvicornServer
+from osmosis_ai.rollout.controller.proxy_client import (
+    EVAL_PROXY_INTEGRATION_MODEL,
+    EVAL_PROXY_WIRE_MODEL,
+    EvalProxyClient,
+    EvalProxyError,
+    EvalProxySession,
+    create_eval_proxy_stub_app,
+)
+
+ROLLOUT_ID = "d" * 32
+MODEL_PATH = "openai/gpt-4.1-mini"
+PLATFORM_TOKEN = "platform-token"
+
+
+def _platform() -> dict[str, str]:
+    return {"Authorization": f"Bearer {PLATFORM_TOKEN}"}
+
+
+async def _asgi_client(app) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://127.0.0.1",
+    )
+
+
+async def test_create_session_binds_rollout_and_model_without_synthetic_model() -> None:
+    app = create_eval_proxy_stub_app()
+    async with await _asgi_client(app) as client:
+        response = await client.post(
+            "/v1/eval-sessions",
+            json={
+                "rollout_id": ROLLOUT_ID,
+                "model_path": MODEL_PATH,
+                "row_index": 3,
+                "run_index": 1,
+            },
+            headers=_platform(),
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["api_base"] == f"/v1/eval-sessions/{ROLLOUT_ID}"
+    assert not body["api_base"].endswith("/chat/completions")
+    assert "/chat/completions" not in body["api_base"]
+    assert body["integration_model"] == EVAL_PROXY_INTEGRATION_MODEL
+    assert body["wire_model"] == EVAL_PROXY_WIRE_MODEL
+    assert body.get("token")
+    assert "model" not in body
+
+
+async def test_create_session_rejects_client_selected_synthetic_model() -> None:
+    app = create_eval_proxy_stub_app()
+    async with await _asgi_client(app) as client:
+        response = await client.post(
+            "/v1/eval-sessions",
+            json={
+                "rollout_id": ROLLOUT_ID,
+                "model_path": MODEL_PATH,
+                "model": EVAL_PROXY_WIRE_MODEL,
+            },
+            headers=_platform(),
+        )
+    assert response.status_code == 400
+
+
+async def test_chat_completions_requires_stream_and_wire_model() -> None:
+    app = create_eval_proxy_stub_app()
+    async with await _asgi_client(app) as client:
+        created = await client.post(
+            "/v1/eval-sessions",
+            json={"rollout_id": ROLLOUT_ID, "model_path": MODEL_PATH},
+            headers=_platform(),
+        )
+        token = created.json()["token"]
+        headers = {"Authorization": f"Bearer {token}"}
+        path = f"/v1/eval-sessions/{ROLLOUT_ID}/chat/completions"
+        missing_stream = await client.post(
+            path,
+            json={"model": EVAL_PROXY_WIRE_MODEL, "messages": []},
+            headers=headers,
+        )
+        wrong_model = await client.post(
+            path,
+            json={
+                "model": MODEL_PATH,
+                "messages": [],
+                "stream": True,
+            },
+            headers=headers,
+        )
+        bad_usage = await client.post(
+            path,
+            json={
+                "model": EVAL_PROXY_WIRE_MODEL,
+                "messages": [],
+                "stream": True,
+                "stream_options": {"include_usage": False},
+            },
+            headers=headers,
+        )
+    assert missing_stream.status_code == 400
+    assert wrong_model.status_code == 400
+    assert bad_usage.status_code == 400
+
+
+async def test_chat_completions_sse_order_and_optional_stream_options() -> None:
+    app = create_eval_proxy_stub_app()
+    async with await _asgi_client(app) as client:
+        created = await client.post(
+            "/v1/eval-sessions",
+            json={"rollout_id": ROLLOUT_ID, "model_path": MODEL_PATH},
+            headers=_platform(),
+        )
+        token = created.json()["token"]
+        response = await client.post(
+            f"/v1/eval-sessions/{ROLLOUT_ID}/chat/completions",
+            json={
+                "model": EVAL_PROXY_WIRE_MODEL,
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": True,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 200
+    events = [
+        line[len("data: ") :]
+        for line in response.text.splitlines()
+        if line.startswith("data: ")
+    ]
+    assert events[-1] == "[DONE]"
+    chunks = [json.loads(item) for item in events[:-1]]
+    assert chunks[0]["choices"][0]["delta"].get("content")
+    assert chunks[1]["choices"][0]["finish_reason"] == "stop"
+    assert chunks[2]["choices"] == []
+    assert "usage" in chunks[2]
+
+
+async def test_client_create_session_posts_frozen_fields_only() -> None:
+    app = create_eval_proxy_stub_app()
+    async with LocalhostUvicornServer(app) as server:
+        origin = server.base_url
+        client = EvalProxyClient(base_url=origin, auth_token="platform-token")
+        try:
+            session = await client.create_session(
+                rollout_id=ROLLOUT_ID,
+                model_path=MODEL_PATH,
+                row_index=2,
+                run_index=0,
+            )
+        finally:
+            await client.aclose()
+
+    recorded = app.state.create_requests[-1]
+    assert recorded["rollout_id"] == ROLLOUT_ID
+    assert recorded["model_path"] == MODEL_PATH
+    assert recorded["row_index"] == 2
+    assert recorded["run_index"] == 0
+    assert "model" not in recorded
+    assert "integration_model" not in recorded
+    assert "wire_model" not in recorded
+    assert session.api_base == f"/v1/eval-sessions/{ROLLOUT_ID}"
+    assert "/chat/completions" not in session.api_base
+    assert session.api_base_url == f"{origin}/v1/eval-sessions/{ROLLOUT_ID}"
+    assert session.integration_model == EVAL_PROXY_INTEGRATION_MODEL
+    assert session.wire_model == EVAL_PROXY_WIRE_MODEL
+
+
+async def test_client_create_session_surfaces_http_errors() -> None:
+    app = create_eval_proxy_stub_app()
+    async with LocalhostUvicornServer(app) as server:
+        client = EvalProxyClient(base_url=server.base_url, auth_token=PLATFORM_TOKEN)
+        try:
+            with pytest.raises(EvalProxyError):
+                await client.create_session(rollout_id="", model_path=MODEL_PATH)
+        finally:
+            await client.aclose()
+
+
+def _create_response_app(body: dict) -> object:
+    from fastapi import FastAPI
+
+    app = FastAPI()
+
+    @app.post("/v1/eval-sessions")
+    async def create() -> dict:
+        return body
+
+    return app
+
+
+async def _create_from_body(body: dict):
+    app = _create_response_app(body)
+    async with LocalhostUvicornServer(app) as server:
+        client = EvalProxyClient(base_url=server.base_url, auth_token=PLATFORM_TOKEN)
+        try:
+            return await client.create_session(
+                rollout_id=ROLLOUT_ID, model_path=MODEL_PATH
+            )
+        finally:
+            await client.aclose()
+
+
+def _valid_create_body(**overrides: object) -> dict:
+    body: dict[str, object] = {
+        "rollout_id": ROLLOUT_ID,
+        "api_base": f"/v1/eval-sessions/{ROLLOUT_ID}",
+        "token": "session-token",
+        "integration_model": EVAL_PROXY_INTEGRATION_MODEL,
+        "wire_model": EVAL_PROXY_WIRE_MODEL,
+    }
+    body.update(overrides)
+    return body
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        _valid_create_body(rollout_id="other-id"),
+        _valid_create_body(
+            api_base=f"https://evil.example/v1/eval-sessions/{ROLLOUT_ID}"
+        ),
+        _valid_create_body(api_base=f"/v1/eval-sessions/{ROLLOUT_ID}/chat/completions"),
+        _valid_create_body(integration_model="openai/gpt-4.1-mini"),
+        _valid_create_body(wire_model="gpt-4.1-mini"),
+        _valid_create_body(token=""),
+        {k: v for k, v in _valid_create_body().items() if k != "token"},
+        {k: v for k, v in _valid_create_body().items() if k != "api_base"},
+        {k: v for k, v in _valid_create_body().items() if k != "integration_model"},
+        {k: v for k, v in _valid_create_body().items() if k != "wire_model"},
+        {k: v for k, v in _valid_create_body().items() if k != "rollout_id"},
+    ],
+)
+async def test_create_session_rejects_invalid_contract_fields(body: dict) -> None:
+    with pytest.raises(EvalProxyError):
+        await _create_from_body(body)
+
+
+def test_session_repr_hides_token() -> None:
+    session = EvalProxySession(
+        rollout_id=ROLLOUT_ID,
+        model_path=MODEL_PATH,
+        api_base=f"/v1/eval-sessions/{ROLLOUT_ID}",
+        api_base_url=f"http://proxy/v1/eval-sessions/{ROLLOUT_ID}",
+        token="super-secret-session-token",
+    )
+    assert "super-secret-session-token" not in repr(session)
+    assert "super-secret-session-token" not in str(session)
+
+
+def test_client_requires_non_empty_platform_token() -> None:
+    with pytest.raises(ValueError, match="auth_token"):
+        EvalProxyClient(base_url="http://proxy", auth_token="")
+    with pytest.raises(ValueError, match="auth_token"):
+        EvalProxyClient(base_url="http://proxy", auth_token="   ")
+
+
+def _close_recording_app(create_body: dict) -> tuple[Any, list[str]]:
+    from fastapi import FastAPI
+
+    closed: list[str] = []
+    app = FastAPI()
+
+    @app.post("/v1/eval-sessions")
+    async def create() -> dict:
+        return create_body
+
+    @app.delete("/v1/eval-sessions/{rollout_id}")
+    async def close(rollout_id: str) -> dict:
+        closed.append(rollout_id)
+        return {"ok": True}
+
+    return app, closed
+
+
+async def test_reflected_platform_token_is_rejected_and_session_closed() -> None:
+    app, closed = _close_recording_app(_valid_create_body(token=PLATFORM_TOKEN))
+    async with LocalhostUvicornServer(app) as server:
+        client = EvalProxyClient(base_url=server.base_url, auth_token=PLATFORM_TOKEN)
+        try:
+            with pytest.raises(EvalProxyError, match="platform"):
+                await client.create_session(
+                    rollout_id=ROLLOUT_ID, model_path=MODEL_PATH
+                )
+        finally:
+            await client.aclose()
+    assert closed == [ROLLOUT_ID]
+
+
+async def test_malformed_create_response_triggers_best_effort_close() -> None:
+    app, closed = _close_recording_app(
+        _valid_create_body(api_base=f"/v1/eval-sessions/{'e' * 32}")
+    )
+    async with LocalhostUvicornServer(app) as server:
+        client = EvalProxyClient(base_url=server.base_url, auth_token=PLATFORM_TOKEN)
+        try:
+            with pytest.raises(EvalProxyError, match="api_base"):
+                await client.create_session(
+                    rollout_id=ROLLOUT_ID, model_path=MODEL_PATH
+                )
+        finally:
+            await client.aclose()
+    assert closed == [ROLLOUT_ID]
+
+
+async def test_cancelled_create_attempts_cleanup_without_masking_cancellation() -> None:
+    from fastapi import FastAPI
+
+    closed: list[str] = []
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    app = FastAPI()
+
+    @app.post("/v1/eval-sessions")
+    async def create() -> dict:
+        entered.set()
+        await release.wait()
+        return _valid_create_body()
+
+    @app.delete("/v1/eval-sessions/{rollout_id}")
+    async def close(rollout_id: str) -> dict:
+        closed.append(rollout_id)
+        return {"ok": True}
+
+    async with LocalhostUvicornServer(app) as server:
+        client = EvalProxyClient(base_url=server.base_url, auth_token=PLATFORM_TOKEN)
+        try:
+            task = asyncio.create_task(
+                client.create_session(rollout_id=ROLLOUT_ID, model_path=MODEL_PATH)
+            )
+            await entered.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            release.set()
+            for _ in range(100):
+                if closed:
+                    break
+                await asyncio.sleep(0.01)
+        finally:
+            await client.aclose()
+    assert closed == [ROLLOUT_ID]
+
+
+async def test_management_routes_use_platform_token_not_session_token() -> None:
+    app = create_eval_proxy_stub_app()
+    async with await _asgi_client(app) as client:
+        created = await client.post(
+            "/v1/eval-sessions",
+            json={"rollout_id": ROLLOUT_ID, "model_path": MODEL_PATH},
+            headers=_platform(),
+        )
+        session_token = created.json()["token"]
+        session_headers = {"Authorization": f"Bearer {session_token}"}
+        usage_session = await client.get(
+            f"/v1/eval-sessions/{ROLLOUT_ID}/usage",
+            headers=session_headers,
+        )
+        close_session = await client.delete(
+            f"/v1/eval-sessions/{ROLLOUT_ID}",
+            headers=session_headers,
+        )
+        usage_platform = await client.get(
+            f"/v1/eval-sessions/{ROLLOUT_ID}/usage",
+            headers=_platform(),
+        )
+        close_platform = await client.delete(
+            f"/v1/eval-sessions/{ROLLOUT_ID}",
+            headers=_platform(),
+        )
+    assert usage_session.status_code == 401
+    assert close_session.status_code == 401
+    assert usage_platform.status_code == 200
+    assert usage_platform.json()["total_tokens"] == 2
+    assert close_platform.status_code == 200
+
+
+async def test_public_get_usage_and_close_session() -> None:
+    app = create_eval_proxy_stub_app()
+    async with LocalhostUvicornServer(app) as server:
+        client = EvalProxyClient(base_url=server.base_url, auth_token=PLATFORM_TOKEN)
+        try:
+            session = await client.create_session(
+                rollout_id=ROLLOUT_ID, model_path=MODEL_PATH
+            )
+            usage = await client.get_usage(session.rollout_id)
+            assert usage["total_tokens"] == 2
+            await client.close_session(session.rollout_id)
+            with pytest.raises(EvalProxyError) as exc:
+                await client.get_usage(session.rollout_id)
+            assert exc.value.status_code == 404
+        finally:
+            await client.aclose()
+
+
+async def test_terminal_commit_hook_can_fetch_usage_before_ack() -> None:
+    from osmosis_ai.rollout.controller.store import CallbackStore
+    from osmosis_ai.rollout.types import (
+        GraderCompleteRequest,
+        GraderStatus,
+        RolloutSample,
+    )
+
+    app = create_eval_proxy_stub_app()
+    async with LocalhostUvicornServer(app) as server:
+        proxy = EvalProxyClient(base_url=server.base_url, auth_token=PLATFORM_TOKEN)
+        try:
+            await proxy.create_session(rollout_id=ROLLOUT_ID, model_path=MODEL_PATH)
+
+            async def commit(result):
+                usage = await proxy.get_usage(result.rollout_id)
+                return {"ok": True, "usage": usage}
+
+            store = CallbackStore(on_terminal_commit=commit)
+            await store.register(ROLLOUT_ID)
+            ack = await store.handle_grader(
+                ROLLOUT_ID,
+                GraderCompleteRequest(
+                    status=GraderStatus.SUCCESS,
+                    rollout_id=ROLLOUT_ID,
+                    sample=RolloutSample(
+                        messages=[{"role": "assistant", "content": "ok"}],
+                        reward=1.0,
+                    ),
+                ),
+            )
+            assert ack["ok"] is True
+            assert ack["usage"]["total_tokens"] == 2
+        finally:
+            await proxy.aclose()

--- a/tests/unit/rollout/controller/test_store.py
+++ b/tests/unit/rollout/controller/test_store.py
@@ -1,0 +1,711 @@
+"""Tests for the eval-agnostic in-memory callback store."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from osmosis_ai.rollout.controller.store import (
+    CallbackStore,
+    DuplicateRegistrationError,
+    TerminalCallbackResult,
+    UnknownRolloutIdError,
+    duplicate_callback_payload,
+)
+from osmosis_ai.rollout.types import (
+    GraderCompleteRequest,
+    GraderStatus,
+    RolloutCompleteRequest,
+    RolloutSample,
+    RolloutStatus,
+)
+
+ROLLOUT_ID = "a" * 32
+
+
+def _completion(**overrides: object) -> RolloutCompleteRequest:
+    payload: dict[str, object] = {
+        "status": RolloutStatus.SUCCESS,
+        "rollout_id": ROLLOUT_ID,
+    }
+    payload.update(overrides)
+    return RolloutCompleteRequest.model_validate(payload)
+
+
+def _grader(**overrides: object) -> GraderCompleteRequest:
+    payload: dict[str, object] = {
+        "status": GraderStatus.SUCCESS,
+        "rollout_id": ROLLOUT_ID,
+        "sample": RolloutSample(
+            messages=[{"role": "assistant", "content": "ok"}],
+            reward=1.0,
+        ),
+    }
+    payload.update(overrides)
+    return GraderCompleteRequest.model_validate(payload)
+
+
+async def test_register_then_discard_forgets_live_rendezvous() -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    ack = await store.handle_completion(ROLLOUT_ID, _completion())
+    assert ack == {"ok": True}
+
+    await store.discard(ROLLOUT_ID)
+
+    with pytest.raises(UnknownRolloutIdError):
+        await store.handle_completion(ROLLOUT_ID, _completion())
+
+
+async def test_completion_is_not_terminal() -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    await store.handle_completion(ROLLOUT_ID, _completion())
+
+    assert store.completion_for(ROLLOUT_ID) is not None
+    assert store.terminal_for(ROLLOUT_ID) is None
+
+
+async def test_wait_completion_returns_accepted_payload() -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    waiter = asyncio.create_task(store.wait_completion(ROLLOUT_ID))
+    await asyncio.sleep(0)
+    first = _completion()
+    await store.handle_completion(ROLLOUT_ID, first)
+    accepted = await waiter
+    assert accepted == first
+    assert await store.wait_completion(ROLLOUT_ID) == first
+    await store.handle_grader(ROLLOUT_ID, _grader())
+    await store.discard(ROLLOUT_ID)
+    assert await store.wait_completion(ROLLOUT_ID) == first
+
+
+async def test_identical_duplicate_completion_does_not_resolve_twice() -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    first = _completion()
+    first_ack = await store.handle_completion(ROLLOUT_ID, first)
+    second_ack = await store.handle_completion(ROLLOUT_ID, _completion())
+    assert second_ack == first_ack
+    assert await store.wait_completion(ROLLOUT_ID) == first
+
+
+async def test_conflicting_duplicate_completion_keeps_first_and_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    first = _completion()
+    await store.handle_completion(ROLLOUT_ID, first)
+    with caplog.at_level(logging.ERROR):
+        ack = await store.handle_completion(
+            ROLLOUT_ID,
+            _completion(status=RolloutStatus.FAILURE, err_message="agent exploded"),
+        )
+    assert ack == {"ok": True}
+    assert await store.wait_completion(ROLLOUT_ID) == first
+    assert any(
+        "conflicting duplicate" in record.message.lower()
+        for record in caplog.records
+        if record.levelno >= logging.ERROR
+    )
+
+
+async def test_discard_cancels_unresolved_completion_and_terminal_futures() -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    completion_waiter = asyncio.create_task(store.wait_completion(ROLLOUT_ID))
+    terminal_waiter = asyncio.create_task(store.wait_terminal(ROLLOUT_ID))
+    await asyncio.sleep(0)
+    await store.discard(ROLLOUT_ID)
+    with pytest.raises(asyncio.CancelledError):
+        await completion_waiter
+    with pytest.raises(asyncio.CancelledError):
+        await terminal_waiter
+
+
+async def test_seeded_terminal_retains_completion_for_wait_and_duplicates() -> None:
+    store = CallbackStore()
+    stored = _completion()
+    store.seed_terminal(
+        ROLLOUT_ID,
+        acknowledgment={"ok": True, "seeded": True},
+        grader=_grader(),
+        completion=stored,
+    )
+    assert await store.wait_completion(ROLLOUT_ID) == stored
+    ack = await store.handle_completion(ROLLOUT_ID, stored)
+    assert ack == {"ok": True, "seeded": True}
+
+
+async def test_grader_commit_hook_runs_before_acknowledgment() -> None:
+    order: list[str] = []
+
+    async def commit(result: TerminalCallbackResult) -> dict[str, object]:
+        order.append("commit-start")
+        order.append("commit-end")
+        return {"ok": True, "durable": True}
+
+    store = CallbackStore(on_terminal_commit=commit)
+    await store.register(ROLLOUT_ID)
+
+    ack = await store.handle_grader(ROLLOUT_ID, _grader())
+    order.append("acked")
+
+    assert ack == {"ok": True, "durable": True}
+    assert order == ["commit-start", "commit-end", "acked"]
+    assert store.terminal_for(ROLLOUT_ID) is not None
+
+
+async def test_identical_duplicate_grader_returns_stored_ack_without_recommit(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    commits = 0
+
+    async def commit(result: TerminalCallbackResult) -> dict[str, object]:
+        nonlocal commits
+        commits += 1
+        return {"ok": True, "n": commits}
+
+    store = CallbackStore(on_terminal_commit=commit)
+    await store.register(ROLLOUT_ID)
+    first = await store.handle_grader(ROLLOUT_ID, _grader())
+    with caplog.at_level(logging.ERROR):
+        second = await store.handle_grader(ROLLOUT_ID, _grader())
+
+    assert first == {"ok": True, "n": 1}
+    assert second == first
+    assert commits == 1
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)
+
+
+async def test_conflicting_duplicate_grader_logs_error_and_returns_stored_ack(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    commits = 0
+
+    async def commit(result: TerminalCallbackResult) -> dict[str, object]:
+        nonlocal commits
+        commits += 1
+        return {"ok": True}
+
+    store = CallbackStore(on_terminal_commit=commit)
+    await store.register(ROLLOUT_ID)
+    first = await store.handle_grader(ROLLOUT_ID, _grader())
+    conflict = _grader(
+        status=GraderStatus.FAILURE,
+        sample=None,
+        err_message="grader exploded",
+    )
+    with caplog.at_level(logging.ERROR):
+        second = await store.handle_grader(ROLLOUT_ID, conflict)
+
+    assert second == first
+    assert commits == 1
+    assert any(
+        "conflicting duplicate" in record.message.lower()
+        for record in caplog.records
+        if record.levelno >= logging.ERROR
+    )
+
+
+async def test_first_terminal_result_wins_timeout_then_late_grader() -> None:
+    commits: list[str] = []
+
+    async def commit(result: TerminalCallbackResult) -> dict[str, object]:
+        source = result.source
+        commits.append(source)
+        return {"ok": True, "source": source}
+
+    store = CallbackStore(on_terminal_commit=commit)
+    await store.register(ROLLOUT_ID)
+
+    timeout_ack = await store.finalize_timeout(
+        ROLLOUT_ID, acknowledgment={"ok": True, "source": "timeout"}
+    )
+    late = await store.handle_grader(ROLLOUT_ID, _grader())
+
+    assert timeout_ack.acknowledgment["source"] == "timeout"
+    assert late == timeout_ack.acknowledgment
+    assert commits == ["timeout"]
+
+
+async def test_wait_terminal_returns_grader_result() -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    waiter = asyncio.create_task(store.wait_terminal(ROLLOUT_ID))
+    await asyncio.sleep(0)
+    await store.handle_grader(ROLLOUT_ID, _grader())
+    result = await waiter
+    assert result.source == "grader"
+    assert result.grader is not None
+    assert result.grader.status == GraderStatus.SUCCESS
+
+
+async def test_seed_terminal_replays_without_commit(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    commits = 0
+
+    async def commit(result: TerminalCallbackResult) -> dict[str, object]:
+        nonlocal commits
+        commits += 1
+        return {"ok": True}
+
+    store = CallbackStore(on_terminal_commit=commit)
+    store.seed_terminal(
+        ROLLOUT_ID,
+        acknowledgment={"ok": True, "seeded": True},
+        grader=_grader(),
+    )
+    with caplog.at_level(logging.ERROR):
+        ack = await store.handle_grader(ROLLOUT_ID, _grader())
+    assert ack == {"ok": True, "seeded": True}
+    assert commits == 0
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)
+
+
+async def test_register_rejects_live_and_finalized_ids() -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    with pytest.raises(DuplicateRegistrationError):
+        await store.register(ROLLOUT_ID)
+    await store.handle_grader(ROLLOUT_ID, _grader())
+    await store.discard(ROLLOUT_ID)
+    with pytest.raises(DuplicateRegistrationError):
+        await store.register(ROLLOUT_ID)
+    ack = await store.handle_grader(ROLLOUT_ID, _grader())
+    assert ack == {"ok": True}
+
+
+async def test_finalized_id_cannot_be_registered_and_committed_again() -> None:
+    commits = 0
+
+    async def commit(result: TerminalCallbackResult) -> dict[str, object]:
+        nonlocal commits
+        commits += 1
+        return {"ok": True, "n": commits}
+
+    store = CallbackStore(on_terminal_commit=commit)
+    await store.register(ROLLOUT_ID)
+    first = await store.handle_grader(ROLLOUT_ID, _grader())
+    await store.discard(ROLLOUT_ID)
+    with pytest.raises(DuplicateRegistrationError):
+        await store.register(ROLLOUT_ID)
+    second = await store.handle_grader(ROLLOUT_ID, _grader())
+    assert first == {"ok": True, "n": 1}
+    assert second == first
+    assert commits == 1
+
+
+async def test_seed_terminal_does_not_overwrite_live_or_finalized(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    with caplog.at_level(logging.ERROR):
+        store.seed_terminal(
+            ROLLOUT_ID,
+            acknowledgment={"ok": True, "seeded": True},
+            grader=_grader(),
+        )
+    assert store.terminal_for(ROLLOUT_ID) is None
+    assert any("live session" in record.message.lower() for record in caplog.records)
+
+    await store.handle_grader(ROLLOUT_ID, _grader())
+    await store.discard(ROLLOUT_ID)
+    stored = store.terminal_for(ROLLOUT_ID)
+    assert stored is not None
+    caplog.clear()
+    with caplog.at_level(logging.ERROR):
+        store.seed_terminal(
+            ROLLOUT_ID,
+            acknowledgment={"ok": True, "seeded": True},
+            grader=_grader(status=GraderStatus.FAILURE, sample=None),
+        )
+    kept = store.terminal_for(ROLLOUT_ID)
+    assert kept is stored
+    assert any(
+        "conflicting seed_terminal" in record.message.lower()
+        for record in caplog.records
+        if record.levelno >= logging.ERROR
+    )
+
+
+async def test_identical_repeated_seed_is_noop() -> None:
+    store = CallbackStore()
+    grader = _grader()
+    store.seed_terminal(
+        ROLLOUT_ID,
+        acknowledgment={"ok": True, "seeded": True},
+        grader=grader,
+    )
+    first = store.terminal_for(ROLLOUT_ID)
+    store.seed_terminal(
+        ROLLOUT_ID,
+        acknowledgment={"ok": True, "seeded": True},
+        grader=_grader(),
+    )
+    assert store.terminal_for(ROLLOUT_ID) is first
+
+
+async def test_unknown_rollout_is_rejected() -> None:
+    store = CallbackStore()
+    with pytest.raises(UnknownRolloutIdError):
+        await store.handle_grader(ROLLOUT_ID, _grader())
+
+
+async def test_timeout_acknowledgment_survives_default_commit_hook() -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    result = await store.finalize_timeout(
+        ROLLOUT_ID, acknowledgment={"ok": True, "source": "timeout"}
+    )
+    assert result.acknowledgment == {"ok": True, "source": "timeout"}
+
+
+async def test_late_completion_after_timeout_returns_stored_ack() -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    timeout = await store.finalize_timeout(
+        ROLLOUT_ID, acknowledgment={"ok": True, "error_type": "callback_timeout"}
+    )
+    await store.discard(ROLLOUT_ID)
+
+    ack = await store.handle_completion(ROLLOUT_ID, _completion())
+    assert ack == timeout.acknowledgment
+
+
+async def test_late_callbacks_after_timeout_do_not_log_conflict_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    timeout = await store.finalize_timeout(
+        ROLLOUT_ID, acknowledgment={"ok": True, "error_type": "callback_timeout"}
+    )
+    await store.discard(ROLLOUT_ID)
+
+    with caplog.at_level(logging.ERROR):
+        grader_ack = await store.handle_grader(ROLLOUT_ID, _grader())
+        completion_ack = await store.handle_completion(ROLLOUT_ID, _completion())
+
+    assert grader_ack == timeout.acknowledgment
+    assert completion_ack == timeout.acknowledgment
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)
+
+
+async def test_late_callbacks_after_cancel_do_not_log_conflict_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    tombstone = await store.acknowledge_without_commit(ROLLOUT_ID)
+    await store.discard(ROLLOUT_ID)
+
+    with caplog.at_level(logging.ERROR):
+        grader_ack = await store.handle_grader(ROLLOUT_ID, _grader())
+        completion_ack = await store.handle_completion(ROLLOUT_ID, _completion())
+
+    assert grader_ack == tombstone.acknowledgment
+    assert completion_ack == tombstone.acknowledgment
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)
+
+
+async def test_stored_real_payload_conflicts_still_log_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = CallbackStore()
+    await store.register(ROLLOUT_ID)
+    await store.handle_completion(ROLLOUT_ID, _completion())
+    await store.handle_grader(ROLLOUT_ID, _grader())
+    await store.discard(ROLLOUT_ID)
+
+    with caplog.at_level(logging.ERROR):
+        await store.handle_grader(
+            ROLLOUT_ID,
+            _grader(status=GraderStatus.FAILURE, sample=None, err_message="boom"),
+        )
+        await store.handle_completion(
+            ROLLOUT_ID,
+            _completion(status=RolloutStatus.FAILURE, err_message="boom"),
+        )
+
+    conflict_errors = [
+        record
+        for record in caplog.records
+        if record.levelno >= logging.ERROR
+        and "conflicting duplicate" in record.message.lower()
+    ]
+    assert len(conflict_errors) == 2
+
+
+async def test_cancel_tombstone_acks_callbacks_without_commit() -> None:
+    commits = 0
+
+    async def commit(result: TerminalCallbackResult) -> dict[str, object]:
+        nonlocal commits
+        commits += 1
+        return {"ok": True}
+
+    store = CallbackStore(on_terminal_commit=commit)
+    await store.register(ROLLOUT_ID)
+    tombstone = await store.acknowledge_without_commit(ROLLOUT_ID)
+
+    assert tombstone.source == "cancelled"
+    assert commits == 0
+    assert await store.handle_grader(ROLLOUT_ID, _grader()) == tombstone.acknowledgment
+    assert await store.handle_completion(ROLLOUT_ID, _completion()) == (
+        tombstone.acknowledgment
+    )
+    assert commits == 0
+
+
+async def test_acknowledge_without_commit_rejects_unknown_rollout_id() -> None:
+    store = CallbackStore()
+    with pytest.raises(UnknownRolloutIdError):
+        await store.acknowledge_without_commit(ROLLOUT_ID)
+
+    await store.register(ROLLOUT_ID)
+    ack = await store.handle_grader(ROLLOUT_ID, _grader())
+    assert ack == {"ok": True}
+
+
+class _BlockingCommit:
+    """Commit hook that blocks so tests can race contenders against it."""
+
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.starts = 0
+        self.completions = 0
+
+    async def __call__(self, result: TerminalCallbackResult) -> dict[str, object]:
+        self.starts += 1
+        self.started.set()
+        await self.release.wait()
+        self.completions += 1
+        return {"ok": True, "durable": True}
+
+
+async def test_cancelled_grader_handler_does_not_rerun_commit_hook() -> None:
+    commit = _BlockingCommit()
+    store = CallbackStore(on_terminal_commit=commit)
+    await store.register(ROLLOUT_ID)
+
+    first = asyncio.create_task(store.handle_grader(ROLLOUT_ID, _grader()))
+    await commit.started.wait()
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+    commit.release.set()
+    retry_ack = await store.handle_grader(ROLLOUT_ID, _grader())
+
+    assert (commit.starts, commit.completions) == (1, 1)
+    assert retry_ack == {"ok": True, "durable": True}
+    stored = store.terminal_for(ROLLOUT_ID)
+    assert stored is not None
+    assert stored.source == "grader"
+
+
+async def test_timeout_observes_commit_surviving_cancelled_grader_handler() -> None:
+    commit = _BlockingCommit()
+    store = CallbackStore(on_terminal_commit=commit)
+    await store.register(ROLLOUT_ID)
+
+    grader_task = asyncio.create_task(store.handle_grader(ROLLOUT_ID, _grader()))
+    await commit.started.wait()
+    grader_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await grader_task
+
+    timeout_task = asyncio.create_task(
+        store.finalize_timeout(
+            ROLLOUT_ID, acknowledgment={"ok": True, "error_type": "callback_timeout"}
+        )
+    )
+    await asyncio.sleep(0)
+    commit.release.set()
+    result = await timeout_task
+
+    assert result.source == "grader"
+    assert (commit.starts, commit.completions) == (1, 1)
+
+
+async def test_cancel_observes_commit_surviving_cancelled_grader_handler() -> None:
+    commit = _BlockingCommit()
+    store = CallbackStore(on_terminal_commit=commit)
+    await store.register(ROLLOUT_ID)
+
+    grader_task = asyncio.create_task(store.handle_grader(ROLLOUT_ID, _grader()))
+    await commit.started.wait()
+    grader_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await grader_task
+
+    cancel_task = asyncio.create_task(store.acknowledge_without_commit(ROLLOUT_ID))
+    await asyncio.sleep(0)
+    commit.release.set()
+    result = await cancel_task
+
+    assert result.source == "grader"
+    assert (commit.starts, commit.completions) == (1, 1)
+
+
+async def test_failed_commit_hook_is_retryable() -> None:
+    calls = 0
+
+    async def commit(result: TerminalCallbackResult) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("journal io error")
+        return {"ok": True, "n": calls}
+
+    store = CallbackStore(on_terminal_commit=commit)
+    await store.register(ROLLOUT_ID)
+    with pytest.raises(RuntimeError, match="journal io error"):
+        await store.handle_grader(ROLLOUT_ID, _grader())
+    assert store.terminal_for(ROLLOUT_ID) is None
+
+    ack = await store.handle_grader(ROLLOUT_ID, _grader())
+    assert ack == {"ok": True, "n": 2}
+
+
+async def test_discard_does_not_cancel_in_flight_commit() -> None:
+    commit = _BlockingCommit()
+    store = CallbackStore(on_terminal_commit=commit)
+    await store.register(ROLLOUT_ID)
+
+    grader_task = asyncio.create_task(store.handle_grader(ROLLOUT_ID, _grader()))
+    await commit.started.wait()
+    discard_task = asyncio.create_task(store.discard(ROLLOUT_ID))
+    await asyncio.sleep(0)
+    commit.release.set()
+
+    ack = await grader_task
+    await discard_task
+
+    assert ack == {"ok": True, "durable": True}
+    assert (commit.starts, commit.completions) == (1, 1)
+    stored = store.terminal_for(ROLLOUT_ID)
+    assert stored is not None
+    assert stored.source == "grader"
+
+
+class _FailFirstBlockingCommit:
+    """Blocks the first commit, then fails it; later commits succeed."""
+
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.attempts = 0
+
+    async def __call__(self, result: TerminalCallbackResult) -> dict[str, object]:
+        self.attempts += 1
+        if self.attempts == 1:
+            self.started.set()
+            await self.release.wait()
+            raise RuntimeError("journal io error")
+        return {"ok": True, "attempt": self.attempts, "source": result.source}
+
+
+async def test_cancel_waiting_on_failed_commit_installs_tombstone() -> None:
+    commit = _FailFirstBlockingCommit()
+    store = CallbackStore(on_terminal_commit=commit)
+    await store.register(ROLLOUT_ID)
+
+    grader_task = asyncio.create_task(store.handle_grader(ROLLOUT_ID, _grader()))
+    await commit.started.wait()
+    cancel_task = asyncio.create_task(store.acknowledge_without_commit(ROLLOUT_ID))
+    await asyncio.sleep(0)
+    commit.release.set()
+
+    with pytest.raises(RuntimeError, match="journal io error"):
+        await grader_task
+    tombstone = await cancel_task
+
+    assert tombstone.source == "cancelled"
+    assert commit.attempts == 1  # cancellation never runs the hook
+    stored = store.terminal_for(ROLLOUT_ID)
+    assert stored is not None
+    assert stored.source == "cancelled"
+
+
+async def test_timeout_waiting_on_failed_commit_claims_timeout_result() -> None:
+    commit = _FailFirstBlockingCommit()
+    store = CallbackStore(on_terminal_commit=commit)
+    await store.register(ROLLOUT_ID)
+
+    grader_task = asyncio.create_task(store.handle_grader(ROLLOUT_ID, _grader()))
+    await commit.started.wait()
+    timeout_task = asyncio.create_task(
+        store.finalize_timeout(
+            ROLLOUT_ID, acknowledgment={"ok": True, "error_type": "callback_timeout"}
+        )
+    )
+    await asyncio.sleep(0)
+    commit.release.set()
+
+    with pytest.raises(RuntimeError, match="journal io error"):
+        await grader_task
+    result = await timeout_task
+
+    assert result.source == "timeout"
+    assert result.acknowledgment == {"ok": True, "attempt": 2, "source": "timeout"}
+    assert commit.attempts == 2
+
+
+async def test_waiter_cancellation_propagates_and_leaves_commit_running() -> None:
+    commit = _BlockingCommit()
+    store = CallbackStore(on_terminal_commit=commit)
+    await store.register(ROLLOUT_ID)
+
+    grader_task = asyncio.create_task(store.handle_grader(ROLLOUT_ID, _grader()))
+    await commit.started.wait()
+    waiter = asyncio.create_task(store.finalize_timeout(ROLLOUT_ID))
+    await asyncio.sleep(0)
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    commit.release.set()
+    ack = await grader_task
+    assert ack == {"ok": True, "durable": True}
+    assert (commit.starts, commit.completions) == (1, 1)
+
+
+async def test_in_flight_commit_wins_over_cancel_tombstone() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def commit(result: TerminalCallbackResult) -> dict[str, object]:
+        started.set()
+        await release.wait()
+        return {"ok": True, "durable": True}
+
+    store = CallbackStore(on_terminal_commit=commit)
+    await store.register(ROLLOUT_ID)
+    grader_task = asyncio.create_task(store.handle_grader(ROLLOUT_ID, _grader()))
+    await started.wait()
+    cancel_task = asyncio.create_task(store.acknowledge_without_commit(ROLLOUT_ID))
+    await asyncio.sleep(0)
+    release.set()
+
+    grader_ack = await grader_task
+    cancelled = await cancel_task
+    assert grader_ack == {"ok": True, "durable": True}
+    assert cancelled.source == "grader"
+    assert cancelled.acknowledgment == grader_ack
+
+
+def test_duplicate_payload_helper_matches_identical_grader_bodies() -> None:
+    assert duplicate_callback_payload(_grader(), _grader())
+    assert not duplicate_callback_payload(
+        _grader(),
+        _grader(status=GraderStatus.FAILURE, sample=None),
+    )

--- a/tests/unit/rollout/controller/test_store.py
+++ b/tests/unit/rollout/controller/test_store.py
@@ -47,6 +47,11 @@ def _grader(**overrides: object) -> GraderCompleteRequest:
     return GraderCompleteRequest.model_validate(payload)
 
 
+def _live_completion(store: CallbackStore) -> RolloutCompleteRequest | None:
+    """Completion payload the live session keeps for duplicate detection."""
+    return store._sessions[ROLLOUT_ID].completion
+
+
 async def test_register_then_discard_forgets_live_rendezvous() -> None:
     store = CallbackStore()
     await store.register(ROLLOUT_ID)
@@ -64,33 +69,18 @@ async def test_completion_is_not_terminal() -> None:
     await store.register(ROLLOUT_ID)
     await store.handle_completion(ROLLOUT_ID, _completion())
 
-    assert store.completion_for(ROLLOUT_ID) is not None
+    assert _live_completion(store) is not None
     assert store.terminal_for(ROLLOUT_ID) is None
 
 
-async def test_wait_completion_returns_accepted_payload() -> None:
-    store = CallbackStore()
-    await store.register(ROLLOUT_ID)
-    waiter = asyncio.create_task(store.wait_completion(ROLLOUT_ID))
-    await asyncio.sleep(0)
-    first = _completion()
-    await store.handle_completion(ROLLOUT_ID, first)
-    accepted = await waiter
-    assert accepted == first
-    assert await store.wait_completion(ROLLOUT_ID) == first
-    await store.handle_grader(ROLLOUT_ID, _grader())
-    await store.discard(ROLLOUT_ID)
-    assert await store.wait_completion(ROLLOUT_ID) == first
-
-
-async def test_identical_duplicate_completion_does_not_resolve_twice() -> None:
+async def test_identical_duplicate_completion_keeps_one_payload() -> None:
     store = CallbackStore()
     await store.register(ROLLOUT_ID)
     first = _completion()
     first_ack = await store.handle_completion(ROLLOUT_ID, first)
     second_ack = await store.handle_completion(ROLLOUT_ID, _completion())
     assert second_ack == first_ack
-    assert await store.wait_completion(ROLLOUT_ID) == first
+    assert _live_completion(store) == first
 
 
 async def test_conflicting_duplicate_completion_keeps_first_and_logs(
@@ -106,7 +96,7 @@ async def test_conflicting_duplicate_completion_keeps_first_and_logs(
             _completion(status=RolloutStatus.FAILURE, err_message="agent exploded"),
         )
     assert ack == {"ok": True}
-    assert await store.wait_completion(ROLLOUT_ID) == first
+    assert _live_completion(store) == first
     assert any(
         "conflicting duplicate" in record.message.lower()
         for record in caplog.records
@@ -114,20 +104,17 @@ async def test_conflicting_duplicate_completion_keeps_first_and_logs(
     )
 
 
-async def test_discard_cancels_unresolved_completion_and_terminal_futures() -> None:
+async def test_discard_cancels_the_unresolved_terminal_future() -> None:
     store = CallbackStore()
     await store.register(ROLLOUT_ID)
-    completion_waiter = asyncio.create_task(store.wait_completion(ROLLOUT_ID))
     terminal_waiter = asyncio.create_task(store.wait_terminal(ROLLOUT_ID))
     await asyncio.sleep(0)
     await store.discard(ROLLOUT_ID)
     with pytest.raises(asyncio.CancelledError):
-        await completion_waiter
-    with pytest.raises(asyncio.CancelledError):
         await terminal_waiter
 
 
-async def test_seeded_terminal_retains_completion_for_wait_and_duplicates() -> None:
+async def test_seeded_terminal_retains_completion_for_duplicates() -> None:
     store = CallbackStore()
     stored = _completion()
     store.seed_terminal(
@@ -136,7 +123,8 @@ async def test_seeded_terminal_retains_completion_for_wait_and_duplicates() -> N
         grader=_grader(),
         completion=stored,
     )
-    assert await store.wait_completion(ROLLOUT_ID) == stored
+    terminal = store.terminal_for(ROLLOUT_ID)
+    assert terminal is not None and terminal.completion == stored
     ack = await store.handle_completion(ROLLOUT_ID, stored)
     assert ack == {"ok": True, "seeded": True}
 

--- a/tests/unit/rollout/eval_proxy_stub.py
+++ b/tests/unit/rollout/eval_proxy_stub.py
@@ -1,0 +1,173 @@
+"""Local OpenAI-compatible eval-proxy contract stub. Test support only.
+
+Not a production eval-proxy: it implements just enough of the frozen
+create/chat wire contract for SDK tests to exercise it end to end. Lives
+under ``tests/`` so the shipped package never carries a fake proxy.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from collections.abc import AsyncIterator
+from typing import Any
+
+from fastapi import FastAPI, Header, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+from osmosis_ai.rollout.controller.proxy_client import (
+    EVAL_PROXY_INTEGRATION_MODEL,
+    EVAL_PROXY_WIRE_MODEL,
+)
+from osmosis_ai.rollout.utils.identifiers import is_single_path_segment
+
+DEFAULT_STUB_PLATFORM_TOKEN = "platform-token"
+
+_CREATE_FORBIDDEN_FIELDS = frozenset(
+    {"model", "integration_model", "wire_model", "synthetic_model"}
+)
+
+
+def create_eval_proxy_stub_app(
+    *, platform_token: str = DEFAULT_STUB_PLATFORM_TOKEN
+) -> FastAPI:
+    """Build the contract stub app, isolated per test."""
+    app = FastAPI()
+    app.state.sessions = {}
+    app.state.create_requests = []
+    app.state.chat_requests = []
+    app.state.platform_token = platform_token
+
+    def _require_platform(authorization: str | None) -> None:
+        expected = f"Bearer {platform_token}"
+        if authorization != expected:
+            raise HTTPException(status_code=401, detail="Unauthorized")
+
+    def _require_session(rollout_id: str, authorization: str | None) -> dict[str, Any]:
+        session = app.state.sessions.get(rollout_id)
+        if session is None:
+            raise HTTPException(status_code=404, detail="unknown session")
+        expected = f"Bearer {session['token']}"
+        if authorization != expected:
+            raise HTTPException(status_code=401, detail="Unauthorized")
+        return session
+
+    @app.post("/v1/eval-sessions")
+    async def create_session(
+        request: Request,
+        authorization: str | None = Header(default=None),
+    ) -> dict[str, Any]:
+        _require_platform(authorization)
+        body = await request.json()
+        if not isinstance(body, dict):
+            raise HTTPException(status_code=400, detail="expected a JSON object")
+        forbidden = _CREATE_FORBIDDEN_FIELDS & body.keys()
+        if forbidden:
+            raise HTTPException(
+                status_code=400,
+                detail="clients may not select the synthetic model",
+            )
+        rollout_id = body.get("rollout_id")
+        model_path = body.get("model_path")
+        if not isinstance(rollout_id, str) or not is_single_path_segment(rollout_id):
+            raise HTTPException(status_code=400, detail="invalid rollout_id")
+        if not isinstance(model_path, str) or not model_path:
+            raise HTTPException(status_code=400, detail="model_path is required")
+        token = secrets.token_urlsafe(16)
+        app.state.create_requests.append(dict(body))
+        app.state.sessions[rollout_id] = {
+            "token": token,
+            "model_path": model_path,
+        }
+        return {
+            "rollout_id": rollout_id,
+            "api_base": f"/v1/eval-sessions/{rollout_id}",
+            "token": token,
+            "integration_model": EVAL_PROXY_INTEGRATION_MODEL,
+            "wire_model": EVAL_PROXY_WIRE_MODEL,
+        }
+
+    @app.post("/v1/eval-sessions/{rollout_id}/chat/completions")
+    async def chat_completions(
+        rollout_id: str,
+        request: Request,
+        authorization: str | None = Header(default=None),
+    ) -> StreamingResponse:
+        _require_session(rollout_id, authorization)
+        body = await request.json()
+        if not isinstance(body, dict):
+            raise HTTPException(status_code=400, detail="expected a JSON object")
+        app.state.chat_requests.append(
+            {"path": str(request.url.path), "body": dict(body)}
+        )
+        if body.get("stream") is not True:
+            raise HTTPException(status_code=400, detail="stream=true is required")
+        if body.get("model") != EVAL_PROXY_WIRE_MODEL:
+            raise HTTPException(status_code=400, detail="model must be osmosis-rollout")
+        stream_options = body.get("stream_options")
+        if (
+            isinstance(stream_options, dict)
+            and "include_usage" in stream_options
+            and stream_options.get("include_usage") is not True
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="include_usage must be true when present",
+            )
+
+        async def events() -> AsyncIterator[str]:
+            completion_id = "chatcmpl-stub"
+            chunks = [
+                {
+                    "id": completion_id,
+                    "object": "chat.completion.chunk",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"role": "assistant", "content": "ok"},
+                            "finish_reason": None,
+                        }
+                    ],
+                },
+                {
+                    "id": completion_id,
+                    "object": "chat.completion.chunk",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                },
+                {
+                    "id": completion_id,
+                    "object": "chat.completion.chunk",
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                },
+            ]
+            for chunk in chunks:
+                yield f"data: {json.dumps(chunk)}\n\n"
+            yield "data: [DONE]\n\n"
+
+        return StreamingResponse(events(), media_type="text/event-stream")
+
+    @app.delete("/v1/eval-sessions/{rollout_id}")
+    async def close_session_provisional(
+        rollout_id: str,
+        authorization: str | None = Header(default=None),
+    ) -> dict[str, Any]:
+        # Provisional path. Not part of the frozen chat/session-create contract.
+        _require_platform(authorization)
+        session = app.state.sessions.get(rollout_id)
+        if session is None:
+            raise HTTPException(status_code=404, detail="unknown session")
+        app.state.sessions.pop(rollout_id, None)
+        return {"ok": True}
+
+    return app

--- a/tests/unit/rollout/integrations/test_eval_proxy_contract.py
+++ b/tests/unit/rollout/integrations/test_eval_proxy_contract.py
@@ -4,8 +4,17 @@ from __future__ import annotations
 
 import pytest
 
+# Skip before importing anything that pulls optional extras: the osmosis
+# imports below require the eval-run extra, and the integrations under test
+# require their own extras. importorskip only protects what comes after it.
+pytest.importorskip("agents")
+pytest.importorskip("litellm")
+pytest.importorskip("strands")
+
 from osmosis_ai.rollout.context import RolloutContext
-from osmosis_ai.rollout.controller.listener import LocalhostUvicornServer
+from osmosis_ai.rollout.controller.listener import (
+    LocalhostUvicornServer,
+)
 from osmosis_ai.rollout.controller.proxy_client import (
     EVAL_PROXY_INTEGRATION_MODEL,
     EVAL_PROXY_WIRE_MODEL,
@@ -15,10 +24,6 @@ from osmosis_ai.rollout.controller.proxy_client import (
 
 ROLLOUT_ID = "e" * 32
 MODEL_PATH = "openai/gpt-4.1-mini"
-
-pytest.importorskip("agents")
-pytest.importorskip("litellm")
-pytest.importorskip("strands")
 
 
 @pytest.fixture

--- a/tests/unit/rollout/integrations/test_eval_proxy_contract.py
+++ b/tests/unit/rollout/integrations/test_eval_proxy_contract.py
@@ -19,6 +19,9 @@ from osmosis_ai.rollout.controller.proxy_client import (
     EVAL_PROXY_INTEGRATION_MODEL,
     EVAL_PROXY_WIRE_MODEL,
     EvalProxyClient,
+)
+from tests.unit.rollout.eval_proxy_stub import (
+    DEFAULT_STUB_PLATFORM_TOKEN,
     create_eval_proxy_stub_app,
 )
 
@@ -30,7 +33,9 @@ MODEL_PATH = "openai/gpt-4.1-mini"
 async def eval_proxy_stub():
     app = create_eval_proxy_stub_app()
     async with LocalhostUvicornServer(app) as server:
-        client = EvalProxyClient(base_url=server.base_url, auth_token="platform-token")
+        client = EvalProxyClient(
+            base_url=server.base_url, auth_token=DEFAULT_STUB_PLATFORM_TOKEN
+        )
         session = await client.create_session(
             rollout_id=ROLLOUT_ID,
             model_path=MODEL_PATH,

--- a/tests/unit/rollout/integrations/test_eval_proxy_contract.py
+++ b/tests/unit/rollout/integrations/test_eval_proxy_contract.py
@@ -1,0 +1,98 @@
+"""Frozen eval-proxy wire contract against real agent integrations."""
+
+from __future__ import annotations
+
+import pytest
+
+from osmosis_ai.rollout.context import RolloutContext
+from osmosis_ai.rollout.controller.listener import LocalhostUvicornServer
+from osmosis_ai.rollout.controller.proxy_client import (
+    EVAL_PROXY_INTEGRATION_MODEL,
+    EVAL_PROXY_WIRE_MODEL,
+    EvalProxyClient,
+    create_eval_proxy_stub_app,
+)
+
+ROLLOUT_ID = "e" * 32
+MODEL_PATH = "openai/gpt-4.1-mini"
+
+pytest.importorskip("agents")
+pytest.importorskip("litellm")
+pytest.importorskip("strands")
+
+
+@pytest.fixture
+async def eval_proxy_stub():
+    app = create_eval_proxy_stub_app()
+    async with LocalhostUvicornServer(app) as server:
+        client = EvalProxyClient(base_url=server.base_url, auth_token="platform-token")
+        session = await client.create_session(
+            rollout_id=ROLLOUT_ID,
+            model_path=MODEL_PATH,
+        )
+        try:
+            yield app, session
+        finally:
+            await client.aclose()
+
+
+async def test_openai_agents_sends_frozen_wire_contract(eval_proxy_stub) -> None:
+    from agents import RunConfig, Runner
+
+    from osmosis_ai.rollout.integrations.agents.openai_agents import (
+        OsmosisAgent,
+        OsmosisMemorySession,
+        OsmosisRolloutModel,
+    )
+
+    app, session = eval_proxy_stub
+    ctx = RolloutContext(
+        chat_completions_url=session.api_base_url,
+        api_key=session.token,
+        rollout_id=session.rollout_id,
+    )
+    with ctx:
+        memory = OsmosisMemorySession()
+        agent = OsmosisAgent(name="main", model=OsmosisRolloutModel())
+        assert agent.model.model == EVAL_PROXY_INTEGRATION_MODEL
+        await Runner.run(
+            agent,
+            "hello",
+            session=memory,
+            run_config=RunConfig(tracing_disabled=True),
+        )
+
+    recorded = app.state.chat_requests[-1]
+    assert recorded["path"] == f"/v1/eval-sessions/{ROLLOUT_ID}/chat/completions"
+    body = recorded["body"]
+    assert body["model"] == EVAL_PROXY_WIRE_MODEL
+    assert body["stream"] is True
+    assert "stream_options" not in body
+
+
+async def test_strands_sends_frozen_wire_contract(eval_proxy_stub) -> None:
+    from osmosis_ai.rollout.integrations.agents.strands import (
+        OsmosisRolloutModel,
+        OsmosisStrandsAgent,
+    )
+
+    app, session = eval_proxy_stub
+    ctx = RolloutContext(
+        chat_completions_url=session.api_base_url,
+        api_key=session.token,
+        rollout_id=session.rollout_id,
+    )
+    with ctx:
+        agent = OsmosisStrandsAgent(name="solver", model=OsmosisRolloutModel())
+        await agent.invoke_async("hello")
+
+    recorded = app.state.chat_requests[-1]
+    assert recorded["path"] == f"/v1/eval-sessions/{ROLLOUT_ID}/chat/completions"
+    body = recorded["body"]
+    assert body["model"] == EVAL_PROXY_WIRE_MODEL
+    assert body["stream"] is True
+    stream_options = body.get("stream_options")
+    if stream_options is not None:
+        assert stream_options.get("include_usage") is True
+    else:
+        pytest.fail("Strands must send include_usage=true when stream_options is set")

--- a/tests/unit/rollout/integrations/test_eval_proxy_contract.py
+++ b/tests/unit/rollout/integrations/test_eval_proxy_contract.py
@@ -92,7 +92,5 @@ async def test_strands_sends_frozen_wire_contract(eval_proxy_stub) -> None:
     assert body["model"] == EVAL_PROXY_WIRE_MODEL
     assert body["stream"] is True
     stream_options = body.get("stream_options")
-    if stream_options is not None:
-        assert stream_options.get("include_usage") is True
-    else:
-        pytest.fail("Strands must send include_usage=true when stream_options is set")
+    assert stream_options is not None, "Strands must always send stream_options"
+    assert stream_options.get("include_usage") is True

--- a/tests/unit/rollout/test_driver.py
+++ b/tests/unit/rollout/test_driver.py
@@ -1,6 +1,10 @@
+from dataclasses import fields
+from inspect import signature
+from typing import Any, get_type_hints
+
 from osmosis_ai.rollout import driver
-from osmosis_ai.rollout.driver import RolloutOutcome
-from osmosis_ai.rollout.types import RolloutStatus
+from osmosis_ai.rollout.driver import RolloutDriver, RolloutOutcome, RolloutRunRequest
+from osmosis_ai.rollout.types import MessageDict, RolloutStatus
 
 
 def test_rollout_outcome_defaults():
@@ -14,5 +18,69 @@ def test_rollout_outcome_defaults():
 
 
 def test_driver_exports_controller_contract_only():
-    assert driver.__all__ == ["RolloutDriver", "RolloutOutcome"]
+    assert driver.__all__ == ["RolloutDriver", "RolloutOutcome", "RolloutRunRequest"]
     assert not hasattr(driver, "InProcessDriver")
+
+
+def test_rollout_run_request_fields_are_eval_agnostic():
+    names = [item.name for item in fields(RolloutRunRequest)]
+    assert names == [
+        "messages",
+        "label",
+        "metadata",
+        "rollout_id",
+        "agent_timeout_sec",
+        "grader_timeout_sec",
+        "extra_fields",
+    ]
+    hints = get_type_hints(RolloutRunRequest)
+    assert "MessageDict" in RolloutRunRequest.__annotations__["messages"]
+    assert hints["messages"] == list[MessageDict]
+    assert hints["label"] == str | None
+    assert hints["metadata"] == dict[str, Any] | None
+    assert hints["rollout_id"] is str
+    assert hints["agent_timeout_sec"] == float | None
+    assert hints["grader_timeout_sec"] == float | None
+    assert hints["extra_fields"] == dict[str, Any] | None
+
+
+def test_rollout_run_request_defaults():
+    request = RolloutRunRequest(messages=[{"role": "user", "content": "hi"}])
+    assert request.label is None
+    assert request.metadata is None
+    assert request.rollout_id == ""
+    assert request.agent_timeout_sec is None
+    assert request.grader_timeout_sec is None
+    assert request.extra_fields is None
+
+
+async def test_driver_run_accepts_a_single_request():
+    parameters = list(signature(RolloutDriver.run).parameters.values())
+    assert [item.name for item in parameters] == ["self", "request"]
+    hints = get_type_hints(RolloutDriver.run)
+    assert hints["request"] is RolloutRunRequest
+    assert hints["return"] is RolloutOutcome
+
+    class RecordingDriver(RolloutDriver):
+        def __init__(self) -> None:
+            self.seen: RolloutRunRequest | None = None
+
+        async def run(self, request: RolloutRunRequest) -> RolloutOutcome:
+            self.seen = request
+            return RolloutOutcome(
+                status=RolloutStatus.SUCCESS, rollout_id=request.rollout_id
+            )
+
+    request = RolloutRunRequest(
+        messages=[{"role": "user", "content": "hi"}],
+        label="yes",
+        metadata={"row_index": 3},
+        rollout_id="abc123",
+        agent_timeout_sec=30.0,
+        grader_timeout_sec=10.0,
+        extra_fields={"run_index": 0},
+    )
+    recorded = RecordingDriver()
+    outcome = await recorded.run(request)
+    assert recorded.seen is request
+    assert outcome.rollout_id == "abc123"

--- a/tests/unit/rollout/test_file_artifacts.py
+++ b/tests/unit/rollout/test_file_artifacts.py
@@ -5,11 +5,15 @@ from pathlib import Path
 
 import pytest
 
+from osmosis_ai.rollout.agent_workflow import AgentWorkflow
+from osmosis_ai.rollout.backend.local.backend import LocalBackend
+from osmosis_ai.rollout.types import AgentWorkflowConfig
 from osmosis_ai.rollout.utils import file_artifacts
 from osmosis_ai.rollout.utils.file_artifacts import (
     artifact_tree_state,
     copy_artifact_tree,
     create_rollout_artifacts_dir,
+    default_artifact_root,
 )
 
 
@@ -208,3 +212,63 @@ class TestCopyArtifactTree:
         assert copied == 1
         assert not (destination / "workflow.txt").exists()
         assert (destination / "grader.txt").read_text() == "grader"
+
+
+class _StubWorkflow(AgentWorkflow):
+    async def run(self, ctx):
+        return None
+
+
+class TestDefaultArtifactRoot:
+    def test_falls_back_to_home_osmosis_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("_OSMOSIS_ROLLOUT_ARTIFACT_ROOT", raising=False)
+
+        assert default_artifact_root() == Path.home() / ".osmosis"
+
+    def test_returns_env_override_without_changing_home(self, tmp_path, monkeypatch):
+        home_before = Path.home()
+        override = tmp_path / "rollout_trials"
+        monkeypatch.setenv("_OSMOSIS_ROLLOUT_ARTIFACT_ROOT", str(override))
+
+        assert default_artifact_root() == override
+        assert Path.home() == home_before
+
+    def test_local_backend_observes_override_at_construction(
+        self, tmp_path, monkeypatch
+    ):
+        home_before = Path.home()
+        override = tmp_path / "local_trials"
+        monkeypatch.setenv("_OSMOSIS_ROLLOUT_ARTIFACT_ROOT", str(override))
+
+        backend = LocalBackend(
+            workflow=_StubWorkflow,
+            workflow_config=AgentWorkflowConfig(name="test"),
+        )
+
+        assert backend.artifact_root == override
+        assert Path.home() == home_before
+
+    def test_harbor_backend_observes_override_at_construction(
+        self, tmp_path, monkeypatch
+    ):
+        from harbor.trial.queue import TrialQueue
+
+        from osmosis_ai.rollout.backend.harbor.backend import HarborBackend
+
+        home_before = Path.home()
+        override = tmp_path / "harbor_trials"
+        monkeypatch.setenv("_OSMOSIS_ROLLOUT_ARTIFACT_ROOT", str(override))
+
+        task = tmp_path / "template-task"
+        (task / "environment").mkdir(parents=True)
+        (task / "environment" / "Dockerfile").write_text("FROM python:3.12-slim\n")
+        (task / "task.toml").write_text('[task]\nname = "template-task"\n')
+
+        backend = HarborBackend(
+            orchestrator=TrialQueue(n_concurrent=1),
+            tasks_dir=task,
+            agent="terminus-2",
+        )
+
+        assert backend.artifact_root == override
+        assert Path.home() == home_before

--- a/tests/unit/rollout/test_http_driver.py
+++ b/tests/unit/rollout/test_http_driver.py
@@ -1,0 +1,734 @@
+"""Tests for the concrete HTTP rollout driver."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+import pytest
+
+from osmosis_ai.rollout.controller.proxy_client import EvalProxySession
+from osmosis_ai.rollout.controller.store import CallbackStore
+from osmosis_ai.rollout.driver import RolloutRunRequest
+from osmosis_ai.rollout.http_driver import (
+    AdmissionUncertainError,
+    HttpRolloutDriver,
+    RolloutProtocolError,
+)
+from osmosis_ai.rollout.types import (
+    GraderCompleteRequest,
+    GraderStatus,
+    RolloutCompleteRequest,
+    RolloutSample,
+    RolloutStatus,
+)
+
+ROLLOUT_ID = "f" * 32
+
+
+class FakeProxyClient:
+    def __init__(self, store: CallbackStore | None = None) -> None:
+        self.created: list[dict[str, Any]] = []
+        self.closed: list[str] = []
+        self._store = store
+        self.registered_at_create: bool | None = None
+
+    async def create_session(
+        self,
+        *,
+        rollout_id: str,
+        model_path: str,
+        row_index: int | None = None,
+        run_index: int | None = None,
+    ) -> EvalProxySession:
+        self.registered_at_create = (
+            self._store is not None and rollout_id in self._store._sessions
+        )
+        self.created.append(
+            {
+                "rollout_id": rollout_id,
+                "model_path": model_path,
+                "row_index": row_index,
+                "run_index": run_index,
+            }
+        )
+        return EvalProxySession(
+            rollout_id=rollout_id,
+            model_path=model_path,
+            api_base=f"/v1/eval-sessions/{rollout_id}",
+            api_base_url=f"http://proxy/v1/eval-sessions/{rollout_id}",
+            token="session-token",
+            row_index=row_index,
+            run_index=run_index,
+        )
+
+    async def aclose(self) -> None:
+        return None
+
+    async def close_session(self, rollout_id: str) -> None:
+        self.closed.append(rollout_id)
+
+
+def _grader() -> GraderCompleteRequest:
+    return GraderCompleteRequest(
+        status=GraderStatus.SUCCESS,
+        rollout_id=ROLLOUT_ID,
+        sample=RolloutSample(
+            messages=[{"role": "assistant", "content": "ok"}],
+            reward=1.0,
+        ),
+    )
+
+
+def _request(**overrides: Any) -> RolloutRunRequest:
+    payload: dict[str, Any] = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "label": "yes",
+        "metadata": {"row_index": 4},
+        "rollout_id": ROLLOUT_ID,
+        "agent_timeout_sec": 30.0,
+        "grader_timeout_sec": 10.0,
+        "extra_fields": {"run_index": 1, "custom": "x"},
+    }
+    payload.update(overrides)
+    return RolloutRunRequest(**payload)
+
+
+def _driver(
+    store: CallbackStore,
+    handler: Any,
+    *,
+    callback_timeout_sec: float | None = 5.0,
+    proxy: FakeProxyClient | None = None,
+    status_poll_attempts: int = 5,
+    status_poll_interval_sec: float = 0.0,
+) -> tuple[HttpRolloutDriver, FakeProxyClient]:
+    proxy = proxy or FakeProxyClient(store)
+    http = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://rollout",
+    )
+    driver = HttpRolloutDriver(
+        rollout_base_url="http://rollout",
+        callback_store=store,
+        completion_url_for=lambda rid: (
+            f"http://cb/v1/rollouts/{quote(rid, safe='')}/completion"
+        ),
+        grader_url_for=lambda rid: (
+            f"http://cb/v1/rollouts/{quote(rid, safe='')}/grader"
+        ),
+        proxy_client=proxy,  # type: ignore[arg-type]
+        controller_api_key="controller-key",
+        model_path="openai/gpt-4.1-mini",
+        http_client=http,
+        callback_timeout_sec=callback_timeout_sec,
+        status_poll_attempts=status_poll_attempts,
+        status_poll_interval_sec=status_poll_interval_sec,
+    )
+    return driver, proxy
+
+
+async def test_202_admission_posts_init_and_returns_grader_outcome() -> None:
+    store = CallbackStore()
+    posted: list[dict[str, Any]] = []
+    admitted = asyncio.Event()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/rollout":
+            posted.append(json_body(request))
+            admitted.set()
+            return httpx.Response(202, json={})
+        raise AssertionError(f"unexpected {request.method} {request.url}")
+
+    driver, proxy = _driver(store, handler)
+    run_task = asyncio.create_task(driver.run(_request()))
+    await admitted.wait()
+    await store.handle_grader(ROLLOUT_ID, _grader())
+    outcome = await run_task
+
+    assert outcome.status == RolloutStatus.SUCCESS
+    assert outcome.sample is not None
+    assert outcome.sample.reward == 1.0
+    assert outcome.rollout_id == ROLLOUT_ID
+    body = posted[0]
+    assert body["rollout_id"] == ROLLOUT_ID
+    assert body["chat_completions_url"] == f"http://proxy/v1/eval-sessions/{ROLLOUT_ID}"
+    assert body["completion_callback_url"].endswith(f"/{ROLLOUT_ID}/completion")
+    assert body["grader_callback_url"].endswith(f"/{ROLLOUT_ID}/grader")
+    assert body["controller_api_key"] == "controller-key"
+    assert body["llm_api_key"] == "session-token"
+    assert body["controller_api_key"] != body["llm_api_key"]
+    assert body["metadata"] == {"row_index": 4}
+    assert body["agent_timeout_sec"] == 30.0
+    assert body["grader_timeout_sec"] == 10.0
+    assert body["extra_fields"]["custom"] == "x"
+    assert proxy.created[0]["row_index"] == 4
+    assert proxy.created[0]["run_index"] == 1
+    assert proxy.registered_at_create is True
+    late_completion = await store.handle_completion(
+        ROLLOUT_ID,
+        RolloutCompleteRequest(status=RolloutStatus.SUCCESS),
+    )
+    assert late_completion == {"ok": True}
+
+
+async def test_429_retries_after_header_without_reregistering() -> None:
+    store = CallbackStore()
+    posts = 0
+    registrations = {"n": 0}
+    admitted = asyncio.Event()
+    real_register = store.register
+
+    async def tracked_register(rollout_id: str) -> None:
+        registrations["n"] += 1
+        await real_register(rollout_id)
+
+    store.register = tracked_register  # type: ignore[method-assign]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal posts
+        if request.url.path == "/rollout":
+            posts += 1
+            if posts == 1:
+                return httpx.Response(
+                    429, json={"detail": "full"}, headers={"Retry-After": "0"}
+                )
+            admitted.set()
+            return httpx.Response(202, json={})
+        raise AssertionError(request.url.path)
+
+    driver, _proxy = _driver(store, handler)
+    run_task = asyncio.create_task(driver.run(_request()))
+    await admitted.wait()
+    await store.handle_grader(ROLLOUT_ID, _grader())
+    outcome = await run_task
+    assert outcome.status == RolloutStatus.SUCCESS
+    assert posts == 2
+    assert registrations["n"] == 1
+
+
+async def test_ambiguous_post_waits_when_status_shows_admitted() -> None:
+    store = CallbackStore()
+    posts = 0
+    statuses = 0
+    admitted = asyncio.Event()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal posts, statuses
+        if request.url.path == "/rollout" and request.method == "POST":
+            posts += 1
+            raise httpx.ConnectError("reset", request=request)
+        if request.url.path == f"/rollout/{ROLLOUT_ID}/status":
+            statuses += 1
+            admitted.set()
+            return httpx.Response(
+                200, json={"rollout_id": ROLLOUT_ID, "status": "running"}
+            )
+        raise AssertionError(request.url.path)
+
+    driver, _proxy = _driver(store, handler)
+    run_task = asyncio.create_task(driver.run(_request()))
+    await admitted.wait()
+    await store.handle_grader(ROLLOUT_ID, _grader())
+    outcome = await run_task
+    assert outcome.status == RolloutStatus.SUCCESS
+    assert posts == 1
+    assert statuses == 1
+
+
+async def test_status_500_never_causes_second_post() -> None:
+    store = CallbackStore()
+    posts = 0
+    statuses = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal posts, statuses
+        if request.url.path == "/rollout" and request.method == "POST":
+            posts += 1
+            raise httpx.ConnectError("reset", request=request)
+        if request.url.path == f"/rollout/{ROLLOUT_ID}/status":
+            statuses += 1
+            return httpx.Response(500, json={"detail": "not ready"})
+        if request.url.path == "/rollout/cancel":
+            return httpx.Response(200, json={"dispositions": {}})
+        raise AssertionError(request.url.path)
+
+    driver, _proxy = _driver(store, handler, status_poll_attempts=3)
+    with pytest.raises(AdmissionUncertainError):
+        await driver.run(_request())
+    assert posts == 1
+    assert statuses == 3
+
+
+async def test_status_network_failure_never_causes_second_post() -> None:
+    store = CallbackStore()
+    posts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal posts
+        if request.url.path == "/rollout" and request.method == "POST":
+            posts += 1
+            raise httpx.ConnectError("reset", request=request)
+        if request.url.path == f"/rollout/{ROLLOUT_ID}/status":
+            raise httpx.ConnectError("status down", request=request)
+        if request.url.path == "/rollout/cancel":
+            return httpx.Response(200, json={"dispositions": {}})
+        raise AssertionError(request.url.path)
+
+    driver, _proxy = _driver(store, handler, status_poll_attempts=3)
+    with pytest.raises(AdmissionUncertainError):
+        await driver.run(_request())
+    assert posts == 1
+
+
+async def test_admission_uncertain_issues_best_effort_remote_cancel() -> None:
+    store = CallbackStore()
+    cancel_posts: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/rollout" and request.method == "POST":
+            raise httpx.ConnectError("reset", request=request)
+        if request.url.path == f"/rollout/{ROLLOUT_ID}/status":
+            return httpx.Response(500, json={"detail": "not ready"})
+        if request.url.path == "/rollout/cancel":
+            cancel_posts.append(json_body(request))
+            return httpx.Response(
+                200, json={"dispositions": {ROLLOUT_ID: "cancelled_queued"}}
+            )
+        raise AssertionError(request.url.path)
+
+    driver, _proxy = _driver(store, handler, status_poll_attempts=2)
+    with pytest.raises(AdmissionUncertainError):
+        await driver.run(_request())
+    assert cancel_posts == [{"ids": [ROLLOUT_ID], "prefix": None, "all": False}]
+
+
+async def test_admission_uncertain_survives_failed_best_effort_cancel() -> None:
+    store = CallbackStore()
+    cancel_attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal cancel_attempts
+        if request.url.path == "/rollout" and request.method == "POST":
+            raise httpx.ConnectError("reset", request=request)
+        if request.url.path == f"/rollout/{ROLLOUT_ID}/status":
+            return httpx.Response(500, json={"detail": "not ready"})
+        if request.url.path == "/rollout/cancel":
+            cancel_attempts += 1
+            raise httpx.ConnectError("cancel down", request=request)
+        raise AssertionError(request.url.path)
+
+    driver, _proxy = _driver(store, handler, status_poll_attempts=2)
+    with pytest.raises(AdmissionUncertainError):
+        await driver.run(_request())
+    assert cancel_attempts == 1
+
+
+async def test_explicit_unknown_safely_retries_post() -> None:
+    store = CallbackStore()
+    posts = 0
+    admitted = asyncio.Event()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal posts
+        if request.url.path == "/rollout" and request.method == "POST":
+            posts += 1
+            if posts == 1:
+                raise httpx.ConnectError("reset", request=request)
+            admitted.set()
+            return httpx.Response(202, json={})
+        if request.url.path == f"/rollout/{ROLLOUT_ID}/status":
+            return httpx.Response(
+                200, json={"rollout_id": ROLLOUT_ID, "status": "unknown"}
+            )
+        raise AssertionError(request.url.path)
+
+    driver, _proxy = _driver(store, handler)
+    run_task = asyncio.create_task(driver.run(_request()))
+    await admitted.wait()
+    await store.handle_grader(ROLLOUT_ID, _grader())
+    await run_task
+    assert posts == 2
+
+
+async def test_malformed_status_is_indeterminate_and_does_not_retry_post() -> None:
+    store = CallbackStore()
+    posts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal posts
+        if request.url.path == "/rollout" and request.method == "POST":
+            posts += 1
+            raise httpx.ConnectError("reset", request=request)
+        if request.url.path == f"/rollout/{ROLLOUT_ID}/status":
+            return httpx.Response(200, text="not-json")
+        if request.url.path == "/rollout/cancel":
+            return httpx.Response(200, json={"dispositions": {}})
+        raise AssertionError(request.url.path)
+
+    driver, _proxy = _driver(store, handler, status_poll_attempts=2)
+    with pytest.raises(AdmissionUncertainError):
+        await driver.run(_request())
+    assert posts == 1
+
+
+async def test_post_200_is_protocol_error_without_looping() -> None:
+    store = CallbackStore()
+    posts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal posts
+        if request.url.path == "/rollout" and request.method == "POST":
+            posts += 1
+            return httpx.Response(200, json={"ok": True})
+        raise AssertionError(request.url.path)
+
+    driver, _proxy = _driver(store, handler)
+    with pytest.raises(RolloutProtocolError, match="200"):
+        await driver.run(_request())
+    assert posts == 1
+
+
+async def test_status_url_encodes_rollout_id() -> None:
+    store = CallbackStore()
+    special_id = "rid:1"
+    status_urls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/rollout" and request.method == "POST":
+            raise httpx.ConnectError("reset", request=request)
+        if request.method == "GET" and "/status" in request.url.path:
+            status_urls.append(str(request.url))
+            return httpx.Response(500, json={"detail": "nope"})
+        if request.url.path == "/rollout/cancel":
+            return httpx.Response(200, json={"dispositions": {}})
+        raise AssertionError(request.url.path)
+
+    driver, _proxy = _driver(store, handler, status_poll_attempts=1)
+    with pytest.raises(AdmissionUncertainError):
+        await driver.run(_request(rollout_id=special_id))
+    assert status_urls
+    assert f"/rollout/{quote(special_id, safe='')}/status" in status_urls[0]
+
+
+async def test_callback_timeout_wins_over_late_grader() -> None:
+    store = CallbackStore()
+    cancelled: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/rollout" and request.method == "POST":
+            return httpx.Response(202, json={})
+        if request.url.path == "/rollout/cancel":
+            cancelled.append(json_body(request))
+            return httpx.Response(
+                200, json={"dispositions": {ROLLOUT_ID: "cancelled_running"}}
+            )
+        raise AssertionError(request.url.path)
+
+    driver, _proxy = _driver(store, handler, callback_timeout_sec=0.05)
+    outcome = await driver.run(_request())
+    late = await store.handle_grader(ROLLOUT_ID, _grader())
+
+    assert outcome.status == RolloutStatus.FAILURE
+    assert outcome.error == "callback_timeout"
+    assert late.get("error_type") == "callback_timeout"
+    assert cancelled and cancelled[0]["ids"] == [ROLLOUT_ID]
+
+
+async def test_timeout_plus_failed_cancel_keeps_timeout_result() -> None:
+    store = CallbackStore()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/rollout" and request.method == "POST":
+            return httpx.Response(202, json={})
+        if request.url.path == "/rollout/cancel":
+            return httpx.Response(503, json={"detail": "unavailable"})
+        raise AssertionError(request.url.path)
+
+    driver, _proxy = _driver(store, handler, callback_timeout_sec=0.05)
+    outcome = await driver.run(_request())
+    assert outcome.status == RolloutStatus.FAILURE
+    assert outcome.error == "callback_timeout"
+
+
+async def test_explicit_cancel_wakes_run_as_cancelled() -> None:
+    store = CallbackStore()
+    cancelled: list[dict[str, Any]] = []
+    admitted = asyncio.Event()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/rollout" and request.method == "POST":
+            admitted.set()
+            return httpx.Response(202, json={})
+        if request.url.path == "/rollout/cancel":
+            cancelled.append(json_body(request))
+            return httpx.Response(
+                200, json={"dispositions": {ROLLOUT_ID: "cancelled_running"}}
+            )
+        raise AssertionError(request.url.path)
+
+    driver, proxy = _driver(store, handler)
+    run_task = asyncio.create_task(driver.run(_request()))
+    await admitted.wait()
+    dispositions = await driver.cancel(ROLLOUT_ID)
+    outcome = await run_task
+    assert outcome.status == RolloutStatus.CANCELLED
+    assert dispositions == {ROLLOUT_ID: "cancelled_running"}
+    assert cancelled and cancelled[0]["ids"] == [ROLLOUT_ID]
+    assert proxy.closed == [ROLLOUT_ID]
+    late_completion = await store.handle_completion(
+        ROLLOUT_ID,
+        RolloutCompleteRequest(status=RolloutStatus.SUCCESS),
+    )
+    late_grader = await store.handle_grader(ROLLOUT_ID, _grader())
+    assert late_completion == {"ok": True}
+    assert late_grader == late_completion
+
+
+async def test_explicit_cancel_503_still_returns_cancelled() -> None:
+    store = CallbackStore()
+    admitted = asyncio.Event()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/rollout" and request.method == "POST":
+            admitted.set()
+            return httpx.Response(202, json={})
+        if request.url.path == "/rollout/cancel":
+            return httpx.Response(503, json={"detail": "unavailable"})
+        raise AssertionError(request.url.path)
+
+    driver, _proxy = _driver(store, handler)
+    run_task = asyncio.create_task(driver.run(_request()))
+    await admitted.wait()
+    dispositions = await driver.cancel(ROLLOUT_ID)
+    outcome = await run_task
+    assert dispositions == {}
+    assert outcome.status == RolloutStatus.CANCELLED
+
+
+async def test_explicit_cancel_malformed_response_still_returns_cancelled() -> None:
+    store = CallbackStore()
+    admitted = asyncio.Event()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/rollout" and request.method == "POST":
+            admitted.set()
+            return httpx.Response(202, json={})
+        if request.url.path == "/rollout/cancel":
+            return httpx.Response(200, text="not-json")
+        raise AssertionError(request.url.path)
+
+    driver, _proxy = _driver(store, handler)
+    run_task = asyncio.create_task(driver.run(_request()))
+    await admitted.wait()
+    dispositions = await driver.cancel(ROLLOUT_ID)
+    outcome = await run_task
+    assert dispositions == {}
+    assert outcome.status == RolloutStatus.CANCELLED
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("inf", 1.0),
+        ("-inf", 1.0),
+        ("nan", 1.0),
+        ("1e999", 1.0),
+        ("junk", 1.0),
+        ("-5", 0.0),
+        ("2.5", 2.5),
+    ],
+)
+def test_retry_after_seconds_is_finite_and_non_negative(
+    raw: str, expected: float
+) -> None:
+    from osmosis_ai.rollout.http_driver import _retry_after_seconds
+
+    response = httpx.Response(429, headers={"Retry-After": raw})
+    assert _retry_after_seconds(response) == expected
+
+
+class BlockingProxyClient(FakeProxyClient):
+    """Proxy client whose create blocks so tests can race cancel against it."""
+
+    def __init__(self, store: CallbackStore) -> None:
+        super().__init__(store)
+        self.entered = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def create_session(self, **kwargs: Any) -> EvalProxySession:
+        self.entered.set()
+        await self.release.wait()
+        return await super().create_session(**kwargs)
+
+
+async def test_cancel_during_proxy_create_prevents_rollout_post() -> None:
+    store = CallbackStore()
+    rollout_posts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal rollout_posts
+        if request.url.path == "/rollout" and request.method == "POST":
+            rollout_posts += 1
+            return httpx.Response(202, json={})
+        if request.url.path == "/rollout/cancel":
+            return httpx.Response(200, json={"dispositions": {}})
+        raise AssertionError(request.url.path)
+
+    proxy = BlockingProxyClient(store)
+    driver, _ = _driver(store, handler, proxy=proxy)
+    run_task = asyncio.create_task(driver.run(_request()))
+    await proxy.entered.wait()
+    await driver.cancel(ROLLOUT_ID)
+    proxy.release.set()
+    outcome = await run_task
+
+    assert outcome.status == RolloutStatus.CANCELLED
+    assert rollout_posts == 0
+    assert proxy.closed == [ROLLOUT_ID]
+
+
+async def test_cancel_racing_successful_post_reissues_remote_cancel() -> None:
+    store = CallbackStore()
+    rollout_posts = 0
+    cancel_posts: list[dict[str, Any]] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal rollout_posts
+        if request.url.path == "/rollout" and request.method == "POST":
+            rollout_posts += 1
+            # Cancel lands while the POST is in flight, after the server
+            # has already committed to admitting the rollout.
+            await store.acknowledge_without_commit(ROLLOUT_ID)
+            return httpx.Response(202, json={})
+        if request.url.path == "/rollout/cancel":
+            cancel_posts.append(json_body(request))
+            return httpx.Response(
+                200, json={"dispositions": {ROLLOUT_ID: "cancelled_running"}}
+            )
+        raise AssertionError(request.url.path)
+
+    driver, _proxy = _driver(store, handler)
+    outcome = await driver.run(_request())
+
+    assert outcome.status == RolloutStatus.CANCELLED
+    assert rollout_posts == 1
+    assert cancel_posts and cancel_posts[0]["ids"] == [ROLLOUT_ID]
+
+
+async def test_cancel_during_429_wait_exits_without_second_post() -> None:
+    store = CallbackStore()
+    rollout_posts = 0
+    first_posted = asyncio.Event()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal rollout_posts
+        if request.url.path == "/rollout" and request.method == "POST":
+            rollout_posts += 1
+            first_posted.set()
+            return httpx.Response(
+                429, json={"detail": "full"}, headers={"Retry-After": "0.05"}
+            )
+        if request.url.path == "/rollout/cancel":
+            return httpx.Response(200, json={"dispositions": {}})
+        raise AssertionError(request.url.path)
+
+    driver, _proxy = _driver(store, handler)
+    run_task = asyncio.create_task(driver.run(_request()))
+    await first_posted.wait()
+    await driver.cancel(ROLLOUT_ID)
+    outcome = await asyncio.wait_for(run_task, timeout=2.0)
+
+    assert outcome.status == RolloutStatus.CANCELLED
+    assert rollout_posts == 1
+
+
+async def test_cancel_unknown_id_leaves_store_clean_for_future_run() -> None:
+    store = CallbackStore()
+    admitted = asyncio.Event()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/rollout" and request.method == "POST":
+            admitted.set()
+            return httpx.Response(202, json={})
+        if request.url.path == "/rollout/cancel":
+            return httpx.Response(200, json={"dispositions": {}})
+        raise AssertionError(request.url.path)
+
+    driver, _proxy = _driver(store, handler)
+    dispositions = await driver.cancel(ROLLOUT_ID)
+    assert dispositions == {}
+
+    run_task = asyncio.create_task(driver.run(_request()))
+    await asyncio.wait_for(admitted.wait(), timeout=2.0)
+    await store.handle_grader(ROLLOUT_ID, _grader())
+    outcome = await run_task
+    assert outcome.status == RolloutStatus.SUCCESS
+
+
+async def test_status_rollout_id_mismatch_never_causes_second_post() -> None:
+    store = CallbackStore()
+    rollout_posts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal rollout_posts
+        if request.url.path == "/rollout" and request.method == "POST":
+            rollout_posts += 1
+            if rollout_posts == 1:
+                raise httpx.ConnectError("reset", request=request)
+            return httpx.Response(202, json={})
+        if request.url.path == f"/rollout/{ROLLOUT_ID}/status":
+            return httpx.Response(
+                200, json={"rollout_id": "e" * 32, "status": "unknown"}
+            )
+        if request.url.path == "/rollout/cancel":
+            return httpx.Response(200, json={"dispositions": {}})
+        raise AssertionError(request.url.path)
+
+    driver, _proxy = _driver(
+        store, handler, status_poll_attempts=2, callback_timeout_sec=0.05
+    )
+    with pytest.raises(AdmissionUncertainError):
+        await driver.run(_request())
+    assert rollout_posts == 1
+
+
+async def test_task_cancellation_reraises_cancelled_error() -> None:
+    store = CallbackStore()
+    cancelled: list[dict[str, Any]] = []
+    admitted = asyncio.Event()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/rollout" and request.method == "POST":
+            admitted.set()
+            return httpx.Response(202, json={})
+        if request.url.path == "/rollout/cancel":
+            cancelled.append(json_body(request))
+            return httpx.Response(
+                200, json={"dispositions": {ROLLOUT_ID: "cancelled_running"}}
+            )
+        raise AssertionError(request.url.path)
+
+    driver, proxy = _driver(store, handler)
+    task = asyncio.create_task(driver.run(_request()))
+    await admitted.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert cancelled and cancelled[0]["ids"] == [ROLLOUT_ID]
+    assert proxy.closed == [ROLLOUT_ID]
+    late_completion = await store.handle_completion(
+        ROLLOUT_ID,
+        RolloutCompleteRequest(status=RolloutStatus.SUCCESS),
+    )
+    late_grader = await store.handle_grader(ROLLOUT_ID, _grader())
+    assert late_completion == {"ok": True}
+    assert late_grader == late_completion
+
+
+def json_body(request: httpx.Request) -> dict[str, Any]:
+    import json
+
+    return json.loads(request.content)

--- a/tests/unit/rollout/test_http_driver.py
+++ b/tests/unit/rollout/test_http_driver.py
@@ -86,11 +86,11 @@ def _request(**overrides: Any) -> RolloutRunRequest:
     payload: dict[str, Any] = {
         "messages": [{"role": "user", "content": "hi"}],
         "label": "yes",
-        "metadata": {"row_index": 4},
+        "metadata": {"split": "train"},
         "rollout_id": ROLLOUT_ID,
         "agent_timeout_sec": 30.0,
         "grader_timeout_sec": 10.0,
-        "extra_fields": {"run_index": 1, "custom": "x"},
+        "extra_fields": {"row_index": 4, "run_index": 1, "custom": "x"},
     }
     payload.update(overrides)
     return RolloutRunRequest(**payload)
@@ -101,11 +101,10 @@ def _driver(
     handler: Any,
     *,
     callback_timeout_sec: float | None = 5.0,
-    proxy: FakeProxyClient | None = None,
     status_poll_attempts: int = 5,
     status_poll_interval_sec: float = 0.0,
 ) -> tuple[HttpRolloutDriver, FakeProxyClient]:
-    proxy = proxy or FakeProxyClient(store)
+    proxy = FakeProxyClient(store)
     http = httpx.AsyncClient(
         transport=httpx.MockTransport(handler),
         base_url="http://rollout",
@@ -160,7 +159,7 @@ async def test_202_admission_posts_init_and_returns_grader_outcome() -> None:
     assert body["controller_api_key"] == "controller-key"
     assert body["llm_api_key"] == "session-token"
     assert body["controller_api_key"] != body["llm_api_key"]
-    assert body["metadata"] == {"row_index": 4}
+    assert body["metadata"] == {"split": "train"}
     assert body["agent_timeout_sec"] == 30.0
     assert body["grader_timeout_sec"] == 10.0
     assert body["extra_fields"]["custom"] == "x"
@@ -172,6 +171,30 @@ async def test_202_admission_posts_init_and_returns_grader_outcome() -> None:
         RolloutCompleteRequest(status=RolloutStatus.SUCCESS),
     )
     assert late_completion == {"ok": True}
+
+
+async def test_row_and_run_indices_are_read_from_extra_fields_only() -> None:
+    store = CallbackStore()
+    admitted = asyncio.Event()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/rollout" and request.method == "POST":
+            admitted.set()
+            return httpx.Response(202, json={})
+        raise AssertionError(f"unexpected {request.method} {request.url}")
+
+    driver, proxy = _driver(store, handler)
+    run_task = asyncio.create_task(
+        driver.run(
+            _request(metadata={"row_index": 7, "run_index": 8}, extra_fields=None)
+        )
+    )
+    await admitted.wait()
+    await store.handle_grader(ROLLOUT_ID, _grader())
+    await run_task
+
+    assert proxy.created[0]["row_index"] is None
+    assert proxy.created[0]["run_index"] is None
 
 
 async def test_429_retries_after_header_without_reregistering() -> None:
@@ -453,82 +476,6 @@ async def test_timeout_plus_failed_cancel_keeps_timeout_result() -> None:
     assert outcome.error == "callback_timeout"
 
 
-async def test_explicit_cancel_wakes_run_as_cancelled() -> None:
-    store = CallbackStore()
-    cancelled: list[dict[str, Any]] = []
-    admitted = asyncio.Event()
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/rollout" and request.method == "POST":
-            admitted.set()
-            return httpx.Response(202, json={})
-        if request.url.path == "/rollout/cancel":
-            cancelled.append(json_body(request))
-            return httpx.Response(
-                200, json={"dispositions": {ROLLOUT_ID: "cancelled_running"}}
-            )
-        raise AssertionError(request.url.path)
-
-    driver, proxy = _driver(store, handler)
-    run_task = asyncio.create_task(driver.run(_request()))
-    await admitted.wait()
-    dispositions = await driver.cancel(ROLLOUT_ID)
-    outcome = await run_task
-    assert outcome.status == RolloutStatus.CANCELLED
-    assert dispositions == {ROLLOUT_ID: "cancelled_running"}
-    assert cancelled and cancelled[0]["ids"] == [ROLLOUT_ID]
-    assert proxy.closed == [ROLLOUT_ID]
-    late_completion = await store.handle_completion(
-        ROLLOUT_ID,
-        RolloutCompleteRequest(status=RolloutStatus.SUCCESS),
-    )
-    late_grader = await store.handle_grader(ROLLOUT_ID, _grader())
-    assert late_completion == {"ok": True}
-    assert late_grader == late_completion
-
-
-async def test_explicit_cancel_503_still_returns_cancelled() -> None:
-    store = CallbackStore()
-    admitted = asyncio.Event()
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/rollout" and request.method == "POST":
-            admitted.set()
-            return httpx.Response(202, json={})
-        if request.url.path == "/rollout/cancel":
-            return httpx.Response(503, json={"detail": "unavailable"})
-        raise AssertionError(request.url.path)
-
-    driver, _proxy = _driver(store, handler)
-    run_task = asyncio.create_task(driver.run(_request()))
-    await admitted.wait()
-    dispositions = await driver.cancel(ROLLOUT_ID)
-    outcome = await run_task
-    assert dispositions == {}
-    assert outcome.status == RolloutStatus.CANCELLED
-
-
-async def test_explicit_cancel_malformed_response_still_returns_cancelled() -> None:
-    store = CallbackStore()
-    admitted = asyncio.Event()
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/rollout" and request.method == "POST":
-            admitted.set()
-            return httpx.Response(202, json={})
-        if request.url.path == "/rollout/cancel":
-            return httpx.Response(200, text="not-json")
-        raise AssertionError(request.url.path)
-
-    driver, _proxy = _driver(store, handler)
-    run_task = asyncio.create_task(driver.run(_request()))
-    await admitted.wait()
-    dispositions = await driver.cancel(ROLLOUT_ID)
-    outcome = await run_task
-    assert dispositions == {}
-    assert outcome.status == RolloutStatus.CANCELLED
-
-
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [
@@ -539,133 +486,17 @@ async def test_explicit_cancel_malformed_response_still_returns_cancelled() -> N
         ("junk", 1.0),
         ("-5", 0.0),
         ("2.5", 2.5),
+        ("60", 60.0),
+        ("86400", 60.0),
     ],
 )
-def test_retry_after_seconds_is_finite_and_non_negative(
+def test_retry_after_seconds_is_finite_non_negative_and_capped(
     raw: str, expected: float
 ) -> None:
     from osmosis_ai.rollout.http_driver import _retry_after_seconds
 
     response = httpx.Response(429, headers={"Retry-After": raw})
     assert _retry_after_seconds(response) == expected
-
-
-class BlockingProxyClient(FakeProxyClient):
-    """Proxy client whose create blocks so tests can race cancel against it."""
-
-    def __init__(self, store: CallbackStore) -> None:
-        super().__init__(store)
-        self.entered = asyncio.Event()
-        self.release = asyncio.Event()
-
-    async def create_session(self, **kwargs: Any) -> EvalProxySession:
-        self.entered.set()
-        await self.release.wait()
-        return await super().create_session(**kwargs)
-
-
-async def test_cancel_during_proxy_create_prevents_rollout_post() -> None:
-    store = CallbackStore()
-    rollout_posts = 0
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal rollout_posts
-        if request.url.path == "/rollout" and request.method == "POST":
-            rollout_posts += 1
-            return httpx.Response(202, json={})
-        if request.url.path == "/rollout/cancel":
-            return httpx.Response(200, json={"dispositions": {}})
-        raise AssertionError(request.url.path)
-
-    proxy = BlockingProxyClient(store)
-    driver, _ = _driver(store, handler, proxy=proxy)
-    run_task = asyncio.create_task(driver.run(_request()))
-    await proxy.entered.wait()
-    await driver.cancel(ROLLOUT_ID)
-    proxy.release.set()
-    outcome = await run_task
-
-    assert outcome.status == RolloutStatus.CANCELLED
-    assert rollout_posts == 0
-    assert proxy.closed == [ROLLOUT_ID]
-
-
-async def test_cancel_racing_successful_post_reissues_remote_cancel() -> None:
-    store = CallbackStore()
-    rollout_posts = 0
-    cancel_posts: list[dict[str, Any]] = []
-
-    async def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal rollout_posts
-        if request.url.path == "/rollout" and request.method == "POST":
-            rollout_posts += 1
-            # Cancel lands while the POST is in flight, after the server
-            # has already committed to admitting the rollout.
-            await store.acknowledge_without_commit(ROLLOUT_ID)
-            return httpx.Response(202, json={})
-        if request.url.path == "/rollout/cancel":
-            cancel_posts.append(json_body(request))
-            return httpx.Response(
-                200, json={"dispositions": {ROLLOUT_ID: "cancelled_running"}}
-            )
-        raise AssertionError(request.url.path)
-
-    driver, _proxy = _driver(store, handler)
-    outcome = await driver.run(_request())
-
-    assert outcome.status == RolloutStatus.CANCELLED
-    assert rollout_posts == 1
-    assert cancel_posts and cancel_posts[0]["ids"] == [ROLLOUT_ID]
-
-
-async def test_cancel_during_429_wait_exits_without_second_post() -> None:
-    store = CallbackStore()
-    rollout_posts = 0
-    first_posted = asyncio.Event()
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal rollout_posts
-        if request.url.path == "/rollout" and request.method == "POST":
-            rollout_posts += 1
-            first_posted.set()
-            return httpx.Response(
-                429, json={"detail": "full"}, headers={"Retry-After": "0.05"}
-            )
-        if request.url.path == "/rollout/cancel":
-            return httpx.Response(200, json={"dispositions": {}})
-        raise AssertionError(request.url.path)
-
-    driver, _proxy = _driver(store, handler)
-    run_task = asyncio.create_task(driver.run(_request()))
-    await first_posted.wait()
-    await driver.cancel(ROLLOUT_ID)
-    outcome = await asyncio.wait_for(run_task, timeout=2.0)
-
-    assert outcome.status == RolloutStatus.CANCELLED
-    assert rollout_posts == 1
-
-
-async def test_cancel_unknown_id_leaves_store_clean_for_future_run() -> None:
-    store = CallbackStore()
-    admitted = asyncio.Event()
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/rollout" and request.method == "POST":
-            admitted.set()
-            return httpx.Response(202, json={})
-        if request.url.path == "/rollout/cancel":
-            return httpx.Response(200, json={"dispositions": {}})
-        raise AssertionError(request.url.path)
-
-    driver, _proxy = _driver(store, handler)
-    dispositions = await driver.cancel(ROLLOUT_ID)
-    assert dispositions == {}
-
-    run_task = asyncio.create_task(driver.run(_request()))
-    await asyncio.wait_for(admitted.wait(), timeout=2.0)
-    await store.handle_grader(ROLLOUT_ID, _grader())
-    outcome = await run_task
-    assert outcome.status == RolloutStatus.SUCCESS
 
 
 async def test_status_rollout_id_mismatch_never_causes_second_post() -> None:

--- a/tests/unit/rollout/test_server_admission.py
+++ b/tests/unit/rollout/test_server_admission.py
@@ -299,29 +299,67 @@ async def test_retry_after_failed_send_returns_202_without_second_execution() ->
     assert backend.execute_count == 1
 
 
-async def test_completed_digest_expires_while_active_entry_does_not(
-    monkeypatch,
-) -> None:
-    monkeypatch.setattr(server_app_module, "_COMPLETED_DIGEST_TTL_SEC", 0.05)
+async def test_completed_digest_dedupes_within_ttl(monkeypatch) -> None:
+    # Generous TTL: the entry cannot age out mid-test on a slow event loop.
+    monkeypatch.setattr(server_app_module, "_COMPLETED_DIGEST_TTL_SEC", 300.0)
     backend = BlockingStubBackend()
     app = create_rollout_server(backend=backend)
     async with httpx.AsyncClient(
         transport=ASGITransport(app=app), base_url="http://rollout"
     ) as client:
         assert (await client.post("/rollout", json=init_body())).status_code == 202
-        await asyncio.sleep(0.1)  # older than the TTL but still executing
-        assert (await client.post("/rollout", json=init_body())).status_code == 202
-        assert backend.execute_count == 1
-
         backend.release.set()
         await _settle()
         assert (await client.post("/rollout", json=init_body())).status_code == 202
+        await _settle()
         assert backend.execute_count == 1  # completed entry dedupes within TTL
 
-        await asyncio.sleep(0.1)  # completed entry ages out
+
+async def test_active_digest_outlives_ttl_and_completed_digest_expires(
+    monkeypatch,
+) -> None:
+    # Tiny TTL with sleeps several multiples longer: a slow event loop only
+    # pushes every assertion further in its safe direction (active entries
+    # never expire; completed entries only age further past the TTL).
+    monkeypatch.setattr(server_app_module, "_COMPLETED_DIGEST_TTL_SEC", 0.01)
+    backend = BlockingStubBackend()
+    app = create_rollout_server(backend=backend)
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://rollout"
+    ) as client:
+        assert (await client.post("/rollout", json=init_body())).status_code == 202
+        await asyncio.sleep(0.05)  # far older than the TTL, still executing
+        assert (await client.post("/rollout", json=init_body())).status_code == 202
+        assert backend.execute_count == 1  # active entry never expires
+
+        backend.release.set()
+        await _settle()
+        await asyncio.sleep(0.05)  # completed entry ages out
         assert (await client.post("/rollout", json=init_body())).status_code == 202
         await _settle()
         assert backend.execute_count == 2
+
+
+async def test_retry_after_scheduled_task_crash_reexecutes(monkeypatch) -> None:
+    # A crashed task never delivered its terminal callbacks, so its digest
+    # must not enter completed retention: the duplicate retry would dedupe
+    # into a 202 and wait forever for callbacks that are never coming.
+    calls: list[str | None] = []
+
+    async def _crash(backend: ExecutionBackend, request: Any) -> None:
+        calls.append(request.rollout_id)
+        raise RuntimeError("boom before any callback")
+
+    monkeypatch.setattr(server_app_module, "_handle_rollout", _crash)
+    app = create_rollout_server(backend=StubBackend())
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://rollout"
+    ) as client:
+        assert (await client.post("/rollout", json=init_body())).status_code == 202
+        await _settle()
+        assert (await client.post("/rollout", json=init_body())).status_code == 202
+        await _settle()
+    assert calls == ["r1", "r1"]
 
 
 def test_health_instance_id_is_captured_at_construction(monkeypatch) -> None:

--- a/tests/unit/rollout/test_server_admission.py
+++ b/tests/unit/rollout/test_server_admission.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 from collections.abc import Sequence
+from typing import Any
 
+import httpx
+import pytest
 from fastapi.testclient import TestClient
+from httpx import ASGITransport
 
 from osmosis_ai.rollout.backend.base import ExecutionBackend, ResultCallback
+from osmosis_ai.rollout.server import app as server_app_module
 from osmosis_ai.rollout.server import create_rollout_server
 from osmosis_ai.rollout.types import ExecutionRequest
 
@@ -15,6 +22,7 @@ class StubBackend(ExecutionBackend):
     def __init__(self, capacity: bool = True) -> None:
         self.capacity = capacity
         self.executed = False
+        self.execute_count = 0
         self.cancel_args: tuple | None = None
 
     async def execute(
@@ -24,6 +32,7 @@ class StubBackend(ExecutionBackend):
         on_grader_complete: ResultCallback | None = None,
     ) -> None:
         self.executed = True
+        self.execute_count += 1
 
     def has_capacity(self) -> bool:
         return self.capacity
@@ -41,6 +50,9 @@ class StubBackend(ExecutionBackend):
         if rollout_id == "known":
             return {"status": "success", "reward": 1.0, "err_message": None}
         return None
+
+    def health(self) -> dict:
+        return {"status": "ok", "backend": "stub", "max_queue_depth": 2}
 
 
 def init_body() -> dict:
@@ -114,3 +126,225 @@ def test_status_unknown_rollout():
     body = client.get("/rollout/nope/status").json()
     assert body["status"] == "unknown"
     assert body["reward"] is None
+
+
+def test_accepted_rollout_status_is_backend_authoritative_unknown():
+    client = TestClient(create_rollout_server(backend=StubBackend()))
+    assert client.post("/rollout", json=init_body()).status_code == 202
+    body = client.get("/rollout/r1/status").json()
+    assert body["status"] == "unknown"
+    assert body["rollout_id"] == "r1"
+
+
+def test_local_backend_status_is_unknown_not_queued() -> None:
+    from osmosis_ai.rollout.agent_workflow import AgentWorkflow
+    from osmosis_ai.rollout.backend.local.backend import LocalBackend
+    from osmosis_ai.rollout.context import AgentWorkflowContext
+
+    class _NoopWorkflow(AgentWorkflow):
+        async def run(self, ctx: AgentWorkflowContext) -> list[dict[str, str]]:
+            return [{"role": "assistant", "content": "ok"}]
+
+    backend = LocalBackend(workflow=_NoopWorkflow)
+
+    async def _noop_execute(
+        request: ExecutionRequest,
+        on_workflow_complete: ResultCallback,
+        on_grader_complete: ResultCallback | None = None,
+    ) -> None:
+        return None
+
+    backend.execute = _noop_execute  # type: ignore[method-assign]
+    client = TestClient(create_rollout_server(backend=backend))
+    assert client.post("/rollout", json=init_body()).status_code == 202
+    body = client.get("/rollout/r1/status").json()
+    assert body["status"] == "unknown"
+
+
+def test_identical_duplicate_schedules_once() -> None:
+    backend = StubBackend()
+    client = TestClient(create_rollout_server(backend=backend))
+    assert client.post("/rollout", json=init_body()).status_code == 202
+    assert client.post("/rollout", json=init_body()).status_code == 202
+    assert backend.execute_count == 1
+
+
+def test_conflicting_duplicate_returns_409() -> None:
+    backend = StubBackend()
+    client = TestClient(create_rollout_server(backend=backend))
+    assert client.post("/rollout", json=init_body()).status_code == 202
+    conflict = init_body()
+    conflict["initial_messages"] = [{"role": "user", "content": "other"}]
+    response = client.post("/rollout", json=conflict)
+    assert response.status_code == 409
+    assert backend.execute_count == 1
+
+
+def test_duplicate_check_precedes_capacity() -> None:
+    backend = StubBackend()
+    client = TestClient(create_rollout_server(backend=backend))
+    assert client.post("/rollout", json=init_body()).status_code == 202
+    backend.capacity = False
+    assert client.post("/rollout", json=init_body()).status_code == 202
+    conflict = init_body()
+    conflict["label"] = "other"
+    assert client.post("/rollout", json=conflict).status_code == 409
+    assert backend.execute_count == 1
+
+
+def test_idempotency_digest_excludes_credentials() -> None:
+    backend = StubBackend()
+    client = TestClient(create_rollout_server(backend=backend))
+    first = init_body()
+    first["controller_api_key"] = "controller-a"
+    first["llm_api_key"] = "session-a"
+    second = init_body()
+    second["controller_api_key"] = "controller-b"
+    second["llm_api_key"] = "session-b"
+    assert client.post("/rollout", json=first).status_code == 202
+    assert client.post("/rollout", json=second).status_code == 202
+    assert backend.execute_count == 1
+
+
+def test_schedule_failure_removes_digest_so_retry_can_admit(monkeypatch) -> None:
+    real_handle_rollout = server_app_module._handle_rollout
+
+    def boom(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("cannot schedule")
+
+    monkeypatch.setattr(server_app_module, "_handle_rollout", boom)
+    backend = StubBackend()
+    client = TestClient(create_rollout_server(backend=backend))
+    response = client.post("/rollout", json=init_body())
+    assert response.status_code == 500
+    assert backend.execute_count == 0
+    monkeypatch.setattr(server_app_module, "_handle_rollout", real_handle_rollout)
+    assert client.post("/rollout", json=init_body()).status_code == 202
+    assert backend.execute_count == 1
+
+
+class BlockingStubBackend(StubBackend):
+    """Backend whose execution blocks until the test releases it."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.release = asyncio.Event()
+
+    async def execute(
+        self,
+        request: ExecutionRequest,
+        on_workflow_complete: ResultCallback,
+        on_grader_complete: ResultCallback | None = None,
+    ) -> None:
+        self.executed = True
+        self.execute_count += 1
+        await self.release.wait()
+
+
+async def _post_rollout_with_failing_send(app: Any, body: dict) -> None:
+    """Drive one POST /rollout whose response send fails (client vanished)."""
+    payload = json.dumps(body).encode()
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/rollout",
+        "raw_path": b"/rollout",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"content-length", str(len(payload)).encode()),
+        ],
+        "client": ("127.0.0.1", 1234),
+        "server": ("127.0.0.1", 80),
+    }
+
+    async def receive() -> dict:
+        return {"type": "http.request", "body": payload, "more_body": False}
+
+    async def send(message: dict) -> None:
+        raise ConnectionResetError("client disconnected before the response")
+
+    with pytest.raises(ConnectionResetError):
+        await app(scope, receive, send)
+
+
+async def _settle() -> None:
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+
+async def test_execution_survives_failed_response_send() -> None:
+    backend = StubBackend()
+    app = create_rollout_server(backend=backend)
+    await _post_rollout_with_failing_send(app, init_body())
+    await _settle()
+    assert backend.execute_count == 1
+
+
+async def test_retry_after_failed_send_returns_202_without_second_execution() -> None:
+    backend = StubBackend()
+    app = create_rollout_server(backend=backend)
+    await _post_rollout_with_failing_send(app, init_body())
+    await _settle()
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://rollout"
+    ) as client:
+        response = await client.post("/rollout", json=init_body())
+    assert response.status_code == 202
+    await _settle()
+    assert backend.execute_count == 1
+
+
+async def test_completed_digest_expires_while_active_entry_does_not(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(server_app_module, "_COMPLETED_DIGEST_TTL_SEC", 0.05)
+    backend = BlockingStubBackend()
+    app = create_rollout_server(backend=backend)
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://rollout"
+    ) as client:
+        assert (await client.post("/rollout", json=init_body())).status_code == 202
+        await asyncio.sleep(0.1)  # older than the TTL but still executing
+        assert (await client.post("/rollout", json=init_body())).status_code == 202
+        assert backend.execute_count == 1
+
+        backend.release.set()
+        await _settle()
+        assert (await client.post("/rollout", json=init_body())).status_code == 202
+        assert backend.execute_count == 1  # completed entry dedupes within TTL
+
+        await asyncio.sleep(0.1)  # completed entry ages out
+        assert (await client.post("/rollout", json=init_body())).status_code == 202
+        await _settle()
+        assert backend.execute_count == 2
+
+
+def test_health_instance_id_is_captured_at_construction(monkeypatch) -> None:
+    monkeypatch.setenv("_OSMOSIS_ROLLOUT_INSTANCE_ID", "srv-initial")
+    app = create_rollout_server(backend=StubBackend())
+    monkeypatch.setenv("_OSMOSIS_ROLLOUT_INSTANCE_ID", "srv-mutated")
+    client = TestClient(app)
+    assert client.get("/health").json()["instance_id"] == "srv-initial"
+
+
+def test_health_omits_instance_id_when_env_absent(monkeypatch):
+    monkeypatch.delenv("_OSMOSIS_ROLLOUT_INSTANCE_ID", raising=False)
+    client = TestClient(create_rollout_server(backend=StubBackend()))
+    body = client.get("/health").json()
+    assert body == {"status": "ok", "backend": "stub", "max_queue_depth": 2}
+    assert "instance_id" not in body
+
+
+def test_health_exposes_instance_id_and_preserves_backend_fields(monkeypatch):
+    monkeypatch.setenv("_OSMOSIS_ROLLOUT_INSTANCE_ID", "srv-abc123")
+    client = TestClient(create_rollout_server(backend=StubBackend()))
+    body = client.get("/health").json()
+    assert body["status"] == "ok"
+    assert body["backend"] == "stub"
+    assert body["max_queue_depth"] == 2
+    assert body["instance_id"] == "srv-abc123"

--- a/tests/unit/rollout/test_server_admission.py
+++ b/tests/unit/rollout/test_server_admission.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Sequence
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
 from typing import Any
 
 import httpx
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from httpx import ASGITransport
 
@@ -400,6 +402,67 @@ async def test_retry_after_scheduled_task_crash_reexecutes(monkeypatch) -> None:
         assert (await client.post("/rollout", json=init_body())).status_code == 202
         await _settle()
     assert calls == ["r1", "r1"]
+
+
+class DrainStubBackend(StubBackend):
+    """Backend whose execution outlives the shutdown signal."""
+
+    def __init__(self, work_sec: float, events: list[str]) -> None:
+        super().__init__()
+        self.work_sec = work_sec
+        self.events = events
+
+    async def execute(
+        self,
+        request: ExecutionRequest,
+        on_workflow_complete: ResultCallback,
+        on_grader_complete: ResultCallback | None = None,
+    ) -> None:
+        self.executed = True
+        self.execute_count += 1
+        try:
+            await asyncio.sleep(self.work_sec)
+        except asyncio.CancelledError:
+            self.events.append("rollout-cancelled")
+            raise
+        self.events.append("rollout-finished")
+        await on_workflow_complete(ExecutionResult(status=RolloutStatus.SUCCESS))
+
+
+async def test_lifespan_exit_drains_rollouts_before_caller_lifespan_closes() -> None:
+    events: list[str] = []
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+        yield
+        events.append("lifespan-closed")
+
+    backend = DrainStubBackend(0.05, events)
+    app = create_rollout_server(backend=backend, lifespan=lifespan)
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://rollout"
+    ) as client:
+        async with app.router.lifespan_context(app):
+            assert (await client.post("/rollout", json=init_body())).status_code == 202
+            await _settle()
+            assert events == []  # still running when shutdown begins
+    assert events == ["rollout-finished", "lifespan-closed"]
+
+
+async def test_lifespan_exit_cancels_rollouts_that_outlast_the_drain(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(server_app_module, "_SHUTDOWN_DRAIN_SEC", 0.01)
+    events: list[str] = []
+    backend = DrainStubBackend(30.0, events)
+    app = create_rollout_server(backend=backend)
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://rollout"
+    ) as client:
+        async with app.router.lifespan_context(app):
+            assert (await client.post("/rollout", json=init_body())).status_code == 202
+            await _settle()
+    assert events == ["rollout-cancelled"]
 
 
 def test_health_instance_id_is_captured_at_construction(monkeypatch) -> None:

--- a/tests/unit/rollout/test_server_admission.py
+++ b/tests/unit/rollout/test_server_admission.py
@@ -15,7 +15,24 @@ from httpx import ASGITransport
 from osmosis_ai.rollout.backend.base import ExecutionBackend, ResultCallback
 from osmosis_ai.rollout.server import app as server_app_module
 from osmosis_ai.rollout.server import create_rollout_server
-from osmosis_ai.rollout.types import ExecutionRequest
+from osmosis_ai.rollout.types import ExecutionRequest, ExecutionResult, RolloutStatus
+
+
+@pytest.fixture(autouse=True)
+def _isolate_side_effects(monkeypatch):
+    """Terminal callbacks succeed without a network; archiving is disabled."""
+
+    async def _delivered(*, url, payload, headers):
+        class _Resp:
+            status_code = 200
+
+        return _Resp()
+
+    async def _no_archive(**kwargs):
+        return None
+
+    monkeypatch.setattr(server_app_module, "post_json_with_retry", _delivered)
+    monkeypatch.setattr(server_app_module, "save_trajectory", _no_archive)
 
 
 class StubBackend(ExecutionBackend):
@@ -33,6 +50,7 @@ class StubBackend(ExecutionBackend):
     ) -> None:
         self.executed = True
         self.execute_count += 1
+        await on_workflow_complete(ExecutionResult(status=RolloutStatus.SUCCESS))
 
     def has_capacity(self) -> bool:
         return self.capacity
@@ -239,6 +257,7 @@ class BlockingStubBackend(StubBackend):
         self.executed = True
         self.execute_count += 1
         await self.release.wait()
+        await on_workflow_complete(ExecutionResult(status=RolloutStatus.SUCCESS))
 
 
 async def _post_rollout_with_failing_send(app: Any, body: dict) -> None:
@@ -338,6 +357,27 @@ async def test_active_digest_outlives_ttl_and_completed_digest_expires(
         assert (await client.post("/rollout", json=init_body())).status_code == 202
         await _settle()
         assert backend.execute_count == 2
+
+
+async def test_retry_after_callback_delivery_failure_reexecutes(monkeypatch) -> None:
+    # The task finishes without an exception, but the terminal callback was
+    # never delivered (the controller saw nothing). The digest must be
+    # dropped so the retry re-executes instead of deduping into a 202 that
+    # waits forever.
+    async def _unreachable(*, url, payload, headers):
+        raise RuntimeError("listener unreachable")
+
+    monkeypatch.setattr(server_app_module, "post_json_with_retry", _unreachable)
+    backend = StubBackend()
+    app = create_rollout_server(backend=backend)
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://rollout"
+    ) as client:
+        assert (await client.post("/rollout", json=init_body())).status_code == 202
+        await _settle()
+        assert (await client.post("/rollout", json=init_body())).status_code == 202
+        await _settle()
+    assert backend.execute_count == 2
 
 
 async def test_retry_after_scheduled_task_crash_reexecutes(monkeypatch) -> None:

--- a/tests/unit/rollout/test_server_app_metadata.py
+++ b/tests/unit/rollout/test_server_app_metadata.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+from pydantic import ValidationError
+
 from osmosis_ai.rollout.backend.base import ExecutionBackend, ResultCallback
+from osmosis_ai.rollout.context import get_rollout_context
 from osmosis_ai.rollout.server import app as app_module
 from osmosis_ai.rollout.server.app import _handle_rollout
 from osmosis_ai.rollout.types import (
     ExecutionRequest,
+    ExecutionResult,
     RolloutInitRequest,
+    RolloutStatus,
 )
 
 
@@ -88,3 +94,83 @@ class TestHandleRolloutMetadata:
 
         await _handle_rollout(FailingBackend(), _make_init_request({"k": "v"}))
         assert "http://controller/complete" in posted
+
+
+class ContextCapturingBackend(ExecutionBackend):
+    def __init__(self) -> None:
+        self.api_key: str | None = None
+
+    async def execute(
+        self,
+        request: ExecutionRequest,
+        on_workflow_complete: ResultCallback,
+        on_grader_complete: ResultCallback | None = None,
+    ) -> None:
+        ctx = get_rollout_context()
+        self.api_key = None if ctx is None else ctx.api_key
+        await on_workflow_complete(ExecutionResult(status=RolloutStatus.SUCCESS))
+
+
+class TestHandleRolloutApiKeys:
+    async def test_llm_api_key_goes_to_context_controller_key_to_callbacks(
+        self, monkeypatch
+    ) -> None:
+        posted_headers: list[dict[str, str] | None] = []
+
+        async def _record(*, url, payload, headers):
+            posted_headers.append(headers)
+
+            class _Resp:
+                status_code = 200
+
+            return _Resp()
+
+        monkeypatch.setattr(app_module, "post_json_with_retry", _record)
+        backend = ContextCapturingBackend()
+        request = RolloutInitRequest(
+            rollout_id="r1",
+            initial_messages=[{"role": "user", "content": "hi"}],
+            chat_completions_url="http://proxy/v1/eval-sessions/r1",
+            controller_api_key="controller-key",
+            llm_api_key="session-token",
+            completion_callback_url="http://controller/complete",
+        )
+        await _handle_rollout(backend, request)
+
+        assert backend.api_key == "session-token"
+        assert posted_headers
+        assert posted_headers[0] == {"Authorization": "Bearer controller-key"}
+
+    async def test_llm_api_key_falls_back_to_controller_api_key(
+        self, monkeypatch
+    ) -> None:
+        async def _record(*, url, payload, headers):
+            class _Resp:
+                status_code = 200
+
+            return _Resp()
+
+        monkeypatch.setattr(app_module, "post_json_with_retry", _record)
+        backend = ContextCapturingBackend()
+        await _handle_rollout(
+            backend,
+            RolloutInitRequest(
+                rollout_id="r1",
+                initial_messages=[{"role": "user", "content": "hi"}],
+                chat_completions_url="http://llm",
+                controller_api_key="shared-key",
+                completion_callback_url="http://controller/complete",
+            ),
+        )
+        assert backend.api_key == "shared-key"
+
+    async def test_explicit_empty_llm_api_key_is_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            RolloutInitRequest(
+                rollout_id="r1",
+                initial_messages=[{"role": "user", "content": "hi"}],
+                chat_completions_url="http://llm",
+                controller_api_key="shared-key",
+                llm_api_key="",
+                completion_callback_url="http://controller/complete",
+            )

--- a/tests/unit/rollout/test_shared_wire_compatibility.py
+++ b/tests/unit/rollout/test_shared_wire_compatibility.py
@@ -73,13 +73,17 @@ def test_init_request_without_llm_api_key_is_valid() -> None:
 async def test_omitted_llm_api_key_preserves_controller_api_key_fallback(
     monkeypatch,
 ) -> None:
-    async def _record(*, url, payload, headers):
+    async def _no_network(*, url, payload, headers):
         class _Resp:
             status_code = 200
 
         return _Resp()
 
-    monkeypatch.setattr(app_module, "post_json_with_retry", _record)
+    # Isolation only, not an exercised path: the stub backend never invokes
+    # the completion/grader callbacks, so no callback POST is expected here.
+    # The patch guarantees that a future _handle_rollout change cannot reach
+    # a real network from this test.
+    monkeypatch.setattr(app_module, "post_json_with_retry", _no_network)
     backend = _ContextCapturingBackend()
     request = RolloutInitRequest.model_validate(_load("init_request.json"))
     await _handle_rollout(backend, request)

--- a/tests/unit/rollout/test_shared_wire_compatibility.py
+++ b/tests/unit/rollout/test_shared_wire_compatibility.py
@@ -1,0 +1,137 @@
+"""Compatibility checks for the shared remote-rollout wire subset.
+
+Fixtures under ``tests/golden/rollout/shared_wire/`` capture the minimum JSON
+contract accepted by remote rollout consumers. These tests stay repository-local
+and verify that additive SDK changes preserve shared required fields and callback
+status values.
+
+The fixture omits ``llm_api_key`` to exercise the backwards-compatible
+``controller_api_key`` fallback. ``RolloutStatus`` retains the richer SDK
+lifecycle and intentionally excludes ``pending``; ``GraderStatus`` includes
+``pending`` as part of its existing contract.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from osmosis_ai.rollout.backend.base import ExecutionBackend, ResultCallback
+from osmosis_ai.rollout.server import app as app_module
+from osmosis_ai.rollout.server.app import _handle_rollout
+from osmosis_ai.rollout.types import (
+    ExecutionRequest,
+    GraderCompleteRequest,
+    GraderStatus,
+    RolloutCompleteRequest,
+    RolloutInitRequest,
+    RolloutStatus,
+)
+
+GOLDEN = Path(__file__).resolve().parents[2] / "golden" / "rollout" / "shared_wire"
+
+SHARED_INIT_REQUIRED = frozenset(
+    {
+        "initial_messages",
+        "chat_completions_url",
+        "completion_callback_url",
+    }
+)
+SHARED_CALLBACK_STATUSES = frozenset({"success", "failure"})
+
+
+def _load(name: str) -> dict[str, Any]:
+    return json.loads((GOLDEN / name).read_text(encoding="utf-8"))
+
+
+class _ContextCapturingBackend(ExecutionBackend):
+    def __init__(self) -> None:
+        self.api_key: str | None = None
+
+    async def execute(
+        self,
+        request: ExecutionRequest,
+        on_workflow_complete: ResultCallback,
+        on_grader_complete: ResultCallback | None = None,
+    ) -> None:
+        from osmosis_ai.rollout.context import get_rollout_context
+
+        ctx = get_rollout_context()
+        self.api_key = None if ctx is None else ctx.api_key
+
+
+def test_init_request_without_llm_api_key_is_valid() -> None:
+    payload = _load("init_request.json")
+    assert "llm_api_key" not in payload
+    request = RolloutInitRequest.model_validate(payload)
+    assert request.llm_api_key is None
+    assert request.controller_api_key == "controller-key"
+    assert request.initial_messages == [{"role": "user", "content": "hi"}]
+
+
+async def test_omitted_llm_api_key_preserves_controller_api_key_fallback(
+    monkeypatch,
+) -> None:
+    async def _record(*, url, payload, headers):
+        class _Resp:
+            status_code = 200
+
+        return _Resp()
+
+    monkeypatch.setattr(app_module, "post_json_with_retry", _record)
+    backend = _ContextCapturingBackend()
+    request = RolloutInitRequest.model_validate(_load("init_request.json"))
+    await _handle_rollout(backend, request)
+    assert backend.api_key == "controller-key"
+
+
+def test_completion_success_and_failure_payloads_parse() -> None:
+    success = RolloutCompleteRequest.model_validate(_load("completion_success.json"))
+    failure = RolloutCompleteRequest.model_validate(_load("completion_failure.json"))
+    assert success.status is RolloutStatus.SUCCESS
+    assert failure.status is RolloutStatus.FAILURE
+    assert failure.err_message == "agent exploded"
+    assert failure.err_category is not None
+    assert failure.err_category.value == "agent_error"
+
+
+def test_grader_payload_with_sample_reward_is_compatible() -> None:
+    request = GraderCompleteRequest.model_validate(_load("grader_with_reward.json"))
+    assert request.status is GraderStatus.SUCCESS
+    assert request.sample is not None
+    assert request.sample.reward == 1.0
+    assert request.sample.remove_sample is False
+
+
+def test_additive_sdk_fields_do_not_change_shared_required_or_callback_statuses() -> (
+    None
+):
+    init_required = {
+        name
+        for name, field in RolloutInitRequest.model_fields.items()
+        if field.is_required()
+    }
+    assert init_required == SHARED_INIT_REQUIRED
+    assert "llm_api_key" in RolloutInitRequest.model_fields
+    assert not RolloutInitRequest.model_fields["llm_api_key"].is_required()
+
+    complete_required = {
+        name
+        for name, field in RolloutCompleteRequest.model_fields.items()
+        if field.is_required()
+    }
+    grader_required = {
+        name
+        for name, field in GraderCompleteRequest.model_fields.items()
+        if field.is_required()
+    }
+    assert complete_required == {"status"}
+    assert grader_required == {"status"}
+
+    complete_statuses = {item.value for item in RolloutStatus}
+    grader_statuses = {item.value for item in GraderStatus}
+    assert complete_statuses >= SHARED_CALLBACK_STATUSES
+    assert grader_statuses >= SHARED_CALLBACK_STATUSES
+    # Keep the richer SDK rollout lifecycle distinct from grader pending state.
+    assert "pending" not in complete_statuses

--- a/tests/unit/test_public_api_imports.py
+++ b/tests/unit/test_public_api_imports.py
@@ -170,6 +170,8 @@ def test_framework_neutral_core_imports_without_optional_dependencies() -> None:
             "osmosis_ai.rollout.types.protocol",
             "osmosis_ai.rollout.utils.errors",
             "osmosis_ai.rollout.utils.ttl_cache",
+            "osmosis_ai.rollout.controller.store",
+            "osmosis_ai.rollout.driver",
         ):
             importlib.import_module(module_name)
         """
@@ -328,6 +330,24 @@ def test_extra_modules_table_matches_pyproject_extras() -> None:
             "litellm",
             "rubric",
         ),
+        (
+            "osmosis_ai.rollout.controller",
+            "create_callback_app",
+            "fastapi",
+            "eval-run",
+        ),
+        (
+            "osmosis_ai.rollout.controller",
+            "EvalProxyClient",
+            "aiohttp",
+            "eval-run",
+        ),
+        (
+            "osmosis_ai.rollout.http_driver",
+            "HttpRolloutDriver",
+            "aiohttp",
+            "eval-run",
+        ),
     ],
 )
 def test_missing_optional_dependency_names_the_install_extra(
@@ -384,3 +404,31 @@ def test_agent_integration_classes_use_canonical_module_paths() -> None:
         OsmosisStrandsAgent.__module__
         == "osmosis_ai.rollout.integrations.agents.strands"
     )
+
+
+def test_callback_store_imports_without_eval_run_extra() -> None:
+    result = _run_python(
+        """
+        import builtins
+        import sys
+
+        real_import = builtins.__import__
+        blocked = {"aiohttp", "fastapi", "uvicorn"}
+
+        def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+            root = name.partition(".")[0]
+            if root in blocked:
+                raise ModuleNotFoundError("No module named " + repr(root), name=root)
+            return real_import(name, globals, locals, fromlist, level)
+
+        builtins.__import__ = guarded_import
+        from osmosis_ai.rollout.controller import CallbackStore
+        from osmosis_ai.rollout.driver import RolloutRunRequest
+
+        CallbackStore()
+        RolloutRunRequest(messages=[])
+        loaded_roots = {name.partition(".")[0] for name in sys.modules}
+        assert not (blocked & loaded_roots)
+        """
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/unit/test_public_api_imports.py
+++ b/tests/unit/test_public_api_imports.py
@@ -336,18 +336,6 @@ def test_extra_modules_table_matches_pyproject_extras() -> None:
             "fastapi",
             "eval-run",
         ),
-        (
-            "osmosis_ai.rollout.controller",
-            "EvalProxyClient",
-            "aiohttp",
-            "eval-run",
-        ),
-        (
-            "osmosis_ai.rollout.http_driver",
-            "HttpRolloutDriver",
-            "aiohttp",
-            "eval-run",
-        ),
     ],
 )
 def test_missing_optional_dependency_names_the_install_extra(
@@ -406,14 +394,19 @@ def test_agent_integration_classes_use_canonical_module_paths() -> None:
     )
 
 
-def test_callback_store_imports_without_eval_run_extra() -> None:
+def test_driver_core_imports_without_eval_run_extra() -> None:
+    """Only the localhost callback listener needs `[eval-run]`.
+
+    The store, the eval-proxy client, and the HTTP driver speak httpx and are
+    part of the base install, so a bare environment must reach all of them.
+    """
     result = _run_python(
         """
         import builtins
         import sys
 
         real_import = builtins.__import__
-        blocked = {"aiohttp", "fastapi", "uvicorn"}
+        blocked = {"fastapi", "uvicorn"}
 
         def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
             root = name.partition(".")[0]
@@ -422,11 +415,14 @@ def test_callback_store_imports_without_eval_run_extra() -> None:
             return real_import(name, globals, locals, fromlist, level)
 
         builtins.__import__ = guarded_import
-        from osmosis_ai.rollout.controller import CallbackStore
+        from osmosis_ai.rollout.controller import CallbackStore, EvalProxyClient
         from osmosis_ai.rollout.driver import RolloutRunRequest
+        from osmosis_ai.rollout.http_driver import HttpRolloutDriver
 
         CallbackStore()
         RolloutRunRequest(messages=[])
+        assert EvalProxyClient is not None
+        assert HttpRolloutDriver is not None
         loaded_roots = {name.partition(".")[0] for name in sys.modules}
         assert not (blocked & loaded_roots)
         """

--- a/uv.lock
+++ b/uv.lock
@@ -1659,6 +1659,12 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+eval-run = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastapi" },
+    { name = "uvicorn" },
+]
 full = [
     { name = "aiohttp" },
     { name = "click" },
@@ -1733,10 +1739,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", marker = "extra == 'eval-run'", specifier = ">=3.14.3" },
     { name = "aiohttp", marker = "extra == 'harbor'", specifier = ">=3.14.3" },
     { name = "aiohttp", marker = "extra == 'openai-agents'", specifier = ">=3.14.3" },
     { name = "aiohttp", marker = "extra == 'rubric'", specifier = ">=3.14.3" },
     { name = "aiohttp", marker = "extra == 'strands'", specifier = ">=3.14.3" },
+    { name = "click", marker = "extra == 'eval-run'", specifier = ">=8.3.3" },
     { name = "click", marker = "extra == 'harbor'", specifier = ">=8.3.3" },
     { name = "click", marker = "extra == 'openai-agents'", specifier = ">=8.3.3" },
     { name = "click", marker = "extra == 'rubric'", specifier = ">=8.3.3" },
@@ -1744,6 +1752,7 @@ requires-dist = [
     { name = "click", marker = "extra == 'strands'", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "dockerfile-parse", marker = "extra == 'harbor'", specifier = ">=2.0.1,<3.0.0" },
+    { name = "fastapi", marker = "extra == 'eval-run'", specifier = ">=0.100.0,<1.0.0" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.100.0,<1.0.0" },
     { name = "harbor", marker = "extra == 'harbor'", specifier = ">=0.20.0,<0.21" },
     { name = "httpx", specifier = ">=0.25.0,<1.0.0" },
@@ -1759,7 +1768,7 @@ requires-dist = [
     { name = "orjson", marker = "extra == 'openai-agents'", specifier = ">=3.11.6,<4.0" },
     { name = "orjson", marker = "extra == 'rubric'", specifier = ">=3.11.6,<4.0" },
     { name = "orjson", marker = "extra == 'strands'", specifier = ">=3.11.6,<4.0" },
-    { name = "osmosis-ai", extras = ["harbor", "openai-agents", "parquet", "rubric", "server", "strands"], marker = "extra == 'full'" },
+    { name = "osmosis-ai", extras = ["eval-run", "harbor", "openai-agents", "parquet", "rubric", "server", "strands"], marker = "extra == 'full'" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "platformdirs", marker = "extra == 'harbor'", specifier = ">=4.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.0,<4.0.0" },
@@ -1774,9 +1783,10 @@ requires-dist = [
     { name = "tqdm", marker = "extra == 'rubric'", specifier = ">=4.0.0,<5.0.0" },
     { name = "typer", specifier = ">=0.27,<0.28" },
     { name = "uv", marker = "extra == 'harbor'", specifier = ">=0.9.7,<0.13" },
+    { name = "uvicorn", marker = "extra == 'eval-run'", specifier = ">=0.23.0,<1.0.0" },
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.23.0,<1.0.0" },
 ]
-provides-extras = ["server", "strands", "openai-agents", "harbor", "rubric", "parquet", "full"]
+provides-extras = ["server", "strands", "openai-agents", "harbor", "rubric", "parquet", "eval-run", "full"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1660,7 +1660,6 @@ dependencies = [
 
 [package.optional-dependencies]
 eval-run = [
-    { name = "aiohttp" },
     { name = "click" },
     { name = "fastapi" },
     { name = "uvicorn" },
@@ -1739,7 +1738,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", marker = "extra == 'eval-run'", specifier = ">=3.14.3" },
     { name = "aiohttp", marker = "extra == 'harbor'", specifier = ">=3.14.3" },
     { name = "aiohttp", marker = "extra == 'openai-agents'", specifier = ">=3.14.3" },
     { name = "aiohttp", marker = "extra == 'rubric'", specifier = ">=3.14.3" },


### PR DESCRIPTION
## What

- Add reusable rollout driver contracts and an HTTP implementation with idempotent admission, status recovery, callback coordination, and cancellation.
- Add an authenticated localhost callback listener, callback store, and hosted eval-proxy session client with strict credential separation.
- Harden rollout server admission with request digests, bounded completion retention, and reliable task scheduling.
- Add optional dependencies, lazy imports, documentation, wheel-install coverage, and comprehensive tests.

## Why

Local evaluation needs to orchestrate the existing rollout execution path without embedding workflow or grader execution in the CLI. These primitives make retries, cancellation, and concurrent callbacks deterministic while separating platform management credentials from session-scoped LLM access.

The higher-level eval supervisor, dataset pipeline, journaling, materialization, and CLI command remain follow-up work.

## How to Test

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright osmosis_ai/`

## Checklist

- [x] PR title follows `[module] type: description` format
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds local‑eval primitives and an HTTP rollout driver so evals reuse the rollout path with deterministic retries and coordinated callbacks. Hardens server idempotency and eval‑proxy management to prevent stuck rollouts and avoid destructive cleanup (old: digests could persist for crashed/undelivered tasks; create() could delete after a definitive 4xx; unbounded Retry‑After; new: digests retained only after delivered callbacks, no delete on 4xx, 30s management timeouts, malformed 2xx raises `EvalProxyError`, non‑2xx/3xx rejected, Retry‑After capped at 60s, and graceful server shutdown drains in‑flight tasks).

- New primitives: `CallbackStore` (in‑process rendezvous), `CallbackListener` (IPv4 localhost, bearer auth, terminal‑only; acks after commit), `EvalProxyClient` (httpx; rollout_id must be a single path segment; rejects all non‑2xx incl. 3xx; malformed 2xx JSON raises `EvalProxyError`; 30s management timeout; bounded failed‑create cleanup; does not delete sessions after definitive 4xx).
- Driver: `HttpRolloutDriver` with idempotent 202/429/status recovery and callback coordination; adds `RolloutRunRequest` to the public driver API; Retry‑After waits capped at 60s.
- Server: idempotency digests exclude secrets and are retained 15 minutes only after completion (and grader, if configured) callbacks were delivered; crashed/cancelled or undelivered‑callback rollouts are not retained and re‑run on retry. `create_rollout_server` now drains in‑flight rollout tasks on lifespan exit (10s, then cancel+gather) for graceful shutdown.
- API: `RolloutInitRequest` adds `llm_api_key` with a `None`→`controller_api_key` fallback; empty string is invalid.
- Packaging: `_OSMOSIS_ROLLOUT_ARTIFACT_ROOT` overrides the default artifact root. New extra `eval-run` installs `fastapi`, `uvicorn`, `click`; `full` includes it. `CallbackStore`, `EvalProxyClient`, and `HttpRolloutDriver` ship in the base install; the listener requires `eval-run`. CI/wheel‑verify cover `eval-run`.

**Migration**
- Update callers and custom drivers to `RolloutDriver.run(RolloutRunRequest)`.
- Install the listener with: pip install "osmosis-ai[eval-run]" to run local eval end‑to‑end.
- Provide `llm_api_key` in `RolloutInitRequest`, or omit it to fall back to `controller_api_key` (do not send an empty string).
- Set `_OSMOSIS_ROLLOUT_ARTIFACT_ROOT` before constructing a backend to change artifact location.

<sup>Written for commit fedb90a112888e75cab07950e8f2bdeac393a7e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

