### PR TITLE
[2/3][eval][cli] feat: add the LocalBackend local evaluation runner

### DIFF
--- a/osmosis_ai/cli/commands/eval.py
+++ b/osmosis_ai/cli/commands/eval.py
@@ -109,6 +109,111 @@ def eval_submit(
     return _submit(config_path, yes=yes, secrets_file=secrets_file)
 
 
+@app.command("run")
+def eval_run(
+    config_path: Path = typer.Argument(
+        ...,
+        exists=False,
+        file_okay=True,
+        dir_okay=False,
+        readable=False,
+        resolve_path=False,
+        help="Path to evaluation config TOML file.",
+    ),
+    name: str | None = typer.Option(
+        None,
+        "--name",
+        help=(
+            "Stable run name. Re-running the same name resumes pending work. "
+            "Omit to create a one-off run with a generated name."
+        ),
+    ),
+    output: str | None = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Run output root (default: .osmosis/evals/).",
+    ),
+    dataset_file: str | None = typer.Option(
+        None,
+        "--dataset-file",
+        help="Local dataset file to run instead of the platform dataset.",
+    ),
+    secrets_file: str | None = typer.Option(
+        None,
+        "--secrets-file",
+        help=(
+            "Dotenv file supplying values for \\[secrets] names; - reads stdin. "
+            "Values are never saved and are re-supplied on every run."
+        ),
+    ),
+    rows: str | None = typer.Option(
+        None,
+        "--rows",
+        help='Dataset rows to run, for example "3,7,10-20". Overrides limit.',
+    ),
+    fresh: bool = typer.Option(
+        False,
+        "--fresh",
+        help="Archive this run name's existing results and start clean.",
+    ),
+    retry_failed: bool = typer.Option(
+        False,
+        "--retry-failed",
+        help="Also re-run failed and skipped work items; successes are kept.",
+    ),
+    max_in_flight: int | None = typer.Option(
+        None,
+        "--max-in-flight",
+        help="Concurrent rollouts (default: evaluation.batch_size, then 1).",
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+    rollout_port: int | None = typer.Option(
+        None,
+        "--rollout-port",
+        help="Fixed rollout-server port (default: an ephemeral port).",
+        rich_help_panel="Advanced",
+    ),
+    skip_llm_preflight: bool = typer.Option(
+        False,
+        "--skip-llm-preflight",
+        help="Skip the eval-proxy session and model check before dispatch.",
+        rich_help_panel="Advanced",
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        help="Stream supervisor and rollout-server log lines to the terminal.",
+        rich_help_panel="Advanced",
+    ),
+    eval_proxy_url: str | None = typer.Option(
+        None,
+        "--eval-proxy-url",
+        help="Override the eval-proxy base URL (development only).",
+        rich_help_panel="Advanced",
+    ),
+) -> CommandResult:
+    """Run an evaluation locally against this workspace's rollout server."""
+    from osmosis_ai.platform.cli.eval_run import run as _run
+
+    return _run(
+        config_path,
+        name=name,
+        output=output,
+        dataset_file=dataset_file,
+        secrets_file=secrets_file,
+        rows=rows,
+        fresh=fresh,
+        retry_failed=retry_failed,
+        max_in_flight=max_in_flight,
+        yes=yes,
+        rollout_port=rollout_port,
+        skip_llm_preflight=skip_llm_preflight,
+        verbose=verbose,
+        eval_proxy_url=eval_proxy_url,
+    )
+
+
 @app.command("list")
 def eval_list(
     limit: int = limit_option("Maximum number of evaluation runs to show."),

--- a/osmosis_ai/eval/local/__init__.py
+++ b/osmosis_ai/eval/local/__init__.py
@@ -1,0 +1,3 @@
+"""Local evaluation runner: supervisor, durable state, and result projections."""
+
+__all__: list[str] = []

--- a/osmosis_ai/eval/local/dataset.py
+++ b/osmosis_ai/eval/local/dataset.py
@@ -1,0 +1,649 @@
+"""Dataset resolution, content-addressed caching, and row normalization.
+
+``experiment.dataset`` is always a platform dataset name -- never a filesystem
+path -- so one TOML means the same thing to ``eval submit`` and ``eval run``
+(design ``local-eval-run-plan.md`` §6). ``--dataset-file`` is the explicit local
+override.
+
+Row normalization is a **shared contract** with the cloud eval controller:
+``row_index`` is the position within the *selected* set, not the original
+dataset offset, because the controller selects rows first and then enumerates
+them. ``source_row_index`` is retained alongside it for local ``--rows`` UX and
+provenance, and never reaches the platform.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import re
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal, Protocol
+
+from osmosis_ai.eval.local.state import atomic_write_json
+from osmosis_ai.rollout.types.sample import MessageDict
+
+#: Dataset extensions the platform validator accepts.
+VALID_EXTENSIONS: frozenset[str] = frozenset({"csv", "jsonl", "parquet"})
+
+#: Column that switches a dataset into metadata mode (``docs/datasets.md``).
+METADATA_COLUMN = "metadata"
+
+_ROW_SELECTOR_RE = re.compile(r"^\d+(?:-\d+)?(?:,\d+(?:-\d+)?)*$")
+_HASH_CHUNK_SIZE = 1024 * 1024
+_CSV_FIELD_SIZE_LIMIT = 16 * 1024 * 1024
+
+DatasetSource = Literal["explicit", "cache", "download"]
+
+
+class DatasetResolutionError(RuntimeError):
+    """The dataset for this run could not be resolved or parsed."""
+
+
+# --------------------------------------------------------------------------- #
+# Normalized rows
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class EvalDatasetRow:
+    """One normalized dataset row bound to a work item's row identity.
+
+    ``row_index`` is the platform-visible position inside the selected set;
+    ``source_row_index`` is the 0-based offset in the dataset file.
+    """
+
+    row_index: int
+    source_row_index: int
+    initial_messages: list[MessageDict]
+    label: str | None
+    metadata: dict[str, Any] | None
+
+
+@dataclass(frozen=True)
+class RowSelection:
+    """The rows this run will execute, plus the dataset's full size."""
+
+    rows: tuple[EvalDatasetRow, ...]
+    total_dataset_rows: int
+
+    @property
+    def source_row_indices(self) -> tuple[int, ...]:
+        return tuple(row.source_row_index for row in self.rows)
+
+
+# --------------------------------------------------------------------------- #
+# --rows selector
+# --------------------------------------------------------------------------- #
+
+
+def parse_row_selector(value: str) -> tuple[int, ...]:
+    """Parse ``"3,7,10-20"`` into deduplicated ascending source-row indices."""
+    text = value.strip()
+    if not _ROW_SELECTOR_RE.fullmatch(text):
+        raise DatasetResolutionError(
+            f"--rows must be comma-separated indices or ranges, for example "
+            f"'3,7,10-20': got {value!r}"
+        )
+    selected: set[int] = set()
+    for part in text.split(","):
+        if "-" in part:
+            start_text, end_text = part.split("-", 1)
+            start, end = int(start_text), int(end_text)
+            if start > end:
+                raise DatasetResolutionError(
+                    f"--rows range {part!r} is inverted; write it as {end}-{start}"
+                )
+            selected.update(range(start, end + 1))
+        else:
+            selected.add(int(part))
+    return tuple(sorted(selected))
+
+
+# --------------------------------------------------------------------------- #
+# Streaming readers
+# --------------------------------------------------------------------------- #
+
+
+def dataset_extension(path: Path) -> str:
+    extension = path.suffix.lstrip(".").lower()
+    if extension not in VALID_EXTENSIONS:
+        raise DatasetResolutionError(
+            f"{path} has extension {extension or '(none)'!r}; expected one of "
+            f"{sorted(VALID_EXTENSIONS)}"
+        )
+    return extension
+
+
+def iter_raw_rows(path: Path, extension: str) -> Iterator[Mapping[str, Any]]:
+    """Stream raw rows so a large dataset never has to fit in memory."""
+    if extension == "jsonl":
+        yield from _iter_jsonl_rows(path)
+    elif extension == "csv":
+        yield from _iter_csv_rows(path)
+    elif extension == "parquet":
+        yield from _iter_parquet_rows(path)
+    else:  # pragma: no cover - dataset_extension() gates this
+        raise DatasetResolutionError(f"unsupported dataset extension {extension!r}")
+
+
+def _iter_jsonl_rows(path: Path) -> Iterator[Mapping[str, Any]]:
+    with path.open("r", encoding="utf-8") as handle:
+        for lineno, line in enumerate(handle, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                payload = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise DatasetResolutionError(
+                    f"{path}:{lineno}: invalid JSON ({exc.msg})"
+                ) from exc
+            if not isinstance(payload, dict):
+                raise DatasetResolutionError(
+                    f"{path}:{lineno}: each line must be a JSON object"
+                )
+            yield payload
+
+
+def _iter_csv_rows(path: Path) -> Iterator[Mapping[str, Any]]:
+    previous_limit = csv.field_size_limit(_CSV_FIELD_SIZE_LIMIT)
+    try:
+        with path.open("r", encoding="utf-8", newline="") as handle:
+            reader = csv.DictReader(handle)
+            if reader.fieldnames is None:
+                raise DatasetResolutionError(f"{path} has no CSV header row")
+            for row in reader:
+                yield {key: value for key, value in row.items() if key is not None}
+    finally:
+        csv.field_size_limit(previous_limit)
+
+
+def _iter_parquet_rows(path: Path) -> Iterator[Mapping[str, Any]]:
+    try:
+        import pyarrow.parquet as pq
+    except ModuleNotFoundError as exc:
+        raise DatasetResolutionError(
+            'Reading Parquet datasets requires: pip install "osmosis-ai[parquet]"'
+        ) from exc
+    parquet_file = pq.ParquetFile(path)
+    for batch in parquet_file.iter_batches():
+        yield from batch.to_pylist()
+
+
+# --------------------------------------------------------------------------- #
+# Row normalization
+# --------------------------------------------------------------------------- #
+
+
+def _text_value(raw: Mapping[str, Any], column: str) -> str | None:
+    value = raw.get(column)
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value or None
+    return str(value)
+
+
+def _parse_metadata(value: Any, *, where: str) -> dict[str, Any] | None:
+    """Accept a JSON object, or an encoded JSON object from a CSV/JSONL string."""
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            decoded = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise DatasetResolutionError(
+                f"{where}: metadata is not valid JSON ({exc.msg})"
+            ) from exc
+        if not isinstance(decoded, dict):
+            raise DatasetResolutionError(f"{where}: metadata must be a JSON object")
+        return decoded
+    raise DatasetResolutionError(f"{where}: metadata must be a JSON object")
+
+
+def normalize_row(
+    raw: Mapping[str, Any], *, row_index: int, source_row_index: int
+) -> EvalDatasetRow:
+    """Normalize one raw row into the shared prompt/metadata shape.
+
+    Prompt mode needs ``user_prompt``; metadata mode (a ``metadata`` column)
+    makes the prompt columns optional. ``system_prompt`` is always optional and
+    ``label`` is an accepted alias for ``ground_truth``. Columns outside this
+    contract are ignored -- they are not part of what the platform normalizes,
+    so consuming them locally would fork behavior.
+    """
+    where = f"row {source_row_index}"
+    metadata = _parse_metadata(raw.get(METADATA_COLUMN), where=where)
+    metadata_mode = METADATA_COLUMN in raw
+
+    system_prompt = _text_value(raw, "system_prompt")
+    user_prompt = _text_value(raw, "user_prompt")
+    if user_prompt is None and not metadata_mode:
+        raise DatasetResolutionError(
+            f"{where}: user_prompt is required for a dataset with no "
+            f"{METADATA_COLUMN!r} column"
+        )
+
+    label = _text_value(raw, "ground_truth")
+    if label is None:
+        label = _text_value(raw, "label")
+    if label is None and not metadata_mode:
+        raise DatasetResolutionError(
+            f"{where}: ground_truth (or label) is required for a dataset with "
+            f"no {METADATA_COLUMN!r} column"
+        )
+
+    messages: list[MessageDict] = []
+    if system_prompt is not None:
+        messages.append({"role": "system", "content": system_prompt})
+    if user_prompt is not None:
+        messages.append({"role": "user", "content": user_prompt})
+
+    return EvalDatasetRow(
+        row_index=row_index,
+        source_row_index=source_row_index,
+        initial_messages=messages,
+        label=label,
+        metadata=metadata,
+    )
+
+
+def select_rows(
+    path: Path,
+    *,
+    extension: str | None = None,
+    limit: int | None = None,
+    row_selector: Sequence[int] | None = None,
+) -> RowSelection:
+    """Select and normalize the rows this run executes, in one streaming pass.
+
+    Without ``--rows``, mirror cloud selection: a positive ``evaluation.limit``
+    takes the first N rows, and otherwise every row runs in dataset order.
+    ``--rows`` is an explicit local override of that selection; an out-of-range
+    index fails here, before the run directory is created.
+    """
+    resolved_extension = extension or dataset_extension(path)
+    wanted = set(row_selector) if row_selector is not None else None
+    rows: list[EvalDatasetRow] = []
+    total = 0
+    for source_row_index, raw in enumerate(iter_raw_rows(path, resolved_extension)):
+        total += 1
+        if wanted is not None:
+            if source_row_index not in wanted:
+                continue
+        elif limit is not None and limit > 0 and len(rows) >= limit:
+            # Keep counting so progress.json can report the dataset's real size.
+            continue
+        rows.append(
+            normalize_row(raw, row_index=len(rows), source_row_index=source_row_index)
+        )
+
+    if wanted is not None:
+        out_of_range = sorted(index for index in wanted if index >= total)
+        if out_of_range:
+            raise DatasetResolutionError(
+                f"--rows selects {out_of_range} but {path.name} has {total} rows "
+                f"(valid indices are 0-{max(total - 1, 0)})"
+            )
+    if not rows:
+        raise DatasetResolutionError(f"{path} selected no rows")
+    return RowSelection(rows=tuple(rows), total_dataset_rows=total)
+
+
+# --------------------------------------------------------------------------- #
+# Content-addressed cache
+# --------------------------------------------------------------------------- #
+
+
+def sha256_of_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(_HASH_CHUNK_SIZE):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def default_dataset_cache_root() -> Path:
+    return Path.home() / ".cache" / "osmosis" / "datasets"
+
+
+def _workspace_cache_key(git_identity: str) -> str:
+    """A readable but collision-free directory name for a workspace identity."""
+    safe = (
+        re.sub(r"[^A-Za-z0-9_.-]", "_", git_identity)[:48].strip("._-") or "workspace"
+    )
+    return f"{safe}-{hashlib.sha256(git_identity.encode()).hexdigest()[:8]}"
+
+
+@dataclass(frozen=True)
+class CachedDataset:
+    """A verified cache entry: the bytes plus the metadata that describes them."""
+
+    path: Path
+    sha256: str
+    extension: str
+    dataset_id: str
+    dataset_name: str
+    version: str | None
+    row_count: int | None
+    organization_id: str | None
+
+
+class DatasetCache:
+    """Content-addressed dataset cache under ``<root>/<workspace>/<dataset-id>/``.
+
+    A hit requires the recorded ``version`` to match the platform's and the
+    stored bytes to hash to their recorded digest, so a truncated or swapped
+    file can never masquerade as the dataset a manifest pinned.
+    """
+
+    def __init__(self, root: Path, *, git_identity: str) -> None:
+        self._root = root / _workspace_cache_key(git_identity)
+
+    def directory_for(self, dataset_id: str) -> Path:
+        safe_id = re.sub(r"[^A-Za-z0-9_.-]", "_", dataset_id)
+        return self._root / safe_id
+
+    def _metadata_path(self, dataset_id: str) -> Path:
+        return self.directory_for(dataset_id) / "metadata.json"
+
+    def lookup(
+        self, dataset_id: str, *, expected_version: str | None
+    ) -> CachedDataset | None:
+        metadata_path = self._metadata_path(dataset_id)
+        try:
+            payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(payload, dict):
+            return None
+        digest = payload.get("sha256")
+        extension = payload.get("extension")
+        if not isinstance(digest, str) or not isinstance(extension, str):
+            return None
+        if expected_version is not None and payload.get("version") != expected_version:
+            return None
+        data_path = self.directory_for(dataset_id) / f"{digest}.{extension}"
+        if not data_path.is_file() or sha256_of_file(data_path) != digest:
+            return None
+        return CachedDataset(
+            path=data_path,
+            sha256=digest,
+            extension=extension,
+            dataset_id=dataset_id,
+            dataset_name=str(payload.get("dataset_name") or dataset_id),
+            version=payload.get("version"),
+            row_count=payload.get("row_count"),
+            organization_id=payload.get("organization_id"),
+        )
+
+    def store(
+        self,
+        *,
+        dataset_id: str,
+        dataset_name: str,
+        source: Path,
+        extension: str,
+        version: str | None,
+        row_count: int | None,
+        organization_id: str | None,
+    ) -> CachedDataset:
+        digest = sha256_of_file(source)
+        directory = self.directory_for(dataset_id)
+        directory.mkdir(parents=True, exist_ok=True)
+        data_path = directory / f"{digest}.{extension}"
+        if source != data_path:
+            source.replace(data_path)
+        atomic_write_json(
+            self._metadata_path(dataset_id),
+            {
+                "dataset_id": dataset_id,
+                "dataset_name": dataset_name,
+                "organization_id": organization_id,
+                "version": version,
+                "sha256": digest,
+                "extension": extension,
+                "row_count": row_count,
+                "cached_at": datetime.now(UTC).isoformat(timespec="seconds"),
+            },
+        )
+        return CachedDataset(
+            path=data_path,
+            sha256=digest,
+            extension=extension,
+            dataset_id=dataset_id,
+            dataset_name=dataset_name,
+            version=version,
+            row_count=row_count,
+            organization_id=organization_id,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Resolution
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class ResolvedDataset:
+    """The dataset bytes this run is pinned to.
+
+    ``sha256`` is the fingerprint the manifest stores: never the path, name, or
+    mtime, so moving or renaming a file never invalidates a resumable run.
+    """
+
+    path: Path
+    sha256: str
+    extension: str
+    source: DatasetSource
+    dataset_name: str
+    dataset_id: str | None = None
+    version: str | None = None
+
+
+def resolve_explicit_dataset_file(path: Path) -> ResolvedDataset:
+    """Resolve ``--dataset-file``: the highest-precedence resolver step."""
+    resolved = path.expanduser()
+    if not resolved.is_file():
+        raise DatasetResolutionError(f"--dataset-file {path} is not a file")
+    extension = dataset_extension(resolved)
+    return ResolvedDataset(
+        path=resolved,
+        sha256=sha256_of_file(resolved),
+        extension=extension,
+        source="explicit",
+        dataset_name=resolved.name,
+    )
+
+
+@dataclass(frozen=True)
+class DatasetDescription:
+    """What the platform knows about a dataset, reduced to what caching needs."""
+
+    dataset_id: str
+    dataset_name: str
+    extension: str
+    version: str | None = None
+    row_count: int | None = None
+    organization_id: str | None = None
+    file_size: int | None = None
+
+
+class DatasetFetcher(Protocol):
+    """The platform surface dataset resolution needs. Fakeable in tests."""
+
+    def describe(self, dataset_name: str) -> DatasetDescription: ...
+
+    def download_to(self, dataset_name: str, destination: Path) -> None: ...
+
+
+def resolve_platform_dataset(
+    dataset_name: str,
+    *,
+    cache: DatasetCache,
+    fetcher: DatasetFetcher,
+    on_event: Callable[[str], None] | None = None,
+) -> ResolvedDataset:
+    """Resolve a platform dataset name through the cache, downloading on a miss.
+
+    A verified cache entry is also the offline fallback: when the platform is
+    unreachable we would rather run against bytes we can prove are the ones we
+    cached than fail a resumable run.
+    """
+
+    def _note(message: str) -> None:
+        if on_event is not None:
+            on_event(message)
+
+    try:
+        description = fetcher.describe(dataset_name)
+    except DatasetResolutionError:
+        raise
+    except Exception as exc:
+        stale = _any_cached_entry(cache, dataset_name)
+        if stale is None:
+            raise DatasetResolutionError(
+                f"could not resolve dataset {dataset_name!r} from the platform "
+                f"({exc}); pass --dataset-file to run against a local file"
+            ) from exc
+        _note(
+            f"platform unreachable ({exc}); using the verified cached copy of "
+            f"{dataset_name!r}"
+        )
+        return _resolved_from_cache(stale)
+
+    cached = cache.lookup(description.dataset_id, expected_version=description.version)
+    if cached is not None:
+        _note(f"dataset cache hit for {dataset_name!r}")
+        return _resolved_from_cache(cached)
+
+    directory = cache.directory_for(description.dataset_id)
+    directory.mkdir(parents=True, exist_ok=True)
+    staging = directory / f".download.{description.extension}"
+    _note(f"downloading dataset {dataset_name!r}")
+    try:
+        fetcher.download_to(dataset_name, staging)
+        stored = cache.store(
+            dataset_id=description.dataset_id,
+            dataset_name=description.dataset_name,
+            source=staging,
+            extension=description.extension,
+            version=description.version,
+            row_count=description.row_count,
+            organization_id=description.organization_id,
+        )
+    finally:
+        staging.unlink(missing_ok=True)
+    return _resolved_from_cache(stored, source="download")
+
+
+def _any_cached_entry(cache: DatasetCache, dataset_name: str) -> CachedDataset | None:
+    """Find a verified cache entry when the platform cannot confirm a version."""
+    for dataset_id in _cached_dataset_ids(cache):
+        entry = cache.lookup(dataset_id, expected_version=None)
+        if entry is not None and dataset_name in (entry.dataset_name, entry.dataset_id):
+            return entry
+    return None
+
+
+def _cached_dataset_ids(cache: DatasetCache) -> list[str]:
+    directory = cache.directory_for("probe").parent
+    if not directory.is_dir():
+        return []
+    return sorted(child.name for child in directory.iterdir() if child.is_dir())
+
+
+def _resolved_from_cache(
+    entry: CachedDataset, *, source: DatasetSource = "cache"
+) -> ResolvedDataset:
+    return ResolvedDataset(
+        path=entry.path,
+        sha256=entry.sha256,
+        extension=entry.extension,
+        source=source,
+        dataset_name=entry.dataset_name,
+        dataset_id=entry.dataset_id,
+        version=entry.version,
+    )
+
+
+class PlatformDatasetFetcher:
+    """:class:`DatasetFetcher` over the platform CLI API.
+
+    The dataset endpoints accept a dataset *name* wherever they document a file
+    id, so no name-to-id lookup pass is needed.
+    """
+
+    def __init__(self, *, credentials: Any, git_identity: str) -> None:
+        self._credentials = credentials
+        self._git_identity = git_identity
+
+    def describe(self, dataset_name: str) -> DatasetDescription:
+        from osmosis_ai.platform.api.client import OsmosisClient
+        from osmosis_ai.platform.api.models import (
+            STATUSES_IN_PROGRESS,
+            STATUSES_SUCCESS,
+        )
+
+        record = OsmosisClient().get_dataset(
+            dataset_name,
+            credentials=self._credentials,
+            git_identity=self._git_identity,
+        )
+        if record.status not in STATUSES_SUCCESS:
+            hint = (
+                " Try again after it finishes uploading."
+                if record.status in STATUSES_IN_PROGRESS
+                else ""
+            )
+            raise DatasetResolutionError(
+                f"dataset {dataset_name!r} is not available "
+                f"(status: {record.status}).{hint}"
+            )
+        return DatasetDescription(
+            dataset_id=record.id,
+            dataset_name=record.file_name or dataset_name,
+            extension=_platform_extension(record),
+            version=record.updated_at or None,
+            row_count=record.row_count,
+            organization_id=record.organization_id,
+            file_size=record.file_size,
+        )
+
+    def download_to(self, dataset_name: str, destination: Path) -> None:
+        from osmosis_ai.platform.api.client import OsmosisClient
+        from osmosis_ai.platform.api.download import download_file_to
+
+        info = OsmosisClient().get_dataset_download_url(
+            dataset_name,
+            credentials=self._credentials,
+            git_identity=self._git_identity,
+        )
+        download_file_to(info.presigned_url, destination)
+
+
+def _platform_extension(record: Any) -> str:
+    for candidate in (record.file_format, record.original_file_format):
+        if (
+            isinstance(candidate, str)
+            and candidate.lstrip(".").lower() in VALID_EXTENSIONS
+        ):
+            return candidate.lstrip(".").lower()
+    name = record.file_name or ""
+    suffix = Path(name).suffix.lstrip(".").lower()
+    if suffix in VALID_EXTENSIONS:
+        return suffix
+    raise DatasetResolutionError(
+        f"dataset {name or record.id!r} has no recognizable format; expected one "
+        f"of {sorted(VALID_EXTENSIONS)}"
+    )

--- a/osmosis_ai/eval/local/dataset.py
+++ b/osmosis_ai/eval/local/dataset.py
@@ -647,3 +647,25 @@ def _platform_extension(record: Any) -> str:
         f"dataset {name or record.id!r} has no recognizable format; expected one "
         f"of {sorted(VALID_EXTENSIONS)}"
     )
+
+
+def format_row_selector(indices: Sequence[int]) -> str:
+    """Render row indices as a compact normalized selector, e.g. ``"0-9,12"``.
+
+    Used in the manifest's resolved-input lock: a compact string keeps the lock
+    readable and its diff meaningful even for a large selection, where a literal
+    index list would dominate the file.
+    """
+    ordered = sorted(set(indices))
+    if not ordered:
+        return ""
+    parts: list[str] = []
+    start = previous = ordered[0]
+    for index in ordered[1:]:
+        if index == previous + 1:
+            previous = index
+            continue
+        parts.append(str(start) if start == previous else f"{start}-{previous}")
+        start = previous = index
+    parts.append(str(start) if start == previous else f"{start}-{previous}")
+    return ",".join(parts)

--- a/osmosis_ai/eval/local/dataset.py
+++ b/osmosis_ai/eval/local/dataset.py
@@ -505,9 +505,9 @@ def resolve_platform_dataset(
 ) -> ResolvedDataset:
     """Resolve a platform dataset name through the cache, downloading on a miss.
 
-    A verified cache entry is also the offline fallback: when the platform is
-    unreachable we would rather run against bytes we can prove are the ones we
-    cached than fail a resumable run.
+    The cache only ever serves bytes the platform has just confirmed the version
+    of: there is no offline mode, so an unreachable platform is an error rather
+    than a run pinned to whatever happened to be on disk.
     """
 
     def _note(message: str) -> None:
@@ -519,17 +519,10 @@ def resolve_platform_dataset(
     except DatasetResolutionError:
         raise
     except Exception as exc:
-        stale = _any_cached_entry(cache, dataset_name)
-        if stale is None:
-            raise DatasetResolutionError(
-                f"could not resolve dataset {dataset_name!r} from the platform "
-                f"({exc}); pass --dataset-file to run against a local file"
-            ) from exc
-        _note(
-            f"platform unreachable ({exc}); using the verified cached copy of "
-            f"{dataset_name!r}"
-        )
-        return _resolved_from_cache(stale)
+        raise DatasetResolutionError(
+            f"could not resolve dataset {dataset_name!r} from the platform "
+            f"({exc}); pass --dataset-file to run against a local file"
+        ) from exc
 
     cached = cache.lookup(description.dataset_id, expected_version=description.version)
     if cached is not None:
@@ -554,22 +547,6 @@ def resolve_platform_dataset(
     finally:
         staging.unlink(missing_ok=True)
     return _resolved_from_cache(stored, source="download")
-
-
-def _any_cached_entry(cache: DatasetCache, dataset_name: str) -> CachedDataset | None:
-    """Find a verified cache entry when the platform cannot confirm a version."""
-    for dataset_id in _cached_dataset_ids(cache):
-        entry = cache.lookup(dataset_id, expected_version=None)
-        if entry is not None and dataset_name in (entry.dataset_name, entry.dataset_id):
-            return entry
-    return None
-
-
-def _cached_dataset_ids(cache: DatasetCache) -> list[str]:
-    directory = cache.directory_for("probe").parent
-    if not directory.is_dir():
-        return []
-    return sorted(child.name for child in directory.iterdir() if child.is_dir())
 
 
 def _resolved_from_cache(

--- a/osmosis_ai/eval/local/dataset.py
+++ b/osmosis_ai/eval/local/dataset.py
@@ -249,6 +249,15 @@ def normalize_row(
     if user_prompt is not None:
         messages.append({"role": "user", "content": user_prompt})
 
+    if not messages and metadata is None:
+        # A CSV with a metadata header supplies every column for every row, so an
+        # empty cell would otherwise waive the prompt requirement and dispatch a
+        # rollout with no input at all.
+        raise DatasetResolutionError(
+            f"{where}: has no prompt and no metadata; a row needs at least a "
+            f"user_prompt or a non-empty {METADATA_COLUMN!r} object"
+        )
+
     return EvalDatasetRow(
         row_index=row_index,
         source_row_index=source_row_index,

--- a/osmosis_ai/eval/local/results.py
+++ b/osmosis_ai/eval/local/results.py
@@ -13,7 +13,9 @@ data loss into a loud local failure.
 from __future__ import annotations
 
 import json
+import logging
 import re
+import shutil
 import statistics
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
@@ -46,6 +48,8 @@ ARTIFACTS_DIRNAME = "artifacts"
 _RESERVED_ARTIFACT_MANIFEST = "manifest.json"
 
 _VALID_STATUSES: frozenset[str] = frozenset({"success", "failed", "skipped"})
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 class IndexContractError(RuntimeError):
@@ -110,6 +114,7 @@ def build_index_row(
     *,
     trajectory_filename: str | None = None,
     resumed: bool = False,
+    tokens: int | None = None,
 ) -> dict[str, Any]:
     """Project one terminal record into an ``index.jsonl`` row.
 
@@ -124,7 +129,7 @@ def build_index_row(
             "trajectory_filename": trajectory_filename,
             "status": record.status,
             "reward": record.reward,
-            "tokens": record.tokens,
+            "tokens": record.tokens if tokens is None else tokens,
             "duration_ms": record.duration_ms,
             "error_type": record.error_type,
             "resumed": True if resumed else None,
@@ -228,15 +233,16 @@ def aggregate_metrics(
 ) -> dict[str, Any]:
     """Replicate the platform worker's ``_aggregate_from_index`` summary (§2.5).
 
-    ``scored`` excludes skipped rows; ``passed`` is ``reward >= pass_threshold``.
-    Platform finalize always recomputes this, so a local number is a display
-    convenience -- but it must agree, or a user sees two truths.
+    ``scored`` is every non-skipped sample; ``passed`` is
+    ``reward >= pass_threshold``. Platform finalize always recomputes this, so a
+    local number is a display convenience -- but it must agree, or a user sees
+    two truths.
     """
     materialized = list(rows)
     passes_by_row: dict[int, int] = {}
     attempts_by_row: dict[int, int] = {}
     rewards: list[float] = []
-    passed = scored = skipped = failed = 0
+    passed = graded = skipped = failed = 0
     tokens_used = 0
     max_run_index = -1
 
@@ -255,23 +261,28 @@ def aggregate_metrics(
             failed += 1
         row_index = row.get("row_index")
         reward = row.get("reward")
+        # A failed attempt usually carries no reward. It is still a non-pass in a
+        # denominator that excludes only skipped rows: dropping it would let a run
+        # where most rows failed report the pass rate of the rows that worked.
+        is_pass = False
         if isinstance(reward, (int, float)) and not isinstance(reward, bool):
-            scored += 1
+            graded += 1
             rewards.append(float(reward))
             is_pass = float(reward) >= pass_threshold
             if is_pass:
                 passed += 1
-            if isinstance(row_index, int):
-                attempts_by_row[row_index] = attempts_by_row.get(row_index, 0) + 1
-                passes_by_row[row_index] = passes_by_row.get(row_index, 0) + int(
-                    is_pass
-                )
+        if isinstance(row_index, int):
+            attempts_by_row[row_index] = attempts_by_row.get(row_index, 0) + 1
+            passes_by_row[row_index] = passes_by_row.get(row_index, 0) + int(is_pass)
 
     total_samples = len(materialized)
+    # ``scored`` excludes skipped rows only (§2.5), which is exactly
+    # ``completed_samples``.
+    scored = total_samples - skipped
     summary: dict[str, Any] = {
         "total_samples": total_samples,
-        "completed_samples": total_samples - skipped,
-        "graded": scored,
+        "completed_samples": scored,
+        "graded": graded,
         "passed": passed,
         "failed": failed,
         "skipped": skipped,
@@ -333,21 +344,25 @@ def safe_artifact_relative_paths(artifacts_dir: Path) -> list[Path]:
     selected: list[Path] = []
     for candidate in sorted(artifacts_dir.rglob("*")):
         relative = candidate.relative_to(artifacts_dir)
+        # An unsafe entry is skipped with a warning, never projected, and never
+        # fatal: one stray symlink must not stop a run whose every terminal
+        # result is already durable.
         if candidate.is_symlink():
-            raise ArtifactProjectionError(
-                f"refusing to project artifact symlink {candidate}"
-            )
+            logger.warning("skipping artifact symlink %s", candidate)
+            continue
         if not candidate.is_file():
             continue
         if any(part in ("", ".", "..") for part in relative.parts):
-            raise ArtifactProjectionError(f"unsafe artifact path {relative}")
+            logger.warning("skipping unsafe artifact path %s", relative)
+            continue
         if len(relative.parts) == 1 and relative.name == _RESERVED_ARTIFACT_MANIFEST:
             # Reserved server-side index name; excluded on both sides (§2.6).
             continue
         if not candidate.resolve().is_relative_to(resolved_root):
-            raise ArtifactProjectionError(
-                f"artifact path {relative} escapes the artifact root"
+            logger.warning(
+                "skipping artifact path %s outside the artifact root", relative
             )
+            continue
         selected.append(relative)
     return selected
 
@@ -404,6 +419,31 @@ class SelectedAttempt:
     record: TerminalRecord
     resumed: bool
     trajectory_filename: str | None
+    tokens: int | None = None
+
+    @property
+    def key(self) -> WorkKey:
+        return self.record.key
+
+
+def atif_total_tokens(document: Mapping[str, Any]) -> int | None:
+    """Token total from an ATIF document's ``final_metrics`` (§7.2 fallback).
+
+    Used when the eval-proxy usage API gave nothing: its path is explicitly not
+    frozen, and a run whose tokens all read zero is worse than one that reads
+    them out of the trajectory the platform already trusts.
+    """
+    metrics = document.get("final_metrics")
+    if not isinstance(metrics, Mapping):
+        return None
+    total = 0
+    seen = False
+    for key in ("total_prompt_tokens", "total_completion_tokens"):
+        value = metrics.get(key)
+        if isinstance(value, int) and not isinstance(value, bool):
+            total += value
+            seen = True
+    return total if seen else None
 
 
 def select_attempts(
@@ -424,6 +464,9 @@ def select_attempts(
         record = latest[key]
         trajectory_path = trials_dir / record.rollout_id / CANONICAL_TRAJECTORY_FILENAME
         document = read_valid_trajectory(trajectory_path, rollout_id=record.rollout_id)
+        tokens = record.tokens
+        if tokens is None and document is not None:
+            tokens = atif_total_tokens(document)
         selected.append(
             SelectedAttempt(
                 record=record,
@@ -431,6 +474,7 @@ def select_attempts(
                 trajectory_filename=(
                     CANONICAL_TRAJECTORY_FILENAME if document is not None else None
                 ),
+                tokens=tokens,
             )
         )
     return selected
@@ -459,13 +503,21 @@ class Materializer:
         sampled_rows: int,
         total_dataset_rows: int,
         total_runs: int,
+        project_keys: Iterable[WorkKey] | None = None,
     ) -> list[dict[str, Any]]:
-        """Rewrite index, progress, summary, metrics, and both projections."""
+        """Rewrite index, progress, summary, metrics, and both projections.
+
+        Snapshots are cheap to rewrite whole; file projections are not. Pass
+        *project_keys* to copy only the work items whose selected attempt
+        changed -- copying every attempt on every refresh is quadratic in the
+        row count and re-fsyncs the entire trajectory set each time.
+        """
         rows = [
             build_index_row(
                 attempt.record,
                 trajectory_filename=attempt.trajectory_filename,
                 resumed=attempt.resumed,
+                tokens=attempt.tokens,
             )
             for attempt in attempts
         ]
@@ -488,23 +540,31 @@ class Materializer:
                 "summary": aggregate_metrics(rows, pass_threshold=pass_threshold),
             },
         )
+        wanted = None if project_keys is None else set(project_keys)
         for attempt in attempts:
-            self.project_attempt(attempt)
+            if wanted is None or attempt.key in wanted:
+                self.project_attempt(attempt)
         return rows
 
     def project_attempt(self, attempt: SelectedAttempt) -> None:
-        """Copy the selected attempt's trajectory and artifacts to top level."""
+        """Copy the selected attempt's trajectory and artifacts to top level.
+
+        The previous attempt's projection is cleared first: the stem is per work
+        item, so a retry whose new attempt produced no trajectory would otherwise
+        leave the superseded attempt's files on disk, attributed to a result that
+        did not produce them (§9.2, §11.1).
+        """
         record = attempt.record
         stem = projection_stem(record.row_index, record.run_index)
         rollout_dir = self.trials_dir / record.rollout_id
+        trajectory_dest = self._run_dir / TRAJECTORIES_DIRNAME / f"{stem}.json"
+        artifacts_dest = self._run_dir / ARTIFACTS_DIRNAME / stem
+        trajectory_dest.unlink(missing_ok=True)
+        shutil.rmtree(artifacts_dest, ignore_errors=True)
         if attempt.trajectory_filename is not None:
             copy_projection_file(
-                rollout_dir / attempt.trajectory_filename,
-                self._run_dir / TRAJECTORIES_DIRNAME / f"{stem}.json",
+                rollout_dir / attempt.trajectory_filename, trajectory_dest
             )
         artifacts_dir = rollout_dir / ARTIFACTS_DIRNAME
         for relative in safe_artifact_relative_paths(artifacts_dir):
-            copy_projection_file(
-                artifacts_dir / relative,
-                self._run_dir / ARTIFACTS_DIRNAME / stem / relative,
-            )
+            copy_projection_file(artifacts_dir / relative, artifacts_dest / relative)

--- a/osmosis_ai/eval/local/results.py
+++ b/osmosis_ai/eval/local/results.py
@@ -1,0 +1,510 @@
+"""Result materialization: contract-linted snapshots and user projections.
+
+Every file here is a **projection** rebuilt from the terminal journal and the
+canonical ``rollout_trials/`` tree; none of it decides whether work reruns
+(design ``local-eval-run-plan.md`` §11).
+
+The contract lint exists because the platform drops malformed ``index.jsonl``
+lines *silently* (§2.2): a missing ``duration_ms`` or a non-32-hex rollout id
+costs a sample with no error anywhere. Validating at write time turns a silent
+data loss into a loud local failure.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import statistics
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from osmosis_ai.eval.local.state import (
+    TerminalRecord,
+    WorkKey,
+    atomic_write_bytes,
+    atomic_write_json,
+    drop_none_values,
+)
+
+#: ``uuid4().hex`` -- the platform's artifact path contract (§2.2).
+ROLLOUT_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+#: The consumer's filename regex; a ``/`` here makes the trajectory invisible.
+TRAJECTORY_FILENAME_RE = re.compile(r"^trajectory[A-Za-z0-9._-]*\.json$")
+
+CANONICAL_TRAJECTORY_FILENAME = "trajectory.json"
+INDEX_FILENAME = "index.jsonl"
+PROGRESS_FILENAME = "progress.json"
+SUMMARY_FILENAME = "summary.jsonl"
+METRICS_FILENAME = "metrics.json"
+TRIALS_DIRNAME = "rollout_trials"
+TRAJECTORIES_DIRNAME = "trajectories"
+ARTIFACTS_DIRNAME = "artifacts"
+
+#: Reserved on both sides of the download contract (§2.6).
+_RESERVED_ARTIFACT_MANIFEST = "manifest.json"
+
+_VALID_STATUSES: frozenset[str] = frozenset({"success", "failed", "skipped"})
+
+
+class IndexContractError(RuntimeError):
+    """An index line would be silently dropped by the platform."""
+
+
+class ArtifactProjectionError(RuntimeError):
+    """An artifact path is unsafe to copy into the user projection."""
+
+
+# --------------------------------------------------------------------------- #
+# index.jsonl
+# --------------------------------------------------------------------------- #
+
+
+def lint_index_row(row: Mapping[str, Any]) -> list[str]:
+    """Return every §2.2 violation in *row*. Empty means the platform accepts it."""
+    problems: list[str] = []
+
+    for key in ("row_index", "run_index", "duration_ms"):
+        value = row.get(key)
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            problems.append(f"{key} must be a number (the line is dropped otherwise)")
+
+    status = row.get("status")
+    if status not in _VALID_STATUSES:
+        problems.append(
+            f"status must be one of {sorted(_VALID_STATUSES)}, got {status!r}"
+        )
+
+    if any(value is None for value in row.values()):
+        nulls = sorted(key for key, value in row.items() if value is None)
+        problems.append(
+            f"None-valued keys must be omitted, not written as null: {nulls}"
+        )
+
+    rollout_id = row.get("rollout_id")
+    sample_id = row.get("sample_id")
+    if rollout_id is None and sample_id is None:
+        problems.append("at least one of rollout_id or sample_id is required")
+    if rollout_id is not None and (
+        not isinstance(rollout_id, str) or not ROLLOUT_ID_RE.fullmatch(rollout_id)
+    ):
+        problems.append(
+            "rollout_id must be 32 lowercase hex characters, or the trajectory "
+            f"and artifacts are silently omitted from download: {rollout_id!r}"
+        )
+
+    filename = row.get("trajectory_filename")
+    if filename is not None and (
+        not isinstance(filename, str) or not TRAJECTORY_FILENAME_RE.fullmatch(filename)
+    ):
+        problems.append(
+            "trajectory_filename must match ^trajectory[A-Za-z0-9._-]*\\.json$ with "
+            f"no path separator: {filename!r}"
+        )
+    return problems
+
+
+def build_index_row(
+    record: TerminalRecord,
+    *,
+    trajectory_filename: str | None = None,
+    resumed: bool = False,
+) -> dict[str, Any]:
+    """Project one terminal record into an ``index.jsonl`` row.
+
+    ``resumed`` marks a result carried forward from an earlier invocation of the
+    same named run, matching the cloud controller's carry-forward flag.
+    """
+    row = drop_none_values(
+        {
+            "row_index": record.row_index,
+            "run_index": record.run_index,
+            "rollout_id": record.rollout_id,
+            "trajectory_filename": trajectory_filename,
+            "status": record.status,
+            "reward": record.reward,
+            "tokens": record.tokens,
+            "duration_ms": record.duration_ms,
+            "error_type": record.error_type,
+            "resumed": True if resumed else None,
+        }
+    )
+    problems = lint_index_row(row)
+    if problems:
+        raise IndexContractError(
+            f"index row for row {record.row_index} run {record.run_index} violates "
+            "the platform contract: " + "; ".join(problems)
+        )
+    return row
+
+
+def render_index_lines(rows: Sequence[Mapping[str, Any]]) -> bytes:
+    """Serialize index rows, sorted by ``(row_index, run_index)``."""
+    ordered = sorted(rows, key=lambda row: (row["row_index"], row["run_index"]))
+    return "".join(
+        json.dumps(row, ensure_ascii=False, allow_nan=False) + "\n" for row in ordered
+    ).encode("utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# ATIF identity
+# --------------------------------------------------------------------------- #
+
+
+def atif_rollout_identity(document: Mapping[str, Any]) -> str | None:
+    """Resolve the rollout id the platform converter will read from an ATIF doc.
+
+    Order per §2.3: ``extra.osmosis.rollout_id``, then top-level ``session_id``,
+    then the prefix before the first ``/`` in ``trajectory_id``. A bare
+    ``trajectory_id`` with no ``/`` is **not** a valid fallback -- the platform
+    converter drops that document, so accepting it locally would let a run look
+    healthy and upload blind.
+    """
+    extra = document.get("extra")
+    if isinstance(extra, Mapping):
+        osmosis = extra.get("osmosis")
+        if isinstance(osmosis, Mapping):
+            candidate = osmosis.get("rollout_id")
+            if isinstance(candidate, str) and candidate:
+                return candidate
+    session_id = document.get("session_id")
+    if isinstance(session_id, str) and session_id:
+        return session_id
+    trajectory_id = document.get("trajectory_id")
+    if isinstance(trajectory_id, str) and "/" in trajectory_id:
+        prefix = trajectory_id.split("/", 1)[0]
+        if prefix:
+            return prefix
+    return None
+
+
+def read_valid_trajectory(path: Path, *, rollout_id: str) -> dict[str, Any] | None:
+    """Return the ATIF document at *path* when it parses and its identity matches.
+
+    ``None`` covers every reason the platform would ignore the file: absent,
+    unparseable, not a single JSON object, or an identity that disagrees with the
+    directory name. The terminal result stays valid either way (§11.3).
+    """
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if atif_rollout_identity(payload) != rollout_id:
+        return None
+    return payload
+
+
+# --------------------------------------------------------------------------- #
+# Metrics (§2.5)
+# --------------------------------------------------------------------------- #
+
+
+def pass_at_k(*, attempts: int, passes: int, k: int) -> float:
+    """Unbiased pass@k for one work row (Chen et al.)."""
+    if k > attempts:
+        raise ValueError("k must not exceed the attempt count")
+    if attempts - passes < k:
+        return 1.0
+    value = 1.0
+    for index in range(k):
+        value *= (attempts - passes - index) / (attempts - index)
+    return 1.0 - value
+
+
+def _powers_of_two_up_to(limit: int) -> list[int]:
+    values: list[int] = []
+    k = 1
+    while k <= limit:
+        values.append(k)
+        k *= 2
+    return values
+
+
+def aggregate_metrics(
+    rows: Iterable[Mapping[str, Any]], *, pass_threshold: float
+) -> dict[str, Any]:
+    """Replicate the platform worker's ``_aggregate_from_index`` summary (§2.5).
+
+    ``scored`` excludes skipped rows; ``passed`` is ``reward >= pass_threshold``.
+    Platform finalize always recomputes this, so a local number is a display
+    convenience -- but it must agree, or a user sees two truths.
+    """
+    materialized = list(rows)
+    passes_by_row: dict[int, int] = {}
+    attempts_by_row: dict[int, int] = {}
+    rewards: list[float] = []
+    passed = scored = skipped = failed = 0
+    tokens_used = 0
+    max_run_index = -1
+
+    for row in materialized:
+        status = row.get("status")
+        run_index = row.get("run_index")
+        if isinstance(run_index, int):
+            max_run_index = max(max_run_index, run_index)
+        tokens = row.get("tokens")
+        if isinstance(tokens, int) and not isinstance(tokens, bool):
+            tokens_used += tokens
+        if status == "skipped":
+            skipped += 1
+            continue
+        if status == "failed":
+            failed += 1
+        row_index = row.get("row_index")
+        reward = row.get("reward")
+        if isinstance(reward, (int, float)) and not isinstance(reward, bool):
+            scored += 1
+            rewards.append(float(reward))
+            is_pass = float(reward) >= pass_threshold
+            if is_pass:
+                passed += 1
+            if isinstance(row_index, int):
+                attempts_by_row[row_index] = attempts_by_row.get(row_index, 0) + 1
+                passes_by_row[row_index] = passes_by_row.get(row_index, 0) + int(
+                    is_pass
+                )
+
+    total_samples = len(materialized)
+    summary: dict[str, Any] = {
+        "total_samples": total_samples,
+        "completed_samples": total_samples - skipped,
+        "graded": scored,
+        "passed": passed,
+        "failed": failed,
+        "skipped": skipped,
+        "pass_rate": (passed / scored) if scored else 0,
+        "pass_threshold": pass_threshold,
+        "tokens_used": tokens_used,
+    }
+    if rewards:
+        summary["reward_stats"] = {
+            "mean": statistics.fmean(rewards),
+            "median": statistics.median(rewards),
+            "std": statistics.pstdev(rewards) if len(rewards) > 1 else 0.0,
+            "min": min(rewards),
+            "max": max(rewards),
+        }
+
+    n_runs = max_run_index + 1
+    if n_runs >= 2:
+        summary["n_runs"] = n_runs
+        # pass@k needs at least two points to be worth plotting, so it appears
+        # only for multi-attempt runs.
+        points: list[dict[str, Any]] = []
+        for k in _powers_of_two_up_to(n_runs):
+            eligible = [
+                pass_at_k(
+                    attempts=attempts_by_row[row_index],
+                    passes=passes_by_row[row_index],
+                    k=k,
+                )
+                for row_index in sorted(attempts_by_row)
+                if attempts_by_row[row_index] >= k
+            ]
+            if eligible:
+                points.append({"k": k, "value": statistics.fmean(eligible)})
+        if len(points) >= 2:
+            summary["pass_at_k"] = points
+    return summary
+
+
+# --------------------------------------------------------------------------- #
+# Projections
+# --------------------------------------------------------------------------- #
+
+
+def projection_stem(row_index: int, run_index: int) -> str:
+    return f"row_{row_index}_run_{run_index}"
+
+
+def safe_artifact_relative_paths(artifacts_dir: Path) -> list[Path]:
+    """Enumerate copyable artifact paths, refusing anything unsafe.
+
+    ``rollout_trials/<id>/artifacts/**`` is the one tree the platform renders
+    wholesale, so a symlink or traversal here would exfiltrate host files into a
+    user-visible projection and, later, into an upload.
+    """
+    if not artifacts_dir.is_dir():
+        return []
+    resolved_root = artifacts_dir.resolve()
+    selected: list[Path] = []
+    for candidate in sorted(artifacts_dir.rglob("*")):
+        relative = candidate.relative_to(artifacts_dir)
+        if candidate.is_symlink():
+            raise ArtifactProjectionError(
+                f"refusing to project artifact symlink {candidate}"
+            )
+        if not candidate.is_file():
+            continue
+        if any(part in ("", ".", "..") for part in relative.parts):
+            raise ArtifactProjectionError(f"unsafe artifact path {relative}")
+        if len(relative.parts) == 1 and relative.name == _RESERVED_ARTIFACT_MANIFEST:
+            # Reserved server-side index name; excluded on both sides (§2.6).
+            continue
+        if not candidate.resolve().is_relative_to(resolved_root):
+            raise ArtifactProjectionError(
+                f"artifact path {relative} escapes the artifact root"
+            )
+        selected.append(relative)
+    return selected
+
+
+def copy_projection_file(source: Path, destination: Path) -> None:
+    """Copy bytes into the user projection, never linking to the upload source.
+
+    Editing ``trajectories/row_*`` must not mutate
+    ``rollout_trials/<id>/trajectory.json``, so this is always an independent
+    copy written through the atomic helper.
+    """
+    atomic_write_bytes(destination, source.read_bytes())
+
+
+# --------------------------------------------------------------------------- #
+# Snapshot writer
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class RunIdentity:
+    """The ``eval_run`` block of ``metrics.json``: layer-2 display only."""
+
+    local_run_id: str
+    run_name: str
+    dataset_name: str
+    model_name: str
+    rollout_name: str
+    started_at: str
+    status: str = "running"
+    completed_at: str | None = None
+    duration_ms: float = 0.0
+
+    def to_payload(self) -> dict[str, Any]:
+        return drop_none_values(
+            {
+                "id": self.local_run_id,
+                "status": self.status,
+                "name": self.run_name,
+                "dataset_name": self.dataset_name,
+                "model_name": self.model_name,
+                "rollout_name": self.rollout_name,
+                "duration_ms": self.duration_ms,
+                "started_at": self.started_at,
+                "completed_at": self.completed_at,
+            }
+        )
+
+
+@dataclass(frozen=True)
+class SelectedAttempt:
+    """One work item's selected terminal attempt, with its trajectory verdict."""
+
+    record: TerminalRecord
+    resumed: bool
+    trajectory_filename: str | None
+
+
+def select_attempts(
+    latest: Mapping[WorkKey, TerminalRecord],
+    *,
+    trials_dir: Path,
+    resumed_keys: Iterable[WorkKey] = (),
+) -> list[SelectedAttempt]:
+    """Bind each work item's terminal record to a verified trajectory, if any.
+
+    Re-checked against the filesystem on every refresh, so a trajectory written
+    just before a crash is picked up on restart with no extra state event
+    (§11.3).
+    """
+    resumed = set(resumed_keys)
+    selected: list[SelectedAttempt] = []
+    for key in sorted(latest):
+        record = latest[key]
+        trajectory_path = trials_dir / record.rollout_id / CANONICAL_TRAJECTORY_FILENAME
+        document = read_valid_trajectory(trajectory_path, rollout_id=record.rollout_id)
+        selected.append(
+            SelectedAttempt(
+                record=record,
+                resumed=key in resumed,
+                trajectory_filename=(
+                    CANONICAL_TRAJECTORY_FILENAME if document is not None else None
+                ),
+            )
+        )
+    return selected
+
+
+class Materializer:
+    """Writes every projection for one run directory.
+
+    Snapshots are refreshed while the run is live, so partial output must always
+    be readable: every file goes through the atomic write helper.
+    """
+
+    def __init__(self, run_dir: Path) -> None:
+        self._run_dir = run_dir
+
+    @property
+    def trials_dir(self) -> Path:
+        return self._run_dir / TRIALS_DIRNAME
+
+    def refresh(
+        self,
+        attempts: Sequence[SelectedAttempt],
+        *,
+        identity: RunIdentity,
+        pass_threshold: float,
+        sampled_rows: int,
+        total_dataset_rows: int,
+        total_runs: int,
+    ) -> list[dict[str, Any]]:
+        """Rewrite index, progress, summary, metrics, and both projections."""
+        rows = [
+            build_index_row(
+                attempt.record,
+                trajectory_filename=attempt.trajectory_filename,
+                resumed=attempt.resumed,
+            )
+            for attempt in attempts
+        ]
+        payload = render_index_lines(rows)
+        atomic_write_bytes(self._run_dir / INDEX_FILENAME, payload)
+        # summary.jsonl is index.jsonl verbatim, not a second schema (§2.4).
+        atomic_write_bytes(self._run_dir / SUMMARY_FILENAME, payload)
+        atomic_write_json(
+            self._run_dir / PROGRESS_FILENAME,
+            {
+                "total_runs": total_runs,
+                "sampled_rows": sampled_rows,
+                "total_dataset_rows": total_dataset_rows,
+            },
+        )
+        atomic_write_json(
+            self._run_dir / METRICS_FILENAME,
+            {
+                "eval_run": identity.to_payload(),
+                "summary": aggregate_metrics(rows, pass_threshold=pass_threshold),
+            },
+        )
+        for attempt in attempts:
+            self.project_attempt(attempt)
+        return rows
+
+    def project_attempt(self, attempt: SelectedAttempt) -> None:
+        """Copy the selected attempt's trajectory and artifacts to top level."""
+        record = attempt.record
+        stem = projection_stem(record.row_index, record.run_index)
+        rollout_dir = self.trials_dir / record.rollout_id
+        if attempt.trajectory_filename is not None:
+            copy_projection_file(
+                rollout_dir / attempt.trajectory_filename,
+                self._run_dir / TRAJECTORIES_DIRNAME / f"{stem}.json",
+            )
+        artifacts_dir = rollout_dir / ARTIFACTS_DIRNAME
+        for relative in safe_artifact_relative_paths(artifacts_dir):
+            copy_projection_file(
+                artifacts_dir / relative,
+                self._run_dir / ARTIFACTS_DIRNAME / stem / relative,
+            )

--- a/osmosis_ai/eval/local/results.py
+++ b/osmosis_ai/eval/local/results.py
@@ -427,11 +427,10 @@ class SelectedAttempt:
 
 
 def atif_total_tokens(document: Mapping[str, Any]) -> int | None:
-    """Token total from an ATIF document's ``final_metrics`` (§7.2 fallback).
+    """Token total from an ATIF document's ``final_metrics`` (§7.2).
 
-    Used when the eval-proxy usage API gave nothing: its path is explicitly not
-    frozen, and a run whose tokens all read zero is worse than one that reads
-    them out of the trajectory the platform already trusts.
+    The trajectory is where a local run reads its tokens: totals the platform
+    already trusts, out of a file that is written anyway.
     """
     metrics = document.get("final_metrics")
     if not isinstance(metrics, Mapping):

--- a/osmosis_ai/eval/local/runner.py
+++ b/osmosis_ai/eval/local/runner.py
@@ -71,15 +71,15 @@ from osmosis_ai.eval.local.state import (
     utc_now,
     validate_run_name,
 )
+from osmosis_ai.rollout.backend.harbor.diagnostics import REDACTED
 from osmosis_ai.rollout.controller import (
     CallbackListener,
     CallbackStore,
     EvalProxyClient,
-    EvalProxyError,
     TerminalCallbackResult,
 )
 from osmosis_ai.rollout.driver import RolloutOutcome, RolloutRunRequest
-from osmosis_ai.rollout.http_driver import HttpRolloutDriver
+from osmosis_ai.rollout.http_driver import HttpRolloutDriver, RolloutProtocolError
 from osmosis_ai.rollout.types.protocol import GraderStatus
 from osmosis_ai.rollout.types.sample import RolloutStatus
 from osmosis_ai.source_scan import reject_directory_symlinks, source_digest
@@ -97,6 +97,8 @@ _TRAJECTORY_POLL_INTERVAL_SEC = 0.2
 _USAGE_TIMEOUT_SEC = 5.0
 _SNAPSHOT_COALESCE_SEC = 1.0
 _CALLBACK_NETWORK_GRACE_SEC = 60.0
+# Floor for the per-item supervisor deadline when the config sets no timeouts.
+_DEFAULT_ITEM_DEADLINE_SEC = 3600.0
 
 #: Supervisor-owned subprocess variables a config must never set (§8).
 RESERVED_ENV_NAMES: frozenset[str] = frozenset(
@@ -319,6 +321,34 @@ def format_input_diff(diffs: Sequence[InputDiff]) -> str:
 # --------------------------------------------------------------------------- #
 
 
+class SecretRedactor:
+    """Replaces known secret values in text bound for the run log (§7.4).
+
+    Substring replacement rather than dropping the whole line: a redacted line
+    still carries its stack frame or status code, which is the reason the line
+    exists. Short values are ignored -- ``dummy`` and friends are placeholders,
+    and redacting them would blank unrelated text.
+    """
+
+    _MIN_LENGTH = 8
+
+    def __init__(self, values: Sequence[str] = ()) -> None:
+        self._values: list[str] = []
+        self.extend(values)
+
+    def extend(self, values: Sequence[str]) -> None:
+        for value in values:
+            if value and len(value) >= self._MIN_LENGTH and value not in self._values:
+                self._values.append(value)
+        # Longest first, so a value containing another is redacted whole.
+        self._values.sort(key=len, reverse=True)
+
+    def scrub(self, text: str) -> str:
+        for value in self._values:
+            text = text.replace(value, REDACTED)
+        return text
+
+
 class RunLog:
     """Appends download-format lines to the run's combined ``logs.txt`` (§2.4).
 
@@ -328,11 +358,19 @@ class RunLog:
     """
 
     def __init__(
-        self, path: Path, *, echo: Callable[[str], None] | None = None
+        self,
+        path: Path,
+        *,
+        echo: Callable[[str], None] | None = None,
+        redact: Callable[[str], str] | None = None,
     ) -> None:
         self._path = path
         self._echo = echo
+        self._redact = redact
         path.parent.mkdir(parents=True, exist_ok=True)
+        # The log carries rollout-server output, so it gets the same owner-only
+        # mode as the journal even though redaction should keep it clean.
+        path.touch(mode=0o600, exist_ok=True)
         self._handle = path.open("a", encoding="utf-8")
 
     def write(self, level: str, step: str, message: str, **details: Any) -> None:
@@ -341,6 +379,8 @@ class RunLog:
             from osmosis_ai.eval.local.state import canonical_json
 
             line = f"{line} {canonical_json(details)}"
+        if self._redact is not None:
+            line = self._redact(line)
         self._handle.write(line + "\n")
         self._handle.flush()
         if self._echo is not None:
@@ -503,8 +543,10 @@ class LocalEvalRunner:
         self._child: asyncio.subprocess.Process | None = None
         self._child_reader: asyncio.Task[None] | None = None
         self._cancelled = asyncio.Event()
-        self._breaker_reason: str | None = None
+        self._halt_reason: str | None = None
+        self._redactor = SecretRedactor()
         self._snapshot_dirty = asyncio.Event()
+        self._pending_projection: set[WorkKey] = set()
         self._snapshot_task: asyncio.Task[None] | None = None
         self._started_at = utc_now()
         self._started_monotonic = time.monotonic()
@@ -566,9 +608,11 @@ class LocalEvalRunner:
                 lock.clear_child()
 
         manifest = self._open_or_create_run(run_dir, inputs=inputs, run_name=run_name)
+        self._redactor.extend([self._proxy_auth_token])
         self._log = RunLog(
             run_dir / LOGS_FILENAME,
             echo=self._hooks.note if self._options.verbose else None,
+            redact=self._redactor.scrub,
         )
         self._local_run_id = manifest.local_run_id
         self._identity = RunIdentity(
@@ -582,31 +626,31 @@ class LocalEvalRunner:
         self._materializer = Materializer(run_dir)
 
         journal = TerminalJournal(run_dir / JOURNAL_FILENAME)
-        replay = journal.replay()
-        if replay.truncated_bytes:
-            self._write_log(
-                "warning",
-                "resume",
-                "discarded a partial trailing journal record",
-                bytes=replay.truncated_bytes,
-            )
-        journal.open_for_append(replay)
-        self._journal = journal
-        self._latest = replay.latest
-        self._resumed_keys = set(self._latest)
-
-        pending = self._pending_work_items()
-        self._refresh_snapshots()
-        if not pending:
-            self._write_log("info", "resume", "no pending work items; finalizing")
-            return self._finalize(cancelled=False)
-
-        self._hooks.confirm_dispatch(
-            pending=len(pending), model_path=self._spec.model_path
-        )
-        secrets = self._hooks.resolve_secrets(list(self._spec.secret_names))
-
         try:
+            replay = journal.replay()
+            if replay.truncated_bytes:
+                self._write_log(
+                    "warning",
+                    "resume",
+                    "discarded a partial trailing journal record",
+                    bytes=replay.truncated_bytes,
+                )
+            journal.open_for_append(replay)
+            self._journal = journal
+            self._latest = replay.latest
+            self._resumed_keys = set(self._latest)
+
+            pending = self._pending_work_items()
+            self._refresh_snapshots(project_all=True)
+            if not pending:
+                self._write_log("info", "resume", "no pending work items; finalizing")
+                return self._finalize(cancelled=False)
+
+            self._hooks.confirm_dispatch(
+                pending=len(pending), model_path=self._spec.model_path
+            )
+            secrets = self._hooks.resolve_secrets(list(self._spec.secret_names))
+            self._redactor.extend(list(secrets.values()))
             return await self._execute(pending, secrets=secrets, lock=lock)
         finally:
             journal.close()
@@ -672,6 +716,7 @@ class LocalEvalRunner:
     ) -> RunSummary:
         assert self._run_dir is not None
         controller_token = uuid.uuid4().hex
+        self._redactor.extend([controller_token])
         store = CallbackStore(on_terminal_commit=self._commit_terminal)
         self._store = store
         self._seed_store_from_journal(store)
@@ -737,52 +782,56 @@ class LocalEvalRunner:
             await self._proxy.create_session(
                 rollout_id=probe_id, model_path=self._spec.model_path
             )
-        except EvalProxyError as exc:
+        except Exception as exc:
+            # Transport failures reach here too: EvalProxyClient only wraps HTTP
+            # status and decode errors, and an unreachable proxy must still read
+            # as a preflight failure rather than a traceback.
             raise LocalEvalError(
                 f"eval-proxy preflight failed for model "
-                f"{self._spec.model_path!r}: {exc}. Pass --skip-llm-preflight to "
-                "dispatch anyway."
+                f"{self._spec.model_path!r}: {type(exc).__name__}: {exc}. Pass "
+                "--skip-llm-preflight to dispatch anyway."
             ) from exc
         finally:
             with contextlib.suppress(Exception):
                 await self._proxy.close_session(probe_id)
         self._write_log("info", "preflight", "eval-proxy session check passed")
 
-    def _trip_breaker(self, exc: EvalProxyError) -> bool:
-        """Stop new dispatch on a definitive eval-proxy error (§10).
+    def _halt_dispatch(self, reason: str, **details: Any) -> None:
+        """Stop new dispatch without stamping the remaining queue failed (§9.3).
 
-        Deliberately narrow: only auth, model-not-found, and budget are
-        definitive. Generic error clustering waits until real runs justify it.
-        Remaining work items are left pending rather than stamped failed, so a
-        later invocation resumes them once the cause is fixed.
+        A process-wide fault -- proxy auth, a dead rollout server, a network
+        outage -- says nothing about the work items that have not run. Leaving
+        them with no terminal record keeps them pending, so a later invocation
+        resumes them once the cause is fixed. Stamping them ``failed`` would
+        instead make a plain resume skip work that never executed.
         """
-        if exc.status_code not in (401, 402, 403, 404):
-            return False
-        if self._breaker_reason is None:
-            self._breaker_reason = str(exc)
-            self._write_log(
-                "error",
-                "breaker",
-                "pausing dispatch on a definitive eval-proxy error",
-                status_code=exc.status_code,
-            )
-            self._hooks.note(f"eval-proxy rejected the run, stopping dispatch: {exc}")
-        return True
+        if self._halt_reason is not None:
+            return
+        self._halt_reason = reason
+        self._write_log(
+            "error", "dispatch", "halting dispatch", reason=reason, **details
+        )
+        self._hooks.note(f"stopping dispatch: {reason}")
 
     def _seed_store_from_journal(self, store: CallbackStore) -> None:
         """Dedupe needs no callback table: seed finalized ids from replay (§9.3)."""
         for record in self._latest.values():
             store.seed_terminal(record.rollout_id, acknowledgment={"ok": True})
 
-    def _callback_deadline(self) -> float | None:
-        """Supervisor deadline = server timeout + callback/network grace (§10)."""
+    def _callback_deadline(self) -> float:
+        """Supervisor deadline = server timeout + callback/network grace (§10).
+
+        Timeouts are optional in the config, but an unbounded wait is not an
+        option: a lost callback would hang every worker forever with no output.
+        With nothing configured, fall back to a generous floor.
+        """
         server_budget = sum(
             value
             for value in (self._spec.agent_timeout_sec, self._spec.grader_timeout_sec)
             if value is not None
         )
         if server_budget <= 0:
-            return None
+            return _DEFAULT_ITEM_DEADLINE_SEC
         return server_budget + _CALLBACK_NETWORK_GRACE_SEC
 
     async def _resolve_concurrency(
@@ -819,13 +868,37 @@ class LocalEvalRunner:
             with contextlib.suppress(NotImplementedError, ValueError):
                 loop.add_signal_handler(sig, self._request_cancel, workers)
                 installed.append(sig)
+        watchdog = asyncio.create_task(self._watch_child(workers))
         try:
             await asyncio.gather(*workers, return_exceptions=True)
         finally:
+            watchdog.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await watchdog
             for sig in installed:
                 with contextlib.suppress(NotImplementedError, ValueError):
                     loop.remove_signal_handler(sig)
-        return self._cancelled.is_set()
+        return self._cancelled.is_set() or self._halt_reason is not None
+
+    async def _watch_child(self, workers: Sequence[asyncio.Task[None]]) -> None:
+        """Abort in-flight waits when the rollout server dies (§10 deadline).
+
+        Without this, every worker sits on a callback that can no longer arrive
+        until its deadline expires -- minutes of silence per item, and each one
+        then looks like a per-item timeout rather than one dead server.
+        """
+        child = self._child
+        if child is None:
+            return
+        returncode = await child.wait()
+        if self._cancelled.is_set() or self._halt_reason is not None:
+            return
+        self._halt_dispatch(
+            f"the rollout server exited with code {returncode}; see {LOGS_FILENAME}",
+            returncode=returncode,
+        )
+        for worker in workers:
+            worker.cancel()
 
     def _request_cancel(self, workers: Sequence[asyncio.Task[None]]) -> None:
         """First interrupt: stop dispatch and cancel in-flight work (§8).
@@ -848,7 +921,7 @@ class LocalEvalRunner:
     async def _worker(
         self, queue: asyncio.Queue[WorkItem], driver: HttpRolloutDriver
     ) -> None:
-        while not self._cancelled.is_set() and self._breaker_reason is None:
+        while not self._cancelled.is_set() and self._halt_reason is None:
             try:
                 item = queue.get_nowait()
             except asyncio.QueueEmpty:
@@ -857,14 +930,23 @@ class LocalEvalRunner:
                 await self._run_work_item(item, driver)
             except asyncio.CancelledError:
                 raise
-            except EvalProxyError as exc:
-                # A definitive proxy error stops dispatch and leaves the rest of
-                # the queue pending; anything else is this item's own failure.
-                if self._trip_breaker(exc):
-                    return
+            except RolloutProtocolError as exc:
+                # The rollout server actively refused *this* request with a
+                # non-202/429 status, so the failure is attributable to the work
+                # item and gets a terminal record.
                 await self._journal_supervisor_failure(item, exc)
             except Exception as exc:
-                await self._journal_supervisor_failure(item, exc)
+                # Everything else -- proxy errors, transport failures, an
+                # indeterminate admission, a supervisor bug -- is process-wide as
+                # far as this item is concerned. Halt dispatch and leave it
+                # pending rather than durably recording a failure that says
+                # nothing about the row (§9.3).
+                self._halt_dispatch(
+                    f"{type(exc).__name__}: {exc}",
+                    row_index=item.row.row_index,
+                    run_index=item.run_index,
+                )
+                return
 
     async def _run_work_item(self, item: WorkItem, driver: HttpRolloutDriver) -> None:
         rollout_id = uuid.uuid4().hex
@@ -902,7 +984,7 @@ class LocalEvalRunner:
             )
             return
         await self._await_trajectory(rollout_id)
-        self._mark_snapshot_dirty()
+        self._mark_snapshot_dirty(item.key)
         self._report_progress()
         self._forget(rollout_id)
         self._log_outcome(item, rollout_id, outcome)
@@ -937,10 +1019,14 @@ class LocalEvalRunner:
         """
         item = self._dispatch_context.get(result.rollout_id)
         if item is None:
-            logger.warning(
-                "terminal callback for unknown rollout %s", result.rollout_id
+            # Returning here would let the store ack a callback with nothing
+            # journaled, breaking "HTTP 200 on the grader callback means the
+            # result is durable". Raising makes the listener 500 and leaves the
+            # terminal slot open, so the work item simply stays pending.
+            raise LocalEvalError(
+                f"terminal callback for rollout {result.rollout_id} has no "
+                "dispatch context; refusing to acknowledge it"
             )
-            return None
         status, reward, error_type = _classify_terminal(result)
         tokens = await self._session_tokens(result.rollout_id)
         record = TerminalRecord(
@@ -962,6 +1048,9 @@ class LocalEvalRunner:
         assert self._journal is not None
         await self._journal.append(record)
         self._latest[record.key] = record
+        # This result was produced now, so it is no longer a carried-forward one:
+        # `resumed` is the platform's carry-forward flag, not "the run resumed".
+        self._resumed_keys.discard(record.key)
 
     async def _journal_supervisor_failure(
         self, item: WorkItem, exc: BaseException
@@ -1000,7 +1089,7 @@ class LocalEvalRunner:
             )
         )
         self._forget(rollout_id)
-        self._mark_snapshot_dirty()
+        self._mark_snapshot_dirty(item.key)
         self._report_progress()
 
     async def _session_tokens(self, rollout_id: str) -> int | None:
@@ -1175,6 +1264,8 @@ class LocalEvalRunner:
                 raise
             if not raw:
                 return
+            # RunLog redacts every line it writes, so a secret echoed by the
+            # workflow or an HTTP debug log never lands in logs.txt (§7.4).
             self._write_log(
                 "info", "rollout-server", raw.decode(errors="replace").rstrip()
             )
@@ -1205,7 +1296,9 @@ class LocalEvalRunner:
     # Snapshots and finalization
     # ------------------------------------------------------------------ #
 
-    def _mark_snapshot_dirty(self) -> None:
+    def _mark_snapshot_dirty(self, key: WorkKey | None = None) -> None:
+        if key is not None:
+            self._pending_projection.add(key)
         self._snapshot_dirty.set()
 
     async def _snapshot_loop(self) -> None:
@@ -1217,13 +1310,21 @@ class LocalEvalRunner:
                 self._refresh_snapshots()
             await asyncio.sleep(_SNAPSHOT_COALESCE_SEC)
 
-    def _refresh_snapshots(self) -> list[dict[str, Any]]:
+    def _refresh_snapshots(self, *, project_all: bool = False) -> list[dict[str, Any]]:
+        """Rewrite snapshots; copy file projections only for changed work items.
+
+        Snapshots are small and always rewritten whole so partial output stays
+        readable. File copies are not: projecting every attempt on every refresh
+        is quadratic in the row count.
+        """
         assert self._materializer is not None and self._identity is not None
         attempts = select_attempts(
             self._latest,
             trials_dir=self._materializer.trials_dir,
             resumed_keys=self._resumed_keys,
         )
+        project_keys = None if project_all else set(self._pending_projection)
+        self._pending_projection.clear()
         return self._materializer.refresh(
             attempts,
             identity=self._identity,
@@ -1231,6 +1332,7 @@ class LocalEvalRunner:
             sampled_rows=len(self._selection.rows),
             total_dataset_rows=self._selection.total_dataset_rows,
             total_runs=len(self._selection.rows) * max(1, self._spec.n),
+            project_keys=project_keys,
         )
 
     def _report_progress(self) -> None:
@@ -1270,7 +1372,7 @@ class LocalEvalRunner:
             duration_ms=duration_ms,
         )
         self._identity = identity
-        rows = self._refresh_snapshots()
+        rows = self._refresh_snapshots(project_all=True)
         statuses = [record.status for record in self._latest.values()]
         return RunSummary(
             run_dir=run_dir,
@@ -1365,13 +1467,6 @@ def _classify_terminal(
 
 
 def _error_type_for(exc: BaseException) -> str:
-    from osmosis_ai.rollout.http_driver import (
-        AdmissionUncertainError,
-        RolloutProtocolError,
-    )
-
-    if isinstance(exc, AdmissionUncertainError):
-        return "admission_uncertain"
     if isinstance(exc, RolloutProtocolError):
         return "rollout_protocol_error"
     return "supervisor_error"

--- a/osmosis_ai/eval/local/runner.py
+++ b/osmosis_ai/eval/local/runner.py
@@ -1,0 +1,1377 @@
+"""The local evaluation supervisor.
+
+Owns run state and resume, the rollout-server subprocess, bounded row x run
+scheduling, cancellation, and result materialization (design
+``local-eval-run-plan.md`` §3.1). It hosts no LLM code: chat traffic goes to the
+hosted eval-proxy, and only a localhost callback listener stays local.
+
+The one ordering invariant everything else serves: a terminal callback is
+acknowledged **only after** its journal record is fully written and ``fsync``-ed,
+so a durably acknowledged work item never runs again after ``kill -9``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import errno
+import logging
+import os
+import signal
+import socket
+import sys
+import time
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+import httpx
+
+from osmosis_ai.consts import PACKAGE_VERSION
+from osmosis_ai.eval.local.dataset import (
+    EvalDatasetRow,
+    ResolvedDataset,
+    RowSelection,
+    format_row_selector,
+)
+from osmosis_ai.eval.local.results import (
+    CANONICAL_TRAJECTORY_FILENAME,
+    TRIALS_DIRNAME,
+    Materializer,
+    RunIdentity,
+    aggregate_metrics,
+    read_valid_trajectory,
+    select_attempts,
+)
+from osmosis_ai.eval.local.state import (
+    DATASET_NORMALIZATION_VERSION,
+    JOURNAL_FILENAME,
+    LOCAL_ARTIFACT_SCHEMA_VERSION,
+    LOCAL_STATE_SCHEMA_VERSION,
+    LOCKS_DIRNAME,
+    MANIFEST_FILENAME,
+    ROLLOUT_PROTOCOL_VERSION,
+    ChildProcessRecord,
+    InputDiff,
+    LocalEvalStateError,
+    OrphanChildError,
+    RunLock,
+    RunManifest,
+    TerminalJournal,
+    TerminalRecord,
+    TerminalStatus,
+    WorkKey,
+    archive_run_directory,
+    diff_inputs,
+    digest_of,
+    process_is_alive,
+    terminate_process_group,
+    utc_now,
+    validate_run_name,
+)
+from osmosis_ai.rollout.controller import (
+    CallbackListener,
+    CallbackStore,
+    EvalProxyClient,
+    EvalProxyError,
+    TerminalCallbackResult,
+)
+from osmosis_ai.rollout.driver import RolloutOutcome, RolloutRunRequest
+from osmosis_ai.rollout.http_driver import HttpRolloutDriver
+from osmosis_ai.rollout.types.protocol import GraderStatus
+from osmosis_ai.rollout.types.sample import RolloutStatus
+from osmosis_ai.source_scan import reject_directory_symlinks, source_digest
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+LOGS_FILENAME = "logs.txt"
+
+_HEALTH_TIMEOUT_SEC = 90.0
+_HEALTH_POLL_INTERVAL_SEC = 0.2
+_PORT_ATTEMPTS = 5
+_SERVER_TERM_GRACE_SEC = 5.0
+_TRAJECTORY_GRACE_SEC = 30.0
+_TRAJECTORY_POLL_INTERVAL_SEC = 0.2
+_USAGE_TIMEOUT_SEC = 5.0
+_SNAPSHOT_COALESCE_SEC = 1.0
+_CALLBACK_NETWORK_GRACE_SEC = 60.0
+
+#: Supervisor-owned subprocess variables a config must never set (§8).
+RESERVED_ENV_NAMES: frozenset[str] = frozenset(
+    {
+        "_OSMOSIS_ROLLOUT_PORT",
+        "_OSMOSIS_ROLLOUT_ARTIFACT_ROOT",
+        "_OSMOSIS_ROLLOUT_INSTANCE_ID",
+    }
+)
+
+
+class LocalEvalError(RuntimeError):
+    """The local run cannot proceed."""
+
+
+class ResumeRefusedError(LocalEvalError):
+    """A named run's resolved inputs changed, so resuming would mix versions."""
+
+    def __init__(self, message: str, *, diffs: Sequence[InputDiff]) -> None:
+        super().__init__(message)
+        self.diffs = list(diffs)
+
+
+# --------------------------------------------------------------------------- #
+# Inputs
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class EvalRunSpec:
+    """Execution-semantic values read from the shared eval TOML (§5).
+
+    Extracted by the CLI layer so the supervisor never imports config or CLI
+    machinery, and so every field here is one the fingerprint may legitimately
+    depend on.
+    """
+
+    rollout_name: str
+    entrypoint: str
+    model_path: str
+    dataset_name: str
+    n: int = 1
+    batch_size: int | None = None
+    pass_threshold: float = 1.0
+    agent_timeout_sec: float | None = None
+    grader_timeout_sec: float | None = None
+    env: Mapping[str, str] = field(default_factory=dict)
+    secret_names: tuple[str, ...] = ()
+    branch: str | None = None
+    commit_sha: str | None = None
+
+
+@dataclass(frozen=True)
+class LocalEvalOptions:
+    """Runtime-only knobs. All CLI flags -- never a config section (§5)."""
+
+    name: str | None = None
+    output: Path | None = None
+    rows: str | None = None
+    fresh: bool = False
+    retry_failed: bool = False
+    max_in_flight: int | None = None
+    yes: bool = False
+    rollout_port: int | None = None
+    skip_llm_preflight: bool = False
+    verbose: bool = False
+
+
+class RunnerHooks(Protocol):
+    """CLI-facing callbacks, so the supervisor holds no CLI dependencies."""
+
+    def note(self, message: str) -> None:
+        """Surface a human-readable status line."""
+
+    def confirm_dispatch(self, *, pending: int, model_path: str) -> None:
+        """Cost boundary before any rollout is dispatched. Raise to abort."""
+
+    def resolve_secrets(self, names: Sequence[str]) -> dict[str, str]:
+        """Resolve workflow-secret values. Called only when work is pending."""
+        ...
+
+    def progress(self, snapshot: ProgressSnapshot) -> None:
+        """Report live counts for the terminal progress bar."""
+
+
+@dataclass(frozen=True)
+class ProgressSnapshot:
+    completed: int
+    total: int
+    passed: int
+    failed: int
+
+    @property
+    def pass_rate(self) -> float:
+        return (self.passed / self.completed) if self.completed else 0.0
+
+
+@dataclass(frozen=True)
+class WorkItem:
+    """One ``(row_index, run_index)`` work item awaiting a terminal result."""
+
+    row: EvalDatasetRow
+    run_index: int
+
+    @property
+    def key(self) -> WorkKey:
+        return (self.row.row_index, self.run_index)
+
+
+@dataclass
+class FailedWorkItem:
+    """A failed or skipped work item, for the end-of-run report (§4.3)."""
+
+    row_index: int
+    source_row_index: int
+    run_index: int
+    rollout_id: str
+    error_type: str | None
+    rollout_dir: Path
+
+
+@dataclass
+class RunSummary:
+    """What the CLI reports when the supervisor returns."""
+
+    run_dir: Path
+    local_run_id: str
+    run_name: str
+    total_work_items: int
+    dispatched: int
+    succeeded: int
+    failed: int
+    skipped: int
+    resumed: int
+    cancelled: bool
+    metrics: dict[str, Any] = field(default_factory=dict)
+    failures: list[FailedWorkItem] = field(default_factory=list)
+
+
+# --------------------------------------------------------------------------- #
+# Fingerprint
+# --------------------------------------------------------------------------- #
+
+
+def compute_source_digest(project_dir: Path, *, exclude: Path | None = None) -> str:
+    """Full SHA-256 of the rollout project's source bytes (§5).
+
+    Shares the packager's traversal, so the bundle cache and the resume lock can
+    never disagree about which files describe the project. *exclude* keeps a run
+    output directory nested inside the project from changing its own digest.
+    """
+    reject_directory_symlinks(project_dir, exclude=exclude, label="rollout source")
+    return source_digest(project_dir, exclude=exclude)
+
+
+def build_run_inputs(
+    spec: EvalRunSpec,
+    *,
+    dataset: ResolvedDataset,
+    selection: RowSelection,
+    rollout_source_digest: str,
+) -> dict[str, Any]:
+    """The resolved-input lock: only execution-semantic inputs (§9.5).
+
+    Deliberately excluded so an unrelated change never refuses a resume: run
+    name, output path, throughput knobs (``--max-in-flight``,
+    ``evaluation.batch_size``), UI flags, SDK version, branch display name, and
+    timestamps. Secret *names* are included; values never are.
+    """
+    return {
+        "model_path": spec.model_path,
+        "dataset": {
+            "sha256": dataset.sha256,
+            "selected_source_rows": format_row_selector(selection.source_row_indices),
+        },
+        "n": spec.n,
+        "rollout": {
+            "name": spec.rollout_name,
+            "entrypoint": spec.entrypoint,
+            "source_digest": rollout_source_digest,
+        },
+        "env": dict(sorted(spec.env.items())),
+        "secret_names": sorted(spec.secret_names),
+        "timeouts": {
+            "agent_timeout_sec": spec.agent_timeout_sec,
+            "grader_timeout_sec": spec.grader_timeout_sec,
+        },
+        "pass_threshold": spec.pass_threshold,
+        "versions": {
+            "rollout_protocol": ROLLOUT_PROTOCOL_VERSION,
+            "dataset_normalization": DATASET_NORMALIZATION_VERSION,
+            "state_schema": LOCAL_STATE_SCHEMA_VERSION,
+            "artifact_schema": LOCAL_ARTIFACT_SCHEMA_VERSION,
+        },
+    }
+
+
+def generated_run_name(
+    config_stem: str, inputs_digest: str, *, now: str | None = None
+) -> str:
+    """``<config-stem>-<timestamp>-<short-fingerprint>`` for an unnamed run (§4.4)."""
+    stamp = now or time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    safe_stem = (
+        "".join(
+            char if char.isalnum() or char in "._-" else "-" for char in config_stem
+        ).strip("-._")
+        or "eval"
+    )
+    return validate_run_name(f"{safe_stem}-{stamp}-{inputs_digest[:8]}")
+
+
+def format_input_diff(diffs: Sequence[InputDiff]) -> str:
+    return "\n".join(
+        f"  - {diff.field}: {diff.previous!r} -> {diff.current!r}" for diff in diffs
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Run log
+# --------------------------------------------------------------------------- #
+
+
+class RunLog:
+    """Appends download-format lines to the run's combined ``logs.txt`` (§2.4).
+
+    Format: ``<ISO> <LEVEL> [<step>] <message> <json details>`` -- shape
+    compatible with what ``eval download`` synthesizes from ``eval_run_log``
+    rows, so a local run and a downloaded run read the same way.
+    """
+
+    def __init__(
+        self, path: Path, *, echo: Callable[[str], None] | None = None
+    ) -> None:
+        self._path = path
+        self._echo = echo
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = path.open("a", encoding="utf-8")
+
+    def write(self, level: str, step: str, message: str, **details: Any) -> None:
+        line = f"{utc_now()} {level.upper()} [{step}] {message}"
+        if details:
+            from osmosis_ai.eval.local.state import canonical_json
+
+            line = f"{line} {canonical_json(details)}"
+        self._handle.write(line + "\n")
+        self._handle.flush()
+        if self._echo is not None:
+            self._echo(line)
+
+    def close(self) -> None:
+        with contextlib.suppress(Exception):
+            self._handle.close()
+
+
+# --------------------------------------------------------------------------- #
+# Rollout-server subprocess
+# --------------------------------------------------------------------------- #
+
+
+def reserve_free_port() -> int:
+    """Pick a free localhost port.
+
+    Inherently racy -- the rollout server binds it in another process -- so the
+    caller must retry startup on a bind failure rather than trust this (§20.3).
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def build_subprocess_env(
+    *,
+    base: Mapping[str, str],
+    config_env: Mapping[str, str],
+    secrets: Mapping[str, str],
+    port: int,
+    artifact_root: Path,
+    instance_id: str,
+) -> dict[str, str]:
+    """Compose the rollout-server child environment, internals applied last (§8).
+
+    A config must not redirect artifacts, spoof the instance id, or change the
+    selected port, so colliding ``[env]``/``[secrets]`` names are refused rather
+    than silently overridden.
+    """
+    collisions = sorted((set(config_env) | set(secrets)) & RESERVED_ENV_NAMES)
+    if collisions:
+        raise LocalEvalError(
+            "[env]/[secrets] must not set supervisor-owned variables: "
+            + ", ".join(collisions)
+        )
+    env = dict(base)
+    env.update(config_env)
+    env.update(secrets)
+    env.update(
+        {
+            "_OSMOSIS_ROLLOUT_PORT": str(port),
+            "_OSMOSIS_ROLLOUT_ARTIFACT_ROOT": str(artifact_root),
+            "_OSMOSIS_ROLLOUT_INSTANCE_ID": instance_id,
+            "PYTHONUNBUFFERED": "1",
+        }
+    )
+    return env
+
+
+async def probe_health(
+    client: httpx.AsyncClient, base_url: str
+) -> dict[str, Any] | None:
+    """Return ``/health`` when reachable, else ``None``."""
+    try:
+        response = await client.get(f"{base_url}/health", timeout=5.0)
+    except httpx.HTTPError:
+        return None
+    if response.status_code >= 400:
+        return None
+    try:
+        payload = response.json()
+    except ValueError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+async def reap_verified_orphan(
+    record: ChildProcessRecord, *, client: httpx.AsyncClient, log: Callable[..., None]
+) -> None:
+    """Kill a rollout-server child left behind by a ``kill -9``ed supervisor (§8).
+
+    Ownership must be *verified* through the health instance id: a bare pid can
+    have been reused by an unrelated process, and killing that would be far
+    worse than leaking one server. When the pid is live but unverifiable, refuse
+    with a cleanup instruction instead of guessing.
+    """
+    if not process_is_alive(record.child_pid):
+        log("info", "orphan", "clearing a stale rollout-server record")
+        return
+    health = await probe_health(client, f"http://127.0.0.1:{record.port}")
+    if health is not None and health.get("instance_id") == record.instance_id:
+        log(
+            "warning",
+            "orphan",
+            "terminating a verified orphan rollout server",
+            pid=record.child_pid,
+            port=record.port,
+        )
+        await asyncio.to_thread(
+            terminate_process_group, record.child_pgid, grace_sec=_SERVER_TERM_GRACE_SEC
+        )
+        return
+    raise OrphanChildError(
+        f"a process with pid {record.child_pid} from a previous run of this eval "
+        f"is still alive, but its identity could not be verified on port "
+        f"{record.port}. It may be an unrelated process that reused the pid. "
+        f"Check it and stop it yourself (for example `ps -p {record.child_pid}`), "
+        "then re-run."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Supervisor
+# --------------------------------------------------------------------------- #
+
+
+class LocalEvalRunner:
+    """One local evaluation run, from lock acquisition to final materialization."""
+
+    def __init__(
+        self,
+        *,
+        spec: EvalRunSpec,
+        options: LocalEvalOptions,
+        dataset: ResolvedDataset,
+        selection: RowSelection,
+        rollout_dir: Path,
+        output_root: Path,
+        proxy_base_url: str,
+        proxy_auth_token: str,
+        hooks: RunnerHooks,
+        provenance: Mapping[str, Any] | None = None,
+        config_stem: str = "eval",
+    ) -> None:
+        self._spec = spec
+        self._options = options
+        self._dataset = dataset
+        self._selection = selection
+        self._rollout_dir = rollout_dir
+        self._output_root = output_root
+        self._proxy_base_url = proxy_base_url
+        self._proxy_auth_token = proxy_auth_token
+        self._hooks = hooks
+        self._provenance = dict(provenance or {})
+        self._config_stem = config_stem
+
+        self._run_dir: Path | None = None
+        self._log: RunLog | None = None
+        self._journal: TerminalJournal | None = None
+        self._latest: dict[WorkKey, TerminalRecord] = {}
+        self._resumed_keys: set[WorkKey] = set()
+        self._dispatch_context: dict[str, WorkItem] = {}
+        self._dispatch_started: dict[str, float] = {}
+        self._proxy: EvalProxyClient | None = None
+        self._store: CallbackStore | None = None
+        self._materializer: Materializer | None = None
+        self._identity: RunIdentity | None = None
+        self._child: asyncio.subprocess.Process | None = None
+        self._child_reader: asyncio.Task[None] | None = None
+        self._cancelled = asyncio.Event()
+        self._breaker_reason: str | None = None
+        self._snapshot_dirty = asyncio.Event()
+        self._snapshot_task: asyncio.Task[None] | None = None
+        self._started_at = utc_now()
+        self._started_monotonic = time.monotonic()
+        self._dispatched = 0
+        self._local_run_id = uuid.uuid4().hex
+
+    # ------------------------------------------------------------------ #
+    # Public entry point
+    # ------------------------------------------------------------------ #
+
+    async def run(self) -> RunSummary:
+        """Execute the full startup order from §8, then schedule and finalize."""
+        run_name = self._options.name or generated_run_name(
+            self._config_stem, self._pending_inputs_digest()
+        )
+        validate_run_name(run_name)
+        lock_path = self._output_root / LOCKS_DIRNAME / f"{run_name}.lock"
+        with RunLock(lock_path) as lock:
+            return await self._run_locked(run_name=run_name, lock=lock)
+
+    # ------------------------------------------------------------------ #
+    # Startup
+    # ------------------------------------------------------------------ #
+
+    def _pending_inputs_digest(self) -> str:
+        return digest_of(self._build_inputs())
+
+    def _build_inputs(self) -> dict[str, Any]:
+        return build_run_inputs(
+            self._spec,
+            dataset=self._dataset,
+            selection=self._selection,
+            rollout_source_digest=self._source_digest(),
+        )
+
+    def _source_digest(self) -> str:
+        cached = getattr(self, "_source_digest_value", None)
+        if cached is None:
+            exclude = (
+                self._output_root
+                if self._output_root.is_relative_to(self._rollout_dir)
+                else None
+            )
+            cached = compute_source_digest(self._rollout_dir, exclude=exclude)
+            self._source_digest_value = cached
+        return cached
+
+    async def _run_locked(self, *, run_name: str, lock: RunLock) -> RunSummary:
+        run_dir = self._output_root / run_name
+        self._run_dir = run_dir
+        inputs = self._build_inputs()
+
+        async with httpx.AsyncClient() as probe_client:
+            recorded_child = lock.read_child()
+            if recorded_child is not None:
+                await reap_verified_orphan(
+                    recorded_child, client=probe_client, log=self._write_log_deferred
+                )
+                lock.clear_child()
+
+        manifest = self._open_or_create_run(run_dir, inputs=inputs, run_name=run_name)
+        self._log = RunLog(
+            run_dir / LOGS_FILENAME,
+            echo=self._hooks.note if self._options.verbose else None,
+        )
+        self._local_run_id = manifest.local_run_id
+        self._identity = RunIdentity(
+            local_run_id=manifest.local_run_id,
+            run_name=run_name,
+            dataset_name=self._spec.dataset_name,
+            model_name=self._spec.model_path,
+            rollout_name=self._spec.rollout_name,
+            started_at=self._started_at,
+        )
+        self._materializer = Materializer(run_dir)
+
+        journal = TerminalJournal(run_dir / JOURNAL_FILENAME)
+        replay = journal.replay()
+        if replay.truncated_bytes:
+            self._write_log(
+                "warning",
+                "resume",
+                "discarded a partial trailing journal record",
+                bytes=replay.truncated_bytes,
+            )
+        journal.open_for_append(replay)
+        self._journal = journal
+        self._latest = replay.latest
+        self._resumed_keys = set(self._latest)
+
+        pending = self._pending_work_items()
+        self._refresh_snapshots()
+        if not pending:
+            self._write_log("info", "resume", "no pending work items; finalizing")
+            return self._finalize(cancelled=False)
+
+        self._hooks.confirm_dispatch(
+            pending=len(pending), model_path=self._spec.model_path
+        )
+        secrets = self._hooks.resolve_secrets(list(self._spec.secret_names))
+
+        try:
+            return await self._execute(pending, secrets=secrets, lock=lock)
+        finally:
+            journal.close()
+            if self._log is not None:
+                self._log.close()
+
+    def _open_or_create_run(
+        self, run_dir: Path, *, inputs: Mapping[str, Any], run_name: str
+    ) -> RunManifest:
+        """Compare, archive, or create -- the resolved-input lock gate (§4.4)."""
+        manifest_path = run_dir / MANIFEST_FILENAME
+        if manifest_path.is_file() and self._options.fresh:
+            archived = archive_run_directory(run_dir)
+            self._hooks.note(f"archived previous results to {archived}")
+        elif manifest_path.is_file():
+            existing = RunManifest.read(manifest_path)
+            diffs = diff_inputs(existing.inputs, inputs)
+            if diffs:
+                raise ResumeRefusedError(
+                    f"run {run_name!r} was created with different resolved inputs, "
+                    "so resuming it would mix versions inside one set of metrics:\n"
+                    f"{format_input_diff(diffs)}\n"
+                    f"Restart under the same name with --fresh (the previous "
+                    "results are archived, never deleted).",
+                    diffs=diffs,
+                )
+            return existing
+
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / TRIALS_DIRNAME).mkdir(exist_ok=True)
+        manifest = RunManifest.create(
+            local_run_id=uuid.uuid4().hex,
+            run_name=run_name,
+            inputs=inputs,
+            provenance={"sdk_version": PACKAGE_VERSION, **self._provenance},
+        )
+        manifest.write(manifest_path)
+        return manifest
+
+    def _pending_work_items(self) -> list[WorkItem]:
+        """Work items with no terminal result, plus retries when asked (§9.4)."""
+        pending: list[WorkItem] = []
+        for row in self._selection.rows:
+            for run_index in range(max(1, self._spec.n)):
+                key = (row.row_index, run_index)
+                record = self._latest.get(key)
+                if record is None:
+                    pending.append(WorkItem(row=row, run_index=run_index))
+                    continue
+                if self._options.retry_failed and record.status in (
+                    "failed",
+                    "skipped",
+                ):
+                    pending.append(WorkItem(row=row, run_index=run_index))
+        return pending
+
+    # ------------------------------------------------------------------ #
+    # Execution
+    # ------------------------------------------------------------------ #
+
+    async def _execute(
+        self, pending: Sequence[WorkItem], *, secrets: Mapping[str, str], lock: RunLock
+    ) -> RunSummary:
+        assert self._run_dir is not None
+        controller_token = uuid.uuid4().hex
+        store = CallbackStore(on_terminal_commit=self._commit_terminal)
+        self._store = store
+        self._seed_store_from_journal(store)
+
+        proxy = EvalProxyClient(
+            base_url=self._proxy_base_url, auth_token=self._proxy_auth_token
+        )
+        self._proxy = proxy
+        listener = CallbackListener(store, auth_token=controller_token)
+        self._snapshot_task = asyncio.create_task(self._snapshot_loop())
+        cancelled = False
+        try:
+            await listener.start()
+            self._write_log("info", "listener", "callback listener started")
+            await self._proxy_preflight()
+            async with httpx.AsyncClient() as client:
+                base_url = await self._start_rollout_server(
+                    secrets=secrets, lock=lock, client=client
+                )
+                driver = HttpRolloutDriver(
+                    rollout_base_url=base_url,
+                    callback_store=store,
+                    completion_url_for=listener.completion_url,
+                    grader_url_for=listener.grader_url,
+                    proxy_client=proxy,
+                    controller_api_key=controller_token,
+                    model_path=self._spec.model_path,
+                    http_client=client,
+                    callback_timeout_sec=self._callback_deadline(),
+                )
+                concurrency = await self._resolve_concurrency(client, base_url)
+                self._write_log(
+                    "info",
+                    "schedule",
+                    "scheduling work items",
+                    pending=len(pending),
+                    max_in_flight=concurrency,
+                )
+                cancelled = await self._schedule(pending, driver, concurrency)
+        finally:
+            await self._stop_rollout_server(lock)
+            with contextlib.suppress(Exception):
+                await listener.stop()
+            with contextlib.suppress(Exception):
+                await proxy.aclose()
+            if self._snapshot_task is not None:
+                self._snapshot_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._snapshot_task
+                self._snapshot_task = None
+        return self._finalize(cancelled=cancelled)
+
+    async def _proxy_preflight(self) -> None:
+        """Open and close a throwaway proxy session to catch config errors early.
+
+        Doing this before any dispatch means an unusable model or an expired
+        login fails once, loudly, instead of failing every work item.
+        """
+        if self._options.skip_llm_preflight or self._proxy is None:
+            return
+        probe_id = uuid.uuid4().hex
+        try:
+            await self._proxy.create_session(
+                rollout_id=probe_id, model_path=self._spec.model_path
+            )
+        except EvalProxyError as exc:
+            raise LocalEvalError(
+                f"eval-proxy preflight failed for model "
+                f"{self._spec.model_path!r}: {exc}. Pass --skip-llm-preflight to "
+                "dispatch anyway."
+            ) from exc
+        finally:
+            with contextlib.suppress(Exception):
+                await self._proxy.close_session(probe_id)
+        self._write_log("info", "preflight", "eval-proxy session check passed")
+
+    def _trip_breaker(self, exc: EvalProxyError) -> bool:
+        """Stop new dispatch on a definitive eval-proxy error (§10).
+
+        Deliberately narrow: only auth, model-not-found, and budget are
+        definitive. Generic error clustering waits until real runs justify it.
+        Remaining work items are left pending rather than stamped failed, so a
+        later invocation resumes them once the cause is fixed.
+        """
+        if exc.status_code not in (401, 402, 403, 404):
+            return False
+        if self._breaker_reason is None:
+            self._breaker_reason = str(exc)
+            self._write_log(
+                "error",
+                "breaker",
+                "pausing dispatch on a definitive eval-proxy error",
+                status_code=exc.status_code,
+            )
+            self._hooks.note(f"eval-proxy rejected the run, stopping dispatch: {exc}")
+        return True
+
+    def _seed_store_from_journal(self, store: CallbackStore) -> None:
+        """Dedupe needs no callback table: seed finalized ids from replay (§9.3)."""
+        for record in self._latest.values():
+            store.seed_terminal(record.rollout_id, acknowledgment={"ok": True})
+
+    def _callback_deadline(self) -> float | None:
+        """Supervisor deadline = server timeout + callback/network grace (§10)."""
+        server_budget = sum(
+            value
+            for value in (self._spec.agent_timeout_sec, self._spec.grader_timeout_sec)
+            if value is not None
+        )
+        if server_budget <= 0:
+            return None
+        return server_budget + _CALLBACK_NETWORK_GRACE_SEC
+
+    async def _resolve_concurrency(
+        self, client: httpx.AsyncClient, base_url: str
+    ) -> int:
+        """``--max-in-flight`` -> ``batch_size`` -> ``/health`` capacity -> 1 (§10)."""
+        health = await probe_health(client, base_url) or {}
+        capacity = health.get("max_queue_depth")
+        hard_cap = capacity if isinstance(capacity, int) and capacity > 0 else None
+        for candidate in (self._options.max_in_flight, self._spec.batch_size):
+            if isinstance(candidate, int) and candidate > 0:
+                return min(candidate, hard_cap) if hard_cap else candidate
+        return hard_cap or 1
+
+    async def _schedule(
+        self, pending: Sequence[WorkItem], driver: HttpRolloutDriver, concurrency: int
+    ) -> bool:
+        """Feed work through a bounded worker pool. Returns True when cancelled.
+
+        A pool rather than a task per row: over-queueing lets LocalBackend queue
+        time consume workflow deadlines and, on Harbor, creates sandboxes the
+        backend cannot service (§10).
+        """
+        queue: asyncio.Queue[WorkItem] = asyncio.Queue()
+        for item in pending:
+            queue.put_nowait(item)
+        workers = [
+            asyncio.create_task(self._worker(queue, driver))
+            for _ in range(max(1, min(concurrency, len(pending))))
+        ]
+        loop = asyncio.get_running_loop()
+        installed: list[signal.Signals] = []
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            with contextlib.suppress(NotImplementedError, ValueError):
+                loop.add_signal_handler(sig, self._request_cancel, workers)
+                installed.append(sig)
+        try:
+            await asyncio.gather(*workers, return_exceptions=True)
+        finally:
+            for sig in installed:
+                with contextlib.suppress(NotImplementedError, ValueError):
+                    loop.remove_signal_handler(sig)
+        return self._cancelled.is_set()
+
+    def _request_cancel(self, workers: Sequence[asyncio.Task[None]]) -> None:
+        """First interrupt: stop dispatch and cancel in-flight work (§8).
+
+        A cancelled attempt writes no terminal record, so it stays pending and
+        the next invocation runs it again -- unlike Harbor, which records a
+        ``CancelledError`` result and then skips the trial as complete.
+        """
+        if self._cancelled.is_set():
+            self._hooks.note("second interrupt: exiting now")
+            raise KeyboardInterrupt
+        self._cancelled.set()
+        self._hooks.note(
+            "interrupted: cancelling in-flight rollouts, press Ctrl-C again to exit now"
+        )
+        self._write_log("warning", "cancel", "supervisor cancellation requested")
+        for worker in workers:
+            worker.cancel()
+
+    async def _worker(
+        self, queue: asyncio.Queue[WorkItem], driver: HttpRolloutDriver
+    ) -> None:
+        while not self._cancelled.is_set() and self._breaker_reason is None:
+            try:
+                item = queue.get_nowait()
+            except asyncio.QueueEmpty:
+                return
+            try:
+                await self._run_work_item(item, driver)
+            except asyncio.CancelledError:
+                raise
+            except EvalProxyError as exc:
+                # A definitive proxy error stops dispatch and leaves the rest of
+                # the queue pending; anything else is this item's own failure.
+                if self._trip_breaker(exc):
+                    return
+                await self._journal_supervisor_failure(item, exc)
+            except Exception as exc:
+                await self._journal_supervisor_failure(item, exc)
+
+    async def _run_work_item(self, item: WorkItem, driver: HttpRolloutDriver) -> None:
+        rollout_id = uuid.uuid4().hex
+        self._dispatch_context[rollout_id] = item
+        self._dispatch_started[rollout_id] = time.monotonic()
+        request = RolloutRunRequest(
+            messages=list(item.row.initial_messages),
+            label=item.row.label,
+            metadata=dict(item.row.metadata) if item.row.metadata else None,
+            rollout_id=rollout_id,
+            agent_timeout_sec=self._spec.agent_timeout_sec,
+            grader_timeout_sec=self._spec.grader_timeout_sec,
+            extra_fields={
+                "row_index": item.row.row_index,
+                "run_index": item.run_index,
+            },
+        )
+        self._write_log(
+            "info",
+            "dispatch",
+            "dispatching rollout",
+            rollout_id=rollout_id,
+            row_index=item.row.row_index,
+            run_index=item.run_index,
+        )
+        try:
+            outcome = await driver.run(request)
+        finally:
+            self._dispatched += 1
+        if outcome.status is RolloutStatus.CANCELLED:
+            # Supervisor-requested cancellation writes no terminal event, so the
+            # work item stays pending for the next invocation.
+            self._write_log(
+                "warning", "cancel", "rollout cancelled", rollout_id=rollout_id
+            )
+            return
+        await self._await_trajectory(rollout_id)
+        self._mark_snapshot_dirty()
+        self._report_progress()
+        self._forget(rollout_id)
+        self._log_outcome(item, rollout_id, outcome)
+
+    def _log_outcome(
+        self, item: WorkItem, rollout_id: str, outcome: RolloutOutcome
+    ) -> None:
+        record = self._latest.get(item.key)
+        self._write_log(
+            "info",
+            "result",
+            "work item finished",
+            rollout_id=rollout_id,
+            row_index=item.row.row_index,
+            run_index=item.run_index,
+            status=record.status if record else str(outcome.status),
+            reward=record.reward if record else None,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Terminal commit -- the durability boundary
+    # ------------------------------------------------------------------ #
+
+    async def _commit_terminal(
+        self, result: TerminalCallbackResult
+    ) -> Mapping[str, Any] | None:
+        """Journal the terminal result, then let the callback be acknowledged.
+
+        Everything the record needs is gathered *before* the append, and the
+        append ``fsync``s before returning, so an HTTP 200 on the grader callback
+        means the result is durable (§9.3).
+        """
+        item = self._dispatch_context.get(result.rollout_id)
+        if item is None:
+            logger.warning(
+                "terminal callback for unknown rollout %s", result.rollout_id
+            )
+            return None
+        status, reward, error_type = _classify_terminal(result)
+        tokens = await self._session_tokens(result.rollout_id)
+        record = TerminalRecord(
+            row_index=item.row.row_index,
+            run_index=item.run_index,
+            rollout_id=result.rollout_id,
+            status=status,
+            recorded_at=utc_now(),
+            source_row_index=item.row.source_row_index,
+            reward=reward,
+            tokens=tokens,
+            duration_ms=self._elapsed_ms(result.rollout_id),
+            error_type=error_type,
+        )
+        await self._append_record(record)
+        return None
+
+    async def _append_record(self, record: TerminalRecord) -> None:
+        assert self._journal is not None
+        await self._journal.append(record)
+        self._latest[record.key] = record
+
+    async def _journal_supervisor_failure(
+        self, item: WorkItem, exc: BaseException
+    ) -> None:
+        """Journal an unambiguous per-item failure that produced no callback (§9.3)."""
+        rollout_id = next(
+            (
+                candidate
+                for candidate, context in self._dispatch_context.items()
+                if context is item
+            ),
+            uuid.uuid4().hex,
+        )
+        if self._latest.get(item.key) is not None:
+            self._forget(rollout_id)
+            return
+        self._write_log(
+            "error",
+            "result",
+            "work item failed before a terminal callback",
+            rollout_id=rollout_id,
+            row_index=item.row.row_index,
+            run_index=item.run_index,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+        await self._append_record(
+            TerminalRecord(
+                row_index=item.row.row_index,
+                run_index=item.run_index,
+                rollout_id=rollout_id,
+                status="failed",
+                recorded_at=utc_now(),
+                source_row_index=item.row.source_row_index,
+                duration_ms=self._elapsed_ms(rollout_id),
+                error_type=_error_type_for(exc),
+            )
+        )
+        self._forget(rollout_id)
+        self._mark_snapshot_dirty()
+        self._report_progress()
+
+    async def _session_tokens(self, rollout_id: str) -> int | None:
+        """Token count from the proxy session's usage API (§7.2).
+
+        Best-effort and bounded: this sits on the callback acknowledgement path,
+        so a slow or failing proxy costs the token field, never durability.
+        """
+        if self._proxy is None:
+            return None
+        try:
+            usage = await asyncio.wait_for(
+                self._proxy.get_usage(rollout_id), timeout=_USAGE_TIMEOUT_SEC
+            )
+        except Exception as exc:
+            logger.debug("usage lookup failed for %s: %s", rollout_id, exc)
+            return None
+        total = usage.get("total_tokens")
+        if isinstance(total, int) and not isinstance(total, bool):
+            return total
+        prompt = usage.get("prompt_tokens")
+        completion = usage.get("completion_tokens")
+        if isinstance(prompt, int) and isinstance(completion, int):
+            return prompt + completion
+        return None
+
+    def _elapsed_ms(self, rollout_id: str) -> float:
+        started = self._dispatch_started.get(rollout_id)
+        if started is None:
+            return 0.0
+        return (time.monotonic() - started) * 1000.0
+
+    def _forget(self, rollout_id: str) -> None:
+        self._dispatch_context.pop(rollout_id, None)
+        self._dispatch_started.pop(rollout_id, None)
+
+    async def _await_trajectory(self, rollout_id: str) -> None:
+        """Poll for a parseable ``trajectory.json`` after the durable result (§11.3).
+
+        The server writes the trajectory in ``finally``, *after* the grader
+        callback is acknowledged, and ``save_trajectory`` never raises -- so the
+        file can arrive late or never. Waiting here, after the journal append,
+        is the only ordering in which the server can reach its own write.
+        """
+        assert self._run_dir is not None
+        path = (
+            self._run_dir / TRIALS_DIRNAME / rollout_id / CANONICAL_TRAJECTORY_FILENAME
+        )
+        deadline = time.monotonic() + _TRAJECTORY_GRACE_SEC
+        while time.monotonic() < deadline:
+            if read_valid_trajectory(path, rollout_id=rollout_id) is not None:
+                return
+            await asyncio.sleep(_TRAJECTORY_POLL_INTERVAL_SEC)
+        self._write_log(
+            "warning",
+            "trajectory",
+            "no parseable trajectory within the archive grace period",
+            rollout_id=rollout_id,
+            rollout_dir=str(path.parent),
+        )
+
+    # ------------------------------------------------------------------ #
+    # Rollout-server lifecycle
+    # ------------------------------------------------------------------ #
+
+    async def _start_rollout_server(
+        self, *, secrets: Mapping[str, str], lock: RunLock, client: httpx.AsyncClient
+    ) -> str:
+        assert self._run_dir is not None
+        entrypoint = self._rollout_dir / self._spec.entrypoint
+        if not entrypoint.is_file():
+            raise LocalEvalError(
+                f"rollout entrypoint {entrypoint} does not exist; check "
+                "experiment.rollout and experiment.entrypoint"
+            )
+        artifact_root = self._run_dir / TRIALS_DIRNAME
+        last_error: BaseException | None = None
+        for attempt in range(1, _PORT_ATTEMPTS + 1):
+            port = self._options.rollout_port or reserve_free_port()
+            instance_id = uuid.uuid4().hex
+            env = build_subprocess_env(
+                base=os.environ,
+                config_env=self._spec.env,
+                secrets=secrets,
+                port=port,
+                artifact_root=artifact_root,
+                instance_id=instance_id,
+            )
+            self._write_log(
+                "info", "server", "starting rollout server", port=port, attempt=attempt
+            )
+            child = await asyncio.create_subprocess_exec(
+                sys.executable,
+                str(entrypoint),
+                cwd=str(self._rollout_dir),
+                env=env,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                start_new_session=True,
+            )
+            self._child = child
+            self._child_reader = asyncio.create_task(self._tee_child_output(child))
+            lock.write_child(
+                ChildProcessRecord(
+                    supervisor_pid=os.getpid(),
+                    child_pid=child.pid,
+                    child_pgid=_process_group_of(child.pid),
+                    port=port,
+                    instance_id=instance_id,
+                )
+            )
+            base_url = f"http://127.0.0.1:{port}"
+            try:
+                await self._wait_for_health(
+                    client, base_url, instance_id=instance_id, child=child
+                )
+            except LocalEvalError as exc:
+                last_error = exc
+                await self._stop_rollout_server(lock)
+                if self._options.rollout_port is not None or attempt == _PORT_ATTEMPTS:
+                    raise
+                self._write_log(
+                    "warning",
+                    "server",
+                    "retrying startup on a new port",
+                    error=str(exc),
+                )
+                continue
+            self._write_log("info", "server", "rollout server healthy", port=port)
+            return base_url
+        raise LocalEvalError(f"rollout server did not start: {last_error}")
+
+    async def _wait_for_health(
+        self,
+        client: httpx.AsyncClient,
+        base_url: str,
+        *,
+        instance_id: str,
+        child: asyncio.subprocess.Process,
+    ) -> None:
+        deadline = time.monotonic() + _HEALTH_TIMEOUT_SEC
+        while time.monotonic() < deadline:
+            if child.returncode is not None:
+                raise LocalEvalError(
+                    f"rollout server exited with code {child.returncode} before "
+                    f"becoming healthy; see {LOGS_FILENAME}"
+                )
+            health = await probe_health(client, base_url)
+            if health is not None:
+                reported = health.get("instance_id")
+                if reported not in (None, instance_id):
+                    raise LocalEvalError(
+                        f"another rollout server is already listening on "
+                        f"{base_url}; choose a different --rollout-port"
+                    )
+                return
+            await asyncio.sleep(_HEALTH_POLL_INTERVAL_SEC)
+        raise LocalEvalError(
+            f"rollout server did not become healthy within {_HEALTH_TIMEOUT_SEC:.0f}s; "
+            f"see {LOGS_FILENAME}"
+        )
+
+    async def _tee_child_output(self, child: asyncio.subprocess.Process) -> None:
+        """Tee the rollout server's combined output into the run log (§4.3)."""
+        stream = child.stdout
+        if stream is None:
+            return
+        while True:
+            try:
+                raw = await stream.readline()
+            except (asyncio.CancelledError, ValueError):
+                raise
+            if not raw:
+                return
+            self._write_log(
+                "info", "rollout-server", raw.decode(errors="replace").rstrip()
+            )
+
+    async def _stop_rollout_server(self, lock: RunLock) -> None:
+        child = self._child
+        if child is None:
+            return
+        self._child = None
+        if child.returncode is None:
+            with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+                await asyncio.to_thread(
+                    terminate_process_group,
+                    _process_group_of(child.pid),
+                    grace_sec=_SERVER_TERM_GRACE_SEC,
+                )
+        with contextlib.suppress(Exception):
+            await child.wait()
+        if self._child_reader is not None:
+            self._child_reader.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._child_reader
+            self._child_reader = None
+        with contextlib.suppress(LocalEvalStateError, OSError):
+            lock.clear_child()
+
+    # ------------------------------------------------------------------ #
+    # Snapshots and finalization
+    # ------------------------------------------------------------------ #
+
+    def _mark_snapshot_dirty(self) -> None:
+        self._snapshot_dirty.set()
+
+    async def _snapshot_loop(self) -> None:
+        """Coalesce snapshot refreshes: durability is the journal's job, not this."""
+        while True:
+            await self._snapshot_dirty.wait()
+            self._snapshot_dirty.clear()
+            with contextlib.suppress(Exception):
+                self._refresh_snapshots()
+            await asyncio.sleep(_SNAPSHOT_COALESCE_SEC)
+
+    def _refresh_snapshots(self) -> list[dict[str, Any]]:
+        assert self._materializer is not None and self._identity is not None
+        attempts = select_attempts(
+            self._latest,
+            trials_dir=self._materializer.trials_dir,
+            resumed_keys=self._resumed_keys,
+        )
+        return self._materializer.refresh(
+            attempts,
+            identity=self._identity,
+            pass_threshold=self._spec.pass_threshold,
+            sampled_rows=len(self._selection.rows),
+            total_dataset_rows=self._selection.total_dataset_rows,
+            total_runs=len(self._selection.rows) * max(1, self._spec.n),
+        )
+
+    def _report_progress(self) -> None:
+        statuses = [record.status for record in self._latest.values()]
+        rewards = [
+            record.reward
+            for record in self._latest.values()
+            if record.status != "skipped" and record.reward is not None
+        ]
+        passed = sum(1 for reward in rewards if reward >= self._spec.pass_threshold)
+        with contextlib.suppress(Exception):
+            self._hooks.progress(
+                ProgressSnapshot(
+                    completed=len(statuses),
+                    total=len(self._selection.rows) * max(1, self._spec.n),
+                    passed=passed,
+                    failed=sum(1 for status in statuses if status == "failed"),
+                )
+            )
+
+    def _finalize(self, *, cancelled: bool) -> RunSummary:
+        run_dir = self._run_dir
+        started = self._identity
+        assert run_dir is not None and started is not None
+        duration_ms = (time.monotonic() - self._started_monotonic) * 1000.0
+        total = len(self._selection.rows) * max(1, self._spec.n)
+        complete = len(self._latest) >= total
+        identity = RunIdentity(
+            local_run_id=started.local_run_id,
+            run_name=started.run_name,
+            dataset_name=started.dataset_name,
+            model_name=started.model_name,
+            rollout_name=started.rollout_name,
+            started_at=started.started_at,
+            status="finished" if complete and not cancelled else "incomplete",
+            completed_at=utc_now() if complete and not cancelled else None,
+            duration_ms=duration_ms,
+        )
+        self._identity = identity
+        rows = self._refresh_snapshots()
+        statuses = [record.status for record in self._latest.values()]
+        return RunSummary(
+            run_dir=run_dir,
+            local_run_id=identity.local_run_id,
+            run_name=identity.run_name,
+            total_work_items=total,
+            dispatched=self._dispatched,
+            succeeded=sum(1 for status in statuses if status == "success"),
+            failed=sum(1 for status in statuses if status == "failed"),
+            skipped=sum(1 for status in statuses if status == "skipped"),
+            resumed=len(self._resumed_keys),
+            cancelled=cancelled,
+            metrics=aggregate_metrics(rows, pass_threshold=self._spec.pass_threshold),
+            failures=self._collect_failures(),
+        )
+
+    def _collect_failures(self) -> list[FailedWorkItem]:
+        assert self._run_dir is not None
+        failures: list[FailedWorkItem] = []
+        for key in sorted(self._latest):
+            record = self._latest[key]
+            if record.status == "success":
+                continue
+            failures.append(
+                FailedWorkItem(
+                    row_index=record.row_index,
+                    source_row_index=(
+                        record.source_row_index
+                        if record.source_row_index is not None
+                        else record.row_index
+                    ),
+                    run_index=record.run_index,
+                    rollout_id=record.rollout_id,
+                    error_type=record.error_type,
+                    rollout_dir=self._run_dir / TRIALS_DIRNAME / record.rollout_id,
+                )
+            )
+        return failures
+
+    # ------------------------------------------------------------------ #
+    # Logging helpers
+    # ------------------------------------------------------------------ #
+
+    def _write_log(self, level: str, step: str, message: str, **details: Any) -> None:
+        if self._log is not None:
+            self._log.write(level, step, message, **details)
+        elif level in ("warning", "error"):
+            self._hooks.note(message)
+
+    def _write_log_deferred(
+        self, level: str, step: str, message: str, **details: Any
+    ) -> None:
+        # Orphan reaping happens before the run directory (and its log) exist.
+        self._write_log(level, step, message, **details)
+
+
+def _process_group_of(pid: int) -> int:
+    try:
+        return os.getpgid(pid)
+    except (ProcessLookupError, PermissionError, OSError) as exc:
+        if isinstance(exc, OSError) and exc.errno not in (
+            errno.ESRCH,
+            errno.EPERM,
+            errno.EINVAL,
+        ):
+            raise
+        # ``start_new_session=True`` makes the child its own group leader, so its
+        # pid is its pgid whenever the lookup itself is unavailable.
+        return pid
+
+
+def _classify_terminal(
+    result: TerminalCallbackResult,
+) -> tuple[TerminalStatus, float | None, str | None]:
+    """Map a callback-store terminal result onto the index status vocabulary."""
+    if result.source == "timeout":
+        return "failed", None, "callback_timeout"
+    grader = result.grader
+    if grader is None:
+        return "failed", None, "missing_grader_callback"
+    sample = grader.sample
+    if sample is not None and sample.remove_sample:
+        # ``remove_sample`` is the workflow saying "do not score this row".
+        return "skipped", None, None
+    reward = sample.reward if sample is not None else None
+    if grader.status is not GraderStatus.SUCCESS:
+        return "failed", reward, grader.err_category or "grader_failed"
+    completion = result.completion
+    if completion is not None and completion.status is not RolloutStatus.SUCCESS:
+        return "failed", reward, completion.err_category or "workflow_failed"
+    return "success", reward, None
+
+
+def _error_type_for(exc: BaseException) -> str:
+    from osmosis_ai.rollout.http_driver import (
+        AdmissionUncertainError,
+        RolloutProtocolError,
+    )
+
+    if isinstance(exc, AdmissionUncertainError):
+        return "admission_uncertain"
+    if isinstance(exc, RolloutProtocolError):
+        return "rollout_protocol_error"
+    return "supervisor_error"

--- a/osmosis_ai/eval/local/runner.py
+++ b/osmosis_ai/eval/local/runner.py
@@ -94,11 +94,14 @@ _PORT_ATTEMPTS = 5
 _SERVER_TERM_GRACE_SEC = 5.0
 _TRAJECTORY_GRACE_SEC = 30.0
 _TRAJECTORY_POLL_INTERVAL_SEC = 0.2
-_USAGE_TIMEOUT_SEC = 5.0
 _SNAPSHOT_COALESCE_SEC = 1.0
 _CALLBACK_NETWORK_GRACE_SEC = 60.0
 # Floor for the per-item supervisor deadline when the config sets no timeouts.
 _DEFAULT_ITEM_DEADLINE_SEC = 3600.0
+# Sanity bound on a recorded reward: rewards near the float ceiling overflow
+# ``statistics.fmean`` when the metrics are aggregated, and because the record is
+# durable that leaves the run unresumable until --fresh.
+_MAX_ABS_REWARD = 1e300
 
 #: Supervisor-owned subprocess variables a config must never set (§8).
 RESERVED_ENV_NAMES: frozenset[str] = frozenset(
@@ -156,12 +159,9 @@ class LocalEvalOptions:
     """Runtime-only knobs. All CLI flags -- never a config section (§5)."""
 
     name: str | None = None
-    output: Path | None = None
-    rows: str | None = None
     fresh: bool = False
     retry_failed: bool = False
     max_in_flight: int | None = None
-    yes: bool = False
     rollout_port: int | None = None
     skip_llm_preflight: bool = False
     verbose: bool = False
@@ -585,6 +585,12 @@ class LocalEvalRunner:
     def _source_digest(self) -> str:
         cached = getattr(self, "_source_digest_value", None)
         if cached is None:
+            if self._output_root == self._rollout_dir:
+                raise LocalEvalError(
+                    f"--output must not be the rollout source directory "
+                    f"{self._rollout_dir}: excluding the output tree would then "
+                    "exclude the whole project, freezing the resume fingerprint."
+                )
             exclude = (
                 self._output_root
                 if self._output_root.is_relative_to(self._rollout_dir)
@@ -823,13 +829,15 @@ class LocalEvalRunner:
 
         Timeouts are optional in the config, but an unbounded wait is not an
         option: a lost callback would hang every worker forever with no output.
-        With nothing configured, fall back to a generous floor.
+        A ``None`` phase means "run unbounded", so summing only the phases that
+        are bounded would stamp still-running work ``callback_timeout``. With
+        anything unbounded, fall back to a generous floor.
         """
-        server_budget = sum(
-            value
-            for value in (self._spec.agent_timeout_sec, self._spec.grader_timeout_sec)
-            if value is not None
-        )
+        agent = self._spec.agent_timeout_sec
+        grader = self._spec.grader_timeout_sec
+        if agent is None or grader is None:
+            return _DEFAULT_ITEM_DEADLINE_SEC
+        server_budget = agent + grader
         if server_budget <= 0:
             return _DEFAULT_ITEM_DEADLINE_SEC
         return server_budget + _CALLBACK_NETWORK_GRACE_SEC
@@ -870,7 +878,7 @@ class LocalEvalRunner:
                 installed.append(sig)
         watchdog = asyncio.create_task(self._watch_child(workers))
         try:
-            await asyncio.gather(*workers, return_exceptions=True)
+            results = await asyncio.gather(*workers, return_exceptions=True)
         finally:
             watchdog.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -878,6 +886,17 @@ class LocalEvalRunner:
             for sig in installed:
                 with contextlib.suppress(NotImplementedError, ValueError):
                     loop.remove_signal_handler(sig)
+        for result in results:
+            # Cancellation is how the supervisor stops in-flight work, so only an
+            # unexpected exception means a worker died with items still queued.
+            # Halting records it and marks the run incomplete, instead of
+            # returning a short run that reads as a clean one.
+            if isinstance(result, BaseException) and not isinstance(
+                result, asyncio.CancelledError
+            ):
+                self._halt_dispatch(
+                    f"a worker failed: {type(result).__name__}: {result}"
+                )
         return self._cancelled.is_set() or self._halt_reason is not None
 
     async def _watch_child(self, workers: Sequence[asyncio.Task[None]]) -> None:
@@ -930,17 +949,22 @@ class LocalEvalRunner:
                 await self._run_work_item(item, driver)
             except asyncio.CancelledError:
                 raise
-            except RolloutProtocolError as exc:
-                # The rollout server actively refused *this* request with a
-                # non-202/429 status, so the failure is attributable to the work
-                # item and gets a terminal record.
-                await self._journal_supervisor_failure(item, exc)
             except Exception as exc:
-                # Everything else -- proxy errors, transport failures, an
-                # indeterminate admission, a supervisor bug -- is process-wide as
-                # far as this item is concerned. Halt dispatch and leave it
-                # pending rather than durably recording a failure that says
-                # nothing about the row (§9.3).
+                if (
+                    isinstance(exc, RolloutProtocolError)
+                    and 400 <= exc.status_code < 500
+                ):
+                    # The rollout server actively refused *this* request, so the
+                    # failure is attributable to the work item and gets a
+                    # terminal record.
+                    await self._journal_supervisor_failure(item, exc)
+                    continue
+                # Everything else -- a 5xx from a restarting server, proxy
+                # errors, transport failures, an indeterminate admission, a
+                # supervisor bug -- is process-wide as far as this item is
+                # concerned. Halt dispatch and leave it pending rather than
+                # durably recording a failure that says nothing about the row
+                # (§9.3).
                 self._halt_dispatch(
                     f"{type(exc).__name__}: {exc}",
                     row_index=item.row.row_index,
@@ -1028,7 +1052,6 @@ class LocalEvalRunner:
                 "dispatch context; refusing to acknowledge it"
             )
         status, reward, error_type = _classify_terminal(result)
-        tokens = await self._session_tokens(result.rollout_id)
         record = TerminalRecord(
             row_index=item.row.row_index,
             run_index=item.run_index,
@@ -1037,7 +1060,6 @@ class LocalEvalRunner:
             recorded_at=utc_now(),
             source_row_index=item.row.source_row_index,
             reward=reward,
-            tokens=tokens,
             duration_ms=self._elapsed_ms(result.rollout_id),
             error_type=error_type,
         )
@@ -1064,7 +1086,10 @@ class LocalEvalRunner:
             ),
             uuid.uuid4().hex,
         )
-        if self._latest.get(item.key) is not None:
+        existing = self._latest.get(item.key)
+        # Only *this* attempt's own terminal record makes the failure redundant.
+        # A record from an earlier attempt is what --retry-failed is replacing.
+        if existing is not None and existing.rollout_id == rollout_id:
             self._forget(rollout_id)
             return
         self._write_log(
@@ -1091,30 +1116,6 @@ class LocalEvalRunner:
         self._forget(rollout_id)
         self._mark_snapshot_dirty(item.key)
         self._report_progress()
-
-    async def _session_tokens(self, rollout_id: str) -> int | None:
-        """Token count from the proxy session's usage API (§7.2).
-
-        Best-effort and bounded: this sits on the callback acknowledgement path,
-        so a slow or failing proxy costs the token field, never durability.
-        """
-        if self._proxy is None:
-            return None
-        try:
-            usage = await asyncio.wait_for(
-                self._proxy.get_usage(rollout_id), timeout=_USAGE_TIMEOUT_SEC
-            )
-        except Exception as exc:
-            logger.debug("usage lookup failed for %s: %s", rollout_id, exc)
-            return None
-        total = usage.get("total_tokens")
-        if isinstance(total, int) and not isinstance(total, bool):
-            return total
-        prompt = usage.get("prompt_tokens")
-        completion = usage.get("completion_tokens")
-        if isinstance(prompt, int) and isinstance(completion, int):
-            return prompt + completion
-        return None
 
     def _elapsed_ms(self, rollout_id: str) -> float:
         started = self._dispatch_started.get(rollout_id)
@@ -1454,12 +1455,16 @@ def _classify_terminal(
     if grader is None:
         return "failed", None, "missing_grader_callback"
     sample = grader.sample
+    reward = sample.reward if sample is not None else None
+    if reward is not None and abs(reward) > _MAX_ABS_REWARD:
+        return "failed", None, "reward_out_of_range"
+    # A crashed grader is a failure even when it asked to drop the sample:
+    # "skipped" would leave the row out of the scored denominator entirely.
+    if grader.status is not GraderStatus.SUCCESS:
+        return "failed", reward, grader.err_category or "grader_failed"
     if sample is not None and sample.remove_sample:
         # ``remove_sample`` is the workflow saying "do not score this row".
         return "skipped", None, None
-    reward = sample.reward if sample is not None else None
-    if grader.status is not GraderStatus.SUCCESS:
-        return "failed", reward, grader.err_category or "grader_failed"
     completion = result.completion
     if completion is not None and completion.status is not RolloutStatus.SUCCESS:
         return "failed", reward, completion.err_category or "workflow_failed"

--- a/osmosis_ai/eval/local/runner.py
+++ b/osmosis_ai/eval/local/runner.py
@@ -117,7 +117,7 @@ class ResumeRefusedError(LocalEvalError):
 
     def __init__(self, message: str, *, diffs: Sequence[InputDiff]) -> None:
         super().__init__(message)
-        self.diffs = list(diffs)
+        self.diffs: list[InputDiff] = list(diffs)
 
 
 # --------------------------------------------------------------------------- #

--- a/osmosis_ai/eval/local/state.py
+++ b/osmosis_ai/eval/local/state.py
@@ -1,0 +1,732 @@
+"""Durable state for a local evaluation run: journal, manifest, and run lock.
+
+Three concepts, and deliberately no more (design ``local-eval-run-plan.md`` §9):
+
+* ``manifest.json`` -- immutable resolved-input lock plus provenance. Written
+  once at run creation and compared structurally on resume, so a semantic
+  change refuses with a field-level diff instead of silently mixing versions.
+* ``events.jsonl`` -- the resume authority. One newline-terminated JSON record
+  per terminal attempt. The record is written in full, ``fsync``-ed, and only
+  then may the terminal callback be acknowledged, so a durably acknowledged
+  work item never runs again after ``kill -9``.
+* everything else -- projections, rebuilt from the journal and the artifact
+  tree. They are never consulted to decide whether work reruns.
+
+The process flock lives outside the run directory because ``--fresh`` renames
+that directory; holding an inode inside it would leave the replacement path
+unlocked and admit a second supervisor.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import errno
+import fcntl
+import hashlib
+import json
+import os
+import signal
+import tempfile
+import time
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from osmosis_ai.rollout.utils.identifiers import is_single_path_segment
+
+# Bumped when the on-disk meaning of events.jsonl or manifest.json changes.
+LOCAL_STATE_SCHEMA_VERSION = 1
+# Bumped when the layout under rollout_trials/ or the projections change.
+LOCAL_ARTIFACT_SCHEMA_VERSION = 1
+# Bumped when dataset row normalization changes what a row_index means.
+DATASET_NORMALIZATION_VERSION = 1
+# The rollout HTTP/callback protocol this runner speaks.
+ROLLOUT_PROTOCOL_VERSION = "0.3"
+
+MANIFEST_FILENAME = "manifest.json"
+JOURNAL_FILENAME = "events.jsonl"
+LOCKS_DIRNAME = ".locks"
+
+#: ``index.jsonl`` status values the platform schema accepts (§2.2).
+TerminalStatus = Literal["success", "failed", "skipped"]
+_TERMINAL_STATUSES: frozenset[str] = frozenset({"success", "failed", "skipped"})
+
+#: Stable work-item identity within a manifest-locked run: ``(row, run)``.
+WorkKey = tuple[int, int]
+
+_RUN_NAME_MAX_LEN = 96
+
+
+class LocalEvalStateError(RuntimeError):
+    """A local run's on-disk state cannot be used as-is."""
+
+
+class JournalCorruptionError(LocalEvalStateError):
+    """A committed journal record is unparseable, so resume is unsafe."""
+
+
+class RunLockedError(LocalEvalStateError):
+    """Another supervisor holds this run's lock."""
+
+
+class OrphanChildError(LocalEvalStateError):
+    """A recorded rollout-server child is alive but could not be verified."""
+
+
+def utc_now() -> str:
+    """Timestamp for provenance fields. Never used to arbitrate attempts."""
+    return datetime.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+# --------------------------------------------------------------------------- #
+# Durable writes
+# --------------------------------------------------------------------------- #
+
+
+def fsync_dir(directory: Path) -> None:
+    """Persist a directory entry so a rename or create survives a crash."""
+    fd = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    except OSError as exc:  # pragma: no cover - platform dependent
+        # Some filesystems refuse fsync on a directory fd; the replace itself
+        # is still atomic, so this is a durability downgrade, not a failure.
+        if exc.errno not in (errno.EINVAL, errno.EACCES):
+            raise
+    finally:
+        os.close(fd)
+
+
+def atomic_write_bytes(path: Path, data: bytes) -> None:
+    """Write *data* to *path* atomically and durably.
+
+    Temp file in the destination directory -> fsync the file -> atomic replace
+    -> fsync the parent directory (§11.1). Readers therefore only ever see a
+    complete previous or complete new file, including across a crash.
+    """
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=parent, prefix=f".{path.name}.", suffix=".tmp")
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            tmp.unlink()
+        raise
+    fsync_dir(parent)
+
+
+def atomic_write_json(path: Path, payload: Any) -> None:
+    """Atomically write *payload* in the repo's 2-space + trailing-newline form."""
+    text = json.dumps(payload, ensure_ascii=False, indent=2, allow_nan=False) + "\n"
+    atomic_write_bytes(path, text.encode("utf-8"))
+
+
+def atomic_write_text(path: Path, text: str) -> None:
+    atomic_write_bytes(path, text.encode("utf-8"))
+
+
+def canonical_json(payload: Any) -> str:
+    """Stable serialization used for digests: sorted keys, no incidental space."""
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def digest_of(payload: Any) -> str:
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def drop_none_values(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Omit ``None``-valued keys rather than writing JSON ``null`` (§2.2)."""
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+# --------------------------------------------------------------------------- #
+# Run naming and directories
+# --------------------------------------------------------------------------- #
+
+
+def validate_run_name(name: str) -> str:
+    """Return *name* if it is one safe path segment, else raise (§4.4)."""
+    if not name:
+        raise LocalEvalStateError("run name must not be empty")
+    if len(name) > _RUN_NAME_MAX_LEN:
+        raise LocalEvalStateError(
+            f"run name must be at most {_RUN_NAME_MAX_LEN} characters: {name!r}"
+        )
+    if not is_single_path_segment(name):
+        raise LocalEvalStateError(
+            f"run name must be a single path segment (no separators, and not "
+            f"'.' or '..'): {name!r}"
+        )
+    if name == LOCKS_DIRNAME:
+        raise LocalEvalStateError(f"run name {name!r} is reserved")
+    if name[0] in "-." or any(
+        char not in "._-" and not char.isalnum() for char in name
+    ):
+        raise LocalEvalStateError(
+            "run name must start with a letter or digit and use only letters, "
+            f"digits, '.', '_', or '-': {name!r}"
+        )
+    return name
+
+
+def archive_run_directory(run_dir: Path, *, now: str | None = None) -> Path:
+    """Rename *run_dir* aside for ``--fresh``. Archive, never silent-delete."""
+    stamp = now or datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    destination = run_dir.parent / f"{run_dir.name}.archive-{stamp}"
+    suffix = 1
+    while destination.exists():
+        destination = run_dir.parent / f"{run_dir.name}.archive-{stamp}-{suffix}"
+        suffix += 1
+    os.replace(run_dir, destination)
+    fsync_dir(run_dir.parent)
+    return destination
+
+
+# --------------------------------------------------------------------------- #
+# Terminal journal
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class TerminalRecord:
+    """One terminal result for one attempt of one work item.
+
+    ``recorded_at`` is provenance only: replay arbitrates by append order, so a
+    skewed clock can never change which attempt wins (§9.4).
+    """
+
+    row_index: int
+    run_index: int
+    rollout_id: str
+    status: TerminalStatus
+    recorded_at: str
+    source_row_index: int | None = None
+    reward: float | None = None
+    tokens: int | None = None
+    duration_ms: float = 0.0
+    error_type: str | None = None
+
+    @property
+    def key(self) -> WorkKey:
+        return (self.row_index, self.run_index)
+
+    def to_payload(self) -> dict[str, Any]:
+        return drop_none_values(
+            {
+                "row_index": self.row_index,
+                "run_index": self.run_index,
+                "rollout_id": self.rollout_id,
+                "status": self.status,
+                "recorded_at": self.recorded_at,
+                "source_row_index": self.source_row_index,
+                "reward": self.reward,
+                "tokens": self.tokens,
+                "duration_ms": self.duration_ms,
+                "error_type": self.error_type,
+            }
+        )
+
+    def to_journal_line(self) -> bytes:
+        return (canonical_json(self.to_payload()) + "\n").encode("utf-8")
+
+    @classmethod
+    def from_payload(cls, payload: Any, *, where: str) -> TerminalRecord:
+        if not isinstance(payload, dict):
+            raise JournalCorruptionError(f"{where}: record is not a JSON object")
+
+        def _int(name: str) -> int:
+            value = payload.get(name)
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise JournalCorruptionError(f"{where}: {name} must be an integer")
+            return value
+
+        def _optional_int(name: str) -> int | None:
+            value = payload.get(name)
+            if value is None:
+                return None
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise JournalCorruptionError(
+                    f"{where}: {name} must be an integer when present"
+                )
+            return value
+
+        def _optional_float(name: str) -> float | None:
+            value = payload.get(name)
+            if value is None:
+                return None
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise JournalCorruptionError(
+                    f"{where}: {name} must be a number when present"
+                )
+            return float(value)
+
+        def _optional_str(name: str) -> str | None:
+            value = payload.get(name)
+            if value is None:
+                return None
+            if not isinstance(value, str):
+                raise JournalCorruptionError(
+                    f"{where}: {name} must be a string when present"
+                )
+            return value
+
+        rollout_id = payload.get("rollout_id")
+        if not isinstance(rollout_id, str) or not rollout_id:
+            raise JournalCorruptionError(f"{where}: rollout_id must be a string")
+        status = payload.get("status")
+        if status not in _TERMINAL_STATUSES:
+            raise JournalCorruptionError(
+                f"{where}: status must be one of {sorted(_TERMINAL_STATUSES)}"
+            )
+        recorded_at = _optional_str("recorded_at") or ""
+        return cls(
+            row_index=_int("row_index"),
+            run_index=_int("run_index"),
+            rollout_id=rollout_id,
+            status=status,  # type: ignore[arg-type]  # membership checked above
+            recorded_at=recorded_at,
+            source_row_index=_optional_int("source_row_index"),
+            reward=_optional_float("reward"),
+            tokens=_optional_int("tokens"),
+            duration_ms=_optional_float("duration_ms") or 0.0,
+            error_type=_optional_str("error_type"),
+        )
+
+
+@dataclass(frozen=True)
+class JournalReplay:
+    """Result of replaying the journal at startup."""
+
+    records: tuple[TerminalRecord, ...] = ()
+    #: Byte offset just past the last complete record; an append must start here.
+    committed_size: int = 0
+    #: Size of a discarded non-newline EOF fragment, if any.
+    truncated_bytes: int = 0
+
+    @property
+    def latest(self) -> dict[WorkKey, TerminalRecord]:
+        """Last valid terminal record per work key, in append order (§9.4)."""
+        selected: dict[WorkKey, TerminalRecord] = {}
+        for record in self.records:
+            selected[record.key] = record
+        return selected
+
+
+class TerminalJournal:
+    """Append-only journal of terminal results; the resume authority.
+
+    The commit unit is a complete newline-terminated record. ``append`` writes
+    every byte, then ``fsync``s, before returning -- callers may only
+    acknowledge a terminal callback after it returns.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._fd: int | None = None
+        self._lock = asyncio.Lock()
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def replay(self) -> JournalReplay:
+        """Read committed records, reporting any partial trailing record.
+
+        A non-newline EOF fragment is a crash mid-append and is discarded even
+        when its JSON happens to parse. A malformed *committed* record is
+        corruption and stops the run.
+        """
+        if not self._path.exists():
+            return JournalReplay()
+        records: list[TerminalRecord] = []
+        committed = 0
+        truncated = 0
+        with self._path.open("rb") as handle:
+            for lineno, raw in enumerate(handle, start=1):
+                if not raw.endswith(b"\n"):
+                    truncated = len(raw)
+                    break
+                text = raw[:-1].strip()
+                if not text:
+                    raise JournalCorruptionError(
+                        f"{self._path}:{lineno}: blank journal record"
+                    )
+                try:
+                    payload = json.loads(text)
+                except json.JSONDecodeError as exc:
+                    raise JournalCorruptionError(
+                        f"{self._path}:{lineno}: invalid JSON ({exc.msg})"
+                    ) from exc
+                records.append(
+                    TerminalRecord.from_payload(payload, where=f"{self._path}:{lineno}")
+                )
+                committed += len(raw)
+        return JournalReplay(
+            records=tuple(records),
+            committed_size=committed,
+            truncated_bytes=truncated,
+        )
+
+    def open_for_append(self, replay: JournalReplay) -> None:
+        """Open the journal for appending, discarding a partial trailing record.
+
+        *replay* must come from :meth:`replay` on this same journal: its
+        ``committed_size`` is where the next record starts.
+        """
+        if self._fd is not None:
+            return
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        created = not self._path.exists()
+        fd = os.open(self._path, os.O_RDWR | os.O_CREAT | os.O_APPEND, 0o600)
+        try:
+            if replay.truncated_bytes:
+                os.ftruncate(fd, replay.committed_size)
+                os.fsync(fd)
+            elif os.lseek(fd, 0, os.SEEK_END) != replay.committed_size:
+                raise LocalEvalStateError(
+                    f"{self._path} changed between replay and open; "
+                    "another supervisor may be writing to this run"
+                )
+        except BaseException:
+            os.close(fd)
+            raise
+        self._fd = fd
+        if created:
+            fsync_dir(self._path.parent)
+
+    async def append(self, record: TerminalRecord) -> None:
+        """Durably append *record*. Returns only once ``fsync`` has completed."""
+        if self._fd is None:
+            raise LocalEvalStateError("journal is not open for appending")
+        payload = record.to_journal_line()
+        async with self._lock:
+            await asyncio.to_thread(self._append_sync, payload)
+
+    def _append_sync(self, payload: bytes) -> None:
+        fd = self._fd
+        if fd is None:  # pragma: no cover - guarded by append()
+            raise LocalEvalStateError("journal is not open for appending")
+        view = memoryview(payload)
+        while view:
+            written = os.write(fd, view)
+            view = view[written:]
+        os.fsync(fd)
+
+    def close(self) -> None:
+        if self._fd is not None:
+            os.close(self._fd)
+            self._fd = None
+
+
+# --------------------------------------------------------------------------- #
+# Manifest and resolved-input lock
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class InputDiff:
+    """One field-level difference between two resolved-input locks."""
+
+    field: str
+    previous: Any
+    current: Any
+
+
+def diff_inputs(
+    previous: Mapping[str, Any], current: Mapping[str, Any]
+) -> list[InputDiff]:
+    """Field-level diff of two ``inputs`` objects, with dotted nested keys."""
+    diffs: list[InputDiff] = []
+    _collect_diffs(previous, current, prefix="", diffs=diffs)
+    return diffs
+
+
+_MISSING = object()
+
+
+def _collect_diffs(
+    previous: Any, current: Any, *, prefix: str, diffs: list[InputDiff]
+) -> None:
+    if isinstance(previous, Mapping) and isinstance(current, Mapping):
+        for key in sorted({*previous.keys(), *current.keys()}):
+            child = f"{prefix}.{key}" if prefix else str(key)
+            _collect_diffs(
+                previous.get(key, _MISSING),
+                current.get(key, _MISSING),
+                prefix=child,
+                diffs=diffs,
+            )
+        return
+    if previous == current:
+        return
+    diffs.append(
+        InputDiff(
+            field=prefix or "inputs",
+            previous=None if previous is _MISSING else previous,
+            current=None if current is _MISSING else current,
+        )
+    )
+
+
+@dataclass(frozen=True)
+class RunManifest:
+    """Immutable local provenance plus the resolved-input lock. Never uploaded."""
+
+    local_run_id: str
+    run_name: str
+    created_at: str
+    inputs: dict[str, Any]
+    inputs_digest: str
+    provenance: dict[str, Any] = field(default_factory=dict)
+    schema_version: int = LOCAL_STATE_SCHEMA_VERSION
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        local_run_id: str,
+        run_name: str,
+        inputs: Mapping[str, Any],
+        provenance: Mapping[str, Any],
+    ) -> RunManifest:
+        resolved = dict(inputs)
+        return cls(
+            local_run_id=local_run_id,
+            run_name=run_name,
+            created_at=utc_now(),
+            inputs=resolved,
+            inputs_digest=digest_of(resolved),
+            provenance=dict(provenance),
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "local_run_id": self.local_run_id,
+            "run_name": self.run_name,
+            "created_at": self.created_at,
+            "inputs": self.inputs,
+            "inputs_digest": self.inputs_digest,
+            "provenance": self.provenance,
+        }
+
+    def write(self, path: Path) -> None:
+        atomic_write_json(path, self.to_payload())
+
+    @classmethod
+    def read(cls, path: Path) -> RunManifest:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise LocalEvalStateError(f"{path} is unreadable: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise LocalEvalStateError(f"{path} is not a JSON object")
+        schema_version = payload.get("schema_version")
+        if schema_version != LOCAL_STATE_SCHEMA_VERSION:
+            raise LocalEvalStateError(
+                f"{path} was written by state schema version {schema_version!r}; "
+                f"this SDK writes version {LOCAL_STATE_SCHEMA_VERSION}. Start a "
+                "new run with --fresh."
+            )
+        inputs = payload.get("inputs")
+        if not isinstance(inputs, dict):
+            raise LocalEvalStateError(f"{path} has no inputs object")
+        digest = payload.get("inputs_digest")
+        if not isinstance(digest, str):
+            raise LocalEvalStateError(f"{path} has no inputs_digest")
+        return cls(
+            local_run_id=str(payload.get("local_run_id", "")),
+            run_name=str(payload.get("run_name", "")),
+            created_at=str(payload.get("created_at", "")),
+            inputs=inputs,
+            inputs_digest=digest,
+            provenance=payload.get("provenance") or {},
+            schema_version=schema_version,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Process lock and orphan-child metadata
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class ChildProcessRecord:
+    """Runtime metadata for verified orphan cleanup. Never resume authority."""
+
+    supervisor_pid: int
+    child_pid: int
+    child_pgid: int
+    port: int
+    instance_id: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "supervisor_pid": self.supervisor_pid,
+            "child_pid": self.child_pid,
+            "child_pgid": self.child_pgid,
+            "port": self.port,
+            "instance_id": self.instance_id,
+        }
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> ChildProcessRecord | None:
+        try:
+            return cls(
+                supervisor_pid=int(payload["supervisor_pid"]),
+                child_pid=int(payload["child_pid"]),
+                child_pgid=int(payload["child_pgid"]),
+                port=int(payload["port"]),
+                instance_id=str(payload["instance_id"]),
+            )
+        except (KeyError, TypeError, ValueError):
+            # Unreadable metadata is a stale record, not a reason to refuse:
+            # it can only cost us an orphan we fail to reap, and the health
+            # instance-id check is what actually authorizes any kill.
+            return None
+
+
+class RunLock:
+    """Exclusive flock for one named run, held outside the run directory.
+
+    The same inode also carries rollout-server child metadata so the next
+    startup can reap a verified orphan. The path is never replaced while held.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._fd: int | None = None
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def acquire(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(self._path, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            os.close(fd)
+            if exc.errno in (errno.EACCES, errno.EAGAIN):
+                raise RunLockedError(
+                    f"another `osmosis eval run` already holds {self._path}. "
+                    "Wait for it to finish, or use a different --name."
+                ) from exc
+            raise
+        self._fd = fd
+
+    def read_child(self) -> ChildProcessRecord | None:
+        if self._fd is None:
+            raise LocalEvalStateError("run lock is not held")
+        raw = os.pread(self._fd, 64 * 1024, 0)
+        if not raw.strip():
+            return None
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(payload, dict):
+            return None
+        child = payload.get("child")
+        if not isinstance(child, dict):
+            return None
+        return ChildProcessRecord.from_payload(child)
+
+    def write_child(self, record: ChildProcessRecord | None) -> None:
+        """Update the held inode in place, then fsync. Never replaces the path."""
+        if self._fd is None:
+            raise LocalEvalStateError("run lock is not held")
+        payload = {"child": record.to_payload()} if record is not None else {}
+        data = (json.dumps(payload, indent=2) + "\n").encode("utf-8")
+        os.ftruncate(self._fd, 0)
+        os.pwrite(self._fd, data, 0)
+        os.fsync(self._fd)
+
+    def clear_child(self) -> None:
+        self.write_child(None)
+
+    def release(self) -> None:
+        if self._fd is not None:
+            with contextlib.suppress(OSError):
+                fcntl.flock(self._fd, fcntl.LOCK_UN)
+            os.close(self._fd)
+            self._fd = None
+
+    def __enter__(self) -> RunLock:
+        self.acquire()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.release()
+
+
+def process_is_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists but is owned by someone else, so it is definitely not our child.
+        return True
+    return True
+
+
+def process_group_is_alive(pgid: int) -> bool:
+    if pgid <= 0:
+        return False
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def terminate_process_group(
+    pgid: int, *, grace_sec: float, poll_sec: float = 0.05
+) -> None:
+    """SIGTERM a process group, escalating to SIGKILL after *grace_sec*.
+
+    Blocking: call from startup reaping, or via ``asyncio.to_thread`` during an
+    async shutdown.
+    """
+    if pgid <= 0:
+        return
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(pgid, signal.SIGTERM)
+    deadline = time.monotonic() + max(0.0, grace_sec)
+    while time.monotonic() < deadline:
+        if not process_group_is_alive(pgid):
+            return
+        time.sleep(poll_sec)
+    if process_group_is_alive(pgid):
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(pgid, signal.SIGKILL)
+
+
+def iter_run_directories(root: Path) -> Iterator[Path]:
+    """Yield run directories under ``<output>/``, skipping ``.locks``."""
+    if not root.is_dir():
+        return
+    for child in sorted(root.iterdir()):
+        if child.is_dir() and child.name != LOCKS_DIRNAME:
+            yield child

--- a/osmosis_ai/packaging.py
+++ b/osmosis_ai/packaging.py
@@ -8,7 +8,6 @@ anywhere with one ``pip install`` — a rollout container or a user's own box.
 
 from __future__ import annotations
 
-import hashlib
 import os
 import shutil
 import subprocess
@@ -26,6 +25,11 @@ from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 
 from osmosis_ai._imports import raise_optional_dependency_error
+from osmosis_ai.source_scan import (
+    EXCLUDE_DIRS,
+    reject_directory_symlinks,
+    source_digest,
+)
 
 # Only the Harbor backend packages rollout projects, so these ship with that
 # extra rather than the base install.
@@ -54,18 +58,6 @@ GRADER_MAIN_TEMPLATE = """\
 def grader_main():
     runner.grader_main({grader_class}, {grader_config})
 """
-
-EXCLUDE_DIRS = {
-    "__pycache__",
-    ".git",
-    ".venv",
-    "venv",
-    "dist",
-    "build",
-    "node_modules",
-    ".pytest_cache",
-    ".ruff_cache",
-}
 
 # PyPA's ``src/`` layout, which ``uv init --lib`` also produces.
 SRC_LAYOUT_DIR = "src"
@@ -104,41 +96,18 @@ def _uv_executable() -> str:
 
 
 def content_hash(path: Path, *, extra: str = "", exclude: Path | None = None) -> str:
-    digest = hashlib.sha256(extra.encode())
-    for file in sorted(
-        p
-        for p in path.rglob("*")
-        if p.is_file()
-        and not (set(p.relative_to(path).parts) & EXCLUDE_DIRS)
-        and not (exclude is not None and p.is_relative_to(exclude))
-    ):
-        digest.update(str(file.relative_to(path)).encode())
-        digest.update(file.read_bytes())
-    return digest.hexdigest()[:32]
+    """Bundle cache key: the shared source digest, truncated."""
+    return source_digest(path, extra=extra, exclude=exclude)[:32]
 
 
 def _reject_directory_symlinks(path: Path, *, exclude: Path | None) -> None:
     """Refuse to build through directory (or broken) symlinks.
 
-    ``content_hash`` cannot see through them — ``rglob`` does not recurse into
-    symlinked directories — while the ``copytree`` staging below dereferences
-    them into the build, so the cache key would not describe what actually
-    ships and a mutated link target would keep serving the stale cached wheel.
-    A link resolving into the build output tree would even recurse. File
-    symlinks stay allowed: hashing and staging both read the target's bytes,
-    so the two agree. Walks the same exclusion rules as ``content_hash``.
+    The bundle cache key cannot see through them, while the ``copytree``
+    staging below dereferences them into the build, so the key would not
+    describe what actually ships.
     """
-    for p in path.rglob("*"):
-        if set(p.relative_to(path).parts) & EXCLUDE_DIRS:
-            continue
-        if exclude is not None and p.is_relative_to(exclude):
-            continue
-        if p.is_symlink() and not p.is_file():
-            raise ValueError(
-                f"bundle source contains a directory or broken symlink: "
-                f"{p} -> {os.readlink(p)}; replace it with a real directory "
-                "or file so the bundle cache can hash what it ships"
-            )
+    reject_directory_symlinks(path, exclude=exclude, label="bundle source")
 
 
 def _stage_ignore(exclude: Path | None) -> Callable[[str, list[str]], set[str]]:

--- a/osmosis_ai/platform/cli/eval_run.py
+++ b/osmosis_ai/platform/cli/eval_run.py
@@ -8,6 +8,7 @@ display, and the result envelope. Scheduling and durable state live in
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -106,6 +107,8 @@ def _numeric(value: Any, *, field: str) -> float | None:
         return None
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise CLIError(f"evaluation.{field} must be a number, got {value!r}")
+    if not math.isfinite(value):
+        raise CLIError(f"evaluation.{field} must be finite, got {value!r}")
     return float(value)
 
 
@@ -180,6 +183,9 @@ def run(
         console.print_warning(warning)
 
     evaluation = config.evaluation_config
+    # ``or 1.0`` would turn a configured 0.0 -- "every graded row passes" -- into
+    # the default, so the fallback has to test for absence, not falsiness.
+    pass_threshold = _numeric(evaluation.get("pass_threshold"), field="pass_threshold")
     spec = EvalRunSpec(
         rollout_name=config.experiment_rollout,
         entrypoint=config.experiment_entrypoint,
@@ -187,10 +193,7 @@ def run(
         dataset_name=config.experiment_dataset,
         n=_integer(evaluation.get("n"), field="n") or 1,
         batch_size=_integer(evaluation.get("batch_size"), field="batch_size"),
-        pass_threshold=_numeric(
-            evaluation.get("pass_threshold"), field="pass_threshold"
-        )
-        or 1.0,
+        pass_threshold=1.0 if pass_threshold is None else pass_threshold,
         agent_timeout_sec=_numeric(
             evaluation.get("agent_workflow_timeout_s"), field="agent_workflow_timeout_s"
         ),
@@ -248,12 +251,9 @@ def run(
         spec=spec,
         options=LocalEvalOptions(
             name=name,
-            output=output_root,
-            rows=rows,
             fresh=fresh,
             retry_failed=retry_failed,
             max_in_flight=max_in_flight,
-            yes=yes,
             rollout_port=rollout_port,
             skip_llm_preflight=skip_llm_preflight,
             verbose=verbose,

--- a/osmosis_ai/platform/cli/eval_run.py
+++ b/osmosis_ai/platform/cli/eval_run.py
@@ -89,9 +89,16 @@ def _missing_extra_error(exc: ModuleNotFoundError) -> CLIError:
 
 
 def _resolve_output_root(output: str | None, workspace_directory: Path) -> Path:
+    """Absolute output root.
+
+    Resolved, not merely expanded: the runner decides whether to exclude the
+    output tree from the rollout source digest by comparing the two paths, and a
+    relative path would silently fail that check and make the run change its own
+    digest on every invocation (§5).
+    """
     if output is None:
-        return workspace_directory.joinpath(*DEFAULT_OUTPUT_SUBPATH)
-    return parse_cli_path(output, expand_user=True).path
+        return workspace_directory.joinpath(*DEFAULT_OUTPUT_SUBPATH).resolve()
+    return parse_cli_path(output, expand_user=True).path.resolve()
 
 
 def _numeric(value: Any, *, field: str) -> float | None:
@@ -196,8 +203,17 @@ def run(
         commit_sha=config.experiment_commit_sha,
     )
 
+    advanced = config.advanced_config
+    if advanced:
+        # §5: recorded as provenance, one warning for the rest. Local execution
+        # consumes no [advanced] keys today.
+        console.print_warning(
+            "\\[advanced] keys are recorded but not consumed by `osmosis eval run`: "
+            + ", ".join(sorted(advanced))
+        )
+
     output_root = _resolve_output_root(output, workspace_directory)
-    rollout_dir = workspace_directory / "rollouts" / spec.rollout_name
+    rollout_dir = (workspace_directory / "rollouts" / spec.rollout_name).resolve()
 
     try:
         if dataset_file is not None:
@@ -249,7 +265,7 @@ def run(
         proxy_base_url=_resolve_proxy_base_url(eval_proxy_url),
         proxy_auth_token=_platform_bearer(context.credentials),
         hooks=_Hooks(yes=yes, secrets_file=secrets_file, model_path=spec.model_path),
-        provenance=_provenance(workspace_directory, spec),
+        provenance=_provenance(workspace_directory, spec, advanced=advanced),
         config_stem=resolved_config_path.stem,
     )
 
@@ -287,7 +303,9 @@ def _platform_bearer(credentials: Any) -> str:
     return str(token)
 
 
-def _provenance(workspace_directory: Path, spec: Any) -> dict[str, Any]:
+def _provenance(
+    workspace_directory: Path, spec: Any, *, advanced: dict[str, Any] | None = None
+) -> dict[str, Any]:
     """Record what actually executed. Never mutates the workspace (§5)."""
     from osmosis_ai.platform.cli.workspace_repo import summarize_local_git_state
 
@@ -295,6 +313,7 @@ def _provenance(workspace_directory: Path, spec: Any) -> dict[str, Any]:
     provenance: dict[str, Any] = {
         "config_branch": spec.branch,
         "config_commit_sha": spec.commit_sha,
+        "advanced": dict(advanced) if advanced else None,
     }
     if state is not None:
         provenance.update(

--- a/osmosis_ai/platform/cli/eval_run.py
+++ b/osmosis_ai/platform/cli/eval_run.py
@@ -1,0 +1,388 @@
+"""`osmosis eval run` -- local evaluation, driven by the shared eval TOML.
+
+This layer owns everything CLI-shaped: workspace and login context, config
+parsing, dataset resolution, confirmation, secret resolution, the progress
+display, and the result envelope. Scheduling and durable state live in
+``osmosis_ai.eval.local``, which holds no CLI dependencies.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from osmosis_ai.cli.console import console
+from osmosis_ai.cli.errors import CLIError, CLIErrorCode
+from osmosis_ai.cli.output import CommandResult, OperationResult
+from osmosis_ai.cli.output.context import get_output_context
+from osmosis_ai.cli.paths import parse_cli_path
+from osmosis_ai.cli.prompts import require_confirmation
+from osmosis_ai.platform.cli.eval_config import (
+    load_eval_submit_config,
+    validate_eval_submit_context_paths,
+)
+from osmosis_ai.platform.cli.secret_resolution import resolve_run_secrets
+from osmosis_ai.platform.cli.utils import require_git_workspace_directory_context
+from osmosis_ai.platform.cli.workspace_directory_context import git_result_context
+from osmosis_ai.platform.cli.workspace_directory_contract import (
+    ensure_workspace_directory_config_path,
+    validate_rollout_backend,
+    validate_workspace_directory_contract,
+)
+
+COMMAND_LABEL = "`osmosis eval run`"
+EVAL_CONFIG_DIR = "configs/eval"
+DEFAULT_OUTPUT_SUBPATH = (".osmosis", "evals")
+
+#: Advanced flag default: the platform-hosted eval-proxy (D6).
+DEFAULT_EVAL_PROXY_PATH = "/api/eval-proxy"
+
+
+@dataclass(frozen=True)
+class _Hooks:
+    """Bridges the supervisor's callbacks onto CLI output primitives."""
+
+    yes: bool
+    secrets_file: str | None
+    model_path: str
+
+    def note(self, message: str) -> None:
+        console.print(message, style="dim")
+
+    def confirm_dispatch(self, *, pending: int, model_path: str) -> None:
+        require_confirmation(
+            f"{pending} rollouts x model {model_path} — continue?",
+            yes=self.yes,
+            default=False,
+        )
+
+    def resolve_secrets(self, names: Sequence[str]) -> dict[str, str]:
+        if not names:
+            return {}
+        # Workflow secrets must resolve locally: a name existing in the platform
+        # store does not satisfy them here (§7.3). Provider keys are the
+        # opposite -- the eval-proxy injects those server-side.
+        return resolve_run_secrets(
+            names=list(names),
+            secrets_file=self.secrets_file,
+            stored_names=set(),
+        )
+
+    def progress(self, snapshot: Any) -> None:
+        console.print(
+            f"{snapshot.completed}/{snapshot.total} "
+            f"pass_rate={snapshot.pass_rate:.2f} failed={snapshot.failed}",
+            style="dim",
+        )
+
+
+def _missing_extra_error(exc: ModuleNotFoundError) -> CLIError:
+    return CLIError(
+        "Local evaluation requires optional dependencies. Install them with "
+        '`pip install "osmosis-ai[eval-run]"` (Harbor backends: '
+        '`pip install "osmosis-ai[eval-run,harbor]"`).',
+        code=CLIErrorCode.VALIDATION,
+        details={"missing_module": exc.name, "extra": "eval-run"},
+    )
+
+
+def _resolve_output_root(output: str | None, workspace_directory: Path) -> Path:
+    if output is None:
+        return workspace_directory.joinpath(*DEFAULT_OUTPUT_SUBPATH)
+    return parse_cli_path(output, expand_user=True).path
+
+
+def _numeric(value: Any, *, field: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise CLIError(f"evaluation.{field} must be a number, got {value!r}")
+    return float(value)
+
+
+def _integer(value: Any, *, field: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise CLIError(f"evaluation.{field} must be an integer, got {value!r}")
+    return value
+
+
+def run(
+    config_path: Path,
+    *,
+    name: str | None = None,
+    output: str | None = None,
+    dataset_file: str | None = None,
+    secrets_file: str | None = None,
+    rows: str | None = None,
+    fresh: bool = False,
+    retry_failed: bool = False,
+    max_in_flight: int | None = None,
+    yes: bool = False,
+    rollout_port: int | None = None,
+    skip_llm_preflight: bool = False,
+    verbose: bool = False,
+    eval_proxy_url: str | None = None,
+) -> CommandResult:
+    """Run an evaluation locally against the workspace's rollout server."""
+    import asyncio
+
+    try:
+        from osmosis_ai.eval.local.dataset import (
+            DatasetCache,
+            DatasetResolutionError,
+            PlatformDatasetFetcher,
+            default_dataset_cache_root,
+            parse_row_selector,
+            resolve_explicit_dataset_file,
+            resolve_platform_dataset,
+            select_rows,
+        )
+        from osmosis_ai.eval.local.runner import (
+            EvalRunSpec,
+            LocalEvalError,
+            LocalEvalOptions,
+            LocalEvalRunner,
+        )
+        from osmosis_ai.eval.local.state import LocalEvalStateError
+    except ModuleNotFoundError as exc:
+        raise _missing_extra_error(exc) from exc
+
+    context = require_git_workspace_directory_context()
+    workspace_directory = context.workspace_directory
+    validate_workspace_directory_contract(workspace_directory)
+
+    resolved_config_path = config_path.expanduser().resolve()
+    ensure_workspace_directory_config_path(
+        resolved_config_path,
+        workspace_directory,
+        config_dir=EVAL_CONFIG_DIR,
+        command_label=COMMAND_LABEL,
+    )
+    config = load_eval_submit_config(resolved_config_path)
+    validate_eval_submit_context_paths(config, workspace_directory)
+    for warning in validate_rollout_backend(
+        workspace_directory=workspace_directory,
+        rollout=config.experiment_rollout,
+        entrypoint=config.experiment_entrypoint,
+        command_label=COMMAND_LABEL,
+    ):
+        console.print_warning(warning)
+
+    evaluation = config.evaluation_config
+    spec = EvalRunSpec(
+        rollout_name=config.experiment_rollout,
+        entrypoint=config.experiment_entrypoint,
+        model_path=config.experiment_model_path,
+        dataset_name=config.experiment_dataset,
+        n=_integer(evaluation.get("n"), field="n") or 1,
+        batch_size=_integer(evaluation.get("batch_size"), field="batch_size"),
+        pass_threshold=_numeric(
+            evaluation.get("pass_threshold"), field="pass_threshold"
+        )
+        or 1.0,
+        agent_timeout_sec=_numeric(
+            evaluation.get("agent_workflow_timeout_s"), field="agent_workflow_timeout_s"
+        ),
+        grader_timeout_sec=_numeric(
+            evaluation.get("grader_timeout_s"), field="grader_timeout_s"
+        ),
+        env=dict(config.env),
+        secret_names=tuple(config.secrets),
+        branch=config.experiment_branch,
+        commit_sha=config.experiment_commit_sha,
+    )
+
+    output_root = _resolve_output_root(output, workspace_directory)
+    rollout_dir = workspace_directory / "rollouts" / spec.rollout_name
+
+    try:
+        if dataset_file is not None:
+            dataset = resolve_explicit_dataset_file(
+                parse_cli_path(dataset_file, expand_user=True).path
+            )
+        else:
+            cache = DatasetCache(
+                default_dataset_cache_root(), git_identity=context.git_identity
+            )
+            fetcher = PlatformDatasetFetcher(
+                credentials=context.credentials, git_identity=context.git_identity
+            )
+            with get_output_context().status("Resolving dataset..."):
+                dataset = resolve_platform_dataset(
+                    spec.dataset_name,
+                    cache=cache,
+                    fetcher=fetcher,
+                    on_event=lambda message: console.print(message, style="dim"),
+                )
+        row_selector = parse_row_selector(rows) if rows else None
+        selection = select_rows(
+            dataset.path,
+            extension=dataset.extension,
+            limit=_integer(evaluation.get("limit"), field="limit"),
+            row_selector=row_selector,
+        )
+    except DatasetResolutionError as exc:
+        raise CLIError(str(exc)) from exc
+
+    runner = LocalEvalRunner(
+        spec=spec,
+        options=LocalEvalOptions(
+            name=name,
+            output=output_root,
+            rows=rows,
+            fresh=fresh,
+            retry_failed=retry_failed,
+            max_in_flight=max_in_flight,
+            yes=yes,
+            rollout_port=rollout_port,
+            skip_llm_preflight=skip_llm_preflight,
+            verbose=verbose,
+        ),
+        dataset=dataset,
+        selection=selection,
+        rollout_dir=rollout_dir,
+        output_root=output_root,
+        proxy_base_url=_resolve_proxy_base_url(eval_proxy_url),
+        proxy_auth_token=_platform_bearer(context.credentials),
+        hooks=_Hooks(yes=yes, secrets_file=secrets_file, model_path=spec.model_path),
+        provenance=_provenance(workspace_directory, spec),
+        config_stem=resolved_config_path.stem,
+    )
+
+    try:
+        summary = asyncio.run(runner.run())
+    except (LocalEvalError, LocalEvalStateError) as exc:
+        raise CLIError(str(exc)) from exc
+    except KeyboardInterrupt:
+        raise CLIError(
+            "Interrupted. Re-run the same command to resume the pending work items.",
+            code=CLIErrorCode.VALIDATION,
+        ) from None
+
+    _print_failures(summary)
+    return _result(summary, context=context, dataset_source=dataset.source)
+
+
+def _resolve_proxy_base_url(override: str | None) -> str:
+    """Advanced flag or the platform-derived hosted eval-proxy base (D6)."""
+    if override:
+        return override.rstrip("/")
+    from osmosis_ai.platform.auth.config import get_platform_url
+
+    return f"{get_platform_url().rstrip('/')}{DEFAULT_EVAL_PROXY_PATH}"
+
+
+def _platform_bearer(credentials: Any) -> str:
+    token = getattr(credentials, "access_token", None)
+    if not token:
+        raise CLIError(
+            "Local evaluation requires an Osmosis login: the eval-proxy session "
+            "is org-authenticated. Run `osmosis auth login`.",
+            code=CLIErrorCode.AUTH_REQUIRED,
+        )
+    return str(token)
+
+
+def _provenance(workspace_directory: Path, spec: Any) -> dict[str, Any]:
+    """Record what actually executed. Never mutates the workspace (§5)."""
+    from osmosis_ai.platform.cli.workspace_repo import summarize_local_git_state
+
+    state = summarize_local_git_state(workspace_directory)
+    provenance: dict[str, Any] = {
+        "config_branch": spec.branch,
+        "config_commit_sha": spec.commit_sha,
+    }
+    if state is not None:
+        provenance.update(
+            {
+                "git_head": state.head_sha,
+                "git_branch": state.branch,
+                "git_dirty": state.is_dirty,
+            }
+        )
+        if spec.commit_sha and state.head_sha != spec.commit_sha:
+            console.print_warning(
+                f"config pins commit {spec.commit_sha} but the workspace is at "
+                f"{state.head_sha}; the local run executes the workspace as it is."
+            )
+        elif spec.branch and state.branch and state.branch != spec.branch:
+            console.print_warning(
+                f"config names branch {spec.branch!r} but the workspace is on "
+                f"{state.branch!r}; the local run executes the workspace as it is."
+            )
+    return {key: value for key, value in provenance.items() if value is not None}
+
+
+def _print_failures(summary: Any) -> None:
+    """Print failed rows with zero-friction paths (§4.3)."""
+    if not summary.failures:
+        return
+    console.separator("Failed rows")
+    for failure in summary.failures:
+        source = (
+            ""
+            if failure.source_row_index == failure.row_index
+            else f" (source {failure.source_row_index})"
+        )
+        error = failure.error_type or "unknown"
+        console.print(
+            f"row {failure.row_index}{source} run {failure.run_index}: "
+            f"error_type={error} -> {failure.rollout_dir}"
+        )
+
+
+def _result(summary: Any, *, context: Any, dataset_source: str) -> OperationResult:
+    resource: dict[str, Any] = {
+        "run_name": summary.run_name,
+        "local_run_id": summary.local_run_id,
+        "output_path": str(summary.run_dir),
+        "dataset_source": dataset_source,
+        "total_work_items": summary.total_work_items,
+        "dispatched": summary.dispatched,
+        "succeeded": summary.succeeded,
+        "failed": summary.failed,
+        "skipped": summary.skipped,
+        "resumed": summary.resumed,
+        "cancelled": summary.cancelled,
+        "metrics": summary.metrics,
+        "failed_rows": [
+            {
+                "row_index": failure.row_index,
+                "source_row_index": failure.source_row_index,
+                "run_index": failure.run_index,
+                "rollout_id": failure.rollout_id,
+                "error_type": failure.error_type,
+                "rollout_dir": str(failure.rollout_dir),
+            }
+            for failure in summary.failures
+        ],
+    }
+    resource.update(git_result_context(context))
+    incomplete = summary.cancelled or (
+        summary.succeeded + summary.failed + summary.skipped < summary.total_work_items
+    )
+    next_steps = []
+    if incomplete:
+        next_steps.append(
+            f"Resume: osmosis eval run <config> --name {summary.run_name}"
+        )
+    if summary.failed:
+        next_steps.append(
+            "Retry failures under the same name: "
+            f"osmosis eval run <config> --name {summary.run_name} --retry-failed"
+        )
+    return OperationResult(
+        operation="eval.run",
+        status="partial" if incomplete else "success",
+        resource=resource,
+        message=(
+            f"Evaluation run {'interrupted' if incomplete else 'finished'}: "
+            f"{summary.run_dir}"
+        ),
+        display_next_steps=next_steps,
+        exit_code=1 if incomplete else 0,
+    )

--- a/osmosis_ai/rollout/controller/__init__.py
+++ b/osmosis_ai/rollout/controller/__init__.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
         EvalProxyClient,
         EvalProxyError,
         EvalProxySession,
+        EvalProxyStubUpstream,
         create_eval_proxy_stub_app,
     )
     from osmosis_ai.rollout.controller.store import (
@@ -51,6 +52,10 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "EvalProxySession": (
         "osmosis_ai.rollout.controller.proxy_client",
         "EvalProxySession",
+    ),
+    "EvalProxyStubUpstream": (
+        "osmosis_ai.rollout.controller.proxy_client",
+        "EvalProxyStubUpstream",
     ),
     "TerminalCallbackResult": (
         "osmosis_ai.rollout.controller.store",
@@ -98,6 +103,7 @@ __all__ = [
     "EvalProxyClient",
     "EvalProxyError",
     "EvalProxySession",
+    "EvalProxyStubUpstream",
     "TerminalCallbackResult",
     "UnknownRolloutIdError",
     "create_callback_app",

--- a/osmosis_ai/rollout/controller/proxy_client.py
+++ b/osmosis_ai/rollout/controller/proxy_client.py
@@ -23,13 +23,16 @@ uses the session bearer token.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import secrets
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import quote
+
+import httpx
 
 from osmosis_ai._imports import raise_optional_dependency_error
 
@@ -295,8 +298,83 @@ class EvalProxyClient:
             return payload
 
 
+@dataclass(frozen=True)
+class EvalProxyStubUpstream:
+    """A real OpenAI-compatible provider behind the contract stub.
+
+    The stub answers with a canned completion by default, which is enough to
+    exercise the wire contract but scores zero against any real grader. Pointing
+    it at a provider lets a local end-to-end run produce genuine rewards while
+    the hosted eval-proxy service is still being built -- the frozen request and
+    SSE contract is unchanged, only the response body becomes real.
+
+    ``api_key`` is held in memory and never logged or persisted.
+    """
+
+    base_url: str
+    api_key: str = field(repr=False)
+    timeout_sec: float = 600.0
+
+    def chat_url(self) -> str:
+        return f"{self.base_url.rstrip('/')}/chat/completions"
+
+
+def _upstream_model(model_path: str) -> str:
+    """Strip the LiteLLM provider prefix: ``openai/gpt-5-mini`` -> ``gpt-5-mini``."""
+    _, separator, remainder = model_path.partition("/")
+    return remainder if separator and remainder else model_path
+
+
+def _record_usage(session: dict[str, Any], payload: Mapping[str, Any]) -> None:
+    usage = payload.get("usage")
+    if not isinstance(usage, Mapping):
+        return
+    totals = session["usage"]
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        value = usage.get(key)
+        if isinstance(value, int) and not isinstance(value, bool):
+            totals[key] = totals.get(key, 0) + value
+
+
+async def _relay_upstream_chat(
+    *,
+    upstream: EvalProxyStubUpstream,
+    session: dict[str, Any],
+    body: Mapping[str, Any],
+) -> AsyncIterator[str]:
+    """Forward one chat request upstream and relay its SSE stream verbatim.
+
+    ``include_usage`` is forced on so metering never depends on the client
+    asking for it, matching the production requirement.
+    """
+    forwarded = dict(body)
+    forwarded["model"] = _upstream_model(session["model_path"])
+    forwarded["stream"] = True
+    forwarded["stream_options"] = {"include_usage": True}
+    headers = {"Authorization": f"Bearer {upstream.api_key}"}
+    async with httpx.AsyncClient(timeout=upstream.timeout_sec) as client:
+        async with client.stream(
+            "POST", upstream.chat_url(), json=forwarded, headers=headers
+        ) as response:
+            if response.status_code >= 400:
+                detail = (await response.aread()).decode(errors="replace")[:500]
+                raise HTTPException(
+                    status_code=502,
+                    detail=f"upstream provider returned {response.status_code}: {detail}",
+                )
+            async for line in response.aiter_lines():
+                if line.startswith("data: "):
+                    data = line[len("data: ") :].strip()
+                    if data and data != "[DONE]":
+                        with contextlib.suppress(json.JSONDecodeError, TypeError):
+                            _record_usage(session, json.loads(data))
+                yield f"{line}\n"
+
+
 def create_eval_proxy_stub_app(
-    *, platform_token: str = _DEFAULT_STUB_PLATFORM_TOKEN
+    *,
+    platform_token: str = _DEFAULT_STUB_PLATFORM_TOKEN,
+    upstream: EvalProxyStubUpstream | None = None,
 ) -> FastAPI:
     """Local contract stub for SDK tests. Not a production eval-proxy."""
     app = FastAPI()
@@ -345,11 +423,11 @@ def create_eval_proxy_stub_app(
         app.state.sessions[rollout_id] = {
             "token": token,
             "model_path": model_path,
-            "usage": {
-                "prompt_tokens": 1,
-                "completion_tokens": 1,
-                "total_tokens": 2,
-            },
+            "usage": (
+                {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+                if upstream is not None
+                else {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            ),
         }
         return {
             "rollout_id": rollout_id,
@@ -365,7 +443,7 @@ def create_eval_proxy_stub_app(
         request: Request,
         authorization: str | None = Header(default=None),
     ) -> StreamingResponse:
-        _require_session(rollout_id, authorization)
+        session = _require_session(rollout_id, authorization)
         body = await request.json()
         if not isinstance(body, dict):
             raise HTTPException(status_code=400, detail="expected a JSON object")
@@ -385,6 +463,12 @@ def create_eval_proxy_stub_app(
             raise HTTPException(
                 status_code=400,
                 detail="include_usage must be true when present",
+            )
+
+        if upstream is not None:
+            return StreamingResponse(
+                _relay_upstream_chat(upstream=upstream, session=session, body=body),
+                media_type="text/event-stream",
             )
 
         async def events() -> AsyncIterator[str]:

--- a/osmosis_ai/rollout/controller/proxy_client.py
+++ b/osmosis_ai/rollout/controller/proxy_client.py
@@ -336,13 +336,18 @@ def _record_usage(session: dict[str, Any], payload: Mapping[str, Any]) -> None:
             totals[key] = totals.get(key, 0) + value
 
 
-async def _relay_upstream_chat(
+async def _open_upstream_chat(
     *,
     upstream: EvalProxyStubUpstream,
     session: dict[str, Any],
     body: Mapping[str, Any],
-) -> AsyncIterator[str]:
-    """Forward one chat request upstream and relay its SSE stream verbatim.
+) -> tuple[httpx.AsyncClient, httpx.Response]:
+    """Start the upstream request and settle its status before streaming begins.
+
+    The status check has to happen here, not inside the relay generator: once
+    ``StreamingResponse`` has sent 200 and its headers, an exception can only
+    truncate the body, which the client reports as a transport error instead of
+    the provider's actual message.
 
     ``include_usage`` is forced on so metering never depends on the client
     asking for it, matching the production requirement.
@@ -352,23 +357,49 @@ async def _relay_upstream_chat(
     forwarded["stream"] = True
     forwarded["stream_options"] = {"include_usage": True}
     headers = {"Authorization": f"Bearer {upstream.api_key}"}
-    async with httpx.AsyncClient(timeout=upstream.timeout_sec) as client:
-        async with client.stream(
+    client = httpx.AsyncClient(timeout=upstream.timeout_sec)
+    try:
+        request = client.build_request(
             "POST", upstream.chat_url(), json=forwarded, headers=headers
-        ) as response:
-            if response.status_code >= 400:
-                detail = (await response.aread()).decode(errors="replace")[:500]
-                raise HTTPException(
-                    status_code=502,
-                    detail=f"upstream provider returned {response.status_code}: {detail}",
-                )
-            async for line in response.aiter_lines():
-                if line.startswith("data: "):
-                    data = line[len("data: ") :].strip()
-                    if data and data != "[DONE]":
-                        with contextlib.suppress(json.JSONDecodeError, TypeError):
-                            _record_usage(session, json.loads(data))
-                yield f"{line}\n"
+        )
+        response = await client.send(request, stream=True)
+    except httpx.HTTPError as exc:
+        await client.aclose()
+        raise HTTPException(
+            status_code=502, detail=f"upstream provider is unreachable: {exc}"
+        ) from exc
+    except BaseException:
+        await client.aclose()
+        raise
+    if response.status_code >= 400:
+        detail = (await response.aread()).decode(errors="replace")[:500]
+        await response.aclose()
+        await client.aclose()
+        raise HTTPException(
+            status_code=502,
+            detail=f"upstream provider returned {response.status_code}: {detail}",
+        )
+    return client, response
+
+
+async def _relay_upstream_chat(
+    *,
+    client: httpx.AsyncClient,
+    response: httpx.Response,
+    session: dict[str, Any],
+) -> AsyncIterator[str]:
+    """Relay an already-accepted upstream SSE stream verbatim, metering usage."""
+    try:
+        async for line in response.aiter_lines():
+            if line.startswith("data: "):
+                data = line[len("data: ") :].strip()
+                if data and data != "[DONE]":
+                    with contextlib.suppress(json.JSONDecodeError, TypeError):
+                        _record_usage(session, json.loads(data))
+            yield f"{line}\n"
+    finally:
+        await response.aclose()
+        await client.aclose()
 
 
 def create_eval_proxy_stub_app(
@@ -466,8 +497,13 @@ def create_eval_proxy_stub_app(
             )
 
         if upstream is not None:
+            client, upstream_response = await _open_upstream_chat(
+                upstream=upstream, session=session, body=body
+            )
             return StreamingResponse(
-                _relay_upstream_chat(upstream=upstream, session=session, body=body),
+                _relay_upstream_chat(
+                    client=client, response=upstream_response, session=session
+                ),
                 media_type="text/event-stream",
             )
 

--- a/osmosis_ai/rollout/http_driver.py
+++ b/osmosis_ai/rollout/http_driver.py
@@ -54,6 +54,10 @@ class _AdmissionProbe(StrEnum):
     INDETERMINATE = "indeterminate"
 
 
+#: Shortest wait the admission loop will honour between 429 retries.
+_RETRY_AFTER_FLOOR_SEC = 0.05
+
+
 class AdmissionUncertainError(RuntimeError):
     """Status recovery could not determine whether POST /rollout was admitted."""
 
@@ -63,7 +67,12 @@ class RolloutProtocolError(RuntimeError):
 
 
 def _retry_after_seconds(response: httpx.Response, default: float = 1.0) -> float:
-    """Parse Retry-After into a finite, non-negative wait; else the default."""
+    """Parse Retry-After into a finite, positive wait; else the default.
+
+    Clamped to a floor rather than honoured exactly at zero: a server that keeps
+    answering ``429`` with ``Retry-After: 0`` would otherwise turn the admission
+    loop into a busy spin against itself.
+    """
     raw = response.headers.get("Retry-After")
     if raw is None:
         return default
@@ -73,7 +82,7 @@ def _retry_after_seconds(response: httpx.Response, default: float = 1.0) -> floa
         return default
     if not math.isfinite(value):
         return default
-    return max(0.0, value)
+    return max(_RETRY_AFTER_FLOOR_SEC, value)
 
 
 def _optional_index(request: RolloutRunRequest, name: str) -> int | None:

--- a/osmosis_ai/rollout/http_driver.py
+++ b/osmosis_ai/rollout/http_driver.py
@@ -63,7 +63,15 @@ class AdmissionUncertainError(RuntimeError):
 
 
 class RolloutProtocolError(RuntimeError):
-    """The rollout server returned a response outside the v0.3 admission contract."""
+    """The rollout server returned a response outside the v0.3 admission contract.
+
+    ``status_code`` is part of the contract: a caller has to tell a refusal of
+    *this* request apart from a server that is simply broken.
+    """
+
+    def __init__(self, message: str, *, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code: int = status_code
 
 
 def _retry_after_seconds(response: httpx.Response, default: float = 1.0) -> float:
@@ -237,7 +245,8 @@ class HttpRolloutDriver(RolloutDriver):
                 continue
             raise RolloutProtocolError(
                 f"POST /rollout returned {response.status_code}; "
-                "only 202 and 429 are accepted"
+                "only 202 and 429 are accepted",
+                status_code=response.status_code,
             )
 
     async def _cancel_remotely_if_cancelled_locally(self, rollout_id: str) -> None:

--- a/osmosis_ai/source_scan.py
+++ b/osmosis_ai/source_scan.py
@@ -1,0 +1,93 @@
+"""Shared traversal for digesting a rollout project's source tree.
+
+Two callers need the same answer to "which files describe this project's
+code?": the Harbor bundle packager keys its wheel cache on it, and local
+evaluation puts it in a run's resolved-input lock so a named run refuses to
+resume across a code change. Keeping one traversal here means those two
+digests can never disagree about which files count -- only the width differs,
+since the packager truncates its cache key while eval stores a full SHA-256.
+
+This module must stay free of optional dependencies: ``osmosis_ai.packaging``
+requires the ``harbor`` extra and local evaluation must not.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+EXCLUDE_DIRS: frozenset[str] = frozenset(
+    {
+        "__pycache__",
+        ".git",
+        ".venv",
+        "venv",
+        "dist",
+        "build",
+        "node_modules",
+        ".pytest_cache",
+        ".ruff_cache",
+    }
+)
+
+
+def _is_excluded(relative: Path, *, path: Path, exclude: Path | None) -> bool:
+    if set(relative.parts) & EXCLUDE_DIRS:
+        return True
+    return exclude is not None and path.is_relative_to(exclude)
+
+
+def iter_source_files(root: Path, *, exclude: Path | None = None) -> Iterator[Path]:
+    """Yield every source file under *root*, in unspecified order.
+
+    Skips anything inside :data:`EXCLUDE_DIRS` and, when given, anything under
+    *exclude* -- used to keep a cache or run-output directory nested in the
+    project from changing the project's own digest.
+    """
+    for candidate in root.rglob("*"):
+        if not candidate.is_file():
+            continue
+        relative = candidate.relative_to(root)
+        if _is_excluded(relative, path=candidate, exclude=exclude):
+            continue
+        yield candidate
+
+
+def reject_directory_symlinks(
+    root: Path, *, exclude: Path | None = None, label: str = "source"
+) -> None:
+    """Refuse to digest through a directory (or broken) symlink.
+
+    ``rglob`` does not recurse into symlinked directories, so the digest cannot
+    see their contents, while consumers that copy the tree dereference them --
+    the digest would not describe what actually ships, and a mutated link
+    target would keep serving stale cached output. A link resolving back into
+    the output tree would even recurse. File symlinks stay allowed: hashing and
+    copying both read the target's bytes, so the two agree.
+    """
+    for candidate in root.rglob("*"):
+        relative = candidate.relative_to(root)
+        if _is_excluded(relative, path=candidate, exclude=exclude):
+            continue
+        if candidate.is_symlink() and not candidate.is_file():
+            raise ValueError(
+                f"{label} contains a directory or broken symlink: "
+                f"{candidate} -> {os.readlink(candidate)}; replace it with a real "
+                "directory or file so the digest can describe what it covers"
+            )
+
+
+def source_digest(root: Path, *, extra: str = "", exclude: Path | None = None) -> str:
+    """Return the full SHA-256 hex digest of *root*'s source bytes.
+
+    Relative paths are hashed alongside file contents so a rename changes the
+    digest. *extra* is mixed in first, letting a caller bind the digest to
+    out-of-tree inputs of its own.
+    """
+    digest = hashlib.sha256(extra.encode())
+    for file in sorted(iter_source_files(root, exclude=exclude)):
+        digest.update(str(file.relative_to(root)).encode())
+        digest.update(file.read_bytes())
+    return digest.hexdigest()

--- a/tests/golden/eval_local/index/contract_cases.json
+++ b/tests/golden/eval_local/index/contract_cases.json
@@ -1,0 +1,90 @@
+{
+  "description": "Every §2.2 index.jsonl rule the platform enforces silently. `problems` lists substrings the SDK contract lint must report; an empty list means the platform accepts the row.",
+  "cases": [
+    {
+      "name": "minimal-valid",
+      "row": {"row_index": 0, "run_index": 0, "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "success", "duration_ms": 1.0},
+      "problems": []
+    },
+    {
+      "name": "full-valid",
+      "row": {"row_index": 3, "run_index": 2, "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "trajectory_filename": "trajectory.json", "status": "success", "reward": 1.0, "tokens": 617, "duration_ms": 59801.2, "error_type": "none", "resumed": true},
+      "problems": []
+    },
+    {
+      "name": "sample-id-instead-of-rollout-id",
+      "row": {"row_index": 0, "run_index": 0, "sample_id": "s-1", "status": "success", "duration_ms": 1.0},
+      "problems": []
+    },
+    {
+      "name": "skipped-status-is-valid",
+      "row": {"row_index": 0, "run_index": 0, "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "skipped", "duration_ms": 1.0},
+      "problems": []
+    },
+    {
+      "name": "missing-row-index",
+      "row": {"run_index": 0, "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "success", "duration_ms": 1.0},
+      "problems": ["row_index must be a number"]
+    },
+    {
+      "name": "missing-run-index",
+      "row": {"row_index": 0, "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "success", "duration_ms": 1.0},
+      "problems": ["run_index must be a number"]
+    },
+    {
+      "name": "missing-duration-ms",
+      "row": {"row_index": 0, "run_index": 0, "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "success"},
+      "problems": ["duration_ms must be a number"]
+    },
+    {
+      "name": "stringified-row-index",
+      "row": {"row_index": "0", "run_index": 0, "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "success", "duration_ms": 1.0},
+      "problems": ["row_index must be a number"]
+    },
+    {
+      "name": "unknown-status",
+      "row": {"row_index": 0, "run_index": 0, "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "cancelled", "duration_ms": 1.0},
+      "problems": ["status must be one of"]
+    },
+    {
+      "name": "null-valued-key",
+      "row": {"row_index": 0, "run_index": 0, "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "success", "duration_ms": 1.0, "reward": null},
+      "problems": ["None-valued keys must be omitted"]
+    },
+    {
+      "name": "no-identity",
+      "row": {"row_index": 0, "run_index": 0, "status": "success", "duration_ms": 1.0},
+      "problems": ["rollout_id or sample_id"]
+    },
+    {
+      "name": "uppercase-rollout-id",
+      "row": {"row_index": 0, "run_index": 0, "rollout_id": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "status": "success", "duration_ms": 1.0},
+      "problems": ["32 lowercase hex"]
+    },
+    {
+      "name": "short-rollout-id",
+      "row": {"row_index": 0, "run_index": 0, "rollout_id": "abc123", "status": "success", "duration_ms": 1.0},
+      "problems": ["32 lowercase hex"]
+    },
+    {
+      "name": "dashed-uuid-rollout-id",
+      "row": {"row_index": 0, "run_index": 0, "rollout_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "status": "success", "duration_ms": 1.0},
+      "problems": ["32 lowercase hex"]
+    },
+    {
+      "name": "trajectory-filename-with-separator",
+      "row": {"row_index": 0, "run_index": 0, "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "trajectory_filename": "nested/trajectory.json", "status": "success", "duration_ms": 1.0},
+      "problems": ["trajectory_filename"]
+    },
+    {
+      "name": "trajectory-filename-wrong-prefix",
+      "row": {"row_index": 0, "run_index": 0, "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "trajectory_filename": "traj.json", "status": "success", "duration_ms": 1.0},
+      "problems": ["trajectory_filename"]
+    },
+    {
+      "name": "trajectory-filename-suffixed-is-valid",
+      "row": {"row_index": 0, "run_index": 0, "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "trajectory_filename": "trajectory_retry-2.json", "status": "success", "duration_ms": 1.0},
+      "problems": []
+    }
+  ]
+}

--- a/tests/golden/eval_local/metrics/all_failed_no_rewards.json
+++ b/tests/golden/eval_local/metrics/all_failed_no_rewards.json
@@ -1,0 +1,19 @@
+{
+  "description": "Every attempt failed with no reward: graded is 0 and pass_rate must not divide by zero.",
+  "pass_threshold": 1.0,
+  "index": [
+    {"row_index": 0, "run_index": 0, "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "failed", "error_type": "callback_timeout", "duration_ms": 450000.0},
+    {"row_index": 1, "run_index": 0, "rollout_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "status": "failed", "error_type": "workflow_error", "duration_ms": 1200.0}
+  ],
+  "expected": {
+    "total_samples": 2,
+    "completed_samples": 2,
+    "graded": 0,
+    "passed": 0,
+    "failed": 2,
+    "skipped": 0,
+    "pass_rate": 0,
+    "pass_threshold": 1.0,
+    "tokens_used": 0
+  }
+}

--- a/tests/golden/eval_local/metrics/multi_attempt_pass_at_k.json
+++ b/tests/golden/eval_local/metrics/multi_attempt_pass_at_k.json
@@ -1,0 +1,32 @@
+{
+  "description": "n=4 over two rows: pass@k over powers of two, unbiased estimator averaged across rows.",
+  "pass_threshold": 1.0,
+  "index": [
+    {"row_index": 0, "run_index": 0, "rollout_id": "a0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "success", "reward": 1.0, "tokens": 10, "duration_ms": 1.0},
+    {"row_index": 0, "run_index": 1, "rollout_id": "a1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "success", "reward": 0.0, "tokens": 10, "duration_ms": 1.0},
+    {"row_index": 0, "run_index": 2, "rollout_id": "a2aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "success", "reward": 0.0, "tokens": 10, "duration_ms": 1.0},
+    {"row_index": 0, "run_index": 3, "rollout_id": "a3aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "success", "reward": 0.0, "tokens": 10, "duration_ms": 1.0},
+    {"row_index": 1, "run_index": 0, "rollout_id": "b0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "status": "success", "reward": 0.0, "tokens": 10, "duration_ms": 1.0},
+    {"row_index": 1, "run_index": 1, "rollout_id": "b1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "status": "success", "reward": 0.0, "tokens": 10, "duration_ms": 1.0},
+    {"row_index": 1, "run_index": 2, "rollout_id": "b2bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "status": "success", "reward": 0.0, "tokens": 10, "duration_ms": 1.0},
+    {"row_index": 1, "run_index": 3, "rollout_id": "b3bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "status": "success", "reward": 0.0, "tokens": 10, "duration_ms": 1.0}
+  ],
+  "expected": {
+    "total_samples": 8,
+    "completed_samples": 8,
+    "graded": 8,
+    "passed": 1,
+    "failed": 0,
+    "skipped": 0,
+    "pass_rate": 0.125,
+    "pass_threshold": 1.0,
+    "tokens_used": 80,
+    "reward_stats": {"mean": 0.125, "median": 0.0, "std": 0.33071891388307384, "min": 0.0, "max": 1.0},
+    "n_runs": 4,
+    "pass_at_k": [
+      {"k": 1, "value": 0.125},
+      {"k": 2, "value": 0.25},
+      {"k": 4, "value": 0.5}
+    ]
+  }
+}

--- a/tests/golden/eval_local/metrics/single_attempt_all_pass.json
+++ b/tests/golden/eval_local/metrics/single_attempt_all_pass.json
@@ -1,0 +1,22 @@
+{
+  "description": "n=1, every row graded and passing. Mirrors the platform worker's _aggregate_from_index.",
+  "pass_threshold": 1.0,
+  "index": [
+    {"row_index": 0, "run_index": 0, "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "trajectory_filename": "trajectory.json", "status": "success", "reward": 1.0, "tokens": 617, "duration_ms": 59801.227005},
+    {"row_index": 1, "run_index": 0, "rollout_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "trajectory_filename": "trajectory.json", "status": "success", "reward": 1.0, "tokens": 1132, "duration_ms": 65646.086694},
+    {"row_index": 2, "run_index": 0, "rollout_id": "cccccccccccccccccccccccccccccccc", "trajectory_filename": "trajectory.json", "status": "success", "reward": 1.0, "tokens": 2871, "duration_ms": 120000.0},
+    {"row_index": 3, "run_index": 0, "rollout_id": "dddddddddddddddddddddddddddddddd", "trajectory_filename": "trajectory.json", "status": "success", "reward": 1.0, "tokens": 2676, "duration_ms": 127844.5}
+  ],
+  "expected": {
+    "total_samples": 4,
+    "completed_samples": 4,
+    "graded": 4,
+    "passed": 4,
+    "failed": 0,
+    "skipped": 0,
+    "pass_rate": 1.0,
+    "pass_threshold": 1.0,
+    "tokens_used": 7296,
+    "reward_stats": {"mean": 1.0, "median": 1.0, "std": 0.0, "min": 1.0, "max": 1.0}
+  }
+}

--- a/tests/golden/eval_local/metrics/skipped_excluded_from_scored.json
+++ b/tests/golden/eval_local/metrics/skipped_excluded_from_scored.json
@@ -1,0 +1,22 @@
+{
+  "description": "remove_sample rows are skipped: excluded from scored, so pass_rate divides by graded only.",
+  "pass_threshold": 0.5,
+  "index": [
+    {"row_index": 0, "run_index": 0, "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "success", "reward": 1.0, "tokens": 100, "duration_ms": 10.0},
+    {"row_index": 1, "run_index": 0, "rollout_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "status": "success", "reward": 0.25, "tokens": 200, "duration_ms": 20.0},
+    {"row_index": 2, "run_index": 0, "rollout_id": "cccccccccccccccccccccccccccccccc", "status": "skipped", "tokens": 5, "duration_ms": 5.0},
+    {"row_index": 3, "run_index": 0, "rollout_id": "dddddddddddddddddddddddddddddddd", "status": "failed", "error_type": "grader_timeout", "duration_ms": 30.0}
+  ],
+  "expected": {
+    "total_samples": 4,
+    "completed_samples": 3,
+    "graded": 2,
+    "passed": 1,
+    "failed": 1,
+    "skipped": 1,
+    "pass_rate": 0.5,
+    "pass_threshold": 0.5,
+    "tokens_used": 305,
+    "reward_stats": {"mean": 0.625, "median": 0.625, "std": 0.375, "min": 0.25, "max": 1.0}
+  }
+}

--- a/tests/golden/eval_local/metrics/skipped_excluded_from_scored.json
+++ b/tests/golden/eval_local/metrics/skipped_excluded_from_scored.json
@@ -1,11 +1,41 @@
 {
-  "description": "remove_sample rows are skipped: excluded from scored, so pass_rate divides by graded only.",
+  "description": "Only remove_sample (skipped) rows leave the pass-rate denominator. A failed row with no reward is not graded but is still a non-pass in scored, so pass_rate is 1/3 here, not 1/2.",
   "pass_threshold": 0.5,
   "index": [
-    {"row_index": 0, "run_index": 0, "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "status": "success", "reward": 1.0, "tokens": 100, "duration_ms": 10.0},
-    {"row_index": 1, "run_index": 0, "rollout_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "status": "success", "reward": 0.25, "tokens": 200, "duration_ms": 20.0},
-    {"row_index": 2, "run_index": 0, "rollout_id": "cccccccccccccccccccccccccccccccc", "status": "skipped", "tokens": 5, "duration_ms": 5.0},
-    {"row_index": 3, "run_index": 0, "rollout_id": "dddddddddddddddddddddddddddddddd", "status": "failed", "error_type": "grader_timeout", "duration_ms": 30.0}
+    {
+      "row_index": 0,
+      "run_index": 0,
+      "rollout_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "status": "success",
+      "reward": 1.0,
+      "tokens": 100,
+      "duration_ms": 10.0
+    },
+    {
+      "row_index": 1,
+      "run_index": 0,
+      "rollout_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "status": "success",
+      "reward": 0.25,
+      "tokens": 200,
+      "duration_ms": 20.0
+    },
+    {
+      "row_index": 2,
+      "run_index": 0,
+      "rollout_id": "cccccccccccccccccccccccccccccccc",
+      "status": "skipped",
+      "tokens": 5,
+      "duration_ms": 5.0
+    },
+    {
+      "row_index": 3,
+      "run_index": 0,
+      "rollout_id": "dddddddddddddddddddddddddddddddd",
+      "status": "failed",
+      "error_type": "grader_timeout",
+      "duration_ms": 30.0
+    }
   ],
   "expected": {
     "total_samples": 4,
@@ -14,9 +44,15 @@
     "passed": 1,
     "failed": 1,
     "skipped": 1,
-    "pass_rate": 0.5,
+    "pass_rate": 0.3333333333333333,
     "pass_threshold": 0.5,
     "tokens_used": 305,
-    "reward_stats": {"mean": 0.625, "median": 0.625, "std": 0.375, "min": 0.25, "max": 1.0}
+    "reward_stats": {
+      "mean": 0.625,
+      "median": 0.625,
+      "std": 0.375,
+      "min": 0.25,
+      "max": 1.0
+    }
   }
 }

--- a/tests/unit/eval/local/conftest.py
+++ b/tests/unit/eval/local/conftest.py
@@ -1,0 +1,261 @@
+"""Shared scaffolding for local-eval runner tests.
+
+The E2E fixtures build a real rollout project on disk and let the supervisor
+spawn it as a subprocess, so the tests exercise the same path a user does:
+subprocess lifecycle, artifact-root override, HTTP dispatch, callbacks,
+journalling, and materialization.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from osmosis_ai.eval.local.dataset import ResolvedDataset, RowSelection, select_rows
+from osmosis_ai.eval.local.runner import (
+    EvalRunSpec,
+    LocalEvalOptions,
+    LocalEvalRunner,
+    ProgressSnapshot,
+)
+
+# A self-contained rollout project. The workflow makes one real chat call
+# through the eval-proxy session so the whole LLM path is exercised, and the
+# grader rewards an exact match against the row's label.
+ROLLOUT_MAIN = """\
+import json
+import os
+import sys
+
+import httpx
+import uvicorn
+
+from osmosis_ai.rollout import (
+    AgentWorkflow,
+    AgentWorkflowContext,
+    AgentWorkflowOutput,
+    Grader,
+    GraderContext,
+    LocalBackend,
+    get_rollout_context,
+)
+from osmosis_ai.rollout.server import create_rollout_server
+
+
+class EchoWorkflow(AgentWorkflow):
+    async def run(self, ctx: AgentWorkflowContext) -> AgentWorkflowOutput:
+        import asyncio
+
+        delay = float(os.environ.get("OSMOSIS_TEST_WORKFLOW_SLEEP", "0") or 0)
+        if delay:
+            await asyncio.sleep(delay)
+        rollout = get_rollout_context()
+        prompt = ctx.prompt[-1]["content"] if ctx.prompt else ""
+        reply = "no-llm"
+        if rollout is not None and rollout.chat_completions_url:
+            headers = {"Authorization": f"Bearer {rollout.api_key}"}
+            body = {
+                "model": "osmosis-rollout",
+                "messages": list(ctx.prompt),
+                "stream": True,
+            }
+            content = []
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                url = rollout.chat_completions_url.rstrip("/") + "/chat/completions"
+                async with client.stream("POST", url, json=body, headers=headers) as r:
+                    r.raise_for_status()
+                    async for line in r.aiter_lines():
+                        if not line.startswith("data: "):
+                            continue
+                        payload = line[6:].strip()
+                        if not payload or payload == "[DONE]":
+                            continue
+                        chunk = json.loads(payload)
+                        for choice in chunk.get("choices") or []:
+                            piece = (choice.get("delta") or {}).get("content")
+                            if piece:
+                                content.append(piece)
+            reply = "".join(content) or "empty"
+        if os.environ.get("OSMOSIS_TEST_WRITE_ARTIFACT") and ctx.artifacts_dir:
+            (ctx.artifacts_dir / "note.txt").write_text(reply)
+        return AgentWorkflowOutput(
+            messages=[*ctx.prompt, {"role": "assistant", "content": reply}]
+        )
+
+
+class MatchGrader(Grader):
+    async def grade(self, ctx: GraderContext) -> None:
+        if os.environ.get("OSMOSIS_TEST_GRADER_CRASH"):
+            raise RuntimeError("grader exploded on purpose")
+        if os.environ.get("OSMOSIS_TEST_REMOVE_SAMPLE") and ctx.sample is not None:
+            ctx.sample.remove_sample = True
+            return
+        messages = list(ctx.sample.messages) if ctx.sample is not None else []
+        final = messages[-1]["content"] if messages else ""
+        ctx.set_reward(1.0 if ctx.label is not None and ctx.label in final else 0.0)
+
+
+backend = LocalBackend(workflow=EchoWorkflow, grader=MatchGrader)
+app = create_rollout_server(backend=backend)
+
+if __name__ == "__main__":
+    uvicorn.run(
+        app,
+        host="127.0.0.1",
+        port=int(os.environ["_OSMOSIS_ROLLOUT_PORT"]),
+        log_level="warning",
+    )
+"""
+
+DATASET_ROWS = [
+    {"user_prompt": "say ok", "ground_truth": "ok"},
+    {"user_prompt": "say ok twice", "ground_truth": "ok"},
+    {"user_prompt": "say ok thrice", "ground_truth": "ok"},
+    {"user_prompt": "say ok again", "ground_truth": "ok"},
+]
+
+
+@dataclass
+class RecordingHooks:
+    """Captures everything the supervisor reports back to the CLI layer."""
+
+    secrets: dict[str, str] = field(default_factory=dict)
+    notes: list[str] = field(default_factory=list)
+    confirmations: list[tuple[int, str]] = field(default_factory=list)
+    progress_snapshots: list[ProgressSnapshot] = field(default_factory=list)
+    secret_requests: list[list[str]] = field(default_factory=list)
+    refuse_confirmation: bool = False
+
+    def note(self, message: str) -> None:
+        self.notes.append(message)
+
+    def confirm_dispatch(self, *, pending: int, model_path: str) -> None:
+        self.confirmations.append((pending, model_path))
+        if self.refuse_confirmation:
+            raise RuntimeError("dispatch declined")
+
+    def resolve_secrets(self, names: Sequence[str]) -> dict[str, str]:
+        self.secret_requests.append(list(names))
+        return dict(self.secrets)
+
+    def progress(self, snapshot: ProgressSnapshot) -> None:
+        self.progress_snapshots.append(snapshot)
+
+
+@dataclass
+class RunnerHarness:
+    """A ready-to-run supervisor plus the paths its assertions need."""
+
+    rollout_dir: Path
+    output_root: Path
+    dataset: ResolvedDataset
+    selection: RowSelection
+    proxy_base_url: str
+    proxy_token: str
+    hooks: RecordingHooks
+
+    def spec(self, **overrides: Any) -> EvalRunSpec:
+        payload: dict[str, Any] = {
+            "rollout_name": "echo-rollout",
+            "entrypoint": "main.py",
+            "model_path": "openai/gpt-5-mini",
+            "dataset_name": "echo",
+            "n": 1,
+            "pass_threshold": 1.0,
+            "agent_timeout_sec": 60.0,
+            "grader_timeout_sec": 30.0,
+        }
+        payload.update(overrides)
+        return EvalRunSpec(**payload)
+
+    def runner(
+        self,
+        *,
+        spec: EvalRunSpec | None = None,
+        options: LocalEvalOptions | None = None,
+        selection: RowSelection | None = None,
+        hooks: RecordingHooks | None = None,
+    ) -> LocalEvalRunner:
+        return LocalEvalRunner(
+            spec=spec or self.spec(),
+            options=options or LocalEvalOptions(name="run-1", yes=True),
+            dataset=self.dataset,
+            selection=selection or self.selection,
+            rollout_dir=self.rollout_dir,
+            output_root=self.output_root,
+            proxy_base_url=self.proxy_base_url,
+            proxy_auth_token=self.proxy_token,
+            hooks=hooks or self.hooks,
+            config_stem="echo-eval",
+        )
+
+    def run_dir(self, name: str = "run-1") -> Path:
+        return self.output_root / name
+
+    def index_rows(self, name: str = "run-1") -> list[dict[str, Any]]:
+        path = self.run_dir(name) / "index.jsonl"
+        if not path.is_file():
+            return []
+        return [json.loads(line) for line in path.read_text().splitlines() if line]
+
+    def journal_lines(self, name: str = "run-1") -> list[dict[str, Any]]:
+        path = self.run_dir(name) / "events.jsonl"
+        if not path.is_file():
+            return []
+        return [json.loads(line) for line in path.read_text().splitlines() if line]
+
+
+@pytest.fixture
+def rollout_project(tmp_path: Path) -> Path:
+    project = tmp_path / "rollouts" / "echo-rollout"
+    project.mkdir(parents=True)
+    (project / "main.py").write_text(ROLLOUT_MAIN, encoding="utf-8")
+    return project
+
+
+@pytest.fixture
+def dataset_file(tmp_path: Path) -> Path:
+    path = tmp_path / "data" / "echo.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row) + "\n" for row in DATASET_ROWS), encoding="utf-8"
+    )
+    return path
+
+
+@pytest.fixture
+async def proxy_stub() -> AsyncIterator[tuple[str, str]]:
+    """A running eval-proxy contract stub. Yields ``(base_url, platform_token)``."""
+    from osmosis_ai.rollout.controller.listener import LocalhostUvicornServer
+    from osmosis_ai.rollout.controller.proxy_client import create_eval_proxy_stub_app
+
+    token = "stub-platform-token"
+    app = create_eval_proxy_stub_app(platform_token=token)
+    async with LocalhostUvicornServer(app) as server:
+        yield server.base_url, token
+
+
+@pytest.fixture
+async def harness(
+    tmp_path: Path,
+    rollout_project: Path,
+    dataset_file: Path,
+    proxy_stub: tuple[str, str],
+) -> RunnerHarness:
+    from osmosis_ai.eval.local.dataset import resolve_explicit_dataset_file
+
+    base_url, token = proxy_stub
+    return RunnerHarness(
+        rollout_dir=rollout_project,
+        output_root=tmp_path / "evals",
+        dataset=resolve_explicit_dataset_file(dataset_file),
+        selection=select_rows(dataset_file),
+        proxy_base_url=base_url,
+        proxy_token=token,
+        hooks=RecordingHooks(),
+    )

--- a/tests/unit/eval/local/conftest.py
+++ b/tests/unit/eval/local/conftest.py
@@ -51,6 +51,8 @@ class EchoWorkflow(AgentWorkflow):
     async def run(self, ctx: AgentWorkflowContext) -> AgentWorkflowOutput:
         import asyncio
 
+        if os.environ.get("OSMOSIS_TEST_ECHO_SECRET"):
+            print("workflow saw MY_TOKEN=" + os.environ.get("MY_TOKEN", ""), flush=True)
         delay = float(os.environ.get("OSMOSIS_TEST_WORKFLOW_SLEEP", "0") or 0)
         if delay:
             await asyncio.sleep(delay)

--- a/tests/unit/eval/local/conftest.py
+++ b/tests/unit/eval/local/conftest.py
@@ -185,7 +185,7 @@ class RunnerHarness:
     ) -> LocalEvalRunner:
         return LocalEvalRunner(
             spec=spec or self.spec(),
-            options=options or LocalEvalOptions(name="run-1", yes=True),
+            options=options or LocalEvalOptions(name="run-1"),
             dataset=self.dataset,
             selection=selection or self.selection,
             rollout_dir=self.rollout_dir,

--- a/tests/unit/eval/local/test_dataset.py
+++ b/tests/unit/eval/local/test_dataset.py
@@ -366,18 +366,16 @@ def test_a_corrupted_cache_entry_is_not_a_hit(tmp_path: Path) -> None:
     assert sha256_of_file(again.path) == again.sha256
 
 
-def test_an_unreachable_platform_falls_back_to_a_verified_cache(tmp_path: Path) -> None:
+def test_an_unreachable_platform_never_serves_the_cache(tmp_path: Path) -> None:
+    # There is no offline mode: a cached copy the platform cannot confirm the
+    # version of would pin the manifest to bytes a resume can never re-verify.
     cache = DatasetCache(tmp_path / "cache", git_identity="github.com/acme/repo")
     fetcher = FakeFetcher(rows=PROMPT_ROWS)
-    first = resolve_platform_dataset("multiply", cache=cache, fetcher=fetcher)
+    resolve_platform_dataset("multiply", cache=cache, fetcher=fetcher)
 
     fetcher.describe_error = RuntimeError("connection refused")
-    notes: list[str] = []
-    fallback = resolve_platform_dataset(
-        "multiply", cache=cache, fetcher=fetcher, on_event=notes.append
-    )
-    assert fallback.sha256 == first.sha256
-    assert any("platform unreachable" in note for note in notes)
+    with pytest.raises(DatasetResolutionError, match="--dataset-file"):
+        resolve_platform_dataset("multiply", cache=cache, fetcher=fetcher)
 
 
 def test_an_unreachable_platform_with_no_cache_asks_for_dataset_file(

--- a/tests/unit/eval/local/test_dataset.py
+++ b/tests/unit/eval/local/test_dataset.py
@@ -1,0 +1,405 @@
+"""Dataset resolver, cache, and row-normalization contract tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from osmosis_ai.eval.local.dataset import (
+    DatasetCache,
+    DatasetDescription,
+    DatasetResolutionError,
+    normalize_row,
+    parse_row_selector,
+    resolve_explicit_dataset_file,
+    resolve_platform_dataset,
+    select_rows,
+    sha256_of_file,
+)
+
+PROMPT_ROWS = [
+    {"system_prompt": "be terse", "user_prompt": "2*3", "ground_truth": "6"},
+    {"system_prompt": "be terse", "user_prompt": "4*5", "ground_truth": "20"},
+    {"system_prompt": "be terse", "user_prompt": "6*7", "ground_truth": "42"},
+    {"system_prompt": "be terse", "user_prompt": "8*9", "ground_truth": "72"},
+]
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> Path:
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# --rows selector
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("3", (3,)),
+        ("3,7", (3, 7)),
+        ("10-13", (10, 11, 12, 13)),
+        ("7,3", (3, 7)),
+        ("3,3,3", (3,)),
+        ("5-6,6-7", (5, 6, 7)),
+        (" 1,2 ", (1, 2)),
+        ("4-4", (4,)),
+    ],
+)
+def test_row_selector_dedupes_and_sorts(value: str, expected: tuple[int, ...]) -> None:
+    assert parse_row_selector(value) == expected
+
+
+@pytest.mark.parametrize("value", ["", "a", "1,", "-1", "1--2", "1,,2", "1 2", "1.5"])
+def test_row_selector_rejects_malformed_input(value: str) -> None:
+    with pytest.raises(DatasetResolutionError, match="--rows"):
+        parse_row_selector(value)
+
+
+def test_row_selector_rejects_an_inverted_range() -> None:
+    with pytest.raises(DatasetResolutionError, match="inverted"):
+        parse_row_selector("9-3")
+
+
+# --------------------------------------------------------------------------- #
+# Row normalization
+# --------------------------------------------------------------------------- #
+
+
+def test_prompt_mode_builds_system_then_user_messages() -> None:
+    row = normalize_row(PROMPT_ROWS[0], row_index=0, source_row_index=3)
+    assert row.initial_messages == [
+        {"role": "system", "content": "be terse"},
+        {"role": "user", "content": "2*3"},
+    ]
+    assert row.label == "6"
+    assert row.metadata is None
+    assert (row.row_index, row.source_row_index) == (0, 3)
+
+
+def test_system_prompt_is_optional() -> None:
+    row = normalize_row(
+        {"user_prompt": "hi", "ground_truth": "1"}, row_index=0, source_row_index=0
+    )
+    assert row.initial_messages == [{"role": "user", "content": "hi"}]
+
+
+def test_label_is_an_accepted_alias_for_ground_truth() -> None:
+    row = normalize_row(
+        {"user_prompt": "hi", "label": "7"}, row_index=0, source_row_index=0
+    )
+    assert row.label == "7"
+
+
+def test_ground_truth_wins_over_label_when_both_are_present() -> None:
+    raw = {"user_prompt": "hi", "ground_truth": "6", "label": "9"}
+    assert normalize_row(raw, row_index=0, source_row_index=0).label == "6"
+
+
+def test_prompt_mode_requires_user_prompt() -> None:
+    with pytest.raises(DatasetResolutionError, match="user_prompt is required"):
+        normalize_row({"ground_truth": "6"}, row_index=0, source_row_index=2)
+
+
+def test_prompt_mode_requires_a_label() -> None:
+    with pytest.raises(DatasetResolutionError, match="ground_truth"):
+        normalize_row({"user_prompt": "hi"}, row_index=0, source_row_index=0)
+
+
+def test_metadata_mode_makes_prompt_columns_optional() -> None:
+    row = normalize_row(
+        {"metadata": {"task": "multiply", "left": 15}}, row_index=0, source_row_index=0
+    )
+    assert row.initial_messages == []
+    assert row.label is None
+    assert row.metadata == {"task": "multiply", "left": 15}
+
+
+def test_metadata_mode_accepts_an_encoded_json_object() -> None:
+    row = normalize_row(
+        {"metadata": '{"task": "multiply"}'}, row_index=0, source_row_index=0
+    )
+    assert row.metadata == {"task": "multiply"}
+
+
+@pytest.mark.parametrize("value", ["[1, 2]", '"text"', "17"])
+def test_metadata_must_decode_to_an_object(value: str) -> None:
+    with pytest.raises(DatasetResolutionError, match="metadata must be a JSON object"):
+        normalize_row({"metadata": value}, row_index=0, source_row_index=0)
+
+
+def test_metadata_with_broken_json_is_reported_with_the_row() -> None:
+    with pytest.raises(
+        DatasetResolutionError, match="row 4: metadata is not valid JSON"
+    ):
+        normalize_row({"metadata": "{oops"}, row_index=0, source_row_index=4)
+
+
+def test_columns_outside_the_contract_are_ignored() -> None:
+    raw = {"user_prompt": "hi", "ground_truth": "6", "notes": "ignore me"}
+    row = normalize_row(raw, row_index=0, source_row_index=0)
+    assert row.initial_messages == [{"role": "user", "content": "hi"}]
+    assert row.metadata is None
+
+
+# --------------------------------------------------------------------------- #
+# Row selection
+# --------------------------------------------------------------------------- #
+
+
+def test_no_limit_selects_every_row_in_order(tmp_path: Path) -> None:
+    selection = select_rows(_write_jsonl(tmp_path / "d.jsonl", PROMPT_ROWS))
+    assert selection.total_dataset_rows == 4
+    assert selection.source_row_indices == (0, 1, 2, 3)
+    assert [row.row_index for row in selection.rows] == [0, 1, 2, 3]
+
+
+def test_positive_limit_takes_the_first_n_rows(tmp_path: Path) -> None:
+    selection = select_rows(_write_jsonl(tmp_path / "d.jsonl", PROMPT_ROWS), limit=2)
+    assert selection.source_row_indices == (0, 1)
+    # total_dataset_rows still reports the whole file, for progress.json.
+    assert selection.total_dataset_rows == 4
+
+
+@pytest.mark.parametrize("limit", [0, -1, None])
+def test_non_positive_limit_selects_every_row(
+    tmp_path: Path, limit: int | None
+) -> None:
+    selection = select_rows(
+        _write_jsonl(tmp_path / "d.jsonl", PROMPT_ROWS), limit=limit
+    )
+    assert selection.source_row_indices == (0, 1, 2, 3)
+
+
+def test_limit_larger_than_the_dataset_is_harmless(tmp_path: Path) -> None:
+    selection = select_rows(_write_jsonl(tmp_path / "d.jsonl", PROMPT_ROWS), limit=99)
+    assert selection.source_row_indices == (0, 1, 2, 3)
+
+
+def test_row_selector_renumbers_row_index_within_the_selected_set(
+    tmp_path: Path,
+) -> None:
+    # The shared contract: row_index is the position in the selected set, and
+    # source_row_index preserves the dataset offset for local UX.
+    selection = select_rows(
+        _write_jsonl(tmp_path / "d.jsonl", PROMPT_ROWS), row_selector=(1, 3)
+    )
+    assert [(r.row_index, r.source_row_index) for r in selection.rows] == [
+        (0, 1),
+        (1, 3),
+    ]
+    assert selection.rows[0].label == "20"
+    assert selection.rows[1].label == "72"
+
+
+def test_row_selector_overrides_limit(tmp_path: Path) -> None:
+    selection = select_rows(
+        _write_jsonl(tmp_path / "d.jsonl", PROMPT_ROWS), limit=1, row_selector=(2, 3)
+    )
+    assert selection.source_row_indices == (2, 3)
+
+
+def test_out_of_range_row_selector_fails_before_the_run_exists(tmp_path: Path) -> None:
+    with pytest.raises(DatasetResolutionError, match=r"selects \[9\].*has 4 rows"):
+        select_rows(
+            _write_jsonl(tmp_path / "d.jsonl", PROMPT_ROWS), row_selector=(0, 9)
+        )
+
+
+def test_an_empty_selection_is_an_error(tmp_path: Path) -> None:
+    with pytest.raises(DatasetResolutionError, match="selected no rows"):
+        select_rows(_write_jsonl(tmp_path / "d.jsonl", []))
+
+
+# --------------------------------------------------------------------------- #
+# Format parity
+# --------------------------------------------------------------------------- #
+
+
+def test_jsonl_and_csv_normalize_identically(tmp_path: Path) -> None:
+    jsonl = select_rows(_write_jsonl(tmp_path / "d.jsonl", PROMPT_ROWS))
+    csv_path = tmp_path / "d.csv"
+    header = "system_prompt,user_prompt,ground_truth\n"
+    body = "".join(
+        f"{row['system_prompt']},{row['user_prompt']},{row['ground_truth']}\n"
+        for row in PROMPT_ROWS
+    )
+    csv_path.write_text(header + body, encoding="utf-8")
+    assert select_rows(csv_path).rows == jsonl.rows
+
+
+def test_parquet_normalizes_identically(tmp_path: Path) -> None:
+    pa = pytest.importorskip("pyarrow")
+    pq = pytest.importorskip("pyarrow.parquet")
+    jsonl = select_rows(_write_jsonl(tmp_path / "d.jsonl", PROMPT_ROWS))
+    table = pa.table(
+        {
+            key: [row[key] for row in PROMPT_ROWS]
+            for key in ("system_prompt", "user_prompt", "ground_truth")
+        }
+    )
+    parquet_path = tmp_path / "d.parquet"
+    pq.write_table(table, parquet_path)
+    assert select_rows(parquet_path).rows == jsonl.rows
+
+
+def test_unknown_extension_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "d.txt"
+    path.write_text("nope")
+    with pytest.raises(DatasetResolutionError, match="expected one of"):
+        select_rows(path)
+
+
+def test_malformed_jsonl_names_the_line(tmp_path: Path) -> None:
+    path = tmp_path / "d.jsonl"
+    path.write_text('{"user_prompt": "a", "ground_truth": "1"}\n{oops\n')
+    with pytest.raises(DatasetResolutionError, match=r"d\.jsonl:2: invalid JSON"):
+        select_rows(path)
+
+
+# --------------------------------------------------------------------------- #
+# Resolution
+# --------------------------------------------------------------------------- #
+
+
+def test_explicit_dataset_file_wins_and_is_hashed(tmp_path: Path) -> None:
+    path = _write_jsonl(tmp_path / "dev.jsonl", PROMPT_ROWS)
+    resolved = resolve_explicit_dataset_file(path)
+    assert resolved.source == "explicit"
+    assert resolved.sha256 == sha256_of_file(path)
+    assert resolved.extension == "jsonl"
+
+
+def test_explicit_dataset_file_must_exist(tmp_path: Path) -> None:
+    with pytest.raises(DatasetResolutionError, match="is not a file"):
+        resolve_explicit_dataset_file(tmp_path / "absent.jsonl")
+
+
+def test_dataset_fingerprint_ignores_the_path(tmp_path: Path) -> None:
+    first = _write_jsonl(tmp_path / "a.jsonl", PROMPT_ROWS)
+    second = _write_jsonl(tmp_path / "b.jsonl", PROMPT_ROWS)
+    assert sha256_of_file(first) == sha256_of_file(second)
+
+
+class FakeFetcher:
+    """Records platform calls so cache hits can be asserted as zero downloads."""
+
+    def __init__(self, *, rows: list[dict[str, Any]], version: str = "v1") -> None:
+        self.rows = rows
+        self.version = version
+        self.describe_calls = 0
+        self.download_calls = 0
+        self.describe_error: Exception | None = None
+
+    def describe(self, dataset_name: str) -> DatasetDescription:
+        self.describe_calls += 1
+        if self.describe_error is not None:
+            raise self.describe_error
+        return DatasetDescription(
+            dataset_id="ds-1",
+            dataset_name=dataset_name,
+            extension="jsonl",
+            version=self.version,
+            row_count=len(self.rows),
+            organization_id="org-1",
+        )
+
+    def download_to(self, dataset_name: str, destination: Path) -> None:
+        self.download_calls += 1
+        _write_jsonl(destination, self.rows)
+
+
+def test_platform_dataset_downloads_then_caches(tmp_path: Path) -> None:
+    cache = DatasetCache(tmp_path / "cache", git_identity="github.com/acme/repo")
+    fetcher = FakeFetcher(rows=PROMPT_ROWS)
+
+    first = resolve_platform_dataset("multiply", cache=cache, fetcher=fetcher)
+    assert first.source == "download"
+    assert fetcher.download_calls == 1
+    assert select_rows(first.path).total_dataset_rows == 4
+
+    second = resolve_platform_dataset("multiply", cache=cache, fetcher=fetcher)
+    assert second.source == "cache"
+    assert second.sha256 == first.sha256
+    assert fetcher.download_calls == 1
+
+
+def test_cache_is_content_addressed(tmp_path: Path) -> None:
+    cache = DatasetCache(tmp_path / "cache", git_identity="github.com/acme/repo")
+    resolved = resolve_platform_dataset(
+        "multiply", cache=cache, fetcher=FakeFetcher(rows=PROMPT_ROWS)
+    )
+    assert resolved.path.name == f"{resolved.sha256}.jsonl"
+    metadata = json.loads((resolved.path.parent / "metadata.json").read_text())
+    assert metadata["sha256"] == resolved.sha256
+    assert metadata["row_count"] == 4
+    assert metadata["organization_id"] == "org-1"
+
+
+def test_a_new_platform_version_invalidates_the_cache(tmp_path: Path) -> None:
+    cache = DatasetCache(tmp_path / "cache", git_identity="github.com/acme/repo")
+    fetcher = FakeFetcher(rows=PROMPT_ROWS)
+    resolve_platform_dataset("multiply", cache=cache, fetcher=fetcher)
+
+    fetcher.version = "v2"
+    fetcher.rows = [*PROMPT_ROWS[:2], {"user_prompt": "1*1", "ground_truth": "1"}]
+    refreshed = resolve_platform_dataset("multiply", cache=cache, fetcher=fetcher)
+    assert refreshed.source == "download"
+    assert fetcher.download_calls == 2
+    assert select_rows(refreshed.path).total_dataset_rows == 3
+
+
+def test_a_corrupted_cache_entry_is_not_a_hit(tmp_path: Path) -> None:
+    cache = DatasetCache(tmp_path / "cache", git_identity="github.com/acme/repo")
+    fetcher = FakeFetcher(rows=PROMPT_ROWS)
+    resolved = resolve_platform_dataset("multiply", cache=cache, fetcher=fetcher)
+    resolved.path.write_text("truncated")
+
+    again = resolve_platform_dataset("multiply", cache=cache, fetcher=fetcher)
+    assert again.source == "download"
+    assert fetcher.download_calls == 2
+    assert sha256_of_file(again.path) == again.sha256
+
+
+def test_an_unreachable_platform_falls_back_to_a_verified_cache(tmp_path: Path) -> None:
+    cache = DatasetCache(tmp_path / "cache", git_identity="github.com/acme/repo")
+    fetcher = FakeFetcher(rows=PROMPT_ROWS)
+    first = resolve_platform_dataset("multiply", cache=cache, fetcher=fetcher)
+
+    fetcher.describe_error = RuntimeError("connection refused")
+    notes: list[str] = []
+    fallback = resolve_platform_dataset(
+        "multiply", cache=cache, fetcher=fetcher, on_event=notes.append
+    )
+    assert fallback.sha256 == first.sha256
+    assert any("platform unreachable" in note for note in notes)
+
+
+def test_an_unreachable_platform_with_no_cache_asks_for_dataset_file(
+    tmp_path: Path,
+) -> None:
+    cache = DatasetCache(tmp_path / "cache", git_identity="github.com/acme/repo")
+    fetcher = FakeFetcher(rows=PROMPT_ROWS)
+    fetcher.describe_error = RuntimeError("connection refused")
+    with pytest.raises(DatasetResolutionError, match="--dataset-file"):
+        resolve_platform_dataset("multiply", cache=cache, fetcher=fetcher)
+
+
+def test_caches_are_scoped_per_workspace(tmp_path: Path) -> None:
+    root = tmp_path / "cache"
+    first = DatasetCache(root, git_identity="github.com/acme/one")
+    second = DatasetCache(root, git_identity="github.com/acme/two")
+    assert first.directory_for("ds-1") != second.directory_for("ds-1")
+
+
+def test_a_dataset_resolution_error_from_describe_is_not_masked(tmp_path: Path) -> None:
+    cache = DatasetCache(tmp_path / "cache", git_identity="github.com/acme/repo")
+    fetcher = FakeFetcher(rows=PROMPT_ROWS)
+    fetcher.describe_error = DatasetResolutionError("still processing")
+    with pytest.raises(DatasetResolutionError, match="still processing"):
+        resolve_platform_dataset("multiply", cache=cache, fetcher=fetcher)

--- a/tests/unit/eval/local/test_golden_contracts.py
+++ b/tests/unit/eval/local/test_golden_contracts.py
@@ -1,0 +1,81 @@
+"""Golden contract fixtures, mirrored with the platform (design §16.3).
+
+These files are the SDK half of a mirrored pair: the same JSON is meant to be
+consumed by the monolith so ``index.jsonl`` validity and the metrics formula can
+never drift silently between producer and consumer.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from osmosis_ai.eval.local.results import aggregate_metrics, lint_index_row
+
+GOLDEN_DIR = Path(__file__).resolve().parents[3] / "golden" / "eval_local"
+METRICS_DIR = GOLDEN_DIR / "metrics"
+INDEX_CASES = GOLDEN_DIR / "index" / "contract_cases.json"
+
+
+def _metrics_fixtures() -> list[Path]:
+    fixtures = sorted(METRICS_DIR.glob("*.json"))
+    assert fixtures, f"no metrics fixtures found under {METRICS_DIR}"
+    return fixtures
+
+
+def _assert_matches(actual: Any, expected: Any, *, where: str) -> None:
+    """Compare nested summaries; ``pytest.approx`` refuses nested mappings."""
+    if isinstance(expected, dict):
+        assert isinstance(actual, dict), where
+        assert sorted(actual) == sorted(expected), where
+        for key in expected:
+            _assert_matches(actual[key], expected[key], where=f"{where}.{key}")
+        return
+    if isinstance(expected, list):
+        assert isinstance(actual, list), where
+        assert len(actual) == len(expected), where
+        for index, item in enumerate(expected):
+            _assert_matches(actual[index], item, where=f"{where}[{index}]")
+        return
+    if isinstance(expected, float):
+        assert actual == pytest.approx(expected), where
+        return
+    assert actual == expected, where
+
+
+@pytest.mark.parametrize("fixture", _metrics_fixtures(), ids=lambda path: path.stem)
+def test_metrics_match_the_golden_aggregate(fixture: Path) -> None:
+    payload = json.loads(fixture.read_text(encoding="utf-8"))
+    summary = aggregate_metrics(
+        payload["index"], pass_threshold=payload["pass_threshold"]
+    )
+    _assert_matches(summary, payload["expected"], where=fixture.stem)
+
+
+def _index_cases() -> list[dict[str, Any]]:
+    payload = json.loads(INDEX_CASES.read_text(encoding="utf-8"))
+    cases = payload["cases"]
+    assert cases, f"no index contract cases found in {INDEX_CASES}"
+    return cases
+
+
+@pytest.mark.parametrize("case", _index_cases(), ids=lambda case: case["name"])
+def test_index_contract_lint_matches_the_golden_case(case: dict[str, Any]) -> None:
+    problems = lint_index_row(case["row"])
+    expected = case["problems"]
+    assert len(problems) == len(expected), (
+        f"{case['name']}: expected {expected}, got {problems}"
+    )
+    for fragment, problem in zip(expected, problems, strict=True):
+        assert fragment in problem
+
+
+def test_every_valid_golden_row_serializes_without_nulls() -> None:
+    for case in _index_cases():
+        if case["problems"]:
+            continue
+        line = json.dumps(case["row"], allow_nan=False)
+        assert "null" not in line, case["name"]

--- a/tests/unit/eval/local/test_results.py
+++ b/tests/unit/eval/local/test_results.py
@@ -9,7 +9,6 @@ from typing import Any
 import pytest
 
 from osmosis_ai.eval.local.results import (
-    ArtifactProjectionError,
     IndexContractError,
     Materializer,
     RunIdentity,
@@ -386,14 +385,46 @@ def test_artifact_enumeration_skips_the_reserved_manifest_name(tmp_path: Path) -
     assert found == {"out.txt", "logs/manifest.json"}
 
 
-def test_artifact_enumeration_refuses_symlinks(tmp_path: Path) -> None:
+def test_artifact_enumeration_skips_symlinks_without_failing_the_run(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Skipped, not fatal: every terminal result is already durable, so one stray
+    # symlink must not stop the run from finalizing.
     artifacts = tmp_path / "artifacts"
     artifacts.mkdir()
     secret = tmp_path / "id_rsa"
     secret.write_text("PRIVATE")
     (artifacts / "leak").symlink_to(secret)
-    with pytest.raises(ArtifactProjectionError, match="symlink"):
-        safe_artifact_relative_paths(artifacts)
+    (artifacts / "real.txt").write_text("kept")
+    with caplog.at_level("WARNING"):
+        found = safe_artifact_relative_paths(artifacts)
+    assert [str(path) for path in found] == ["real.txt"]
+    assert "symlink" in caplog.text
+
+
+def test_a_symlinked_artifact_is_never_copied_into_the_projection(
+    tmp_path: Path,
+) -> None:
+    trials = tmp_path / "rollout_trials"
+    _write_trajectory(trials, ROLLOUT_A, _atif(ROLLOUT_A))
+    artifacts = trials / ROLLOUT_A / "artifacts"
+    artifacts.mkdir(parents=True, exist_ok=True)
+    secret = tmp_path / "id_rsa"
+    secret.write_text("PRIVATE")
+    (artifacts / "leak").symlink_to(secret)
+
+    latest = {(0, 0): _record(0, 0, rollout_id=ROLLOUT_A)}
+    Materializer(tmp_path).refresh(
+        select_attempts(latest, trials_dir=trials),
+        identity=_identity(),
+        pass_threshold=1.0,
+        sampled_rows=1,
+        total_dataset_rows=1,
+        total_runs=1,
+    )
+    projected = tmp_path / "artifacts" / "row_0_run_0"
+    assert not (projected / "leak").exists()
+    assert "PRIVATE" not in (tmp_path / "index.jsonl").read_text()
 
 
 def test_a_missing_artifacts_dir_yields_nothing(tmp_path: Path) -> None:
@@ -553,3 +584,150 @@ def test_a_cancelled_attempt_is_never_projected_as_success(tmp_path: Path) -> No
     )
     assert rows == []
     assert (tmp_path / "index.jsonl").read_text() == ""
+
+
+# --------------------------------------------------------------------------- #
+# Review fixes: pass-rate denominator, projection pruning, token fallback
+# --------------------------------------------------------------------------- #
+
+
+def test_reward_less_failures_stay_in_the_pass_rate_denominator() -> None:
+    # Excluding them would report pass_rate 1.0 for a run where half the rows
+    # failed -- the metric would hide exactly what the user needs to see.
+    summary = aggregate_metrics(
+        [_row(0, 0, "success", 1.0), _row(1, 0, "failed", None)], pass_threshold=1.0
+    )
+    assert summary["graded"] == 1
+    assert summary["completed_samples"] == 2
+    assert summary["pass_rate"] == 0.5
+
+
+def test_skipped_rows_are_the_only_thing_excluded_from_scored() -> None:
+    summary = aggregate_metrics(
+        [
+            _row(0, 0, "success", 1.0),
+            _row(1, 0, "failed", None),
+            _row(2, 0, "skipped", None),
+        ],
+        pass_threshold=1.0,
+    )
+    assert summary["completed_samples"] == 2
+    assert summary["pass_rate"] == 0.5
+
+
+def test_pass_at_k_counts_a_reward_less_failure_as_a_non_pass() -> None:
+    rows = [
+        _row(0, 0, "success", 1.0),
+        _row(0, 1, "failed", None),
+        _row(1, 0, "failed", None),
+        _row(1, 1, "failed", None),
+    ]
+    summary = aggregate_metrics(rows, pass_threshold=1.0)
+    assert summary["pass_at_k"] == [{"k": 1, "value": 0.25}, {"k": 2, "value": 0.5}]
+
+
+def test_a_retry_without_a_trajectory_clears_the_superseded_projection(
+    tmp_path: Path,
+) -> None:
+    trials = tmp_path / "rollout_trials"
+    _write_trajectory(trials, ROLLOUT_A, _atif(ROLLOUT_A))
+    (trials / ROLLOUT_A / "artifacts").mkdir(parents=True)
+    (trials / ROLLOUT_A / "artifacts" / "out.txt").write_text("attempt A")
+    materializer = Materializer(tmp_path)
+    kwargs: dict[str, Any] = {
+        "identity": _identity(),
+        "pass_threshold": 1.0,
+        "sampled_rows": 1,
+        "total_dataset_rows": 1,
+        "total_runs": 1,
+    }
+    materializer.refresh(
+        select_attempts(
+            {(0, 0): _record(0, 0, rollout_id=ROLLOUT_A)}, trials_dir=trials
+        ),
+        **kwargs,
+    )
+    assert (tmp_path / "trajectories" / "row_0_run_0.json").is_file()
+    assert (tmp_path / "artifacts" / "row_0_run_0" / "out.txt").is_file()
+
+    # Attempt B times out: no trajectory, no artifacts. The stem is per work
+    # item, so A's files must not survive attributed to B's result.
+    retried = _record(0, 0, rollout_id=ROLLOUT_B, status="failed", reward=None)
+    rows = materializer.refresh(
+        select_attempts({(0, 0): retried}, trials_dir=trials), **kwargs
+    )
+    assert "trajectory_filename" not in rows[0]
+    assert not (tmp_path / "trajectories" / "row_0_run_0.json").exists()
+    assert not (tmp_path / "artifacts" / "row_0_run_0").exists()
+
+
+def test_refresh_projects_only_the_requested_work_items(tmp_path: Path) -> None:
+    trials = tmp_path / "rollout_trials"
+    _write_trajectory(trials, ROLLOUT_A, _atif(ROLLOUT_A))
+    _write_trajectory(trials, ROLLOUT_B, _atif(ROLLOUT_B))
+    latest = {
+        (0, 0): _record(0, 0, rollout_id=ROLLOUT_A),
+        (1, 0): _record(1, 0, rollout_id=ROLLOUT_B),
+    }
+    Materializer(tmp_path).refresh(
+        select_attempts(latest, trials_dir=trials),
+        identity=_identity(),
+        pass_threshold=1.0,
+        sampled_rows=2,
+        total_dataset_rows=2,
+        total_runs=2,
+        project_keys=[(1, 0)],
+    )
+    # Both rows reach index.jsonl; only the requested one is copied.
+    assert len((tmp_path / "index.jsonl").read_text().splitlines()) == 2
+    assert not (tmp_path / "trajectories" / "row_0_run_0.json").exists()
+    assert (tmp_path / "trajectories" / "row_1_run_0.json").is_file()
+
+
+def test_tokens_fall_back_to_the_trajectory_when_the_usage_api_gave_nothing(
+    tmp_path: Path,
+) -> None:
+    trials = tmp_path / "rollout_trials"
+    document = _atif(ROLLOUT_A)
+    document["final_metrics"] = {
+        "total_prompt_tokens": 100,
+        "total_completion_tokens": 23,
+    }
+    _write_trajectory(trials, ROLLOUT_A, document)
+    latest = {(0, 0): _record(0, 0, rollout_id=ROLLOUT_A, tokens=None)}
+    rows = Materializer(tmp_path).refresh(
+        select_attempts(latest, trials_dir=trials),
+        identity=_identity(),
+        pass_threshold=1.0,
+        sampled_rows=1,
+        total_dataset_rows=1,
+        total_runs=1,
+    )
+    assert rows[0]["tokens"] == 123
+
+
+def test_the_usage_api_wins_over_the_trajectory_fallback(tmp_path: Path) -> None:
+    trials = tmp_path / "rollout_trials"
+    document = _atif(ROLLOUT_A)
+    document["final_metrics"] = {"total_prompt_tokens": 999}
+    _write_trajectory(trials, ROLLOUT_A, document)
+    latest = {(0, 0): _record(0, 0, rollout_id=ROLLOUT_A, tokens=7)}
+    [attempt] = select_attempts(latest, trials_dir=trials)
+    assert attempt.tokens == 7
+
+
+def test_a_trajectory_without_final_metrics_leaves_tokens_absent(
+    tmp_path: Path,
+) -> None:
+    trials = tmp_path / "rollout_trials"
+    _write_trajectory(trials, ROLLOUT_A, _atif(ROLLOUT_A))
+    latest = {(0, 0): _record(0, 0, rollout_id=ROLLOUT_A, tokens=None)}
+    rows = Materializer(tmp_path).refresh(
+        select_attempts(latest, trials_dir=trials),
+        identity=_identity(),
+        pass_threshold=1.0,
+        sampled_rows=1,
+        total_dataset_rows=1,
+        total_runs=1,
+    )
+    assert "tokens" not in rows[0]

--- a/tests/unit/eval/local/test_results.py
+++ b/tests/unit/eval/local/test_results.py
@@ -684,7 +684,7 @@ def test_refresh_projects_only_the_requested_work_items(tmp_path: Path) -> None:
     assert (tmp_path / "trajectories" / "row_1_run_0.json").is_file()
 
 
-def test_tokens_fall_back_to_the_trajectory_when_the_usage_api_gave_nothing(
+def test_tokens_come_from_the_trajectorys_final_metrics(
     tmp_path: Path,
 ) -> None:
     trials = tmp_path / "rollout_trials"
@@ -704,16 +704,6 @@ def test_tokens_fall_back_to_the_trajectory_when_the_usage_api_gave_nothing(
         total_runs=1,
     )
     assert rows[0]["tokens"] == 123
-
-
-def test_the_usage_api_wins_over_the_trajectory_fallback(tmp_path: Path) -> None:
-    trials = tmp_path / "rollout_trials"
-    document = _atif(ROLLOUT_A)
-    document["final_metrics"] = {"total_prompt_tokens": 999}
-    _write_trajectory(trials, ROLLOUT_A, document)
-    latest = {(0, 0): _record(0, 0, rollout_id=ROLLOUT_A, tokens=7)}
-    [attempt] = select_attempts(latest, trials_dir=trials)
-    assert attempt.tokens == 7
 
 
 def test_a_trajectory_without_final_metrics_leaves_tokens_absent(

--- a/tests/unit/eval/local/test_results.py
+++ b/tests/unit/eval/local/test_results.py
@@ -1,0 +1,555 @@
+"""Materializer tests: index contract lint, metrics formula, and projections."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from osmosis_ai.eval.local.results import (
+    ArtifactProjectionError,
+    IndexContractError,
+    Materializer,
+    RunIdentity,
+    aggregate_metrics,
+    atif_rollout_identity,
+    build_index_row,
+    lint_index_row,
+    pass_at_k,
+    read_valid_trajectory,
+    render_index_lines,
+    safe_artifact_relative_paths,
+    select_attempts,
+)
+from osmosis_ai.eval.local.state import TerminalRecord
+
+ROLLOUT_A = "a" * 32
+ROLLOUT_B = "b" * 32
+
+
+def _record(
+    row: int, run: int, *, rollout_id: str | None = None, **overrides: Any
+) -> TerminalRecord:
+    payload: dict[str, Any] = {
+        "row_index": row,
+        "run_index": run,
+        "rollout_id": rollout_id or f"{row:016x}{run:016x}",
+        "status": "success",
+        "recorded_at": "2026-08-14T00:00:00Z",
+        "reward": 1.0,
+        "tokens": 11,
+        "duration_ms": 42.0,
+    }
+    payload.update(overrides)
+    return TerminalRecord(**payload)
+
+
+def _atif(rollout_id: str, **overrides: Any) -> dict[str, Any]:
+    document: dict[str, Any] = {
+        "session_id": rollout_id,
+        "trajectory_id": rollout_id,
+        "steps": [],
+        "extra": {"osmosis": {"rollout_id": rollout_id, "reward": 1.0}},
+    }
+    document.update(overrides)
+    return document
+
+
+def _write_trajectory(trials_dir: Path, rollout_id: str, document: Any) -> Path:
+    path = trials_dir / rollout_id / "trajectory.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document), encoding="utf-8")
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# Contract lint (§2.2)
+# --------------------------------------------------------------------------- #
+
+
+def test_a_well_formed_row_passes_the_lint() -> None:
+    row = build_index_row(_record(0, 0, rollout_id=ROLLOUT_A))
+    assert lint_index_row(row) == []
+    assert row == {
+        "row_index": 0,
+        "run_index": 0,
+        "rollout_id": ROLLOUT_A,
+        "status": "success",
+        "reward": 1.0,
+        "tokens": 11,
+        "duration_ms": 42.0,
+    }
+
+
+@pytest.mark.parametrize("missing", ["row_index", "run_index", "duration_ms"])
+def test_missing_required_numbers_are_caught(missing: str) -> None:
+    row = build_index_row(_record(0, 0, rollout_id=ROLLOUT_A))
+    del row[missing]
+    assert any(missing in problem for problem in lint_index_row(row))
+
+
+def test_null_values_are_caught_rather_than_written() -> None:
+    row = build_index_row(_record(0, 0, rollout_id=ROLLOUT_A))
+    row["reward"] = None
+    assert any("None-valued keys must be omitted" in p for p in lint_index_row(row))
+
+
+def test_none_valued_fields_are_omitted_by_the_builder() -> None:
+    row = build_index_row(_record(0, 0, rollout_id=ROLLOUT_A, reward=None, tokens=None))
+    assert "reward" not in row
+    assert "tokens" not in row
+    assert lint_index_row(row) == []
+
+
+@pytest.mark.parametrize(
+    "rollout_id",
+    ["A" * 32, "a" * 31, "a" * 33, "g" * 32, "a1b2-c3d4", ""],
+)
+def test_non_32_hex_rollout_ids_are_caught(rollout_id: str) -> None:
+    row = {
+        "row_index": 0,
+        "run_index": 0,
+        "rollout_id": rollout_id,
+        "status": "success",
+        "duration_ms": 1.0,
+    }
+    assert any("32 lowercase hex" in p for p in lint_index_row(row))
+
+
+def test_a_row_needs_a_rollout_id_or_sample_id() -> None:
+    row = {"row_index": 0, "run_index": 0, "status": "success", "duration_ms": 1.0}
+    assert any("rollout_id or sample_id" in p for p in lint_index_row(row))
+    row["sample_id"] = "s-1"
+    assert lint_index_row(row) == []
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "nested/trajectory.json",
+        "traj.json",
+        "trajectory.txt",
+        "trajectory",
+        "../x.json",
+    ],
+)
+def test_bad_trajectory_filenames_are_caught(filename: str) -> None:
+    row = {
+        "row_index": 0,
+        "run_index": 0,
+        "rollout_id": ROLLOUT_A,
+        "trajectory_filename": filename,
+        "status": "success",
+        "duration_ms": 1.0,
+    }
+    assert any("trajectory_filename" in p for p in lint_index_row(row))
+
+
+@pytest.mark.parametrize(
+    "filename", ["trajectory.json", "trajectory_2.json", "trajectory-a.b.json"]
+)
+def test_accepted_trajectory_filenames(filename: str) -> None:
+    row = {
+        "row_index": 0,
+        "run_index": 0,
+        "rollout_id": ROLLOUT_A,
+        "trajectory_filename": filename,
+        "status": "success",
+        "duration_ms": 1.0,
+    }
+    assert lint_index_row(row) == []
+
+
+def test_invalid_status_is_caught() -> None:
+    row = {
+        "row_index": 0,
+        "run_index": 0,
+        "rollout_id": ROLLOUT_A,
+        "status": "cancelled",
+        "duration_ms": 1.0,
+    }
+    assert any("status must be one of" in p for p in lint_index_row(row))
+
+
+def test_the_builder_refuses_to_write_a_dropped_line() -> None:
+    with pytest.raises(IndexContractError, match="32 lowercase hex"):
+        build_index_row(_record(0, 0, rollout_id="not-hex"))
+
+
+def test_resumed_is_written_only_when_true() -> None:
+    assert "resumed" not in build_index_row(_record(0, 0, rollout_id=ROLLOUT_A))
+    assert (
+        build_index_row(_record(0, 0, rollout_id=ROLLOUT_A), resumed=True)["resumed"]
+        is True
+    )
+
+
+def test_index_lines_are_sorted_by_row_then_run() -> None:
+    rows = [
+        build_index_row(_record(1, 0, rollout_id=ROLLOUT_A)),
+        build_index_row(_record(0, 1, rollout_id=ROLLOUT_B)),
+        build_index_row(_record(0, 0, rollout_id=ROLLOUT_A)),
+    ]
+    keys = [
+        (json.loads(line)["row_index"], json.loads(line)["run_index"])
+        for line in render_index_lines(rows).decode().splitlines()
+    ]
+    assert keys == [(0, 0), (0, 1), (1, 0)]
+
+
+# --------------------------------------------------------------------------- #
+# ATIF identity (§2.3)
+# --------------------------------------------------------------------------- #
+
+
+def test_identity_prefers_extra_osmosis_rollout_id() -> None:
+    document = _atif(ROLLOUT_A, session_id="other")
+    assert atif_rollout_identity(document) == ROLLOUT_A
+
+
+def test_identity_falls_back_to_session_id() -> None:
+    document = {"session_id": ROLLOUT_A, "trajectory_id": "x/y"}
+    assert atif_rollout_identity(document) == ROLLOUT_A
+
+
+def test_identity_falls_back_to_the_trajectory_id_prefix() -> None:
+    document = {"trajectory_id": f"{ROLLOUT_A}/step-1"}
+    assert atif_rollout_identity(document) == ROLLOUT_A
+
+
+def test_a_bare_trajectory_id_is_not_a_valid_fallback() -> None:
+    # The platform converter drops this document, so the lint must too.
+    assert atif_rollout_identity({"trajectory_id": ROLLOUT_A}) is None
+
+
+def test_read_valid_trajectory_accepts_a_matching_document(tmp_path: Path) -> None:
+    path = _write_trajectory(tmp_path, ROLLOUT_A, _atif(ROLLOUT_A))
+    assert read_valid_trajectory(path, rollout_id=ROLLOUT_A) is not None
+
+
+@pytest.mark.parametrize(
+    "document",
+    [_atif(ROLLOUT_B), [1, 2], "text"],
+    ids=["identity-mismatch", "not-an-object", "not-an-object-string"],
+)
+def test_read_valid_trajectory_rejects_unusable_documents(
+    tmp_path: Path, document: Any
+) -> None:
+    path = _write_trajectory(tmp_path, ROLLOUT_A, document)
+    assert read_valid_trajectory(path, rollout_id=ROLLOUT_A) is None
+
+
+def test_read_valid_trajectory_tolerates_absent_and_unparseable_files(
+    tmp_path: Path,
+) -> None:
+    assert read_valid_trajectory(tmp_path / "nope.json", rollout_id=ROLLOUT_A) is None
+    broken = tmp_path / "broken.json"
+    broken.write_text("{oops")
+    assert read_valid_trajectory(broken, rollout_id=ROLLOUT_A) is None
+
+
+# --------------------------------------------------------------------------- #
+# Metrics (§2.5)
+# --------------------------------------------------------------------------- #
+
+
+def _row(
+    row: int, run: int, status: str, reward: float | None, tokens: int = 10
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "row_index": row,
+        "run_index": run,
+        "rollout_id": ROLLOUT_A,
+        "status": status,
+        "duration_ms": 1.0,
+        "tokens": tokens,
+    }
+    if reward is not None:
+        payload["reward"] = reward
+    return payload
+
+
+def test_pass_rate_excludes_skipped_from_scored() -> None:
+    summary = aggregate_metrics(
+        [
+            _row(0, 0, "success", 1.0),
+            _row(1, 0, "success", 0.0),
+            _row(2, 0, "skipped", None),
+        ],
+        pass_threshold=1.0,
+    )
+    assert summary["total_samples"] == 3
+    assert summary["skipped"] == 1
+    assert summary["completed_samples"] == 2
+    assert summary["graded"] == 2
+    assert summary["passed"] == 1
+    assert summary["pass_rate"] == 0.5
+
+
+def test_passed_uses_a_greater_or_equal_threshold() -> None:
+    summary = aggregate_metrics([_row(0, 0, "success", 0.7)], pass_threshold=0.7)
+    assert summary["passed"] == 1
+
+
+def test_a_failed_row_without_a_reward_is_not_graded() -> None:
+    summary = aggregate_metrics([_row(0, 0, "failed", None)], pass_threshold=1.0)
+    assert summary["failed"] == 1
+    assert summary["graded"] == 0
+    assert summary["passed"] == 0
+    assert summary["pass_rate"] == 0
+    assert "reward_stats" not in summary
+
+
+def test_tokens_are_summed_across_every_row() -> None:
+    summary = aggregate_metrics(
+        [_row(0, 0, "success", 1.0, tokens=617), _row(1, 0, "skipped", None, tokens=3)],
+        pass_threshold=1.0,
+    )
+    assert summary["tokens_used"] == 620
+
+
+def test_reward_stats_shape_matches_the_download_projection() -> None:
+    summary = aggregate_metrics(
+        [_row(0, 0, "success", 0.0), _row(1, 0, "success", 1.0)], pass_threshold=1.0
+    )
+    assert summary["reward_stats"] == {
+        "mean": 0.5,
+        "median": 0.5,
+        "std": 0.5,
+        "min": 0.0,
+        "max": 1.0,
+    }
+
+
+def test_single_attempt_runs_have_no_pass_at_k() -> None:
+    summary = aggregate_metrics([_row(0, 0, "success", 1.0)], pass_threshold=1.0)
+    assert "pass_at_k" not in summary
+    assert "n_runs" not in summary
+
+
+def test_pass_at_k_is_reported_for_multi_attempt_runs() -> None:
+    rows = [
+        _row(0, 0, "success", 1.0),
+        _row(0, 1, "success", 0.0),
+        _row(1, 0, "success", 0.0),
+        _row(1, 1, "success", 0.0),
+    ]
+    summary = aggregate_metrics(rows, pass_threshold=1.0)
+    assert summary["n_runs"] == 2
+    assert summary["pass_at_k"] == [{"k": 1, "value": 0.25}, {"k": 2, "value": 0.5}]
+
+
+@pytest.mark.parametrize(
+    ("attempts", "passes", "k", "expected"),
+    [
+        (1, 1, 1, 1.0),
+        (1, 0, 1, 0.0),
+        (2, 1, 1, 0.5),
+        (2, 1, 2, 1.0),
+        (4, 1, 2, 0.5),
+        (4, 0, 4, 0.0),
+    ],
+)
+def test_unbiased_pass_at_k(
+    attempts: int, passes: int, k: int, expected: float
+) -> None:
+    assert pass_at_k(attempts=attempts, passes=passes, k=k) == pytest.approx(expected)
+
+
+def test_pass_at_k_rejects_k_beyond_the_attempt_count() -> None:
+    with pytest.raises(ValueError, match="k must not exceed"):
+        pass_at_k(attempts=1, passes=0, k=2)
+
+
+def test_an_empty_index_aggregates_without_dividing_by_zero() -> None:
+    summary = aggregate_metrics([], pass_threshold=1.0)
+    assert summary["total_samples"] == 0
+    assert summary["pass_rate"] == 0
+    assert summary["tokens_used"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# Artifact path safety (§2.6)
+# --------------------------------------------------------------------------- #
+
+
+def test_artifact_enumeration_skips_the_reserved_manifest_name(tmp_path: Path) -> None:
+    artifacts = tmp_path / "artifacts"
+    (artifacts / "logs").mkdir(parents=True)
+    (artifacts / "manifest.json").write_text("{}")
+    (artifacts / "logs" / "manifest.json").write_text("{}")
+    (artifacts / "out.txt").write_text("hi")
+    found = {str(path) for path in safe_artifact_relative_paths(artifacts)}
+    # Only the exact top-level name is reserved; a nested one is a real artifact.
+    assert found == {"out.txt", "logs/manifest.json"}
+
+
+def test_artifact_enumeration_refuses_symlinks(tmp_path: Path) -> None:
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    secret = tmp_path / "id_rsa"
+    secret.write_text("PRIVATE")
+    (artifacts / "leak").symlink_to(secret)
+    with pytest.raises(ArtifactProjectionError, match="symlink"):
+        safe_artifact_relative_paths(artifacts)
+
+
+def test_a_missing_artifacts_dir_yields_nothing(tmp_path: Path) -> None:
+    assert safe_artifact_relative_paths(tmp_path / "absent") == []
+
+
+# --------------------------------------------------------------------------- #
+# Selection and full materialization
+# --------------------------------------------------------------------------- #
+
+
+def _identity() -> RunIdentity:
+    return RunIdentity(
+        local_run_id="c" * 32,
+        run_name="my-run",
+        dataset_name="multiply",
+        model_name="openai/gpt-5-mini",
+        rollout_name="multiply-local-openai",
+        started_at="2026-08-14T00:00:00Z",
+    )
+
+
+def test_select_attempts_binds_a_valid_trajectory(tmp_path: Path) -> None:
+    trials = tmp_path / "rollout_trials"
+    _write_trajectory(trials, ROLLOUT_A, _atif(ROLLOUT_A))
+    latest = {(0, 0): _record(0, 0, rollout_id=ROLLOUT_A)}
+    [attempt] = select_attempts(latest, trials_dir=trials)
+    assert attempt.trajectory_filename == "trajectory.json"
+    assert attempt.resumed is False
+
+
+def test_select_attempts_omits_a_never_written_trajectory(tmp_path: Path) -> None:
+    latest = {(0, 0): _record(0, 0, rollout_id=ROLLOUT_A)}
+    [attempt] = select_attempts(latest, trials_dir=tmp_path / "rollout_trials")
+    # A missing trajectory never invalidates the terminal result (§11.3).
+    assert attempt.trajectory_filename is None
+    assert attempt.record.status == "success"
+
+
+def test_select_attempts_marks_replayed_keys_as_resumed(tmp_path: Path) -> None:
+    latest = {(0, 0): _record(0, 0, rollout_id=ROLLOUT_A)}
+    [attempt] = select_attempts(
+        latest, trials_dir=tmp_path / "rollout_trials", resumed_keys=[(0, 0)]
+    )
+    assert attempt.resumed is True
+
+
+def test_a_late_trajectory_is_picked_up_on_the_next_refresh(tmp_path: Path) -> None:
+    trials = tmp_path / "rollout_trials"
+    latest = {(0, 0): _record(0, 0, rollout_id=ROLLOUT_A)}
+    assert select_attempts(latest, trials_dir=trials)[0].trajectory_filename is None
+    _write_trajectory(trials, ROLLOUT_A, _atif(ROLLOUT_A))
+    assert (
+        select_attempts(latest, trials_dir=trials)[0].trajectory_filename
+        == "trajectory.json"
+    )
+
+
+def test_refresh_writes_the_full_download_layout(tmp_path: Path) -> None:
+    trials = tmp_path / "rollout_trials"
+    _write_trajectory(trials, ROLLOUT_A, _atif(ROLLOUT_A))
+    (trials / ROLLOUT_A / "artifacts" / "logs").mkdir(parents=True)
+    (trials / ROLLOUT_A / "artifacts" / "logs" / "run.log").write_text("hello")
+
+    latest = {(0, 0): _record(0, 0, rollout_id=ROLLOUT_A)}
+    attempts = select_attempts(latest, trials_dir=trials)
+    Materializer(tmp_path).refresh(
+        attempts,
+        identity=_identity(),
+        pass_threshold=1.0,
+        sampled_rows=1,
+        total_dataset_rows=1000,
+        total_runs=1,
+    )
+
+    index = (tmp_path / "index.jsonl").read_text()
+    assert json.loads(index)["trajectory_filename"] == "trajectory.json"
+    # summary.jsonl is index.jsonl verbatim.
+    assert (tmp_path / "summary.jsonl").read_text() == index
+    assert json.loads((tmp_path / "progress.json").read_text()) == {
+        "total_runs": 1,
+        "sampled_rows": 1,
+        "total_dataset_rows": 1000,
+    }
+    metrics = json.loads((tmp_path / "metrics.json").read_text())
+    assert metrics["eval_run"]["name"] == "my-run"
+    assert metrics["summary"]["pass_rate"] == 1
+    assert (tmp_path / "trajectories" / "row_0_run_0.json").is_file()
+    assert (
+        tmp_path / "artifacts" / "row_0_run_0" / "logs" / "run.log"
+    ).read_text() == "hello"
+
+
+def test_metrics_json_uses_two_space_json_with_a_trailing_newline(
+    tmp_path: Path,
+) -> None:
+    Materializer(tmp_path).refresh(
+        select_attempts({}, trials_dir=tmp_path / "rollout_trials"),
+        identity=_identity(),
+        pass_threshold=1.0,
+        sampled_rows=0,
+        total_dataset_rows=0,
+        total_runs=0,
+    )
+    text = (tmp_path / "metrics.json").read_text()
+    assert text.endswith("}\n")
+    assert '\n  "eval_run"' in text
+
+
+def test_projections_are_independent_copies(tmp_path: Path) -> None:
+    trials = tmp_path / "rollout_trials"
+    canonical = _write_trajectory(trials, ROLLOUT_A, _atif(ROLLOUT_A))
+    latest = {(0, 0): _record(0, 0, rollout_id=ROLLOUT_A)}
+    Materializer(tmp_path).refresh(
+        select_attempts(latest, trials_dir=trials),
+        identity=_identity(),
+        pass_threshold=1.0,
+        sampled_rows=1,
+        total_dataset_rows=1,
+        total_runs=1,
+    )
+    projection = tmp_path / "trajectories" / "row_0_run_0.json"
+    projection.write_text('{"edited": true}')
+    # Editing the projection must never mutate the canonical upload source.
+    assert json.loads(canonical.read_text())["session_id"] == ROLLOUT_A
+
+
+def test_a_retried_work_item_projects_only_the_selected_attempt(tmp_path: Path) -> None:
+    trials = tmp_path / "rollout_trials"
+    _write_trajectory(trials, ROLLOUT_A, _atif(ROLLOUT_A))
+    _write_trajectory(trials, ROLLOUT_B, _atif(ROLLOUT_B))
+    # The journal's latest record for (0, 0) points at the second attempt.
+    latest = {(0, 0): _record(0, 0, rollout_id=ROLLOUT_B)}
+    rows = Materializer(tmp_path).refresh(
+        select_attempts(latest, trials_dir=trials),
+        identity=_identity(),
+        pass_threshold=1.0,
+        sampled_rows=1,
+        total_dataset_rows=1,
+        total_runs=1,
+    )
+    assert [row["rollout_id"] for row in rows] == [ROLLOUT_B]
+    # The superseded attempt stays on disk as diagnostic evidence.
+    assert (trials / ROLLOUT_A / "trajectory.json").is_file()
+
+
+def test_a_cancelled_attempt_is_never_projected_as_success(tmp_path: Path) -> None:
+    # The Harbor footgun: a cancelled attempt writes no terminal record, so it
+    # simply is not in the index at all.
+    rows = Materializer(tmp_path).refresh(
+        select_attempts({}, trials_dir=tmp_path / "rollout_trials"),
+        identity=_identity(),
+        pass_threshold=1.0,
+        sampled_rows=1,
+        total_dataset_rows=1,
+        total_runs=1,
+    )
+    assert rows == []
+    assert (tmp_path / "index.jsonl").read_text() == ""

--- a/tests/unit/eval/local/test_runner_crash_resume.py
+++ b/tests/unit/eval/local/test_runner_crash_resume.py
@@ -71,7 +71,7 @@ async def main() -> int:
             grader_timeout_sec=30.0,
             batch_size=1,
         ),
-        options=LocalEvalOptions(name="run-1", yes=True, max_in_flight=1),
+        options=LocalEvalOptions(name="run-1", max_in_flight=1),
         dataset=resolve_explicit_dataset_file(dataset_file),
         selection=select_rows(dataset_file),
         rollout_dir=Path(rollout_dir),

--- a/tests/unit/eval/local/test_runner_crash_resume.py
+++ b/tests/unit/eval/local/test_runner_crash_resume.py
@@ -1,0 +1,281 @@
+"""The crash-recovery acceptance gates (§17).
+
+A durably acknowledged terminal result must never run again across ``kill -9``
+or Ctrl-C; unacknowledged work must. Both are exercised against a real
+supervisor in its own process, because that is the only way to remove the
+supervisor without letting it clean up after itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from osmosis_ai.eval.local.dataset import select_rows
+from osmosis_ai.eval.local.state import RunLock
+
+from .conftest import RecordingHooks, RunnerHarness
+
+pytestmark = pytest.mark.slow
+
+_SUPERVISOR_SCRIPT = '''\
+"""Run one local eval supervisor, driven entirely by argv/env. Test-only."""
+
+import asyncio
+import sys
+from pathlib import Path
+
+from osmosis_ai.eval.local.dataset import resolve_explicit_dataset_file, select_rows
+from osmosis_ai.eval.local.runner import (
+    EvalRunSpec,
+    LocalEvalOptions,
+    LocalEvalRunner,
+)
+
+
+class Hooks:
+    def note(self, message):
+        print(f"NOTE {message}", flush=True)
+
+    def confirm_dispatch(self, *, pending, model_path):
+        print(f"PENDING {pending}", flush=True)
+
+    def resolve_secrets(self, names):
+        return {}
+
+    def progress(self, snapshot):
+        print(f"PROGRESS {snapshot.completed}/{snapshot.total}", flush=True)
+
+
+async def main() -> int:
+    rollout_dir, output_root, dataset_path, proxy_url, proxy_token = sys.argv[1:6]
+    dataset_file = Path(dataset_path)
+    runner = LocalEvalRunner(
+        spec=EvalRunSpec(
+            rollout_name="echo-rollout",
+            entrypoint="main.py",
+            model_path="openai/gpt-5-mini",
+            dataset_name="echo",
+            n=1,
+            pass_threshold=1.0,
+            agent_timeout_sec=60.0,
+            grader_timeout_sec=30.0,
+            batch_size=1,
+        ),
+        options=LocalEvalOptions(name="run-1", yes=True, max_in_flight=1),
+        dataset=resolve_explicit_dataset_file(dataset_file),
+        selection=select_rows(dataset_file),
+        rollout_dir=Path(rollout_dir),
+        output_root=Path(output_root),
+        proxy_base_url=proxy_url,
+        proxy_auth_token=proxy_token,
+        hooks=Hooks(),
+        config_stem="echo-eval",
+    )
+    try:
+        summary = await runner.run()
+    except KeyboardInterrupt:
+        print("INTERRUPTED", flush=True)
+        return 130
+    print(f"DONE succeeded={summary.succeeded} cancelled={summary.cancelled}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))
+'''
+
+
+def _write_supervisor_script(tmp_path: Path) -> Path:
+    path = tmp_path / "run_supervisor.py"
+    path.write_text(_SUPERVISOR_SCRIPT, encoding="utf-8")
+    return path
+
+
+def _spawn_supervisor(
+    script: Path, harness: RunnerHarness, *, workflow_sleep: str
+) -> subprocess.Popen[str]:
+    env = {
+        **os.environ,
+        "OSMOSIS_TEST_WORKFLOW_SLEEP": workflow_sleep,
+        "PYTHONUNBUFFERED": "1",
+    }
+    return subprocess.Popen(
+        [
+            sys.executable,
+            str(script),
+            str(harness.rollout_dir),
+            str(harness.output_root),
+            str(harness.dataset.path),
+            harness.proxy_base_url,
+            harness.proxy_token,
+        ],
+        cwd=str(Path(__file__).resolve().parents[4]),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        start_new_session=True,
+    )
+
+
+def _journal_records(harness: RunnerHarness) -> list[dict[str, object]]:
+    path = harness.run_dir() / "events.jsonl"
+    if not path.is_file():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text().splitlines()
+        if line.strip() and line.endswith("}")
+    ]
+
+
+async def _wait_for_journal(
+    harness: RunnerHarness,
+    *,
+    count: int,
+    process: subprocess.Popen[str] | None = None,
+    timeout: float = 60.0,
+) -> list[dict[str, object]]:
+    """Poll the journal without blocking: the stub proxy shares this event loop."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        records = _journal_records(harness)
+        if len(records) >= count:
+            return records
+        if process is not None and process.poll() is not None:
+            break
+        await asyncio.sleep(0.05)
+    output = ""
+    if process is not None and process.stdout is not None:
+        with contextlib.suppress(Exception):
+            output = process.stdout.read() or ""
+    raise AssertionError(
+        f"journal never reached {count} records "
+        f"(got {len(_journal_records(harness))}); supervisor output:\n{output}"
+    )
+
+
+async def _await_exit(process: subprocess.Popen[str], *, timeout: float) -> int | None:
+    """Reap the supervisor off-loop so the stub proxy keeps serving."""
+    try:
+        return await asyncio.to_thread(process.wait, timeout)
+    except subprocess.TimeoutExpired:
+        return None
+
+
+def _kill_group(process: subprocess.Popen[str], sig: int) -> None:
+    os.killpg(os.getpgid(process.pid), sig)
+
+
+async def test_kill_9_never_reruns_a_durably_acknowledged_item(
+    tmp_path: Path, harness: RunnerHarness
+) -> None:
+    script = _write_supervisor_script(tmp_path)
+    # One worker and a slow workflow, so exactly the first item lands durably.
+    process = _spawn_supervisor(script, harness, workflow_sleep="1.5")
+    try:
+        durable = await _wait_for_journal(harness, count=1, process=process)
+        _kill_group(process, signal.SIGKILL)
+    finally:
+        await _await_exit(process, timeout=30)
+
+    survivors = _journal_records(harness)
+    assert len(survivors) >= 1
+    committed = {(r["row_index"], r["run_index"]) for r in survivors}
+    committed_ids = {r["rollout_id"] for r in survivors}
+    assert (durable[0]["row_index"], durable[0]["run_index"]) in committed
+
+    # Resume in-process. The killed supervisor left the rollout server alive, so
+    # this also exercises verified orphan reaping through the lock metadata.
+    hooks = RecordingHooks()
+    summary = await harness.runner(hooks=hooks).run()
+
+    assert summary.dispatched == 4 - len(survivors)
+    assert summary.resumed == len(survivors)
+    assert summary.succeeded + summary.failed + summary.skipped == 4
+    # Every previously committed attempt keeps its original rollout id: it was
+    # never re-executed.
+    final_ids = {row["rollout_id"] for row in harness.index_rows()}
+    assert committed_ids <= final_ids
+
+
+async def test_sigint_leaves_cancelled_work_pending(
+    tmp_path: Path, harness: RunnerHarness
+) -> None:
+    script = _write_supervisor_script(tmp_path)
+    process = _spawn_supervisor(script, harness, workflow_sleep="2.0")
+    try:
+        await _wait_for_journal(harness, count=1, process=process)
+        _kill_group(process, signal.SIGINT)
+        exit_code = await _await_exit(process, timeout=90)
+    finally:
+        if process.poll() is None:
+            _kill_group(process, signal.SIGKILL)
+            await _await_exit(process, timeout=30)
+
+    assert exit_code in (0, 130)
+    committed = _journal_records(harness)
+    # A cancelled attempt writes no terminal record, unlike Harbor's
+    # CancelledError result which is then skipped as complete.
+    assert len(committed) < 4
+
+    hooks = RecordingHooks()
+    summary = await harness.runner(hooks=hooks).run()
+    assert summary.dispatched == 4 - len(committed)
+    assert summary.succeeded + summary.failed + summary.skipped == 4
+    assert len(harness.index_rows()) == 4
+
+
+async def test_a_partial_journal_record_is_truncated_on_resume(
+    harness: RunnerHarness,
+) -> None:
+    selection = select_rows(harness.dataset.path, row_selector=(0, 1))
+    await harness.runner(selection=selection).run()
+    journal = harness.run_dir() / "events.jsonl"
+    committed = journal.read_bytes()
+
+    # Simulate a crash mid-append: a complete-looking record with no newline.
+    journal.write_bytes(committed + b'{"row_index": 1, "run_index": 0, "roll')
+
+    hooks = RecordingHooks()
+    summary = await harness.runner(hooks=hooks, selection=selection).run()
+    assert summary.dispatched == 0
+    assert journal.read_bytes() == committed
+    logs = (harness.run_dir() / "logs.txt").read_text()
+    assert "discarded a partial trailing journal record" in logs
+
+
+async def test_the_lock_records_the_child_while_the_run_is_live(
+    harness: RunnerHarness,
+) -> None:
+    """The orphan-cleanup metadata must be written and fsynced right after spawn."""
+    observed: list[object] = []
+    runner = harness.runner()
+    original = runner._start_rollout_server
+
+    async def spying_start(*, secrets, lock, client):
+        base_url = await original(secrets=secrets, lock=lock, client=client)
+        observed.append(lock.read_child())
+        return base_url
+
+    runner._start_rollout_server = spying_start  # type: ignore[method-assign]
+    await runner.run()
+
+    assert len(observed) == 1
+    record = observed[0]
+    assert record is not None
+    assert record.child_pid > 0  # type: ignore[union-attr]
+    assert record.instance_id  # type: ignore[union-attr]
+    # Cleared again after a confirmed clean exit.
+    with RunLock(harness.output_root / ".locks" / "run-1.lock") as lock:
+        assert lock.read_child() is None

--- a/tests/unit/eval/local/test_runner_e2e.py
+++ b/tests/unit/eval/local/test_runner_e2e.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -460,3 +461,132 @@ def test_the_e2e_rollout_project_is_isolated_from_the_repo_venv(
     # rollout project needs no virtualenv of its own.
     assert not (rollout_project / ".venv").exists()
     assert os.access(rollout_project / "main.py", os.R_OK)
+
+
+# --------------------------------------------------------------------------- #
+# Process-wide failures must not stamp the queue failed (§9.3)
+# --------------------------------------------------------------------------- #
+
+
+async def test_an_unreachable_proxy_halts_dispatch_and_leaves_work_pending(
+    harness: RunnerHarness,
+) -> None:
+    # The queue says nothing about a dead proxy. Stamping the remaining items
+    # `failed` would make a plain resume skip work that never executed.
+    runner = harness.runner()
+    runner._proxy_base_url = "http://127.0.0.1:1"  # nothing listens here
+    hooks = RecordingHooks()
+    runner._hooks = hooks
+
+    from osmosis_ai.eval.local.runner import LocalEvalError
+
+    with pytest.raises(LocalEvalError, match="preflight failed"):
+        await runner.run()
+    # Preflight fails before any dispatch, so nothing is journaled at all.
+    assert harness.journal_lines() == []
+
+    # With the proxy reachable again, every item is still pending.
+    summary = await harness.runner().run()
+    assert summary.dispatched == 4
+    assert summary.succeeded == 4
+
+
+async def test_a_proxy_failure_after_preflight_halts_rather_than_failing_rows(
+    harness: RunnerHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from osmosis_ai.rollout.controller import EvalProxyClient, EvalProxyError
+
+    calls = {"n": 0}
+    real_create = EvalProxyClient.create_session
+
+    async def flaky_create(self: Any, **kwargs: Any) -> Any:
+        calls["n"] += 1
+        # Let preflight and the first work item through, then break.
+        if calls["n"] > 2:
+            raise EvalProxyError("proxy exploded", status_code=503)
+        return await real_create(self, **kwargs)
+
+    monkeypatch.setattr(EvalProxyClient, "create_session", flaky_create)
+    hooks = RecordingHooks()
+    summary = await harness.runner(
+        hooks=hooks, options=LocalEvalOptions(name="run-1", yes=True, max_in_flight=1)
+    ).run()
+
+    assert summary.succeeded == 1
+    # The three items that never ran have no terminal record at all.
+    assert len(harness.journal_lines()) == 1
+    assert summary.failed == 0
+    assert summary.cancelled is True
+    assert any("stopping dispatch" in note for note in hooks.notes)
+
+    monkeypatch.undo()
+    resumed = await harness.runner().run()
+    assert resumed.dispatched == 3
+    assert resumed.succeeded == 4
+
+
+async def test_a_dead_rollout_server_halts_instead_of_waiting_out_deadlines(
+    harness: RunnerHarness,
+) -> None:
+    runner = harness.runner(
+        options=LocalEvalOptions(name="run-1", yes=True, max_in_flight=1)
+    )
+    original_run_item = runner._run_work_item
+    killed = {"done": False}
+
+    async def kill_after_first(item: Any, driver: Any) -> None:
+        if killed["done"]:
+            return await original_run_item(item, driver)
+        result = await original_run_item(item, driver)
+        killed["done"] = True
+        child = runner._child
+        assert child is not None
+        child.kill()
+        return result
+
+    runner._run_work_item = kill_after_first  # type: ignore[method-assign]
+    summary = await runner.run()
+
+    # One item completed; the rest are pending, not failed, and the run did not
+    # sit on a callback that can no longer arrive.
+    assert summary.succeeded == 1
+    assert summary.failed == 0
+    assert len(harness.journal_lines()) == 1
+    logs = (harness.run_dir() / "logs.txt").read_text()
+    assert "halting dispatch" in logs
+
+
+async def test_a_retried_item_is_not_marked_resumed(
+    harness: RunnerHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OSMOSIS_TEST_GRADER_CRASH", "1")
+    selection = select_rows(harness.dataset.path, row_selector=(0,))
+    await harness.runner(selection=selection).run()
+    assert harness.index_rows()[0].get("resumed") is None
+
+    monkeypatch.delenv("OSMOSIS_TEST_GRADER_CRASH")
+    await harness.runner(
+        selection=selection,
+        options=LocalEvalOptions(name="run-1", yes=True, retry_failed=True),
+    ).run()
+    row = harness.index_rows()[0]
+    assert row["status"] == "success"
+    # `resumed` is the platform's carry-forward flag; this result was produced now.
+    assert "resumed" not in row
+
+
+async def test_secret_values_never_reach_logs_txt(
+    harness: RunnerHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    secret = "sk-live-supersecretvalue123"
+    monkeypatch.setenv("OSMOSIS_TEST_ECHO_SECRET", "1")
+    hooks = RecordingHooks(secrets={"MY_TOKEN": secret})
+    await harness.runner(
+        hooks=hooks, spec=harness.spec(secret_names=("MY_TOKEN",))
+    ).run()
+    run_dir = harness.run_dir()
+    logs = (run_dir / "logs.txt").read_text()
+    assert secret not in logs
+    assert "[REDACTED]" in logs
+    assert secret not in (run_dir / "manifest.json").read_text()
+    assert secret not in (run_dir / "events.jsonl").read_text()

--- a/tests/unit/eval/local/test_runner_e2e.py
+++ b/tests/unit/eval/local/test_runner_e2e.py
@@ -1,0 +1,462 @@
+"""LocalBackend end-to-end: a real rollout-server subprocess and a real stub proxy.
+
+These tests spawn the rollout server the way ``osmosis eval run`` does, so they
+cover the parts no in-process fake can: artifact-root override, HTTP dispatch,
+callback delivery, journal-before-ack ordering, and resume across processes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from osmosis_ai.eval.local.dataset import select_rows
+from osmosis_ai.eval.local.runner import LocalEvalOptions, ResumeRefusedError
+from osmosis_ai.eval.local.state import TerminalJournal, TerminalRecord, utc_now
+
+from .conftest import RecordingHooks, RunnerHarness
+
+pytestmark = pytest.mark.slow
+
+
+async def test_a_full_run_produces_the_download_layout(harness: RunnerHarness) -> None:
+    summary = await harness.runner().run()
+
+    assert summary.total_work_items == 4
+    assert summary.dispatched == 4
+    assert summary.succeeded == 4
+
+    run_dir = harness.run_dir()
+    for name in (
+        "manifest.json",
+        "events.jsonl",
+        "index.jsonl",
+        "progress.json",
+        "summary.jsonl",
+        "metrics.json",
+        "logs.txt",
+    ):
+        assert (run_dir / name).is_file(), name
+    assert (run_dir / "rollout_trials").is_dir()
+
+    rows = harness.index_rows()
+    assert [(row["row_index"], row["run_index"]) for row in rows] == [
+        (0, 0),
+        (1, 0),
+        (2, 0),
+        (3, 0),
+    ]
+    for row in rows:
+        assert len(row["rollout_id"]) == 32
+        assert row["trajectory_filename"] == "trajectory.json"
+        assert isinstance(row["duration_ms"], float)
+    assert (run_dir / "summary.jsonl").read_text() == (
+        run_dir / "index.jsonl"
+    ).read_text()
+
+
+async def test_the_stub_completion_is_graded_and_rewarded(
+    harness: RunnerHarness,
+) -> None:
+    # The contract stub replies "ok" and every row's label is "ok", so a correct
+    # end-to-end path yields reward 1.0 -- this is the reward-plumbing assertion.
+    summary = await harness.runner().run()
+    assert summary.succeeded == 4
+    assert summary.metrics["pass_rate"] == 1
+    assert summary.metrics["graded"] == 4
+    rewards = {row["reward"] for row in harness.index_rows()}
+    assert rewards == {1.0}
+
+
+async def test_tokens_come_from_the_proxy_usage_api(harness: RunnerHarness) -> None:
+    await harness.runner().run()
+    # The stub meters 2 tokens per session.
+    assert {row["tokens"] for row in harness.index_rows()} == {2}
+    assert harness.run_dir().joinpath("metrics.json").is_file()
+    metrics = json.loads((harness.run_dir() / "metrics.json").read_text())
+    assert metrics["summary"]["tokens_used"] == 8
+
+
+async def test_trajectories_and_projections_are_written(harness: RunnerHarness) -> None:
+    await harness.runner().run()
+    run_dir = harness.run_dir()
+    for row_index in range(4):
+        projection = run_dir / "trajectories" / f"row_{row_index}_run_0.json"
+        assert projection.is_file()
+        document = json.loads(projection.read_text())
+        rollout_id = document["extra"]["osmosis"]["rollout_id"]
+        canonical = run_dir / "rollout_trials" / rollout_id / "trajectory.json"
+        assert canonical.is_file()
+        # Independent copies: editing the projection must not touch the source.
+        assert projection.resolve() != canonical.resolve()
+        assert document["extra"]["osmosis"]["request_extra_fields"] == {
+            "row_index": row_index,
+            "run_index": 0,
+        }
+
+
+async def test_artifacts_are_projected_when_the_workflow_writes_them(
+    harness: RunnerHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OSMOSIS_TEST_WRITE_ARTIFACT", "1")
+    await harness.runner().run()
+    projected = sorted((harness.run_dir() / "artifacts").glob("row_*_run_0/note.txt"))
+    assert len(projected) == 4
+    assert projected[0].read_text() == "ok"
+
+
+async def test_progress_json_reports_the_dataset_size(harness: RunnerHarness) -> None:
+    selection = select_rows(harness.dataset.path, row_selector=(1, 2))
+    await harness.runner(selection=selection).run()
+    assert json.loads((harness.run_dir() / "progress.json").read_text()) == {
+        "total_runs": 2,
+        "sampled_rows": 2,
+        "total_dataset_rows": 4,
+    }
+
+
+async def test_row_index_is_the_position_in_the_selected_set(
+    harness: RunnerHarness,
+) -> None:
+    selection = select_rows(harness.dataset.path, row_selector=(2, 3))
+    await harness.runner(selection=selection).run()
+    rows = harness.index_rows()
+    assert [row["row_index"] for row in rows] == [0, 1]
+    # The dataset offset survives in the journal, for local UX and provenance.
+    assert [line["source_row_index"] for line in harness.journal_lines()] == [2, 3]
+
+
+async def test_multiple_attempts_per_row(harness: RunnerHarness) -> None:
+    selection = select_rows(harness.dataset.path, row_selector=(0,))
+    summary = await harness.runner(spec=harness.spec(n=3), selection=selection).run()
+    assert summary.total_work_items == 3
+    rows = harness.index_rows()
+    assert [row["run_index"] for row in rows] == [0, 1, 2]
+    assert summary.metrics["n_runs"] == 3
+    assert len(summary.metrics["pass_at_k"]) >= 2
+
+
+async def test_logs_txt_uses_the_download_line_format(harness: RunnerHarness) -> None:
+    await harness.runner().run()
+    lines = (harness.run_dir() / "logs.txt").read_text().splitlines()
+    assert lines, "no log lines written"
+    for line in lines:
+        stamp, level, rest = line.split(" ", 2)
+        assert stamp.endswith("Z")
+        assert level in ("INFO", "WARNING", "ERROR")
+        assert rest.startswith("[")
+    assert any("[rollout-server]" in line for line in lines)
+
+
+# --------------------------------------------------------------------------- #
+# Resume, fresh, retry
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_second_run_of_the_same_name_dispatches_nothing(
+    harness: RunnerHarness,
+) -> None:
+    await harness.runner().run()
+    hooks = RecordingHooks()
+    summary = await harness.runner(hooks=hooks).run()
+    assert summary.dispatched == 0
+    assert summary.resumed == 4
+    assert hooks.confirmations == []
+    # No pending work means credentials and the subprocess are never needed.
+    assert hooks.secret_requests == []
+    assert all(row["resumed"] is True for row in harness.index_rows())
+
+
+async def test_a_partial_journal_reruns_only_the_missing_items(
+    harness: RunnerHarness,
+) -> None:
+    # Simulate a crash after two work items were durably journaled.
+    await harness.runner(
+        selection=select_rows(harness.dataset.path, row_selector=(0, 1))
+    ).run()
+    first_pass = {(r["row_index"], r["run_index"]) for r in harness.index_rows()}
+    assert first_pass == {(0, 0), (1, 0)}
+
+    hooks = RecordingHooks()
+    summary = await harness.runner(
+        hooks=hooks,
+        options=LocalEvalOptions(name="run-1", yes=True),
+        selection=select_rows(harness.dataset.path, row_selector=(0, 1)),
+    ).run()
+    assert summary.dispatched == 0
+    assert summary.resumed == 2
+
+
+async def test_a_changed_fingerprint_refuses_with_a_field_diff(
+    harness: RunnerHarness,
+) -> None:
+    await harness.runner().run()
+    with pytest.raises(ResumeRefusedError) as excinfo:
+        await harness.runner(spec=harness.spec(model_path="openai/gpt-4o")).run()
+    message = str(excinfo.value)
+    assert "model_path" in message
+    assert "--fresh" in message
+    assert [diff.field for diff in excinfo.value.diffs] == ["model_path"]
+
+
+async def test_changed_rollout_code_refuses_resume(harness: RunnerHarness) -> None:
+    await harness.runner().run()
+    (harness.rollout_dir / "extra.py").write_text("# a code change\n")
+    with pytest.raises(ResumeRefusedError, match=r"rollout\.source_digest"):
+        await harness.runner().run()
+
+
+async def test_fresh_archives_the_previous_results_under_the_same_name(
+    harness: RunnerHarness,
+) -> None:
+    await harness.runner().run()
+    original_manifest = json.loads((harness.run_dir() / "manifest.json").read_text())
+
+    hooks = RecordingHooks()
+    summary = await harness.runner(
+        hooks=hooks,
+        spec=harness.spec(model_path="openai/gpt-4o"),
+        options=LocalEvalOptions(name="run-1", yes=True, fresh=True),
+    ).run()
+
+    assert summary.dispatched == 4
+    assert summary.resumed == 0
+    archives = sorted(harness.output_root.glob("run-1.archive-*"))
+    assert len(archives) == 1
+    # Archive, never silent-delete: the old journal is still readable.
+    assert (archives[0] / "events.jsonl").is_file()
+    assert json.loads((archives[0] / "manifest.json").read_text()) == original_manifest
+    assert any("archived previous results" in note for note in hooks.notes)
+
+
+async def test_retry_failed_reruns_failures_with_a_fresh_rollout_id(
+    harness: RunnerHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OSMOSIS_TEST_GRADER_CRASH", "1")
+    selection = select_rows(harness.dataset.path, row_selector=(0,))
+    first = await harness.runner(selection=selection).run()
+    assert first.failed == 1
+    failed_rollout_id = harness.index_rows()[0]["rollout_id"]
+
+    monkeypatch.delenv("OSMOSIS_TEST_GRADER_CRASH")
+    second = await harness.runner(
+        selection=selection,
+        options=LocalEvalOptions(name="run-1", yes=True, retry_failed=True),
+    ).run()
+    assert second.succeeded == 1
+    row = harness.index_rows()[0]
+    assert row["status"] == "success"
+    assert row["rollout_id"] != failed_rollout_id
+    # Both attempts stay in the journal; the later one wins.
+    assert len(harness.journal_lines()) == 2
+    # The superseded attempt's artifacts remain for diagnosis.
+    assert (harness.run_dir() / "rollout_trials" / failed_rollout_id).is_dir()
+
+
+async def test_failures_are_skipped_by_default_on_resume(
+    harness: RunnerHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OSMOSIS_TEST_GRADER_CRASH", "1")
+    selection = select_rows(harness.dataset.path, row_selector=(0,))
+    await harness.runner(selection=selection).run()
+
+    monkeypatch.delenv("OSMOSIS_TEST_GRADER_CRASH")
+    summary = await harness.runner(selection=selection).run()
+    assert summary.dispatched == 0
+    assert summary.failed == 1
+
+
+async def test_a_durably_journaled_item_never_reruns(harness: RunnerHarness) -> None:
+    """The kill -9 gate, exercised by pre-seeding the journal directly."""
+    run_dir = harness.run_dir()
+    selection = select_rows(harness.dataset.path, row_selector=(0, 1))
+    # Create the run so its manifest matches, then journal one result by hand.
+    await harness.runner(selection=selection).run()
+    baseline = harness.journal_lines()
+    assert len(baseline) == 2
+
+    # A journal that already covers every work item leaves nothing to dispatch,
+    # even though no rollout directory for the hand-written id exists.
+    journal = TerminalJournal(run_dir / "events.jsonl")
+    replay = journal.replay()
+    journal.open_for_append(replay)
+    try:
+        await journal.append(
+            TerminalRecord(
+                row_index=0,
+                run_index=0,
+                rollout_id="f" * 32,
+                status="failed",
+                recorded_at=utc_now(),
+                source_row_index=0,
+                duration_ms=1.0,
+                error_type="hand_written",
+            )
+        )
+    finally:
+        journal.close()
+
+    summary = await harness.runner(selection=selection).run()
+    assert summary.dispatched == 0
+    row = next(r for r in harness.index_rows() if r["row_index"] == 0)
+    assert row["rollout_id"] == "f" * 32
+    assert row["error_type"] == "hand_written"
+    # No trajectory exists for the hand-written attempt, so the key is omitted.
+    assert "trajectory_filename" not in row
+
+
+# --------------------------------------------------------------------------- #
+# Failure and skip handling
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_grader_crash_is_a_terminal_failure(
+    harness: RunnerHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OSMOSIS_TEST_GRADER_CRASH", "1")
+    summary = await harness.runner().run()
+    assert summary.failed == 4
+    assert summary.metrics["graded"] == 0
+    assert summary.metrics["pass_rate"] == 0
+    assert len(summary.failures) == 4
+    assert summary.failures[0].rollout_dir.is_dir()
+
+
+async def test_remove_sample_becomes_a_skipped_row(
+    harness: RunnerHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OSMOSIS_TEST_REMOVE_SAMPLE", "1")
+    summary = await harness.runner().run()
+    assert summary.skipped == 4
+    assert summary.metrics["skipped"] == 4
+    assert summary.metrics["completed_samples"] == 0
+    assert all(row["status"] == "skipped" for row in harness.index_rows())
+
+
+async def test_a_missing_entrypoint_fails_before_dispatch(
+    harness: RunnerHarness,
+) -> None:
+    from osmosis_ai.eval.local.runner import LocalEvalError
+
+    with pytest.raises(LocalEvalError, match="entrypoint"):
+        await harness.runner(spec=harness.spec(entrypoint="absent.py")).run()
+
+
+# --------------------------------------------------------------------------- #
+# Concurrency and confirmation
+# --------------------------------------------------------------------------- #
+
+
+async def test_batch_size_bounds_in_flight_work(harness: RunnerHarness) -> None:
+    summary = await harness.runner(spec=harness.spec(batch_size=2)).run()
+    assert summary.dispatched == 4
+
+
+async def test_max_in_flight_overrides_batch_size(harness: RunnerHarness) -> None:
+    summary = await harness.runner(
+        spec=harness.spec(batch_size=1),
+        options=LocalEvalOptions(name="run-1", yes=True, max_in_flight=4),
+    ).run()
+    assert summary.dispatched == 4
+
+
+async def test_confirmation_receives_the_pending_count(harness: RunnerHarness) -> None:
+    hooks = RecordingHooks()
+    await harness.runner(hooks=hooks).run()
+    assert hooks.confirmations == [(4, "openai/gpt-5-mini")]
+    assert hooks.progress_snapshots[-1].completed == 4
+
+
+async def test_declining_confirmation_dispatches_nothing(
+    harness: RunnerHarness,
+) -> None:
+    hooks = RecordingHooks(refuse_confirmation=True)
+    with pytest.raises(RuntimeError, match="declined"):
+        await harness.runner(hooks=hooks).run()
+    assert harness.index_rows() == []
+    # The run directory and manifest exist, so the next attempt resumes cleanly.
+    assert (harness.run_dir() / "manifest.json").is_file()
+
+
+async def test_secrets_are_requested_only_when_work_is_pending(
+    harness: RunnerHarness,
+) -> None:
+    hooks = RecordingHooks()
+    await harness.runner(
+        hooks=hooks, spec=harness.spec(secret_names=("MY_TOKEN",))
+    ).run()
+    assert hooks.secret_requests == [["MY_TOKEN"]]
+
+
+async def test_a_second_supervisor_is_refused(harness: RunnerHarness) -> None:
+    from osmosis_ai.eval.local.state import RunLock, RunLockedError
+
+    lock_path = harness.output_root / ".locks" / "run-1.lock"
+    with RunLock(lock_path):
+        with pytest.raises(RunLockedError, match="already holds"):
+            await harness.runner().run()
+
+
+async def test_the_child_record_is_cleared_after_a_clean_shutdown(
+    harness: RunnerHarness,
+) -> None:
+    from osmosis_ai.eval.local.state import RunLock
+
+    await harness.runner().run()
+    with RunLock(harness.output_root / ".locks" / "run-1.lock") as lock:
+        assert lock.read_child() is None
+
+
+async def test_the_rollout_server_child_does_not_outlive_the_run(
+    harness: RunnerHarness,
+) -> None:
+    await harness.runner().run()
+    logs = (harness.run_dir() / "logs.txt").read_text()
+    port_line = next(
+        line for line in logs.splitlines() if "rollout server healthy" in line
+    )
+    port = json.loads(port_line[port_line.index("{") :])["port"]
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(1.0)
+        assert sock.connect_ex(("127.0.0.1", port)) != 0
+
+
+async def test_an_unnamed_run_gets_a_generated_directory(
+    harness: RunnerHarness,
+) -> None:
+    summary = await harness.runner(options=LocalEvalOptions(yes=True)).run()
+    assert summary.run_name.startswith("echo-eval-")
+    assert summary.run_dir.name == summary.run_name
+    assert (summary.run_dir / "index.jsonl").is_file()
+
+
+async def test_the_manifest_records_provenance_but_no_secret_values(
+    harness: RunnerHarness,
+) -> None:
+    hooks = RecordingHooks(secrets={"MY_TOKEN": "super-secret-value"})
+    await harness.runner(
+        hooks=hooks, spec=harness.spec(secret_names=("MY_TOKEN",))
+    ).run()
+    run_dir = harness.run_dir()
+    manifest_text = (run_dir / "manifest.json").read_text()
+    assert "super-secret-value" not in manifest_text
+    assert "MY_TOKEN" in manifest_text
+    assert "super-secret-value" not in (run_dir / "logs.txt").read_text()
+    assert "super-secret-value" not in (run_dir / "events.jsonl").read_text()
+    manifest = json.loads(manifest_text)
+    assert manifest["provenance"]["sdk_version"]
+    assert manifest["schema_version"] == 1
+
+
+def test_the_e2e_rollout_project_is_isolated_from_the_repo_venv(
+    rollout_project: Path,
+) -> None:
+    # The supervisor launches the entrypoint with the current interpreter, so a
+    # rollout project needs no virtualenv of its own.
+    assert not (rollout_project / ".venv").exists()
+    assert os.access(rollout_project / "main.py", os.R_OK)

--- a/tests/unit/eval/local/test_runner_e2e.py
+++ b/tests/unit/eval/local/test_runner_e2e.py
@@ -72,15 +72,6 @@ async def test_the_stub_completion_is_graded_and_rewarded(
     assert rewards == {1.0}
 
 
-async def test_tokens_come_from_the_proxy_usage_api(harness: RunnerHarness) -> None:
-    await harness.runner().run()
-    # The stub meters 2 tokens per session.
-    assert {row["tokens"] for row in harness.index_rows()} == {2}
-    assert harness.run_dir().joinpath("metrics.json").is_file()
-    metrics = json.loads((harness.run_dir() / "metrics.json").read_text())
-    assert metrics["summary"]["tokens_used"] == 8
-
-
 async def test_trajectories_and_projections_are_written(harness: RunnerHarness) -> None:
     await harness.runner().run()
     run_dir = harness.run_dir()
@@ -184,7 +175,7 @@ async def test_a_partial_journal_reruns_only_the_missing_items(
     hooks = RecordingHooks()
     summary = await harness.runner(
         hooks=hooks,
-        options=LocalEvalOptions(name="run-1", yes=True),
+        options=LocalEvalOptions(name="run-1"),
         selection=select_rows(harness.dataset.path, row_selector=(0, 1)),
     ).run()
     assert summary.dispatched == 0
@@ -220,7 +211,7 @@ async def test_fresh_archives_the_previous_results_under_the_same_name(
     summary = await harness.runner(
         hooks=hooks,
         spec=harness.spec(model_path="openai/gpt-4o"),
-        options=LocalEvalOptions(name="run-1", yes=True, fresh=True),
+        options=LocalEvalOptions(name="run-1", fresh=True),
     ).run()
 
     assert summary.dispatched == 4
@@ -245,7 +236,7 @@ async def test_retry_failed_reruns_failures_with_a_fresh_rollout_id(
     monkeypatch.delenv("OSMOSIS_TEST_GRADER_CRASH")
     second = await harness.runner(
         selection=selection,
-        options=LocalEvalOptions(name="run-1", yes=True, retry_failed=True),
+        options=LocalEvalOptions(name="run-1", retry_failed=True),
     ).run()
     assert second.succeeded == 1
     row = harness.index_rows()[0]
@@ -359,7 +350,7 @@ async def test_batch_size_bounds_in_flight_work(harness: RunnerHarness) -> None:
 async def test_max_in_flight_overrides_batch_size(harness: RunnerHarness) -> None:
     summary = await harness.runner(
         spec=harness.spec(batch_size=1),
-        options=LocalEvalOptions(name="run-1", yes=True, max_in_flight=4),
+        options=LocalEvalOptions(name="run-1", max_in_flight=4),
     ).run()
     assert summary.dispatched == 4
 
@@ -430,7 +421,7 @@ async def test_the_rollout_server_child_does_not_outlive_the_run(
 async def test_an_unnamed_run_gets_a_generated_directory(
     harness: RunnerHarness,
 ) -> None:
-    summary = await harness.runner(options=LocalEvalOptions(yes=True)).run()
+    summary = await harness.runner(options=LocalEvalOptions()).run()
     assert summary.run_name.startswith("echo-eval-")
     assert summary.run_dir.name == summary.run_name
     assert (summary.run_dir / "index.jsonl").is_file()
@@ -509,7 +500,7 @@ async def test_a_proxy_failure_after_preflight_halts_rather_than_failing_rows(
     monkeypatch.setattr(EvalProxyClient, "create_session", flaky_create)
     hooks = RecordingHooks()
     summary = await harness.runner(
-        hooks=hooks, options=LocalEvalOptions(name="run-1", yes=True, max_in_flight=1)
+        hooks=hooks, options=LocalEvalOptions(name="run-1", max_in_flight=1)
     ).run()
 
     assert summary.succeeded == 1
@@ -528,9 +519,7 @@ async def test_a_proxy_failure_after_preflight_halts_rather_than_failing_rows(
 async def test_a_dead_rollout_server_halts_instead_of_waiting_out_deadlines(
     harness: RunnerHarness,
 ) -> None:
-    runner = harness.runner(
-        options=LocalEvalOptions(name="run-1", yes=True, max_in_flight=1)
-    )
+    runner = harness.runner(options=LocalEvalOptions(name="run-1", max_in_flight=1))
     original_run_item = runner._run_work_item
     killed = {"done": False}
 
@@ -556,6 +545,71 @@ async def test_a_dead_rollout_server_halts_instead_of_waiting_out_deadlines(
     assert "halting dispatch" in logs
 
 
+def _refuse_admission(monkeypatch: pytest.MonkeyPatch, status_code: int) -> None:
+    """Refuse every admission the way a POST /rollout *status_code* would."""
+    from osmosis_ai.rollout.http_driver import HttpRolloutDriver, RolloutProtocolError
+
+    async def refused(self: Any, init: Any) -> None:
+        raise RolloutProtocolError(
+            f"POST /rollout returned {status_code}; only 202 and 429 are accepted",
+            status_code=status_code,
+        )
+
+    monkeypatch.setattr(HttpRolloutDriver, "_admit", refused)
+
+
+async def test_a_5xx_admission_halts_instead_of_failing_the_rows(
+    harness: RunnerHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A misbehaving or restarting server says nothing about the rows it refused,
+    # so they must stay pending rather than earn a durable failed record.
+    _refuse_admission(monkeypatch, 503)
+    hooks = RecordingHooks()
+    summary = await harness.runner(hooks=hooks).run()
+
+    assert summary.failed == 0
+    assert harness.journal_lines() == []
+    assert summary.cancelled is True
+    assert any("stopping dispatch" in note for note in hooks.notes)
+
+    monkeypatch.undo()
+    resumed = await harness.runner().run()
+    assert resumed.succeeded == 4
+
+
+async def test_a_4xx_admission_is_a_terminal_row_failure(
+    harness: RunnerHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The server refused *these* requests, so each one is attributable.
+    _refuse_admission(monkeypatch, 422)
+    summary = await harness.runner().run()
+
+    assert summary.failed == 4
+    assert summary.cancelled is False
+    assert {row["error_type"] for row in harness.index_rows()} == {
+        "rollout_protocol_error"
+    }
+
+
+async def test_a_crashed_worker_is_surfaced_instead_of_a_silent_short_run(
+    harness: RunnerHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from osmosis_ai.eval.local.runner import LocalEvalRunner
+
+    async def exploding_journal(self: Any, item: Any, exc: BaseException) -> None:
+        raise OSError("journal write failed")
+
+    _refuse_admission(monkeypatch, 422)
+    monkeypatch.setattr(
+        LocalEvalRunner, "_journal_supervisor_failure", exploding_journal
+    )
+    summary = await harness.runner().run()
+
+    assert harness.journal_lines() == []
+    assert summary.cancelled is True
+    assert "a worker failed: OSError" in (harness.run_dir() / "logs.txt").read_text()
+
+
 async def test_a_retried_item_is_not_marked_resumed(
     harness: RunnerHarness, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -567,7 +621,7 @@ async def test_a_retried_item_is_not_marked_resumed(
     monkeypatch.delenv("OSMOSIS_TEST_GRADER_CRASH")
     await harness.runner(
         selection=selection,
-        options=LocalEvalOptions(name="run-1", yes=True, retry_failed=True),
+        options=LocalEvalOptions(name="run-1", retry_failed=True),
     ).run()
     row = harness.index_rows()[0]
     assert row["status"] == "success"

--- a/tests/unit/eval/local/test_runner_units.py
+++ b/tests/unit/eval/local/test_runner_units.py
@@ -378,3 +378,93 @@ def test_explicit_dataset_flows_into_the_fingerprint(tmp_path: Path) -> None:
         rollout_source_digest="b" * 64,
     )
     assert inputs["dataset"]["sha256"] == resolved.sha256
+
+
+# --------------------------------------------------------------------------- #
+# Supervisor deadline and secret redaction
+# --------------------------------------------------------------------------- #
+
+
+def _runner(spec: EvalRunSpec, tmp_path: Path) -> Any:
+    from osmosis_ai.eval.local.dataset import select_rows
+    from osmosis_ai.eval.local.runner import LocalEvalOptions, LocalEvalRunner
+
+    data = tmp_path / "d.jsonl"
+    data.write_text('{"user_prompt": "a", "ground_truth": "1"}\n')
+
+    class _Hooks:
+        def note(self, message: str) -> None: ...
+        def confirm_dispatch(self, *, pending: int, model_path: str) -> None: ...
+        def resolve_secrets(self, names: Any) -> dict[str, str]:
+            return {}
+
+        def progress(self, snapshot: Any) -> None: ...
+
+    return LocalEvalRunner(
+        spec=spec,
+        options=LocalEvalOptions(name="run-1", yes=True),
+        dataset=_dataset(),
+        selection=select_rows(data),
+        rollout_dir=tmp_path,
+        output_root=tmp_path / "evals",
+        proxy_base_url="http://127.0.0.1:1",
+        proxy_auth_token="platform-token-value",
+        hooks=_Hooks(),
+    )
+
+
+def test_configured_timeouts_set_the_supervisor_deadline(tmp_path: Path) -> None:
+    runner = _runner(_spec(agent_timeout_sec=450.0, grader_timeout_sec=150.0), tmp_path)
+    # Server budget plus the callback/network grace (§10).
+    assert runner._callback_deadline() == 450.0 + 150.0 + 60.0
+
+
+def test_an_unconfigured_timeout_still_yields_a_finite_deadline(tmp_path: Path) -> None:
+    # An unbounded wait would hang every worker forever on a lost callback.
+    runner = _runner(_spec(), tmp_path)
+    deadline = runner._callback_deadline()
+    assert deadline is not None
+    assert deadline > 0
+
+
+def test_the_redactor_replaces_secrets_and_keeps_context() -> None:
+    from osmosis_ai.eval.local.runner import SecretRedactor
+
+    redactor = SecretRedactor(["sk-super-secret-value"])
+    scrubbed = redactor.scrub("Traceback: auth failed with sk-super-secret-value here")
+    assert "sk-super-secret-value" not in scrubbed
+    assert "Traceback: auth failed with" in scrubbed
+    assert "[REDACTED]" in scrubbed
+
+
+def test_the_redactor_ignores_short_placeholder_values() -> None:
+    from osmosis_ai.eval.local.runner import SecretRedactor
+
+    # "dummy" and friends are placeholders; redacting them would blank
+    # unrelated text.
+    redactor = SecretRedactor(["dummy", ""])
+    assert redactor.scrub("using dummy credentials") == "using dummy credentials"
+
+
+def test_the_redactor_prefers_the_longest_overlapping_value() -> None:
+    from osmosis_ai.eval.local.runner import SecretRedactor
+
+    redactor = SecretRedactor(["token-abcdef", "token-abcdef-longer"])
+    scrubbed = redactor.scrub("value=token-abcdef-longer")
+    assert scrubbed == "value=[REDACTED]"
+
+
+def test_the_run_log_redacts_and_is_owner_only(tmp_path: Path) -> None:
+    from osmosis_ai.eval.local.runner import RunLog, SecretRedactor
+
+    redactor = SecretRedactor(["sk-live-abcdef123456"])
+    log = RunLog(tmp_path / "logs.txt", redact=redactor.scrub)
+    try:
+        log.write("info", "rollout-server", "boom sk-live-abcdef123456")
+        log.write("info", "dispatch", "detail", token="sk-live-abcdef123456")
+    finally:
+        log.close()
+    text = (tmp_path / "logs.txt").read_text()
+    assert "sk-live-abcdef123456" not in text
+    assert text.count("[REDACTED]") == 2
+    assert (tmp_path / "logs.txt").stat().st_mode & 0o077 == 0

--- a/tests/unit/eval/local/test_runner_units.py
+++ b/tests/unit/eval/local/test_runner_units.py
@@ -1,0 +1,380 @@
+"""Supervisor unit tests that need no subprocess: fingerprint, env, orphans."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from osmosis_ai.eval.local.dataset import (
+    ResolvedDataset,
+    resolve_explicit_dataset_file,
+    select_rows,
+)
+from osmosis_ai.eval.local.runner import (
+    RESERVED_ENV_NAMES,
+    EvalRunSpec,
+    LocalEvalError,
+    build_run_inputs,
+    build_subprocess_env,
+    compute_source_digest,
+    format_input_diff,
+    generated_run_name,
+    reap_verified_orphan,
+    reserve_free_port,
+)
+from osmosis_ai.eval.local.state import (
+    ChildProcessRecord,
+    OrphanChildError,
+    diff_inputs,
+    digest_of,
+)
+
+
+def _spec(**overrides: Any) -> EvalRunSpec:
+    payload: dict[str, Any] = {
+        "rollout_name": "echo-rollout",
+        "entrypoint": "main.py",
+        "model_path": "openai/gpt-5-mini",
+        "dataset_name": "echo",
+        "n": 1,
+        "pass_threshold": 1.0,
+    }
+    payload.update(overrides)
+    return EvalRunSpec(**payload)
+
+
+def _dataset(sha: str = "a" * 64) -> ResolvedDataset:
+    return ResolvedDataset(
+        path=Path("/tmp/echo.jsonl"),
+        sha256=sha,
+        extension="jsonl",
+        source="explicit",
+        dataset_name="echo.jsonl",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Source digest
+# --------------------------------------------------------------------------- #
+
+
+def test_source_digest_changes_with_code(tmp_path: Path) -> None:
+    project = tmp_path / "rollout"
+    project.mkdir()
+    (project / "main.py").write_text("print(1)")
+    before = compute_source_digest(project)
+    (project / "main.py").write_text("print(2)")
+    assert compute_source_digest(project) != before
+
+
+def test_source_digest_is_a_full_sha256(tmp_path: Path) -> None:
+    project = tmp_path / "rollout"
+    project.mkdir()
+    (project / "main.py").write_text("print(1)")
+    digest = compute_source_digest(project)
+    assert len(digest) == 64
+    assert all(char in "0123456789abcdef" for char in digest)
+
+
+def test_source_digest_excludes_a_nested_output_dir(tmp_path: Path) -> None:
+    # Otherwise the run would change its own digest just by writing results.
+    project = tmp_path / "rollout"
+    output = project / ".osmosis" / "evals"
+    output.mkdir(parents=True)
+    (project / "main.py").write_text("print(1)")
+    before = compute_source_digest(project, exclude=project / ".osmosis")
+    (output / "index.jsonl").write_text('{"row_index": 0}\n')
+    assert compute_source_digest(project, exclude=project / ".osmosis") == before
+
+
+def test_source_digest_ignores_caches(tmp_path: Path) -> None:
+    project = tmp_path / "rollout"
+    (project / "__pycache__").mkdir(parents=True)
+    (project / "main.py").write_text("print(1)")
+    before = compute_source_digest(project)
+    (project / "__pycache__" / "main.pyc").write_bytes(b"\x00")
+    assert compute_source_digest(project) == before
+
+
+def test_source_digest_refuses_a_directory_symlink(tmp_path: Path) -> None:
+    project = tmp_path / "rollout"
+    project.mkdir()
+    (project / "main.py").write_text("print(1)")
+    (tmp_path / "elsewhere").mkdir()
+    (project / "link").symlink_to(tmp_path / "elsewhere")
+    with pytest.raises(ValueError, match="rollout source contains a directory"):
+        compute_source_digest(project)
+
+
+# --------------------------------------------------------------------------- #
+# Fingerprint (§9.5)
+# --------------------------------------------------------------------------- #
+
+
+def _inputs(
+    spec: EvalRunSpec, dataset: ResolvedDataset, tmp_path: Path, **kw: Any
+) -> dict[str, Any]:
+    path = tmp_path / "d.jsonl"
+    if not path.exists():
+        path.write_text(
+            '{"user_prompt": "a", "ground_truth": "1"}\n'
+            '{"user_prompt": "b", "ground_truth": "2"}\n'
+        )
+    selection = select_rows(path, **kw)
+    return build_run_inputs(
+        spec, dataset=dataset, selection=selection, rollout_source_digest="b" * 64
+    )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("model_path", "openai/gpt-4o"),
+        ("n", 3),
+        ("entrypoint", "server.py"),
+        ("pass_threshold", 0.5),
+        ("agent_timeout_sec", 999.0),
+    ],
+)
+def test_semantic_changes_change_the_fingerprint(
+    tmp_path: Path, field_name: str, value: Any
+) -> None:
+    baseline = _inputs(_spec(), _dataset(), tmp_path)
+    changed = _inputs(_spec(**{field_name: value}), _dataset(), tmp_path)
+    assert digest_of(changed) != digest_of(baseline)
+    assert diff_inputs(baseline, changed) != []
+
+
+def test_dataset_bytes_change_the_fingerprint(tmp_path: Path) -> None:
+    baseline = _inputs(_spec(), _dataset(), tmp_path)
+    changed = _inputs(_spec(), _dataset(sha="c" * 64), tmp_path)
+    assert digest_of(changed) != digest_of(baseline)
+
+
+def test_source_digest_changes_the_fingerprint(tmp_path: Path) -> None:
+    path = tmp_path / "d.jsonl"
+    path.write_text('{"user_prompt": "a", "ground_truth": "1"}\n')
+    selection = select_rows(path)
+    first = build_run_inputs(
+        _spec(), dataset=_dataset(), selection=selection, rollout_source_digest="1" * 64
+    )
+    second = build_run_inputs(
+        _spec(), dataset=_dataset(), selection=selection, rollout_source_digest="2" * 64
+    )
+    assert digest_of(first) != digest_of(second)
+
+
+def test_row_selection_changes_the_fingerprint(tmp_path: Path) -> None:
+    baseline = _inputs(_spec(), _dataset(), tmp_path)
+    narrowed = _inputs(_spec(), _dataset(), tmp_path, row_selector=(0,))
+    assert digest_of(narrowed) != digest_of(baseline)
+    assert baseline["dataset"]["selected_source_rows"] == "0-1"
+    assert narrowed["dataset"]["selected_source_rows"] == "0"
+
+
+@pytest.mark.parametrize("field_name", ["batch_size", "branch", "commit_sha"])
+def test_throughput_and_display_fields_are_excluded(
+    tmp_path: Path, field_name: str
+) -> None:
+    values: dict[str, Any] = {
+        "batch_size": 32,
+        "branch": "other",
+        "commit_sha": "abcdef1",
+    }
+    baseline = _inputs(_spec(), _dataset(), tmp_path)
+    changed = _inputs(_spec(**{field_name: values[field_name]}), _dataset(), tmp_path)
+    assert digest_of(changed) == digest_of(baseline)
+
+
+def test_secret_names_are_included_and_values_are_never_present(tmp_path: Path) -> None:
+    baseline = _inputs(_spec(), _dataset(), tmp_path)
+    with_secret = _inputs(_spec(secret_names=("OPENAI_API_KEY",)), _dataset(), tmp_path)
+    assert digest_of(with_secret) != digest_of(baseline)
+    assert with_secret["secret_names"] == ["OPENAI_API_KEY"]
+    assert "OPENAI_API_KEY" not in str(with_secret).replace("'OPENAI_API_KEY'", "")
+
+
+def test_env_ordering_does_not_change_the_fingerprint(tmp_path: Path) -> None:
+    first = _inputs(_spec(env={"A": "1", "B": "2"}), _dataset(), tmp_path)
+    second = _inputs(_spec(env={"B": "2", "A": "1"}), _dataset(), tmp_path)
+    assert digest_of(first) == digest_of(second)
+
+
+def test_input_diff_renders_field_level_lines() -> None:
+    diffs = diff_inputs({"n": 1, "model_path": "a"}, {"n": 5, "model_path": "a"})
+    rendered = format_input_diff(diffs)
+    assert rendered == "  - n: 1 -> 5"
+
+
+# --------------------------------------------------------------------------- #
+# Generated run names (§4.4)
+# --------------------------------------------------------------------------- #
+
+
+def test_generated_name_carries_stem_stamp_and_fingerprint() -> None:
+    name = generated_run_name("my-eval", "abc123def456", now="20260814T010203Z")
+    assert name == "my-eval-20260814T010203Z-abc123de"
+
+
+def test_generated_name_sanitizes_an_unsafe_stem() -> None:
+    name = generated_run_name("my eval/v2", "abc123def456", now="20260814T010203Z")
+    assert "/" not in name
+    assert name.startswith("my-eval-v2-")
+
+
+def test_generated_name_survives_an_empty_stem() -> None:
+    assert generated_run_name("", "abc123def456", now="20260814T010203Z").startswith(
+        "eval-"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Subprocess environment (§8)
+# --------------------------------------------------------------------------- #
+
+
+def _env(**kw: Any) -> dict[str, str]:
+    payload: dict[str, Any] = {
+        "base": {"PATH": "/usr/bin"},
+        "config_env": {},
+        "secrets": {},
+        "port": 1234,
+        "artifact_root": Path("/runs/rollout_trials"),
+        "instance_id": "iid",
+    }
+    payload.update(kw)
+    return build_subprocess_env(**payload)
+
+
+def test_internal_variables_are_applied_last() -> None:
+    env = _env(config_env={"LOG_LEVEL": "DEBUG"}, secrets={"OPENAI_API_KEY": "sk-x"})
+    assert env["_OSMOSIS_ROLLOUT_PORT"] == "1234"
+    assert env["_OSMOSIS_ROLLOUT_ARTIFACT_ROOT"] == "/runs/rollout_trials"
+    assert env["_OSMOSIS_ROLLOUT_INSTANCE_ID"] == "iid"
+    assert env["PYTHONUNBUFFERED"] == "1"
+    assert env["LOG_LEVEL"] == "DEBUG"
+    assert env["PATH"] == "/usr/bin"
+
+
+@pytest.mark.parametrize("reserved", sorted(RESERVED_ENV_NAMES))
+def test_config_cannot_hijack_supervisor_variables(reserved: str) -> None:
+    with pytest.raises(LocalEvalError, match="supervisor-owned"):
+        _env(config_env={reserved: "hijacked"})
+
+
+@pytest.mark.parametrize("reserved", sorted(RESERVED_ENV_NAMES))
+def test_secrets_cannot_hijack_supervisor_variables(reserved: str) -> None:
+    with pytest.raises(LocalEvalError, match="supervisor-owned"):
+        _env(secrets={reserved: "hijacked"})
+
+
+def test_secrets_override_config_env_for_the_same_name() -> None:
+    env = _env(config_env={"TOKEN": "from-config"}, secrets={"TOKEN": "from-secret"})
+    assert env["TOKEN"] == "from-secret"
+
+
+# --------------------------------------------------------------------------- #
+# Port reservation
+# --------------------------------------------------------------------------- #
+
+
+def test_reserved_port_is_usable() -> None:
+    import socket
+
+    port = reserve_free_port()
+    assert 1024 < port < 65536
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(("127.0.0.1", port))
+
+
+# --------------------------------------------------------------------------- #
+# Verified orphan cleanup (§8)
+# --------------------------------------------------------------------------- #
+
+
+def _child(pid: int, *, port: int = 9, instance_id: str = "iid") -> ChildProcessRecord:
+    return ChildProcessRecord(
+        supervisor_pid=os.getpid(),
+        child_pid=pid,
+        child_pgid=pid,
+        port=port,
+        instance_id=instance_id,
+    )
+
+
+def _logs() -> tuple[list[tuple[str, str, str]], Any]:
+    entries: list[tuple[str, str, str]] = []
+
+    def log(level: str, step: str, message: str, **_details: Any) -> None:
+        entries.append((level, step, message))
+
+    return entries, log
+
+
+async def test_a_dead_recorded_child_is_just_cleared() -> None:
+    entries, log = _logs()
+    async with httpx.AsyncClient() as client:
+        # PID 2**31-1 is above every real pid on the platforms we support.
+        await reap_verified_orphan(_child(2**31 - 1), client=client, log=log)
+    assert entries == [("info", "orphan", "clearing a stale rollout-server record")]
+
+
+async def test_a_live_but_unverifiable_child_refuses_with_instructions() -> None:
+    _, log = _logs()
+    transport = httpx.MockTransport(lambda request: httpx.Response(500))
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(OrphanChildError, match="could not be verified"):
+            await reap_verified_orphan(_child(os.getpid()), client=client, log=log)
+
+
+async def test_a_child_whose_instance_id_mismatches_is_never_killed() -> None:
+    # A reused pid must not be killed just because something answers /health.
+    _, log = _logs()
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(200, json={"instance_id": "someone-else"})
+    )
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(OrphanChildError):
+            await reap_verified_orphan(_child(os.getpid()), client=client, log=log)
+
+
+async def test_a_verified_orphan_is_terminated(monkeypatch: pytest.MonkeyPatch) -> None:
+    killed: list[int] = []
+
+    def fake_terminate(pgid: int, *, grace_sec: float, poll_sec: float = 0.05) -> None:
+        killed.append(pgid)
+
+    monkeypatch.setattr(
+        "osmosis_ai.eval.local.runner.terminate_process_group", fake_terminate
+    )
+    entries, log = _logs()
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(200, json={"instance_id": "iid"})
+    )
+    async with httpx.AsyncClient(transport=transport) as client:
+        await reap_verified_orphan(_child(os.getpid()), client=client, log=log)
+    assert killed == [os.getpid()]
+    assert entries[0][0] == "warning"
+
+
+# --------------------------------------------------------------------------- #
+# Dataset plumbing sanity
+# --------------------------------------------------------------------------- #
+
+
+def test_explicit_dataset_flows_into_the_fingerprint(tmp_path: Path) -> None:
+    path = tmp_path / "d.jsonl"
+    path.write_text('{"user_prompt": "a", "ground_truth": "1"}\n')
+    resolved = resolve_explicit_dataset_file(path)
+    inputs = build_run_inputs(
+        _spec(),
+        dataset=resolved,
+        selection=select_rows(path),
+        rollout_source_digest="b" * 64,
+    )
+    assert inputs["dataset"]["sha256"] == resolved.sha256

--- a/tests/unit/eval/local/test_runner_units.py
+++ b/tests/unit/eval/local/test_runner_units.py
@@ -18,6 +18,7 @@ from osmosis_ai.eval.local.runner import (
     RESERVED_ENV_NAMES,
     EvalRunSpec,
     LocalEvalError,
+    _classify_terminal,
     build_run_inputs,
     build_subprocess_env,
     compute_source_digest,
@@ -32,6 +33,8 @@ from osmosis_ai.eval.local.state import (
     diff_inputs,
     digest_of,
 )
+from osmosis_ai.rollout.controller import TerminalCallbackResult
+from osmosis_ai.rollout.types import GraderCompleteRequest, GraderStatus, RolloutSample
 
 
 def _spec(**overrides: Any) -> EvalRunSpec:
@@ -385,7 +388,9 @@ def test_explicit_dataset_flows_into_the_fingerprint(tmp_path: Path) -> None:
 # --------------------------------------------------------------------------- #
 
 
-def _runner(spec: EvalRunSpec, tmp_path: Path) -> Any:
+def _runner(
+    spec: EvalRunSpec, tmp_path: Path, *, output_root: Path | None = None
+) -> Any:
     from osmosis_ai.eval.local.dataset import select_rows
     from osmosis_ai.eval.local.runner import LocalEvalOptions, LocalEvalRunner
 
@@ -402,11 +407,11 @@ def _runner(spec: EvalRunSpec, tmp_path: Path) -> Any:
 
     return LocalEvalRunner(
         spec=spec,
-        options=LocalEvalOptions(name="run-1", yes=True),
+        options=LocalEvalOptions(name="run-1"),
         dataset=_dataset(),
         selection=select_rows(data),
         rollout_dir=tmp_path,
-        output_root=tmp_path / "evals",
+        output_root=output_root or tmp_path / "evals",
         proxy_base_url="http://127.0.0.1:1",
         proxy_auth_token="platform-token-value",
         hooks=_Hooks(),
@@ -425,6 +430,32 @@ def test_an_unconfigured_timeout_still_yields_a_finite_deadline(tmp_path: Path) 
     deadline = runner._callback_deadline()
     assert deadline is not None
     assert deadline > 0
+
+
+@pytest.mark.parametrize(
+    ("agent", "grader"),
+    [(None, 30.0), (30.0, None)],
+)
+def test_an_unbounded_phase_keeps_the_default_deadline(
+    tmp_path: Path, agent: float | None, grader: float | None
+) -> None:
+    # ``None`` means "run unbounded", so bounding the item to the phase that is
+    # configured would stamp still-running work `callback_timeout` -- a durable
+    # failed record that a plain resume then skips.
+    from osmosis_ai.eval.local.runner import _DEFAULT_ITEM_DEADLINE_SEC
+
+    runner = _runner(
+        _spec(agent_timeout_sec=agent, grader_timeout_sec=grader), tmp_path
+    )
+    assert runner._callback_deadline() == _DEFAULT_ITEM_DEADLINE_SEC
+
+
+def test_an_output_root_equal_to_the_rollout_dir_is_refused(tmp_path: Path) -> None:
+    # Excluding the output tree would exclude the whole project, freezing the
+    # digest that resume compares against.
+    runner = _runner(_spec(), tmp_path, output_root=tmp_path)
+    with pytest.raises(LocalEvalError, match="rollout source directory"):
+        runner._source_digest()
 
 
 def test_the_redactor_replaces_secrets_and_keeps_context() -> None:
@@ -452,6 +483,84 @@ def test_the_redactor_prefers_the_longest_overlapping_value() -> None:
     redactor = SecretRedactor(["token-abcdef", "token-abcdef-longer"])
     scrubbed = redactor.scrub("value=token-abcdef-longer")
     assert scrubbed == "value=[REDACTED]"
+
+
+# --------------------------------------------------------------------------- #
+# Terminal classification and per-item journalling
+# --------------------------------------------------------------------------- #
+
+
+def _terminal(
+    *,
+    status: GraderStatus = GraderStatus.SUCCESS,
+    reward: float | None = 1.0,
+    remove_sample: bool = False,
+) -> TerminalCallbackResult:
+    return TerminalCallbackResult(
+        rollout_id="f" * 32,
+        source="grader",
+        grader=GraderCompleteRequest(
+            status=status,
+            rollout_id="f" * 32,
+            sample=RolloutSample(
+                messages=[{"role": "assistant", "content": "ok"}],
+                reward=reward,
+                remove_sample=remove_sample,
+            ),
+        ),
+    )
+
+
+def test_a_crashed_grader_that_removed_the_sample_is_a_failure() -> None:
+    # "skipped" would drop the row from the scored denominator, so a run whose
+    # graders all crashed would report a clean pass rate and exit 0.
+    assert _classify_terminal(
+        _terminal(status=GraderStatus.FAILURE, reward=None, remove_sample=True)
+    ) == ("failed", None, "grader_failed")
+
+
+def test_remove_sample_from_a_successful_grader_is_still_skipped() -> None:
+    assert _classify_terminal(_terminal(remove_sample=True)) == ("skipped", None, None)
+
+
+def test_an_out_of_range_reward_fails_the_row_rather_than_being_recorded() -> None:
+    # Recording it would overflow the mean on every later snapshot refresh, and
+    # the record is durable -- the run would stay unresumable until --fresh.
+    assert _classify_terminal(_terminal(reward=1e308)) == (
+        "failed",
+        None,
+        "reward_out_of_range",
+    )
+
+
+async def test_a_retried_failure_writes_its_own_terminal_record(tmp_path: Path) -> None:
+    from osmosis_ai.eval.local.runner import WorkItem
+    from osmosis_ai.eval.local.state import TerminalJournal, TerminalRecord, utc_now
+
+    runner = _runner(_spec(), tmp_path)
+    journal = TerminalJournal(tmp_path / "events.jsonl")
+    journal.open_for_append(journal.replay())
+    runner._journal = journal
+    item = WorkItem(row=runner._selection.rows[0], run_index=0)
+    runner._latest[item.key] = TerminalRecord(
+        row_index=item.row.row_index,
+        run_index=0,
+        rollout_id="a" * 32,
+        status="failed",
+        recorded_at=utc_now(),
+        error_type="stale",
+    )
+    runner._dispatch_context["b" * 32] = item
+    try:
+        await runner._journal_supervisor_failure(item, RuntimeError("boom"))
+    finally:
+        journal.close()
+
+    # Keeping the earlier attempt's record would leave --retry-failed reporting
+    # a stale error with nothing in the journal about the attempt that just ran.
+    record = runner._latest[item.key]
+    assert record.rollout_id == "b" * 32
+    assert (record.status, record.error_type) == ("failed", "supervisor_error")
 
 
 def test_the_run_log_redacts_and_is_owner_only(tmp_path: Path) -> None:

--- a/tests/unit/eval/local/test_state.py
+++ b/tests/unit/eval/local/test_state.py
@@ -1,0 +1,395 @@
+"""Durable-state tests: journal replay, manifest lock, and the run flock."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from osmosis_ai.eval.local.state import (
+    LOCAL_STATE_SCHEMA_VERSION,
+    ChildProcessRecord,
+    JournalCorruptionError,
+    LocalEvalStateError,
+    RunLock,
+    RunLockedError,
+    RunManifest,
+    TerminalJournal,
+    TerminalRecord,
+    archive_run_directory,
+    atomic_write_json,
+    diff_inputs,
+    digest_of,
+    validate_run_name,
+)
+
+
+def _record(
+    row: int, run: int, *, status: str = "success", **overrides: object
+) -> TerminalRecord:
+    payload: dict[str, object] = {
+        "row_index": row,
+        "run_index": run,
+        "rollout_id": f"{row:016x}{run:016x}",
+        "status": status,
+        "recorded_at": "2026-08-14T00:00:00.000000Z",
+        "reward": 1.0,
+        "tokens": 7,
+        "duration_ms": 12.5,
+    }
+    payload.update(overrides)
+    return TerminalRecord(**payload)  # type: ignore[arg-type]
+
+
+async def _open_journal(path: Path) -> TerminalJournal:
+    journal = TerminalJournal(path)
+    journal.open_for_append(journal.replay())
+    return journal
+
+
+# --------------------------------------------------------------------------- #
+# Journal
+# --------------------------------------------------------------------------- #
+
+
+async def test_append_then_replay_round_trips(tmp_path: Path) -> None:
+    journal = await _open_journal(tmp_path / "events.jsonl")
+    try:
+        await journal.append(_record(0, 0))
+        await journal.append(
+            _record(1, 0, status="failed", reward=None, error_type="boom")
+        )
+    finally:
+        journal.close()
+
+    replay = TerminalJournal(tmp_path / "events.jsonl").replay()
+    assert [r.key for r in replay.records] == [(0, 0), (1, 0)]
+    assert replay.truncated_bytes == 0
+    failed = replay.latest[(1, 0)]
+    assert failed.status == "failed"
+    assert failed.reward is None
+    assert failed.error_type == "boom"
+
+
+async def test_none_values_are_omitted_not_null(tmp_path: Path) -> None:
+    path = tmp_path / "events.jsonl"
+    journal = await _open_journal(path)
+    try:
+        await journal.append(_record(0, 0, reward=None, tokens=None))
+    finally:
+        journal.close()
+    payload = json.loads(path.read_text().splitlines()[0])
+    assert "reward" not in payload
+    assert "tokens" not in payload
+
+
+async def test_every_record_is_newline_terminated(tmp_path: Path) -> None:
+    path = tmp_path / "events.jsonl"
+    journal = await _open_journal(path)
+    try:
+        await journal.append(_record(0, 0))
+        await journal.append(_record(0, 1))
+    finally:
+        journal.close()
+    raw = path.read_bytes()
+    assert raw.endswith(b"\n")
+    assert raw.count(b"\n") == 2
+
+
+def test_latest_terminal_record_wins_in_append_order(tmp_path: Path) -> None:
+    path = tmp_path / "events.jsonl"
+    # A retry appends a second record for the same key; append order decides,
+    # not the wall clock -- the later line carries the *earlier* timestamp here.
+    first = _record(
+        0, 0, status="failed", reward=0.0, recorded_at="2026-08-14T09:00:00Z"
+    )
+    second = _record(
+        0, 0, status="success", reward=1.0, recorded_at="2026-08-14T08:00:00Z"
+    )
+    path.write_bytes(first.to_journal_line() + second.to_journal_line())
+
+    latest = TerminalJournal(path).replay().latest
+    assert latest[(0, 0)].status == "success"
+
+
+def test_replay_discards_a_partial_trailing_record(tmp_path: Path) -> None:
+    path = tmp_path / "events.jsonl"
+    good = _record(0, 0)
+    # A crash mid-append can leave valid JSON with no terminating newline.
+    fragment = _record(0, 1).to_journal_line().rstrip(b"\n")
+    path.write_bytes(good.to_journal_line() + fragment)
+
+    replay = TerminalJournal(path).replay()
+    assert [r.key for r in replay.records] == [(0, 0)]
+    assert replay.truncated_bytes == len(fragment)
+    assert replay.committed_size == len(good.to_journal_line())
+
+
+async def test_open_for_append_truncates_the_fragment(tmp_path: Path) -> None:
+    path = tmp_path / "events.jsonl"
+    good = _record(0, 0)
+    path.write_bytes(good.to_journal_line() + b'{"row_index": 0, "run_i')
+
+    journal = TerminalJournal(path)
+    journal.open_for_append(journal.replay())
+    try:
+        await journal.append(_record(0, 1))
+    finally:
+        journal.close()
+
+    replay = TerminalJournal(path).replay()
+    assert [r.key for r in replay.records] == [(0, 0), (0, 1)]
+    assert replay.truncated_bytes == 0
+
+
+def test_replay_refuses_a_malformed_committed_record(tmp_path: Path) -> None:
+    path = tmp_path / "events.jsonl"
+    path.write_bytes(
+        _record(0, 0).to_journal_line()
+        + b"not json\n"
+        + _record(0, 1).to_journal_line()
+    )
+    with pytest.raises(JournalCorruptionError, match="invalid JSON"):
+        TerminalJournal(path).replay()
+
+
+@pytest.mark.parametrize(
+    ("mutation", "match"),
+    [
+        ({"row_index": "0"}, "row_index must be an integer"),
+        ({"status": "cancelled"}, "status must be one of"),
+        ({"rollout_id": ""}, "rollout_id must be a string"),
+        ({"tokens": "many"}, "tokens must be an integer"),
+    ],
+)
+def test_replay_refuses_records_with_bad_fields(
+    tmp_path: Path, mutation: dict[str, object], match: str
+) -> None:
+    payload = _record(0, 0).to_payload()
+    payload.update(mutation)
+    path = tmp_path / "events.jsonl"
+    path.write_text(json.dumps(payload) + "\n")
+    with pytest.raises(JournalCorruptionError, match=match):
+        TerminalJournal(path).replay()
+
+
+def test_replay_of_a_missing_journal_is_empty(tmp_path: Path) -> None:
+    replay = TerminalJournal(tmp_path / "absent.jsonl").replay()
+    assert replay.records == ()
+    assert replay.committed_size == 0
+    assert replay.latest == {}
+
+
+async def test_append_before_open_is_refused(tmp_path: Path) -> None:
+    journal = TerminalJournal(tmp_path / "events.jsonl")
+    with pytest.raises(LocalEvalStateError, match="not open for appending"):
+        await journal.append(_record(0, 0))
+
+
+def test_open_refuses_a_journal_that_grew_since_replay(tmp_path: Path) -> None:
+    path = tmp_path / "events.jsonl"
+    path.write_bytes(_record(0, 0).to_journal_line())
+    journal = TerminalJournal(path)
+    replay = journal.replay()
+    with path.open("ab") as handle:
+        handle.write(_record(0, 1).to_journal_line())
+    with pytest.raises(LocalEvalStateError, match="changed between replay and open"):
+        journal.open_for_append(replay)
+
+
+# --------------------------------------------------------------------------- #
+# Manifest and resolved-input lock
+# --------------------------------------------------------------------------- #
+
+
+def _inputs(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "model_path": "openai/gpt-5-mini",
+        "dataset_sha256": "a" * 64,
+        "n": 1,
+        "rollout": {"entrypoint": "main.py", "source_digest": "b" * 64},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_manifest_round_trips(tmp_path: Path) -> None:
+    manifest = RunManifest.create(
+        local_run_id="c" * 32,
+        run_name="my-run",
+        inputs=_inputs(),
+        provenance={"sdk_version": "0.3.0", "git_head": "d" * 40},
+    )
+    path = tmp_path / "manifest.json"
+    manifest.write(path)
+    loaded = RunManifest.read(path)
+    assert loaded.inputs == manifest.inputs
+    assert loaded.inputs_digest == digest_of(_inputs())
+    assert loaded.provenance["sdk_version"] == "0.3.0"
+    assert path.read_text().endswith("}\n")
+
+
+def test_manifest_digest_ignores_key_order() -> None:
+    reordered = dict(reversed(list(_inputs().items())))
+    assert digest_of(reordered) == digest_of(_inputs())
+
+
+def test_manifest_read_refuses_a_foreign_schema_version(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.json"
+    atomic_write_json(
+        path,
+        {
+            "schema_version": LOCAL_STATE_SCHEMA_VERSION + 1,
+            "inputs": {},
+            "inputs_digest": "x",
+        },
+    )
+    with pytest.raises(LocalEvalStateError, match="state schema version"):
+        RunManifest.read(path)
+
+
+def test_diff_inputs_reports_dotted_nested_fields() -> None:
+    diffs = diff_inputs(
+        _inputs(),
+        _inputs(n=5, rollout={"entrypoint": "main.py", "source_digest": "e" * 64}),
+    )
+    fields = {diff.field: (diff.previous, diff.current) for diff in diffs}
+    assert fields["n"] == (1, 5)
+    assert fields["rollout.source_digest"] == ("b" * 64, "e" * 64)
+    assert "model_path" not in fields
+
+
+def test_diff_inputs_reports_added_and_removed_fields() -> None:
+    diffs = {d.field: (d.previous, d.current) for d in diff_inputs({"a": 1}, {"b": 2})}
+    assert diffs == {"a": (1, None), "b": (None, 2)}
+
+
+def test_identical_inputs_have_no_diff() -> None:
+    assert diff_inputs(_inputs(), _inputs()) == []
+
+
+# --------------------------------------------------------------------------- #
+# Run naming and archive
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("name", ["my-run", "run_1", "a", "v0.3.0-smoke"])
+def test_valid_run_names(name: str) -> None:
+    assert validate_run_name(name) == name
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["", ".", "..", ".locks", "a/b", "a\\b", "-lead", ".lead", "has space", "a" * 200],
+)
+def test_invalid_run_names(name: str) -> None:
+    with pytest.raises(LocalEvalStateError):
+        validate_run_name(name)
+
+
+def test_archive_run_directory_moves_results_aside(tmp_path: Path) -> None:
+    run_dir = tmp_path / "my-run"
+    (run_dir / "rollout_trials").mkdir(parents=True)
+    (run_dir / "events.jsonl").write_text("{}\n")
+
+    archived = archive_run_directory(run_dir, now="20260814T000000Z")
+    assert archived.name == "my-run.archive-20260814T000000Z"
+    assert (archived / "events.jsonl").read_text() == "{}\n"
+    assert not run_dir.exists()
+
+
+def test_archive_run_directory_never_overwrites_an_archive(tmp_path: Path) -> None:
+    (tmp_path / "my-run.archive-20260814T000000Z").mkdir()
+    run_dir = tmp_path / "my-run"
+    run_dir.mkdir()
+    archived = archive_run_directory(run_dir, now="20260814T000000Z")
+    assert archived.name == "my-run.archive-20260814T000000Z-1"
+
+
+# --------------------------------------------------------------------------- #
+# Run lock
+# --------------------------------------------------------------------------- #
+
+
+def test_lock_refuses_a_second_supervisor(tmp_path: Path) -> None:
+    path = tmp_path / ".locks" / "my-run.lock"
+    with RunLock(path):
+        with pytest.raises(RunLockedError, match="already holds"):
+            RunLock(path).acquire()
+
+
+def test_lock_is_reacquirable_after_release(tmp_path: Path) -> None:
+    path = tmp_path / ".locks" / "my-run.lock"
+    with RunLock(path):
+        pass
+    with RunLock(path):
+        pass
+
+
+def test_child_metadata_survives_a_released_lock(tmp_path: Path) -> None:
+    path = tmp_path / ".locks" / "my-run.lock"
+    record = ChildProcessRecord(
+        supervisor_pid=os.getpid(),
+        child_pid=os.getpid() + 1,
+        child_pgid=os.getpid() + 1,
+        port=54321,
+        instance_id="f" * 16,
+    )
+    lock = RunLock(path)
+    with lock:
+        assert lock.read_child() is None
+        lock.write_child(record)
+        inode = path.stat().st_ino
+
+    with RunLock(path) as reopened:
+        assert reopened.read_child() == record
+        # The path is never replaced while held, so orphan metadata is durable.
+        assert path.stat().st_ino == inode
+        reopened.clear_child()
+        assert reopened.read_child() is None
+
+
+def test_child_metadata_survives_an_archived_run_directory(tmp_path: Path) -> None:
+    # The lock lives outside the run dir precisely so --fresh cannot unlock it.
+    evals = tmp_path / "evals"
+    run_dir = evals / "my-run"
+    run_dir.mkdir(parents=True)
+    lock_path = evals / ".locks" / "my-run.lock"
+    with RunLock(lock_path):
+        archive_run_directory(run_dir, now="20260814T000000Z")
+        with pytest.raises(RunLockedError):
+            RunLock(lock_path).acquire()
+
+
+def test_unreadable_child_metadata_is_treated_as_absent(tmp_path: Path) -> None:
+    path = tmp_path / ".locks" / "my-run.lock"
+    path.parent.mkdir(parents=True)
+    path.write_text("{ not json")
+    with RunLock(path) as lock:
+        assert lock.read_child() is None
+
+
+def test_child_metadata_requires_a_held_lock(tmp_path: Path) -> None:
+    lock = RunLock(tmp_path / "my-run.lock")
+    with pytest.raises(LocalEvalStateError, match="not held"):
+        lock.read_child()
+
+
+# --------------------------------------------------------------------------- #
+# Atomic writes
+# --------------------------------------------------------------------------- #
+
+
+def test_atomic_write_json_leaves_no_temp_files(tmp_path: Path) -> None:
+    path = tmp_path / "metrics.json"
+    atomic_write_json(path, {"summary": {"pass_rate": 0.5}})
+    atomic_write_json(path, {"summary": {"pass_rate": 1.0}})
+    assert json.loads(path.read_text())["summary"]["pass_rate"] == 1.0
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["metrics.json"]
+
+
+def test_atomic_write_json_refuses_non_finite_numbers(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        atomic_write_json(tmp_path / "metrics.json", {"reward": float("nan")})

--- a/tests/unit/platform/cli/test_eval_run.py
+++ b/tests/unit/platform/cli/test_eval_run.py
@@ -353,6 +353,32 @@ def test_the_missing_extra_hint_names_the_install_command() -> None:
     assert error.details == {"missing_module": "fastapi", "extra": "eval-run"}
 
 
+def _with_pass_threshold(workspace: Path, value: str) -> None:
+    (workspace / "configs" / "eval" / "echo.toml").write_text(
+        EVAL_CONFIG.replace("pass_threshold = 0.5", f"pass_threshold = {value}"),
+        encoding="utf-8",
+    )
+
+
+def test_a_zero_pass_threshold_survives_the_default(
+    workspace: Path, captured_runner: type[_CapturedRunner], console_capture: StringIO
+) -> None:
+    # 0.0 means "every graded row passes"; falling back to 1.0 would silently
+    # apply the strictest threshold instead.
+    _with_pass_threshold(workspace, "0.0")
+    _run(workspace)
+    assert captured_runner.calls[0]["spec"].pass_threshold == 0.0
+
+
+@pytest.mark.parametrize("value", ["nan", "inf"])
+def test_a_non_finite_pass_threshold_is_a_cli_error(
+    workspace: Path, console_capture: StringIO, value: str
+) -> None:
+    _with_pass_threshold(workspace, value)
+    with pytest.raises(CLIError, match=r"evaluation\.pass_threshold must be finite"):
+        _run(workspace)
+
+
 @pytest.mark.parametrize(
     ("field", "value", "match"),
     [

--- a/tests/unit/platform/cli/test_eval_run.py
+++ b/tests/unit/platform/cli/test_eval_run.py
@@ -1,0 +1,484 @@
+"""`osmosis eval run` CLI-layer tests: config extraction, options, and error UX."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import osmosis_ai.platform.cli.eval_run as eval_run_module
+from osmosis_ai.cli.console import Console
+from osmosis_ai.cli.errors import CLIError
+
+GIT_IDENTITY = "acme/rollouts"
+ROLLOUT = "echo-rollout"
+
+ROLLOUT_MAIN = """
+from osmosis_ai.rollout import AgentWorkflow, Grader
+
+
+class EchoWorkflow(AgentWorkflow):
+    async def run(self, ctx):
+        return None
+
+
+class EchoGrader(Grader):
+    async def grade(self, ctx):
+        return 1.0
+""".strip()
+
+EVAL_CONFIG = """
+[experiment]
+rollout = "echo-rollout"
+entrypoint = "main.py"
+model_path = "openai/gpt-5-mini"
+dataset = "multiply"
+
+[evaluation]
+limit = 3
+n = 2
+batch_size = 4
+pass_threshold = 0.5
+agent_workflow_timeout_s = 450
+grader_timeout_s = 150
+
+[env]
+LOG_LEVEL = "INFO"
+
+[secrets]
+required = ["MY_TOKEN"]
+""".strip()
+
+DATASET_ROWS = [
+    {"user_prompt": "a", "ground_truth": "1"},
+    {"user_prompt": "b", "ground_truth": "2"},
+    {"user_prompt": "c", "ground_truth": "3"},
+    {"user_prompt": "d", "ground_truth": "4"},
+]
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    root = tmp_path / "workspace"
+    subprocess.run(
+        ["git", "init", "-b", "main", str(root)], check=True, capture_output=True
+    )
+    for rel in (
+        ".osmosis",
+        f"rollouts/{ROLLOUT}",
+        "configs/eval",
+        "configs/training",
+        "data",
+    ):
+        (root / rel).mkdir(parents=True, exist_ok=True)
+    (root / "rollouts" / ROLLOUT / "main.py").write_text(ROLLOUT_MAIN, encoding="utf-8")
+    (root / "configs" / "eval" / "echo.toml").write_text(EVAL_CONFIG, encoding="utf-8")
+    (root / "data" / "echo.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in DATASET_ROWS), encoding="utf-8"
+    )
+    return root
+
+
+@pytest.fixture
+def console_capture(monkeypatch: pytest.MonkeyPatch) -> StringIO:
+    output = StringIO()
+    monkeypatch.setattr(
+        eval_run_module,
+        "console",
+        Console(file=output, force_terminal=False, width=200),
+    )
+    return output
+
+
+@pytest.fixture(autouse=True)
+def _stub_context(monkeypatch: pytest.MonkeyPatch, workspace: Path) -> None:
+    credentials = type("Credentials", (), {"access_token": "platform-token"})()
+    context = type(
+        "GitContext",
+        (),
+        {
+            "workspace_directory": workspace.resolve(),
+            "git_identity": GIT_IDENTITY,
+            "repo_url": f"https://github.com/{GIT_IDENTITY}.git",
+            "credentials": credentials,
+        },
+    )()
+    monkeypatch.setattr(
+        eval_run_module, "require_git_workspace_directory_context", lambda: context
+    )
+    monkeypatch.setattr(
+        eval_run_module, "validate_workspace_directory_contract", lambda _: None
+    )
+    monkeypatch.setattr(eval_run_module, "validate_rollout_backend", lambda **_: [])
+
+
+class _CapturedRunner:
+    """Stands in for the supervisor and records exactly how it was constructed."""
+
+    calls: list[dict[str, Any]] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        type(self).calls.append(kwargs)
+        self.kwargs = kwargs
+
+    async def run(self) -> Any:
+        from osmosis_ai.eval.local.runner import RunSummary
+
+        return RunSummary(
+            run_dir=self.kwargs["output_root"] / "run-1",
+            local_run_id="a" * 32,
+            run_name="run-1",
+            total_work_items=6,
+            dispatched=6,
+            succeeded=6,
+            failed=0,
+            skipped=0,
+            resumed=0,
+            cancelled=False,
+            metrics={"pass_rate": 1.0},
+        )
+
+
+@pytest.fixture
+def captured_runner(monkeypatch: pytest.MonkeyPatch) -> type[_CapturedRunner]:
+    _CapturedRunner.calls = []
+    import osmosis_ai.eval.local.runner as runner_module
+
+    monkeypatch.setattr(runner_module, "LocalEvalRunner", _CapturedRunner)
+    return _CapturedRunner
+
+
+def _run(workspace: Path, **kwargs: Any) -> Any:
+    return eval_run_module.run(
+        workspace / "configs" / "eval" / "echo.toml",
+        dataset_file=str(workspace / "data" / "echo.jsonl"),
+        yes=True,
+        **kwargs,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Config extraction
+# --------------------------------------------------------------------------- #
+
+
+def test_the_shared_eval_toml_maps_onto_the_run_spec(
+    workspace: Path, captured_runner: type[_CapturedRunner], console_capture: StringIO
+) -> None:
+    _run(workspace)
+    spec = captured_runner.calls[0]["spec"]
+    assert spec.rollout_name == ROLLOUT
+    assert spec.entrypoint == "main.py"
+    assert spec.model_path == "openai/gpt-5-mini"
+    assert spec.dataset_name == "multiply"
+    assert spec.n == 2
+    assert spec.batch_size == 4
+    assert spec.pass_threshold == 0.5
+    assert spec.agent_timeout_sec == 450.0
+    assert spec.grader_timeout_sec == 150.0
+    assert spec.env == {"LOG_LEVEL": "INFO"}
+    assert spec.secret_names == ("MY_TOKEN",)
+
+
+def test_evaluation_limit_selects_the_first_rows(
+    workspace: Path, captured_runner: type[_CapturedRunner], console_capture: StringIO
+) -> None:
+    _run(workspace)
+    selection = captured_runner.calls[0]["selection"]
+    assert selection.source_row_indices == (0, 1, 2)
+    assert selection.total_dataset_rows == 4
+
+
+def test_rows_overrides_the_configured_limit(
+    workspace: Path, captured_runner: type[_CapturedRunner], console_capture: StringIO
+) -> None:
+    _run(workspace, rows="3")
+    assert captured_runner.calls[0]["selection"].source_row_indices == (3,)
+
+
+def test_runtime_flags_reach_the_options_object(
+    workspace: Path, captured_runner: type[_CapturedRunner], console_capture: StringIO
+) -> None:
+    _run(
+        workspace,
+        name="my-run",
+        fresh=True,
+        retry_failed=True,
+        max_in_flight=7,
+        rollout_port=8123,
+        skip_llm_preflight=True,
+        verbose=True,
+    )
+    options = captured_runner.calls[0]["options"]
+    assert options.name == "my-run"
+    assert options.fresh is True
+    assert options.retry_failed is True
+    assert options.max_in_flight == 7
+    assert options.rollout_port == 8123
+    assert options.skip_llm_preflight is True
+    assert options.verbose is True
+
+
+def test_the_default_output_root_is_the_workspace_evals_dir(
+    workspace: Path, captured_runner: type[_CapturedRunner], console_capture: StringIO
+) -> None:
+    _run(workspace)
+    assert captured_runner.calls[0]["output_root"] == workspace / ".osmosis" / "evals"
+
+
+def test_output_override_is_honored(
+    workspace: Path,
+    captured_runner: type[_CapturedRunner],
+    console_capture: StringIO,
+    tmp_path: Path,
+) -> None:
+    _run(workspace, output=str(tmp_path / "elsewhere"))
+    assert captured_runner.calls[0]["output_root"] == tmp_path / "elsewhere"
+
+
+def test_the_rollout_dir_is_resolved_under_the_workspace(
+    workspace: Path, captured_runner: type[_CapturedRunner], console_capture: StringIO
+) -> None:
+    _run(workspace)
+    assert captured_runner.calls[0]["rollout_dir"] == workspace / "rollouts" / ROLLOUT
+
+
+def test_the_config_stem_seeds_a_generated_run_name(
+    workspace: Path, captured_runner: type[_CapturedRunner], console_capture: StringIO
+) -> None:
+    _run(workspace)
+    assert captured_runner.calls[0]["config_stem"] == "echo"
+
+
+# --------------------------------------------------------------------------- #
+# Eval-proxy wiring (D6)
+# --------------------------------------------------------------------------- #
+
+
+def test_the_proxy_base_defaults_to_the_platform_url(
+    workspace: Path,
+    captured_runner: type[_CapturedRunner],
+    console_capture: StringIO,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OSMOSIS_PLATFORM_URL", "https://platform.example.com")
+    _run(workspace)
+    assert captured_runner.calls[0]["proxy_base_url"] == (
+        "https://platform.example.com/api/eval-proxy"
+    )
+
+
+def test_the_proxy_base_can_be_overridden_for_development(
+    workspace: Path, captured_runner: type[_CapturedRunner], console_capture: StringIO
+) -> None:
+    _run(workspace, eval_proxy_url="http://127.0.0.1:9999/")
+    assert captured_runner.calls[0]["proxy_base_url"] == "http://127.0.0.1:9999"
+
+
+def test_the_platform_bearer_is_passed_but_never_printed(
+    workspace: Path, captured_runner: type[_CapturedRunner], console_capture: StringIO
+) -> None:
+    _run(workspace)
+    assert captured_runner.calls[0]["proxy_auth_token"] == "platform-token"
+    assert "platform-token" not in console_capture.getvalue()
+
+
+def test_a_missing_login_is_an_auth_error(
+    workspace: Path,
+    captured_runner: type[_CapturedRunner],
+    console_capture: StringIO,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = eval_run_module.require_git_workspace_directory_context()
+    monkeypatch.setattr(context.credentials, "access_token", "", raising=False)
+    with pytest.raises(CLIError, match="requires an Osmosis login"):
+        _run(workspace)
+
+
+# --------------------------------------------------------------------------- #
+# Errors and UX
+# --------------------------------------------------------------------------- #
+
+
+def test_the_retired_local_eval_schema_is_rejected(
+    workspace: Path, console_capture: StringIO
+) -> None:
+    config = workspace / "configs" / "eval" / "legacy.toml"
+    config.write_text(
+        "[eval]\n"
+        'rollout = "echo-rollout"\n'
+        'entrypoint = "main.py"\n'
+        'dataset = "data/echo.jsonl"\n\n'
+        "[llm]\n"
+        'model = "openai/gpt-5-mini"\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(CLIError, match=r"Missing \[experiment\] section"):
+        eval_run_module.run(config, yes=True)
+
+
+def test_a_malformed_rows_selector_is_a_validation_error(
+    workspace: Path, console_capture: StringIO
+) -> None:
+    with pytest.raises(CLIError, match="--rows"):
+        _run(workspace, rows="not-rows")
+
+
+def test_an_out_of_range_row_fails_before_the_run_exists(
+    workspace: Path, console_capture: StringIO
+) -> None:
+    with pytest.raises(CLIError, match="has 4 rows"):
+        _run(workspace, rows="9")
+
+
+def test_a_missing_dataset_file_is_a_validation_error(
+    workspace: Path, console_capture: StringIO
+) -> None:
+    with pytest.raises(CLIError, match="is not a file"):
+        eval_run_module.run(
+            workspace / "configs" / "eval" / "echo.toml",
+            dataset_file=str(workspace / "data" / "absent.jsonl"),
+            yes=True,
+        )
+
+
+def test_the_missing_extra_hint_names_the_install_command() -> None:
+    error = eval_run_module._missing_extra_error(ModuleNotFoundError(name="fastapi"))
+    assert 'pip install "osmosis-ai[eval-run]"' in error.message
+    assert "osmosis-ai[eval-run,harbor]" in error.message
+    assert error.details == {"missing_module": "fastapi", "extra": "eval-run"}
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("n", '"two"', "evaluation.n must be an integer"),
+        ("pass_threshold", '"high"', "evaluation.pass_threshold must be a number"),
+        ("batch_size", "1.5", "evaluation.batch_size must be an integer"),
+    ],
+)
+def test_non_numeric_evaluation_fields_are_reported(
+    workspace: Path, console_capture: StringIO, field: str, value: str, match: str
+) -> None:
+    config = workspace / "configs" / "eval" / "echo.toml"
+    body = EVAL_CONFIG.replace(f"{field} = 2", f"{field} = {value}")
+    body = body.replace(f"{field} = 4", f"{field} = {value}")
+    body = body.replace(f"{field} = 0.5", f"{field} = {value}")
+    config.write_text(body, encoding="utf-8")
+    with pytest.raises(CLIError, match=match):
+        _run(workspace)
+
+
+# --------------------------------------------------------------------------- #
+# Result envelope
+# --------------------------------------------------------------------------- #
+
+
+def test_a_complete_run_reports_success_with_the_output_path(
+    workspace: Path, captured_runner: type[_CapturedRunner], console_capture: StringIO
+) -> None:
+    result = _run(workspace)
+    assert result.operation == "eval.run"
+    assert result.status == "success"
+    assert result.exit_code == 0
+    assert result.resource["run_name"] == "run-1"
+    assert result.resource["succeeded"] == 6
+    assert result.resource["dataset_source"] == "explicit"
+    assert result.resource["output_path"].endswith("run-1")
+    assert result.display_next_steps == []
+
+
+def test_an_incomplete_run_is_partial_and_suggests_resuming(
+    workspace: Path,
+    captured_runner: type[_CapturedRunner],
+    console_capture: StringIO,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from osmosis_ai.eval.local.runner import FailedWorkItem, RunSummary
+
+    async def partial_run(self: Any) -> RunSummary:
+        return RunSummary(
+            run_dir=self.kwargs["output_root"] / "run-1",
+            local_run_id="a" * 32,
+            run_name="run-1",
+            total_work_items=6,
+            dispatched=3,
+            succeeded=2,
+            failed=1,
+            skipped=0,
+            resumed=0,
+            cancelled=True,
+            metrics={"pass_rate": 0.5},
+            failures=[
+                FailedWorkItem(
+                    row_index=1,
+                    source_row_index=4,
+                    run_index=0,
+                    rollout_id="b" * 32,
+                    error_type="grader_timeout",
+                    rollout_dir=Path("/runs/rollout_trials/bbbb"),
+                )
+            ],
+        )
+
+    monkeypatch.setattr(captured_runner, "run", partial_run)
+    result = _run(workspace)
+    assert result.status == "partial"
+    assert result.exit_code == 1
+    assert any("--name run-1" in step for step in result.display_next_steps)
+    assert any("--retry-failed" in step for step in result.display_next_steps)
+    assert result.resource["failed_rows"][0]["error_type"] == "grader_timeout"
+    printed = console_capture.getvalue()
+    assert "row 1 (source 4) run 0" in printed
+    assert "error_type=grader_timeout" in printed
+    assert "/runs/rollout_trials/bbbb" in printed
+
+
+# --------------------------------------------------------------------------- #
+# Through the CLI entry point
+# --------------------------------------------------------------------------- #
+
+
+def test_the_json_envelope_carries_the_run_resource(
+    workspace: Path,
+    captured_runner: type[_CapturedRunner],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import osmosis_ai.cli.main as cli
+
+    monkeypatch.chdir(workspace)
+    exit_code = cli.main(
+        [
+            "--json",
+            "eval",
+            "run",
+            "configs/eval/echo.toml",
+            "--dataset-file",
+            "data/echo.jsonl",
+            "--name",
+            "run-1",
+            "--yes",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.err
+    envelope = json.loads(captured.out)
+    assert envelope["status"] == "success"
+    assert envelope["operation"] == "eval.run"
+    assert envelope["resource"]["run_name"] == "run-1"
+    assert envelope["resource"]["metrics"]["pass_rate"] == 1.0
+
+
+def test_the_command_is_registered_under_the_eval_group() -> None:
+    from osmosis_ai.cli.commands.eval import app
+
+    names = {
+        command.name or command.callback.__name__  # type: ignore[union-attr]
+        for command in app.registered_commands
+    }
+    assert "run" in names

--- a/tests/unit/rollout/controller/test_proxy_stub_upstream.py
+++ b/tests/unit/rollout/controller/test_proxy_stub_upstream.py
@@ -1,0 +1,246 @@
+"""The contract stub's real-provider passthrough.
+
+The stub's canned reply is enough to lock the wire contract but scores zero
+against any real grader, so a local end-to-end run points it at a provider. The
+passthrough must keep the frozen request/SSE contract and, critically, surface an
+upstream error as an error rather than a truncated stream.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import pytest
+
+from osmosis_ai.rollout.controller.proxy_client import (
+    EvalProxyStubUpstream,
+    create_eval_proxy_stub_app,
+)
+
+PLATFORM_TOKEN = "platform-token"
+ROLLOUT_ID = "a" * 32
+
+_SSE_BODY = (
+    'data: {"id":"c1","object":"chat.completion.chunk","choices":'
+    '[{"index":0,"delta":{"role":"assistant","content":"42"},"finish_reason":null}]}\n'
+    "\n"
+    'data: {"id":"c1","object":"chat.completion.chunk","choices":'
+    '[{"index":0,"delta":{},"finish_reason":"stop"}]}\n'
+    "\n"
+    'data: {"id":"c1","object":"chat.completion.chunk","choices":[],'
+    '"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18}}\n'
+    "\n"
+    "data: [DONE]\n"
+    "\n"
+)
+
+
+class _Upstream:
+    """A fake provider that records what the stub forwarded to it."""
+
+    def __init__(self, *, status: int = 200, body: str = _SSE_BODY) -> None:
+        self.status = status
+        self.body = body
+        self.requests: list[dict[str, Any]] = []
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(json.loads(request.content))
+        if self.status >= 400:
+            return httpx.Response(
+                self.status, json={"error": {"message": "unsupported parameter"}}
+            )
+        return httpx.Response(
+            200, text=self.body, headers={"content-type": "text/event-stream"}
+        )
+
+
+@pytest.fixture
+def upstream_client(monkeypatch: pytest.MonkeyPatch) -> _Upstream:
+    """Route the stub's outbound provider calls to an in-process fake."""
+    fake = _Upstream()
+    real_client = httpx.AsyncClient
+
+    def patched(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs.setdefault("transport", httpx.MockTransport(fake.handler))
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "osmosis_ai.rollout.controller.proxy_client.httpx.AsyncClient", patched
+    )
+    return fake
+
+
+@asynccontextmanager
+async def _session_client(app: Any) -> AsyncIterator[tuple[httpx.AsyncClient, str]]:
+    """Open a client against the stub app and create one session on it."""
+    from httpx import ASGITransport
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://stub"
+    ) as client:
+        response = await client.post(
+            "/v1/eval-sessions",
+            json={"rollout_id": ROLLOUT_ID, "model_path": "openai/gpt-4o-mini"},
+            headers={"Authorization": f"Bearer {PLATFORM_TOKEN}"},
+        )
+        assert response.status_code == 200
+        yield client, response.json()["token"]
+
+
+def _app(upstream_base: str = "https://provider.test/v1") -> Any:
+    return create_eval_proxy_stub_app(
+        platform_token=PLATFORM_TOKEN,
+        upstream=EvalProxyStubUpstream(base_url=upstream_base, api_key="sk-fake"),
+    )
+
+
+async def test_the_wire_model_is_mapped_to_the_session_model_path(
+    upstream_client: _Upstream,
+) -> None:
+    app = _app()
+    async with _session_client(app) as (client, token):
+        response = await client.post(
+            f"/v1/eval-sessions/{ROLLOUT_ID}/chat/completions",
+            json={
+                "model": "osmosis-rollout",
+                "messages": [{"role": "user", "content": "2*21"}],
+                "stream": True,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+    forwarded = upstream_client.requests[0]
+    # The provider prefix is stripped, exactly as the locked LiteLLM path does.
+    assert forwarded["model"] == "gpt-4o-mini"
+    assert forwarded["stream"] is True
+    # Metering must never depend on the client asking for usage.
+    assert forwarded["stream_options"] == {"include_usage": True}
+
+
+async def test_the_upstream_stream_is_relayed_verbatim(
+    upstream_client: _Upstream,
+) -> None:
+    app = _app()
+    async with _session_client(app) as (client, token):
+        response = await client.post(
+            f"/v1/eval-sessions/{ROLLOUT_ID}/chat/completions",
+            json={
+                "model": "osmosis-rollout",
+                "messages": [{"role": "user", "content": "2*21"}],
+                "stream": True,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        assert "42" in response.text
+        assert response.text.rstrip().endswith("data: [DONE]")
+
+
+async def test_relayed_usage_is_metered_on_the_session(
+    upstream_client: _Upstream,
+) -> None:
+    app = _app()
+    async with _session_client(app) as (client, token):
+        await client.post(
+            f"/v1/eval-sessions/{ROLLOUT_ID}/chat/completions",
+            json={
+                "model": "osmosis-rollout",
+                "messages": [{"role": "user", "content": "2*21"}],
+                "stream": True,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        usage = await client.get(
+            f"/v1/eval-sessions/{ROLLOUT_ID}/usage",
+            headers={"Authorization": f"Bearer {PLATFORM_TOKEN}"},
+        )
+    assert usage.json() == {
+        "prompt_tokens": 11,
+        "completion_tokens": 7,
+        "total_tokens": 18,
+    }
+
+
+async def test_an_upstream_error_surfaces_as_a_status_not_a_truncated_stream(
+    upstream_client: _Upstream,
+) -> None:
+    # Raising inside the SSE generator would send 200 + headers first, so the
+    # client would report a transport error instead of the provider's message.
+    upstream_client.status = 400
+    app = _app()
+    async with _session_client(app) as (client, token):
+        response = await client.post(
+            f"/v1/eval-sessions/{ROLLOUT_ID}/chat/completions",
+            json={
+                "model": "osmosis-rollout",
+                "messages": [{"role": "user", "content": "2*21"}],
+                "stream": True,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 502
+    detail = response.json()["detail"]
+    assert "upstream provider returned 400" in detail
+    assert "unsupported parameter" in detail
+
+
+async def test_the_frozen_request_contract_still_applies_with_a_passthrough(
+    upstream_client: _Upstream,
+) -> None:
+    app = _app()
+    async with _session_client(app) as (client, token):
+        non_streaming = await client.post(
+            f"/v1/eval-sessions/{ROLLOUT_ID}/chat/completions",
+            json={"model": "osmosis-rollout", "messages": [], "stream": False},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        wrong_model = await client.post(
+            f"/v1/eval-sessions/{ROLLOUT_ID}/chat/completions",
+            json={"model": "gpt-4o-mini", "messages": [], "stream": True},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        unauthorized = await client.post(
+            f"/v1/eval-sessions/{ROLLOUT_ID}/chat/completions",
+            json={"model": "osmosis-rollout", "messages": [], "stream": True},
+            headers={"Authorization": "Bearer wrong"},
+        )
+    assert non_streaming.status_code == 400
+    assert wrong_model.status_code == 400
+    assert unauthorized.status_code == 401
+    assert upstream_client.requests == []
+
+
+async def test_usage_starts_at_zero_when_a_passthrough_is_configured() -> None:
+    # Without a passthrough the stub reports its canned 2 tokens; with one, real
+    # usage is the only source, so a session with no calls must report zero.
+    app = _app()
+    async with _session_client(app) as (client, _token):
+        usage = await client.get(
+            f"/v1/eval-sessions/{ROLLOUT_ID}/usage",
+            headers={"Authorization": f"Bearer {PLATFORM_TOKEN}"},
+        )
+    assert usage.json() == {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+    }
+
+
+async def test_the_canned_stub_is_unchanged_without_a_passthrough() -> None:
+    app = create_eval_proxy_stub_app(platform_token=PLATFORM_TOKEN)
+    async with _session_client(app) as (client, token):
+        response = await client.post(
+            f"/v1/eval-sessions/{ROLLOUT_ID}/chat/completions",
+            json={"model": "osmosis-rollout", "messages": [], "stream": True},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        usage = await client.get(
+            f"/v1/eval-sessions/{ROLLOUT_ID}/usage",
+            headers={"Authorization": f"Bearer {PLATFORM_TOKEN}"},
+        )
+    assert "chatcmpl-stub" in response.text
+    assert usage.json()["total_tokens"] == 2

--- a/tests/unit/rollout/test_http_driver.py
+++ b/tests/unit/rollout/test_http_driver.py
@@ -537,7 +537,9 @@ async def test_explicit_cancel_malformed_response_still_returns_cancelled() -> N
         ("nan", 1.0),
         ("1e999", 1.0),
         ("junk", 1.0),
-        ("-5", 0.0),
+        # Negative and zero waits clamp to the floor so a 429 loop cannot spin.
+        ("-5", 0.05),
+        ("0", 0.05),
         ("2.5", 2.5),
     ],
 )

--- a/tests/unit/rollout/test_http_driver.py
+++ b/tests/unit/rollout/test_http_driver.py
@@ -386,9 +386,12 @@ async def test_post_200_is_protocol_error_without_looping() -> None:
         raise AssertionError(request.url.path)
 
     driver, _proxy = _driver(store, handler)
-    with pytest.raises(RolloutProtocolError, match="200"):
+    with pytest.raises(RolloutProtocolError, match="200") as excinfo:
         await driver.run(_request())
     assert posts == 1
+    # The supervisor needs the status to tell a refusal of this request apart
+    # from a server that is simply broken.
+    assert excinfo.value.status_code == 200
 
 
 async def test_status_url_encodes_rollout_id() -> None:


### PR DESCRIPTION
## What

- Add `osmosis_ai/eval/local/state.py`: the terminal-result journal (`events.jsonl`), the `manifest.json` resolved-input lock and its field-level diff, the stable run flock with orphan-child metadata, and the atomic/fsync write primitives.
- Add `osmosis_ai/eval/local/dataset.py`: platform dataset resolution with a content-addressed cache, streaming JSONL/CSV/Parquet readers, and the row-normalization contract shared with the cloud eval controller (`row_index` is the position in the selected set; `source_row_index` keeps the dataset offset) plus `--rows` parsing.
- Add `osmosis_ai/eval/local/results.py`: the write-time `index.jsonl` contract lint, the platform metrics formula including pass@k, ATIF identity validation, and the download-shaped user projections.
- Add `osmosis_ai/eval/local/runner.py`: the supervisor — bounded worker pool, rollout-server subprocess lifecycle with verified orphan reaping, journal-before-ack terminal commits, named-run resume/fresh/retry, eval-proxy preflight, and coalesced live materialization.
- Add `osmosis eval run` (`osmosis_ai/platform/cli/eval_run.py` + the `run` subcommand) under its final command name, with an `[eval-run]` missing-extra install hint.
- Extract `osmosis_ai/source_scan.py` so the Harbor bundle packager and the resume fingerprint share one source traversal instead of two; `packaging.content_hash` now delegates to it.
- Add an optional real-provider passthrough to the Phase 1 eval-proxy contract stub (`EvalProxyStubUpstream`), so a local end-to-end run produces genuine rewards while the hosted eval-proxy service does not exist yet. The frozen request/SSE contract is unchanged; only the response body becomes real.
- Add `tests/golden/eval_local/`: mirrored index-contract and metrics fixtures, so `index.jsonl` validity and the metrics formula cannot drift from the platform silently.

## Why

Phase 2a of `design/local-eval-run-plan.md` §15 — the first internally usable local-eval milestone. It fills the `RolloutDriver` seam that Phase 1 opened with an actual supervisor, so an existing `eval submit` TOML runs locally against the workspace's own rollout server and produces a run directory that matches the frozen on-disk contract in §2.

The design's load-bearing invariant is ordering, not storage: a terminal callback is acknowledged only after its journal record is fully written and `fsync`-ed, so a durably acknowledged work item never runs again after `kill -9`, while cancelled or crashed work has no terminal record and stays pending. The cloud controller cannot make that guarantee today (§0), and Harbor gets it wrong in the opposite direction by recording a `CancelledError` result and then skipping the trial as complete. Both behaviors are covered by tests that kill a real supervisor process mid-run.

A pre-PR review caught a §9.3 violation worth calling out for reviewers: a process-wide fault (a dead rollout server, an unreachable proxy) used to stamp every remaining work item durably `failed`, so a plain resume skipped rows that never executed. Only a `RolloutProtocolError` — the server refusing one specific request — now journals a per-item failure; everything else halts dispatch and leaves the queue pending. The same pass fixed the `pass_rate` denominator to exclude only skipped rows per §2.5, added a deadline floor for configs with no timeouts, and routed rollout-server output through a secret redactor before it reaches `logs.txt` (§7.4).

No `[local]`/`[execution]` config section is added: every runtime difference is a CLI flag, per §5. Upload, remote sandboxes, and Harbor hardening stay out of scope (Phases 2b/3/4).

## How to Test

- `uv run pytest tests/unit/eval/local/ tests/unit/platform/cli/test_eval_run.py tests/unit/rollout/controller/` — the runner, CLI, and stub-passthrough suites.
- `uv run pytest tests/unit/eval/local/test_runner_crash_resume.py` — the §17 acceptance gates: `kill -9` and SIGINT against a real supervisor subprocess.
- `uv run pytest tests/unit/eval/local/test_golden_contracts.py` — the mirrored index/metrics fixtures.
- `uv run pytest && uv run ruff check . && uv run ruff format --check . && uv run pyright osmosis_ai/`
- `uv run --no-editable --reinstall-package osmosis-ai pyright --verifytypes osmosis_ai --ignoreexternal` — reports 100% type completeness.
- End-to-end against a workspace: `osmosis eval run configs/eval/<config>.toml --name smoke --rows 0-1 --yes`. Re-running the same `--name` must report `dispatched=0`; changing `--rows` must refuse with a field-level diff and an explicit `--fresh` hint.

## Checklist

- [x] PR title follows `[module] type: description` format
      (labels are derived from it automatically — no need to add them by hand)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pyright osmosis_ai/` passes
- [x] `pytest` passes (new tests added if applicable)
- [x] Public API changes are documented
- [x] No secrets or credentials included
