### PR TITLE
[cli] fix: drop harness secret requirement for mini-swe-agent benchmark submits

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -30,7 +30,6 @@ task_set = "parity"
 
 [[agents]]                          # required, 1-8 entries
 harness = "mini-swe-agent"
-harness_api_key_secret = "MSWEA_API_KEY"
 
 [agents.model]
 type = "provider"
@@ -89,7 +88,7 @@ Three rules exist because the platform injects a referenced secret's value as an
 
 - **Env collisions are rejected.** A literal env var with the same name as a referenced secret would be silently overwritten, so submit errors instead. The check is scoped per agent against the effective env (`[env]` merged with that agent's `[agents.env]`), so one agent's secret name may still be another agent's literal env var.
 - **Some model secret names are reserved.** `api_key_secret` cannot be `DAYTONA_API_KEY`, `DAYTONA_API_URL`, `SKYPILOT_SERVICE_ACCOUNT_TOKEN`, or `SKYPILOT_API_SERVER_ENDPOINT` — the runner removes those before model-key aliasing.
-- **Harness credentials travel a separate channel.** `cursor-cli` reads `CURSOR_API_KEY` and `mini-swe-agent` reads `MSWEA_API_KEY`. A credentialed harness must set `harness_api_key_secret` to a record named *exactly* that variable, and cannot also set that name as a literal env var.
+- **Harness credentials travel a separate channel.** `cursor-cli` reads `CURSOR_API_KEY`. A credentialed harness must set `harness_api_key_secret` to a record named *exactly* that variable, and cannot also set that name as a literal env var. `mini-swe-agent` takes no harness secret: the platform injects the agent's model key as `MSWEA_API_KEY` for provider and endpoint models, so a literal `MSWEA_API_KEY` env var is rejected for those and only allowed on hosted models (where nothing is injected).
 
 ### SDK vs backend validation
 

--- a/osmosis_ai/platform/cli/benchmark_config.py
+++ b/osmosis_ai/platform/cli/benchmark_config.py
@@ -20,8 +20,12 @@ from osmosis_ai.platform.cli.shared_config import (
 _BENCHMARK_CONFIG_LABEL = "benchmark"
 _HARNESS_API_KEY_ENV = {
     "cursor-cli": "CURSOR_API_KEY",
-    "mini-swe-agent": "MSWEA_API_KEY",
 }
+# mini-swe-agent takes no harness secret: the platform injects the agent's
+# model key as MSWEA_API_KEY for provider/endpoint models. A literal
+# MSWEA_API_KEY env var is only allowed on hosted models, where nothing is
+# injected.
+_MINI_SWE_AGENT_KEY_ENV = "MSWEA_API_KEY"
 _RESERVED_MODEL_API_KEY_SECRET_NAMES = frozenset(
     {
         "DAYTONA_API_KEY",
@@ -261,6 +265,27 @@ def _validate_secret_references(config: BenchmarkSubmitConfig, path: Path) -> No
                 f"the variable the {agent.harness} harness reads. Store the "
                 f"credential in a Platform secret record named exactly "
                 f"{harness_env_name} and reference that name."
+            )
+        if harness_env_name is None and agent.harness_api_key_secret is not None:
+            subject = (
+                f'the "{agent.harness}" harness'
+                if agent.harness
+                else "the official scaffold"
+            )
+            raise CLIError(
+                f"Agent {index}'s harness_api_key_secret in {path} is not "
+                f"used by {subject}; remove it."
+            )
+        if (
+            agent.harness == "mini-swe-agent"
+            and not isinstance(model, BenchmarkHostedModel)
+            and _MINI_SWE_AGENT_KEY_ENV in effective_env
+        ):
+            source = _env_source_label(_MINI_SWE_AGENT_KEY_ENV, index, agent.env)
+            raise CLIError(
+                f"'{_MINI_SWE_AGENT_KEY_ENV}' appears in {source} but the "
+                f"platform injects agent {index}'s model key under that name "
+                f"for the mini-swe-agent harness in {path}. Remove the env var."
             )
 
 

--- a/tests/unit/platform/cli/test_benchmark_config.py
+++ b/tests/unit/platform/cli/test_benchmark_config.py
@@ -545,7 +545,6 @@ api_key_secret = "OPENAI_API_KEY"
     "harness, destination_env",
     [
         ("cursor-cli", "CURSOR_API_KEY"),
-        ("mini-swe-agent", "MSWEA_API_KEY"),
     ],
 )
 def test_load_benchmark_submit_config_accepts_pinned_harness_secret_name(
@@ -579,7 +578,6 @@ api_key_secret = "OPENAI_API_KEY"
     "harness, destination_env",
     [
         ("cursor-cli", "CURSOR_API_KEY"),
-        ("mini-swe-agent", "MSWEA_API_KEY"),
     ],
 )
 def test_load_benchmark_submit_config_rejects_unpinned_harness_secret_name(
@@ -613,7 +611,6 @@ api_key_secret = "OPENAI_API_KEY"
     "harness, destination_env",
     [
         ("cursor-cli", "CURSOR_API_KEY"),
-        ("mini-swe-agent", "MSWEA_API_KEY"),
     ],
 )
 def test_load_benchmark_submit_config_rejects_harness_destination_env_collision(
@@ -681,7 +678,7 @@ def test_load_benchmark_submit_config_requires_known_harness_secret(
 benchmark = "DeepSWE"
 
 [[agents]]
-harness = "mini-swe-agent"
+harness = "cursor-cli"
 
 [agents.model]
 type = "hosted"
@@ -692,6 +689,110 @@ lora_model_name = "deep-swe-agent"
 
     with pytest.raises(CLIError, match=r"requires harness_api_key_secret"):
         load_benchmark_submit_config(path)
+
+
+def test_load_benchmark_submit_config_mini_swe_agent_needs_no_harness_secret(
+    tmp_path: Path,
+) -> None:
+    """mini-swe-agent reuses the model key as MSWEA_API_KEY; no separate secret."""
+    path = _write_config(
+        tmp_path / "benchmark.toml",
+        """
+[experiment]
+benchmark = "DeepSWE"
+
+[[agents]]
+harness = "mini-swe-agent"
+
+[agents.model]
+type = "provider"
+model = "openai/gpt-5"
+api_key_secret = "OPENAI_API_KEY"
+""",
+    )
+
+    config = load_benchmark_submit_config(path)
+
+    assert config.required_secrets == ["OPENAI_API_KEY"]
+
+
+def test_load_benchmark_submit_config_rejects_mini_swe_agent_harness_secret(
+    tmp_path: Path,
+) -> None:
+    path = _write_config(
+        tmp_path / "benchmark.toml",
+        """
+[experiment]
+benchmark = "DeepSWE"
+
+[[agents]]
+harness = "mini-swe-agent"
+harness_api_key_secret = "MSWEA_API_KEY"
+
+[agents.model]
+type = "provider"
+model = "openai/gpt-5"
+api_key_secret = "OPENAI_API_KEY"
+""",
+    )
+
+    with pytest.raises(CLIError, match=r"not used by"):
+        load_benchmark_submit_config(path)
+
+
+def test_load_benchmark_submit_config_rejects_mini_swe_agent_key_env_collision(
+    tmp_path: Path,
+) -> None:
+    """Provider/endpoint models get the model key injected as MSWEA_API_KEY."""
+    path = _write_config(
+        tmp_path / "benchmark.toml",
+        """
+[experiment]
+benchmark = "DeepSWE"
+
+[[agents]]
+harness = "mini-swe-agent"
+
+[agents.model]
+type = "provider"
+model = "openai/gpt-5"
+api_key_secret = "OPENAI_API_KEY"
+
+[agents.env]
+MSWEA_API_KEY = "literal-for-the-agent"
+""",
+    )
+
+    with pytest.raises(CLIError, match=r"MSWEA_API_KEY"):
+        load_benchmark_submit_config(path)
+
+
+def test_load_benchmark_submit_config_allows_mini_swe_agent_key_env_for_hosted(
+    tmp_path: Path,
+) -> None:
+    """Hosted models get no injected key, so a literal MSWEA_API_KEY is allowed."""
+    path = _write_config(
+        tmp_path / "benchmark.toml",
+        """
+[experiment]
+benchmark = "DeepSWE"
+
+[[agents]]
+harness = "mini-swe-agent"
+
+[agents.model]
+type = "hosted"
+base_model = "Qwen/Qwen3-8B"
+lora_model_name = "deep-swe-agent"
+
+[agents.env]
+MSWEA_API_KEY = "literal-for-the-agent"
+""",
+    )
+
+    config = load_benchmark_submit_config(path)
+
+    assert config.agents[0].env["MSWEA_API_KEY"] == "literal-for-the-agent"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Companion to Osmosis-AI/osmosis-monolith#1002, which moved mini-swe-agent benchmark runs off a separate harness secret: the platform now injects the agent's model key as `MSWEA_API_KEY` (Pier copies it) and **rejects** `harness_api_key_secret` for mini-swe-agent. The CLI still required a secret record named `MSWEA_API_KEY`, so every mini-swe-agent benchmark submit failed local validation against the new platform.

- Remove `mini-swe-agent` from the harness-key map; reject `harness_api_key_secret` on any harness that uses no harness credential (mirrors the platform's "does not use harness_api_key_secret" error, but fails locally)
- Reject a literal `MSWEA_API_KEY` env var for provider/endpoint models (collides with the injected model key); still allowed for hosted models, which get no injected key
- Update tests + `docs/benchmark.md`

**Compat note:** released CLI 0.3.0 cannot submit mini-swe-agent benchmarks against the new platform contract — merging this needs a release (or platform-side version gate) so users aren't stuck between the two.

## Test plan

- [x] `pytest tests/unit/platform/cli/test_benchmark_config.py` — 50 passed, including new coverage: mini-swe-agent without a harness secret loads; with one is rejected; `MSWEA_API_KEY` literal env rejected for provider models, allowed for hosted
- [x] End-to-end: used this branch to submit a DeepSWE mini-swe-agent run to a devel platform on the #1002 branch — submit passes validation and the run starts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns CLI benchmark submit validation with the platform by removing the harness secret requirement for the mini-swe-agent harness. Previously the CLI required a MSWEA_API_KEY harness secret; now the platform injects the agent’s model key and rejects harness_api_key_secret, so the CLI does too and blocks env collisions.

- Reject harness_api_key_secret for harnesses that use no harness credential (including mini-swe-agent); remove mini-swe-agent from the harness-key map.
- For mini-swe-agent with provider or endpoint models, reject a literal MSWEA_API_KEY env var; allow it only for hosted models.
- Update docs and tests to match the new contract.
- Compatibility: existing CLI 0.3.0 cannot submit mini-swe-agent to the new platform. Release this change or gate on CLI version. Migration: remove harness_api_key_secret from mini-swe-agent configs; do not set MSWEA_API_KEY unless using a hosted model.

<sup>Written for commit 3003aafa69af0e80f0c0fb2fe152c26b08e79805. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Osmosis-AI/osmosis-sdk-python/pull/308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

